### PR TITLE
fix(containerbase): support `constraints.rust=nightly`

### DIFF
--- a/lib/util/exec/containerbase.spec.ts
+++ b/lib/util/exec/containerbase.spec.ts
@@ -110,18 +110,24 @@ describe('util/exec/containerbase', () => {
       expect(await resolveConstraint({ toolName: 'composer' })).toBe('2.0.14');
     });
 
-    it('supports rust docker tags', async () => {
+    it('supports rust release channels', async () => {
       datasource.getPkgReleases.mockResolvedValueOnce({
         releases: [
           { version: '1' },
           { version: '1.65' },
           { version: '1.65.0' },
-          { version: '1.65.0-slim' },
-          { version: '1.65.0-buster' },
-          { version: '1.66' },
         ],
       });
       expect(await resolveConstraint({ toolName: 'rust' })).toBe('1.65.0');
+    });
+
+    it('supports nightly rust release channels', async () => {
+      datasource.getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'nightly' }, { version: 'nightly-2026-06-19' }],
+      });
+      expect(await resolveConstraint({ toolName: 'rust' })).toBe(
+        'nightly-2026-06-19',
+      );
     });
 
     it('throws for unknown tools', async () => {

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -203,9 +203,9 @@ export const allToolConfig: Record<ToolName, ToolConfig> = {
     versioning: 'ruby',
   },
   rust: {
-    datasource: 'docker',
+    datasource: 'rust-version',
     packageName: 'rust',
-    versioning: 'semver',
+    versioning: 'rust-release-channel',
   },
   uv: {
     datasource: 'pypi',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->


As noted in #43489, it's not currently possible to install the nightly
variant of Rust.

Although Containerbase does have support for `install-tool rust nightly`
it never gets that far, as the version lookup occurs through the
`docker` datasource.

We can instead make sure we move to the `rust-version` datasource and
its associated `rust-release-channel` versioning.

The result from the `rust-release-channel` returns a version like
`nightly-2026-06-19`, which needs extra handling in Containerbase https://github.com/containerbase/base/pull/6768.




## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
