### PR TITLE
chore(tools/mkdocs): support live reload when modifying `docs`

### DIFF
--- a/tools/mkdocs.ts
+++ b/tools/mkdocs.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import type { ExecaSyncReturnValue } from 'execa';
+import type { ExecaChildProcess, ExecaReturnValue } from 'execa';
+import { execa } from 'execa';
 import fs from 'fs-extra';
 import { init, logger } from '../lib/logger/index.ts';
 import { generateDocs } from './docs/index.ts';
@@ -46,19 +47,50 @@ program
   .option('--no-build', 'do not build docs from source')
   .option('--no-strict', 'do not build in strict mode')
   .action(async (opts) => {
-    await prepareDocs(opts);
     logger.info('serving docs');
-    logger.info('* running mkdocs serve');
-    const args = ['run', 'mkdocs', 'serve'];
+    const mkdocsArgs = ['run', 'mkdocs', 'serve'];
     if (opts.strict) {
-      args.push('--strict');
+      mkdocsArgs.push('--strict');
     }
-    const res = await exec('pdm', args, {
-      cwd: 'tools/mkdocs',
-      stdio: 'inherit',
-      reject: false,
+    const spawnServe = (): ExecaChildProcess<string> =>
+      execa('pdm', mkdocsArgs, {
+        cwd: 'tools/mkdocs',
+        stdio: 'inherit',
+        reject: false,
+        maxBuffer: 20 * 1024 * 1024,
+        encoding: 'utf8',
+      });
+
+    if (!opts.build) {
+      await prepareDocs(opts);
+      checkResult(await spawnServe());
+      return;
+    }
+
+    let activeChild: ExecaChildProcess<string> | null = null;
+    let shouldRestart = false;
+    let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+    fs.watch('docs', { recursive: true }, () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => {
+        logger.info('docs changed, restarting mkdocs...');
+        shouldRestart = true;
+        activeChild?.kill();
+      }, 300);
     });
-    checkResult(res);
+
+    while (true) {
+      shouldRestart = false;
+      await prepareDocs(opts);
+      logger.info('* running mkdocs serve');
+      activeChild = spawnServe();
+      const res = await activeChild;
+      if (!shouldRestart) {
+        checkResult(res);
+        break;
+      }
+    }
   });
 
 async function prepareDocs(opts: any): Promise<void> {
@@ -72,7 +104,7 @@ async function prepareDocs(opts: any): Promise<void> {
   }
 }
 
-function checkResult(res: ExecaSyncReturnValue<string>): void {
+function checkResult(res: ExecaReturnValue<string>): void {
   if (res.signal) {
     logger.error(`Signal received: ${res.signal}`);
     process.exit(-1);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As noted in #40757, when using `tools/mkdocs.ts serve`, any changes to
source files require a full restart of the command, which can be
awkward.

We can add a live reload by watching for file changes in `docs/` and
retriggering the `mkdocs` process.

Co-authored-by: Claude Sonnet 4.6 <jamie.tanna+claude-code@mend.io>


<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #40757,
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
