### PR TITLE
refactor(cache): support package cache result predicate

### DIFF
--- a/lib/util/cache/package/with-cache.spec.ts
+++ b/lib/util/cache/package/with-cache.spec.ts
@@ -137,6 +137,78 @@ describe('util/cache/package/with-cache', () => {
     );
   });
 
+  it('does not cache values rejected by cacheResult predicate', async () => {
+    const fn = async (): Promise<string | null> => {
+      await getValue();
+      return null;
+    };
+    const shouldCacheResult = (value: unknown): boolean => value !== null;
+
+    expect(
+      await withCache(
+        { namespace: '_test-namespace', key: 'key', shouldCacheResult },
+        fn,
+      ),
+    ).toBeNull();
+    expect(
+      await withCache(
+        { namespace: '_test-namespace', key: 'key', shouldCacheResult },
+        fn,
+      ),
+    ).toBeNull();
+    expect(
+      await withCache(
+        { namespace: '_test-namespace', key: 'key', shouldCacheResult },
+        fn,
+      ),
+    ).toBeNull();
+
+    expect(getValue).toHaveBeenCalledTimes(3);
+    expect(setCache).not.toHaveBeenCalled();
+  });
+
+  it('ignores cached values rejected by cacheResult predicate', async () => {
+    const nullFn = async (): Promise<string | null> => {
+      await getValue();
+      return null;
+    };
+    const fn = () => getValue();
+    const cacheResult = (value: unknown): boolean => value !== null;
+
+    expect(
+      await withCache({ namespace: '_test-namespace', key: 'key' }, nullFn),
+    ).toBeNull();
+    expect(
+      await withCache(
+        {
+          namespace: '_test-namespace',
+          key: 'key',
+          shouldCacheResult: cacheResult,
+        },
+        fn,
+      ),
+    ).toBe('222');
+    expect(
+      await withCache(
+        {
+          namespace: '_test-namespace',
+          key: 'key',
+          shouldCacheResult: cacheResult,
+        },
+        fn,
+      ),
+    ).toBe('222');
+
+    expect(getValue).toHaveBeenCalledTimes(2);
+    expect(setCache).toHaveBeenCalledTimes(2);
+    expect(setCache).toHaveBeenLastCalledWith(
+      '_test-namespace',
+      'cache-decorator:key',
+      { cachedAt: expect.any(String), value: '222' },
+      30,
+    );
+  });
+
   it('does not cache undefined', async () => {
     const fn = async (): Promise<string | undefined> => {
       await getValue();
@@ -335,6 +407,46 @@ describe('util/cache/package/with-cache', () => {
           fn,
         ),
       ).toBe('111');
+      expect(getValue).toHaveBeenCalledTimes(2);
+      expect(setCache).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not return stale values rejected by cacheResult predicate', async () => {
+      const nullFn = async (): Promise<string | null> => {
+        await getValue();
+        return null;
+      };
+      const fn = () => getValue();
+      const shouldCacheResult = (value: unknown): boolean => value !== null;
+
+      expect(
+        await withCache(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+          },
+          nullFn,
+        ),
+      ).toBeNull();
+      expect(getValue).toHaveBeenCalledTimes(1);
+      expect(setCache).toHaveBeenCalledTimes(1);
+
+      vi.advanceTimersByTime(60 * 1000);
+      getValue.mockRejectedValueOnce(new Error('test'));
+      await expect(
+        withCache(
+          {
+            namespace: '_test-namespace',
+            key: 'key',
+            ttlMinutes: 1,
+            fallback: true,
+            shouldCacheResult,
+          },
+          fn,
+        ),
+      ).rejects.toThrow('test');
       expect(getValue).toHaveBeenCalledTimes(2);
       expect(setCache).toHaveBeenCalledTimes(1);
     });

--- a/lib/util/cache/package/with-cache.ts
+++ b/lib/util/cache/package/with-cache.ts
@@ -32,6 +32,12 @@ interface CachedOptions {
   cacheable?: boolean;
 
   /**
+   * Whether a cache result is safe to use and store for this call.
+   * @default value !== undefined
+   */
+  shouldCacheResult?: (value: unknown) => boolean;
+
+  /**
    * Enable extended hard TTL for graceful degradation.
    * When true and upstream errors occur, stale cached data is returned.
    * @default false
@@ -62,6 +68,11 @@ export async function withCache<T>(
   const isCacheable = cachePrivatePackages || cacheable;
   if (!isCacheable) {
     return fn();
+  }
+
+  let shouldCacheResult = (value: unknown): boolean => true;
+  if (options.shouldCacheResult) {
+    shouldCacheResult = options.shouldCacheResult;
   }
 
   // istanbul ignore if -- TODO: add test #40625
@@ -95,7 +106,7 @@ export async function withCache<T>(
     const hardTtlMinutes = fallback ? resolvedHardTtl : softTtlMinutes;
 
     let fallbackValue: unknown;
-    if (cachedRecord) {
+    if (cachedRecord && shouldCacheResult(cachedRecord.value)) {
       const now = DateTime.local();
       const cachedAt = DateTime.fromISO(cachedRecord.cachedAt);
 
@@ -124,7 +135,7 @@ export async function withCache<T>(
       throw err;
     }
 
-    if (!isUndefined(newValue)) {
+    if (!isUndefined(newValue) && shouldCacheResult(newValue)) {
       const newRecord: CachedRecord = {
         cachedAt: DateTime.local().toISO(),
         value: newValue,


### PR DESCRIPTION
## Changes

Add `shouldCacheResult` to package `withCache()` so callers can alter the caching behavior based on result values.

Existing behavior is preserved by default, including default null caching and never writing `undefined`.

## Context

- [x] This does not close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related to GitHub Discussion #40718.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No - I did not use AI for this contribution.
- [ ] Yes - minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes - substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes - other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I have tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository