### PR TITLE
test: test `config.cts` with actual TypeScript syntax

### DIFF
--- a/lib/workers/global/config/parse/__fixtures__/config.cts
+++ b/lib/workers/global/config/parse/__fixtures__/config.cts
@@ -1,5 +1,7 @@
-// Actual TypeScript syntax cannot be used here until the PR below is merged:
-// https://github.com/vitejs/vite/pull/22459
-module.exports = {
+import type { AllConfig } from '../../../../../config/types.ts';
+
+const config: AllConfig = {
   token: 'abcdefg',
 };
+
+module.exports = config;

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -74,7 +74,7 @@ export default defineConfig(() =>
   mergeConfig(
     {
       resolve: { tsconfigPaths: true },
-      oxc: { include: /\.(cm?ts|[jt]sx)$/ }, // https://github.com/vitejs/vite/pull/22459
+      oxc: { include: /\.([cm]?ts|[jt]sx)$/ }, // Fixes .cts fixtures not being transformed
       cacheDir: ci ? '.cache/vitest' : undefined,
       test: {
         globals: true,

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -74,6 +74,7 @@ export default defineConfig(() =>
   mergeConfig(
     {
       resolve: { tsconfigPaths: true },
+      oxc: { include: /\.(cm?ts|[jt]sx)$/ }, // https://github.com/vitejs/vite/pull/22459
       cacheDir: ci ? '.cache/vitest' : undefined,
       test: {
         globals: true,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

- Addresses the Vite/Vitest "limitation" mentioned in https://github.com/renovatebot/renovate/pull/43381
- References https://github.com/vitejs/vite/pull/22459

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
