### PR TITLE
fix(custom/jsonata): support autoReplaceStringTemplate

### DIFF
--- a/lib/modules/manager/custom/jsonata/index.spec.ts
+++ b/lib/modules/manager/custom/jsonata/index.spec.ts
@@ -371,8 +371,6 @@ describe('modules/manager/custom/jsonata/index', () => {
       matchStrings: [`{"depName": "foo"}`, `{"depName": "bar"}`],
       currentValueTemplate: '1.0.0',
       datasourceTemplate: 'npm',
-      // should be included present extract result as it is not valid jsonata manager template
-      // adding here for testing
       autoReplaceStringTemplate: `{{{depName}}}:{{{newValue}}}`,
     };
     const res = await extractPackageFile('{}', 'unused', config);
@@ -393,6 +391,7 @@ describe('modules/manager/custom/jsonata/index', () => {
       matchStrings: [`{"depName": "foo"}`, `{"depName": "bar"}`],
       currentValueTemplate: '1.0.0',
       datasourceTemplate: 'npm',
+      autoReplaceStringTemplate: `{{{depName}}}:{{{newValue}}}`,
     });
   });
 

--- a/lib/modules/manager/custom/jsonata/index.ts
+++ b/lib/modules/manager/custom/jsonata/index.ts
@@ -66,6 +66,9 @@ export async function extractPackageFile(
       res[field] = config[field];
     }
   }
+  if (config.autoReplaceStringTemplate) {
+    res.autoReplaceStringTemplate = config.autoReplaceStringTemplate;
+  }
 
   return res;
 }

--- a/lib/modules/manager/custom/jsonata/types.ts
+++ b/lib/modules/manager/custom/jsonata/types.ts
@@ -10,6 +10,11 @@ export interface JSONataManagerTemplates {
   currentDigestTemplate?: string;
   extractVersionTemplate?: string;
   registryUrlTemplate?: string;
+  /**
+   * Lets a JSONata manager reshape the updated value before it is written back,
+   * e.g. to re-pad a 4-segment version that the datasource returns as 3 segments
+   * Needed because the extracted value and the new value can differ in format
+   */
   autoReplaceStringTemplate?: string;
 }
 

--- a/lib/modules/manager/custom/jsonata/types.ts
+++ b/lib/modules/manager/custom/jsonata/types.ts
@@ -10,6 +10,7 @@ export interface JSONataManagerTemplates {
   currentDigestTemplate?: string;
   extractVersionTemplate?: string;
   registryUrlTemplate?: string;
+  autoReplaceStringTemplate?: string;
 }
 
 export interface JSONataManagerConfig extends JSONataManagerTemplates {

--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -218,14 +218,11 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.packageFile = '.gitlab-ci.yml';
       upgrade.autoReplaceStringTemplate =
         "'{{{depName}}}'\nref: {{{newValue}}}";
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'docker';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStringsStrategy = 'combination';
 
       // If the new "name" is not added to the matchStrings, the regex matcher fails to extract from `newContent` as
       // there's nothing defined in there anymore that it can match
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         '[\'"]?(?<depName>pipeline-fragments\\/docker-lint)[\'"]?\\s*ref:\\s[\'"]?(?<currentValue>[\\d-]*)[\'"]?',
         '[\'"]?(?<depName>pipeline-solutions\\/gitlab\\/fragments\\/docker-lint)[\'"]?\\s*ref:\\s[\'"]?(?<currentValue>[\\d-]*)[\'"]?',
@@ -253,11 +250,9 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.replaceString =
         'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
       upgrade.packageFile = 'k8s/base/defaults.yaml';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         'image:\\s*\\\'?\\"?(?<depName>[^:]+):(?<currentValue>[^\\s\\\'\\"]+)\\\'?\\"?\\s*',
       ];
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'docker';
       const res = doAutoReplace(upgrade, yml, reuseExistingBranch);
       await expect(res).rejects.toThrow(WORKER_FILE_UPDATE_FAILED);
@@ -320,11 +315,9 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.replaceString =
         'image: "1111111111.dkr.ecr.us-east-1.amazonaws.com/my-repository:1"\n\n';
       upgrade.packageFile = 'k8s/base/defaults.yaml';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         'image:\\s*\\\'?\\"?(?<depName>[^:]+):(?<currentValue>[^\\s\\\'\\"]+)\\\'?\\"?\\s*',
       ];
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'docker';
       const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
       expect(res).toBe(yml);
@@ -1320,11 +1313,9 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newName = 'some.other.url.com/some-new-repo';
       upgrade.newValue = '3.16';
       upgrade.newDigest = 'sha256:p0o9i8u7z6t5r4e3w2q1';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         'image:\\s*?\\\'?\\"?(?<depName>[^:\\\'\\"]+):(?<currentValue>[^@\\\'\\"]+)@?(?<currentDigest>[^\\s\\\'\\"]+)?\\"?\\\'?\\s*',
       ];
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'docker';
       const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
       expect(res).toBe('image: "some.other.url.com/some-new-repo:3.16"');
@@ -1346,11 +1337,9 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newName = 'some.other.url.com/some-new-repo';
       upgrade.newValue = '3.16';
       upgrade.newDigest = 'sha256:p0o9i8u7z6t5r4e3w2q1';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         'image:\\s*[\\\'\\"]?(?<depName>[^:]+):(?<currentValue>[^@]+)?@?(?<currentDigest>[^\\s\\\'\\"]+)?[\\\'\\"]?\\s*',
       ];
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'docker';
       const res = await doAutoReplace(upgrade, yml, reuseExistingBranch);
       expect(res).toBe(
@@ -1367,11 +1356,8 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newValue = '1.2.4';
       upgrade.depIndex = 0;
       upgrade.packageFile = 'deps.json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.fileFormat = 'json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'github-releases';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
       ];
@@ -1391,11 +1377,8 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newDigest = 'badbeef';
       upgrade.depIndex = 0;
       upgrade.packageFile = 'deps.json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.fileFormat = 'json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'github-releases';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
       ];
@@ -1416,11 +1399,8 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newDigest = 'badbeef';
       upgrade.depIndex = 0;
       upgrade.packageFile = 'deps.json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.fileFormat = 'json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'github-releases';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
       ];
@@ -1440,11 +1420,8 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newDigest = 'badbeef';
       upgrade.depIndex = 0;
       upgrade.packageFile = 'deps.json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.fileFormat = 'json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'github-releases';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         '*.{"depName": package, "currentDigest": digest, "currentValue": version }',
       ];
@@ -1462,11 +1439,8 @@ describe('workers/repository/update/branch/auto-replace', () => {
       upgrade.newValue = '27.0.0';
       upgrade.depIndex = 0;
       upgrade.packageFile = 'deps.json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.fileFormat = 'json';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.datasourceTemplate = 'nuget';
-      // @ts-expect-error -- TODO: improve typing
       upgrade.matchStrings = [
         '*.{"depName": package, "currentValue": version }',
       ];
@@ -1475,6 +1449,28 @@ describe('workers/repository/update/branch/auto-replace', () => {
 
       const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
       expect(res).toBe('[ { "version": "27.0.0.0", "package": "foo" } ]');
+    });
+
+    it('jsonata: rebases when autoReplaceStringTemplate fails to compile', async () => {
+      const source = '[ { "version": "26.0.0.1", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.baseDeps = [{ depName: 'foo' }];
+      upgrade.depName = 'foo';
+      upgrade.currentValue = '26.0.0.1';
+      upgrade.newValue = '27.0.0';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      upgrade.fileFormat = 'json';
+      upgrade.datasourceTemplate = 'nuget';
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentValue": version }',
+      ];
+      // invalid handlebars template throws during confirmIfDepUpdated
+      upgrade.autoReplaceStringTemplate = '{{#if}}';
+      reuseExistingBranch = true;
+
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBeNull();
     });
 
     it('github-actions: updates with newValue only', async () => {

--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -1454,6 +1454,29 @@ describe('workers/repository/update/branch/auto-replace', () => {
       );
     });
 
+    it('jsonata: reformats newValue via autoReplaceStringTemplate', async () => {
+      const source = '[ { "version": "26.0.0.1", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.depName = 'foo';
+      upgrade.currentValue = '26.0.0.1';
+      upgrade.newValue = '27.0.0';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.fileFormat = 'json';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.datasourceTemplate = 'nuget';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentValue": version }',
+      ];
+      upgrade.autoReplaceStringTemplate =
+        '{{replace "^(\\d+\\.\\d+\\.\\d+)$" "$1.0" newValue}}';
+
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBe('[ { "version": "27.0.0.0", "package": "foo" } ]');
+    });
+
     it('github-actions: updates with newValue only', async () => {
       const githubAction = codeBlock`
         jobs:

--- a/lib/workers/repository/update/branch/auto-replace.spec.ts
+++ b/lib/workers/repository/update/branch/auto-replace.spec.ts
@@ -1430,6 +1430,29 @@ describe('workers/repository/update/branch/auto-replace', () => {
       );
     });
 
+    it('jsonata: reformats newValue via autoReplaceStringTemplate', async () => {
+      const source = '[ { "version": "26.0.0.1", "package": "foo" } ]';
+      upgrade.manager = 'jsonata';
+      upgrade.depName = 'foo';
+      upgrade.currentValue = '26.0.0.1';
+      upgrade.newValue = '27.0.0';
+      upgrade.depIndex = 0;
+      upgrade.packageFile = 'deps.json';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.fileFormat = 'json';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.datasourceTemplate = 'nuget';
+      // @ts-expect-error -- TODO: improve typing
+      upgrade.matchStrings = [
+        '*.{"depName": package, "currentValue": version }',
+      ];
+      upgrade.autoReplaceStringTemplate =
+        '{{replace "^(\\d+\\.\\d+\\.\\d+)$" "$1.0" newValue}}';
+
+      const res = await doAutoReplace(upgrade, source, reuseExistingBranch);
+      expect(res).toBe('[ { "version": "27.0.0.0", "package": "foo" } ]');
+    });
+
     it('github-actions: updates with newValue only', async () => {
       const githubAction = codeBlock`
         jobs:

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -90,17 +90,37 @@ export async function confirmIfDepUpdated(
   }
 
   if (upgrade.newValue && upgrade.newValue !== newUpgrade.currentValue) {
-    logger.debug(
-      {
-        depName: upgrade.depName,
-        manager,
-        packageFile,
-        expectedValue: upgrade.newValue,
-        foundValue: newUpgrade.currentValue,
-      },
-      'Value is not updated',
-    );
-    return false;
+    // accept reshaped values produced by autoReplaceStringTemplate
+    let templateMatchesExtractedValue = false;
+    if (upgrade.autoReplaceStringTemplate) {
+      try {
+        const compiledValue = compile(
+          upgrade.autoReplaceStringTemplate,
+          upgrade,
+          false,
+        );
+        templateMatchesExtractedValue =
+          compiledValue === newUpgrade.currentValue;
+      } catch (err) /* istanbul ignore next */ {
+        logger.debug(
+          { err, manager, packageFile },
+          'Failed to compile autoReplaceStringTemplate in confirmIfDepUpdated',
+        );
+      }
+    }
+    if (!templateMatchesExtractedValue) {
+      logger.debug(
+        {
+          depName: upgrade.depName,
+          manager,
+          packageFile,
+          expectedValue: upgrade.newValue,
+          foundValue: newUpgrade.currentValue,
+        },
+        'Value is not updated',
+      );
+      return false;
+    }
   }
 
   if (

--- a/lib/workers/repository/update/branch/auto-replace.ts
+++ b/lib/workers/repository/update/branch/auto-replace.ts
@@ -101,7 +101,7 @@ export async function confirmIfDepUpdated(
         );
         templateMatchesExtractedValue =
           compiledValue === newUpgrade.currentValue;
-      } catch (err) /* istanbul ignore next */ {
+      } catch (err) {
         logger.debug(
           { err, manager, packageFile },
           'Failed to compile autoReplaceStringTemplate in confirmIfDepUpdated',

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -8,6 +8,8 @@ import type {
   ValidationMessage,
 } from '../config/types.ts';
 import type { Release } from '../modules/datasource/types.ts';
+import type { JSONataManagerConfig } from '../modules/manager/custom/jsonata/types.ts';
+import type { RegexManagerConfig } from '../modules/manager/custom/regex/types.ts';
 import type {
   ArtifactError,
   ArtifactNotice,
@@ -33,6 +35,8 @@ export interface BranchUpgradeConfig
   extends
     Merge<RenovateConfig, PackageDependency>,
     Partial<LookupUpdate>,
+    Partial<RegexManagerConfig>,
+    Partial<JSONataManagerConfig>,
     RenovateSharedConfig {
   artifactErrors?: ArtifactError[];
   artifactNotices?: ArtifactNotice[];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Propagate `autoReplaceStringTemplate` from the JSONata custom manager config to the package-file result (matching the regex manager), and relax the strict `newValue` check in `confirmIfDepUpdated` to accept the value produced by the template. Without these, JSONata users cannot reshape the write-back format (e.g. NuGet returns `27.0.0` but the file requires `27.0.0.0`).

Refs https://github.com/renovatebot/renovate/discussions/34567

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, tests, and PR text drafted with Claude (Opus 4.7), reviewed and edited by me.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->