### PR TITLE
fix(datasource/docker): avoid caching null digest results

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -218,6 +218,35 @@ describe('modules/datasource/docker/index', () => {
       expect(res).toBeNull();
     });
 
+    it('does not cache null digest results', async () => {
+      const registryUrl = 'https://registry.company.com/v2';
+      const packageName = 'registry.company.com/cache-poison';
+
+      httpMock
+        .scope(registryUrl)
+        .get('/', undefined, { badheaders: ['authorization'] })
+        .reply(401, '', {
+          'www-authenticate': 'Basic realm="My Private Docker Registry Server"',
+        })
+        .head('/cache-poison/manifests/some-tag')
+        .reply(403);
+      httpMock
+        .scope(registryUrl)
+        .get('/', undefined, { badheaders: ['authorization'] })
+        .reply(401, '', {
+          'www-authenticate': 'Basic realm="My Private Docker Registry Server"',
+        })
+        .head('/cache-poison/manifests/some-tag')
+        .reply(200, '', { 'docker-content-digest': 'sha256:some-digest' });
+
+      expect(
+        await getDigest({ datasource: 'docker', packageName }, 'some-tag'),
+      ).toBeNull();
+      expect(
+        await getDigest({ datasource: 'docker', packageName }, 'some-tag'),
+      ).toBe('sha256:some-digest');
+    });
+
     it.each(amazonHosts)(
       'passes credentials to ECR client for host $host',
       async ({ host }) => {
@@ -1519,6 +1548,64 @@ describe('modules/datasource/docker/index', () => {
       );
 
       expect(res).toBe(newDigest);
+    });
+  });
+
+  describe('getImageArchitecture', () => {
+    it('does not cache null architecture results', async () => {
+      const datasource = new DockerDatasource();
+      const registryHost = 'https://registry.company.com';
+      const dockerRepository = 'cache-arch';
+      const currentDigest =
+        'sha256:0101010101010101010101010101010101010101010101010101010101010101';
+
+      httpMock
+        .scope(`${registryHost}/v2`)
+        .get('/')
+        .reply(200)
+        .head(`/cache-arch/manifests/${currentDigest}`)
+        .reply(200, '', {
+          'content-type':
+            'application/vnd.docker.distribution.manifest.list.v2+json',
+        });
+      httpMock
+        .scope(`${registryHost}/v2`)
+        .get('/')
+        .times(3)
+        .reply(200)
+        .head(`/cache-arch/manifests/${currentDigest}`)
+        .reply(200, '', {
+          'content-type':
+            'application/vnd.docker.distribution.manifest.v2+json',
+        })
+        .get(`/cache-arch/manifests/${currentDigest}`)
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+          config: {
+            digest: 'sha256:config-digest',
+            mediaType: 'application/vnd.docker.container.image.v1+json',
+          },
+        })
+        .get('/cache-arch/blobs/sha256:config-digest')
+        .reply(200, {
+          architecture: 'amd64',
+        });
+
+      expect(
+        await datasource.getImageArchitecture(
+          registryHost,
+          dockerRepository,
+          currentDigest,
+        ),
+      ).toBeNull();
+      expect(
+        await datasource.getImageArchitecture(
+          registryHost,
+          dockerRepository,
+          currentDigest,
+        ),
+      ).toBe('amd64');
     });
   });
 

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -454,6 +454,7 @@ export class DockerDatasource extends Datasource {
         namespace: 'datasource-docker-architecture',
         key: `${registryHost}:${dockerRepository}@${currentDigest}`,
         ttlMinutes: 1440 * 28,
+        shouldCacheResult: isNonEmptyString,
       },
       () =>
         this._getImageArchitecture(
@@ -1062,6 +1063,7 @@ export class DockerDatasource extends Datasource {
         namespace: 'datasource-docker-digest',
         key: `${registryHost}:${dockerRepository}:${newTag}${digest}`,
         fallback: true,
+        shouldCacheResult: isNonEmptyString,
       },
       () => this._getDigest(config, newValue),
     );


### PR DESCRIPTION
## Changes

Use the package cache result predicate for Docker digest and image architecture lookups so only non-empty string results are accepted from or written to the shared cache.

This keeps positive shared Docker cache entries while preventing `null` results from failed auth or manifest lookups from poisoning later lookups with the same image/tag/digest cache key.

## Context

- [x] This does not close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related to GitHub Discussion #40718.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No - I did not use AI for this contribution.
- [ ] Yes - minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes - substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes - other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I have tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Ran `pnpm check "lib/modules/datasource/docker/index.ts" "lib/modules/datasource/docker/index.spec.ts"`.