### PR TITLE
feat(datasource/github-runners): add windows-11-arm label

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -59,6 +59,7 @@ describe('modules/datasource/github-runners/index', () => {
 
       expect(res).toMatchObject({
         releases: [
+          { version: '11-arm' },
           { version: '2016', isDeprecated: true },
           { version: '2019', isDeprecated: true },
           { version: '2022' },

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -46,6 +46,7 @@ export class GithubRunnersDatasource extends Datasource {
     windows: [
       { version: '2025' },
       { version: '2022' },
+      { version: '11-arm' },
       { version: '2019', isDeprecated: true },
       { version: '2016', isDeprecated: true },
     ],

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -31,6 +31,8 @@ jobs:
        labels: ubuntu-20.04-16core
   test10:
       runs-on: abc-123
+  test11:
+      runs-on: windows-11-arm
 `;
 
 describe('modules/manager/github-actions/extract', () => {
@@ -740,6 +742,14 @@ describe('modules/manager/github-actions/extract', () => {
           depName: 'windows',
           currentValue: '2022',
           replaceString: 'windows-2022',
+          depType: 'github-runner',
+          datasource: 'github-runners',
+          autoReplaceStringTemplate: '{{depName}}-{{newValue}}',
+        },
+        {
+          depName: 'windows',
+          currentValue: '11-arm',
+          replaceString: 'windows-11-arm',
           depType: 'github-runner',
           datasource: 'github-runners',
           autoReplaceStringTemplate: '{{depName}}-{{newValue}}',

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -757,7 +757,7 @@ describe('modules/manager/github-actions/extract', () => {
       ]);
       expect(
         res?.deps.filter((d) => d.datasource === 'github-runners'),
-      ).toHaveLength(7);
+      ).toHaveLength(8);
     });
 
     it('extracts x-version from actions/setup-x', () => {


### PR DESCRIPTION
## Changes

Add support for Windows 11 ARM runners in the GitHub Runners datasource.

- [Standard GitHub-hosted runners for public repositories](https://docs.github.com/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)
- [arm64 hosted runners for public repositories are now generally available](https://github.blog/changelog/2025-08-07-arm64-hosted-runners-for-public-repositories-are-now-generally-available/)
- [Marked as "generally available"](https://github.com/actions/partner-runner-images#available-images)
- [Arm64 runner images now maintained by GitHub](https://github.blog/changelog/2026-05-14-github-actions-upcoming-image-migrations/#arm64-runner-images-now-maintained-by-github)

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
