### PR TITLE
docs: add "previously known as" to renamed options

### DIFF
--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -1,4 +1,4 @@
-import { isArray, isNonEmptyString } from '@sindresorhus/is';
+import { isArray } from '@sindresorhus/is';
 import JSON5 from 'json5';
 import { getEnvName } from '../../../../config/options/env.ts';
 import { getOptions } from '../../../../config/options/index.ts';
@@ -77,18 +77,44 @@ function massageEnvKeyValues(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return result;
 }
 
-// these experimental env vars have been converted into self-hosted config options
-const convertedExperimentalEnvVars = [
-  'RENOVATE_X_AUTODISCOVER_REPO_SORT',
-  'RENOVATE_X_AUTODISCOVER_REPO_ORDER',
-  'RENOVATE_X_DOCKER_MAX_PAGES',
-  'RENOVATE_X_DELETE_CONFIG_FILE',
-  'RENOVATE_X_S3_ENDPOINT',
-  'RENOVATE_X_S3_PATH_STYLE',
-  'RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL',
-  'RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES',
-  'RENOVATE_X_REPO_CACHE_FORCE_LOCAL',
-];
+interface ConvertedExperimentalEnvVar {
+  optionName: string;
+  // Normalize the raw env var value before passing it through, if needed.
+  normalizeValue?: (value: string) => string;
+}
+
+// Maps RENOVATE_X_ env vars that have been promoted to regular config options
+// to the option name they now correspond to.
+export const convertedExperimentalEnvVars: ReadonlyMap<
+  string,
+  ConvertedExperimentalEnvVar
+> = new Map([
+  ['RENOVATE_X_AUTODISCOVER_REPO_SORT', { optionName: 'autodiscoverRepoSort' }],
+  [
+    'RENOVATE_X_AUTODISCOVER_REPO_ORDER',
+    { optionName: 'autodiscoverRepoOrder' },
+  ],
+  ['RENOVATE_X_DOCKER_MAX_PAGES', { optionName: 'dockerMaxPages' }],
+  ['RENOVATE_X_DELETE_CONFIG_FILE', { optionName: 'deleteConfigFile' }],
+  ['RENOVATE_X_S3_ENDPOINT', { optionName: 's3Endpoint' }],
+  ['RENOVATE_X_S3_PATH_STYLE', { optionName: 's3PathStyle' }],
+  [
+    'RENOVATE_X_MERGE_CONFIDENCE_API_BASE_URL',
+    { optionName: 'mergeConfidenceEndpoint' },
+  ],
+  [
+    'RENOVATE_X_MERGE_CONFIDENCE_SUPPORTED_DATASOURCES',
+    { optionName: 'mergeConfidenceDatasources' },
+  ],
+  [
+    'RENOVATE_X_REPO_CACHE_FORCE_LOCAL',
+    {
+      optionName: 'repositoryCacheForceLocal',
+      // The old env var was treated as a flag: any non-empty value meant true.
+      normalizeValue: (v: string) => (v ? 'true' : v),
+    },
+  ],
+]);
 
 /**
  * Massages the experimental env vars which have been converted to config options
@@ -99,20 +125,16 @@ function massageConvertedExperimentalVars(
   env: NodeJS.ProcessEnv,
 ): NodeJS.ProcessEnv {
   const result = { ...env };
-  for (const key of convertedExperimentalEnvVars) {
-    if (env[key] !== undefined) {
-      let newKey = key.replace('RENOVATE_X_', 'RENOVATE_');
-
-      // special case to use a more consistent prefix with other `repositoryCache` options
-      if (key === 'RENOVATE_X_REPO_CACHE_FORCE_LOCAL') {
-        newKey = 'RENOVATE_REPOSITORY_CACHE_FORCE_LOCAL';
-        if (isNonEmptyString(env[key])) {
-          env[key] = 'true';
-        }
-      }
-
-      result[newKey] = env[key];
-      delete result[key];
+  for (const [
+    oldKey,
+    { optionName, normalizeValue },
+  ] of convertedExperimentalEnvVars) {
+    if (env[oldKey] !== undefined) {
+      const newKey = getEnvName({ name: optionName });
+      result[newKey] = normalizeValue
+        ? normalizeValue(env[oldKey])
+        : env[oldKey];
+      delete result[oldKey];
     }
   }
   return result;

--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -17,6 +17,7 @@ import {
   toolNames,
 } from '../../lib/util/exec/types.ts';
 import { getCliName } from '../../lib/workers/global/config/parse/cli.ts';
+import { convertedExperimentalEnvVars } from '../../lib/workers/global/config/parse/env.ts';
 import { readFile, updateFile } from '../utils/index.ts';
 import { formatCell, replaceContent } from './utils.ts';
 
@@ -25,14 +26,24 @@ const managers = new Set(allManagersList);
 
 const previousNames: ReadonlyMap<string, string[]> = (() => {
   const map = new Map<string, string[]>();
-  for (const [oldName, newName] of MigrationsService.renamedProperties) {
-    const existing = map.get(newName);
+
+  function add(optionName: string, previousName: string): void {
+    const existing = map.get(optionName);
     if (existing) {
-      existing.push(oldName);
+      existing.push(previousName);
     } else {
-      map.set(newName, [oldName]);
+      map.set(optionName, [previousName]);
     }
   }
+
+  for (const [oldName, newName] of MigrationsService.renamedProperties) {
+    add(newName, oldName);
+  }
+
+  for (const [oldEnvVar, { optionName }] of convertedExperimentalEnvVars) {
+    add(optionName, oldEnvVar);
+  }
+
   return map;
 })();
 

--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import stringify from 'json-stringify-pretty-compact';
 import { getConfigFileNames } from '../../lib/config/app-strings.ts';
+import { MigrationsService } from '../../lib/config/migrations/index.ts';
 import { getEnvName } from '../../lib/config/options/env.ts';
 import { getOptions } from '../../lib/config/options/index.ts';
 import {
@@ -21,6 +22,19 @@ import { formatCell, replaceContent } from './utils.ts';
 
 const options = getOptions();
 const managers = new Set(allManagersList);
+
+const previousNames: ReadonlyMap<string, string[]> = (() => {
+  const map = new Map<string, string[]>();
+  for (const [oldName, newName] of MigrationsService.renamedProperties) {
+    const existing = map.get(newName);
+    if (existing) {
+      existing.push(oldName);
+    } else {
+      map.set(newName, [oldName]);
+    }
+  }
+  return map;
+})();
 
 /**
  * Merge string arrays one by one
@@ -141,7 +155,9 @@ function genTable(obj: [string, string][], type: string, def: any): string {
         ((type === 'object' || type === 'array') &&
           (el[0] === 'default' || el[0] === 'additionalProperties')) ||
         // enum values for `allowedValues` should be printed in JSON notation
-        el[0] === 'allowedValues'
+        el[0] === 'allowedValues' ||
+        // previous names should be printed in JSON notation
+        el[0] === 'previouslyKnownAs'
       ) {
         // only show array and object defaults if they are not null and are not empty
         if (Object.keys(el[1] ?? []).length === 0) {
@@ -172,7 +188,12 @@ function genTable(obj: [string, string][], type: string, def: any): string {
 }
 
 function stringifyArrays(el: Record<string, any>): void {
-  const ignoredKeys = ['allowedValues', 'default', 'experimentalIssues'];
+  const ignoredKeys = [
+    'allowedValues',
+    'default',
+    'experimentalIssues',
+    'previouslyKnownAs',
+  ];
 
   for (const [key, value] of Object.entries(el)) {
     if (!ignoredKeys.includes(key) && Array.isArray(value)) {
@@ -380,6 +401,10 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
 
       el.cli = getCliName(option);
       el.env = getEnvName(option);
+      const prevNames = previousNames.get(option.name);
+      if (prevNames) {
+        el.previouslyKnownAs = prevNames;
+      }
       stringifyArrays(el);
 
       for (const key of lookupKeys) {


### PR DESCRIPTION
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes


To provide a more searchable set of docs in the case that we migrate a
config option, we can introduce a `previouslyKnownAs` field in the
resulting generated documentation.

This allows someone to search for the previous name and find the new
option name.

Adding this for  `RENOVATE_X_` variables is a little more involved (and could be split out to its own change).

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
