### PR TITLE
feat(config): allow specifying `registryStrategy`

### DIFF
--- a/lib/config/options/index.spec.ts
+++ b/lib/config/options/index.spec.ts
@@ -157,6 +157,18 @@ describe('config/options/index', () => {
     }
   });
 
+  describe('registryStrategy option', () => {
+    it('is defined with correct properties', () => {
+      const opts = getOptions();
+      const option = opts.find((o) => o.name === 'registryStrategy');
+      expect(option).toBeDefined();
+      expect(option?.type).toBe('string');
+      expect(option?.allowedValues).toEqual(['first', 'hunt', 'merge']);
+      expect(option?.cli).toBe(false);
+      expect(option?.env).toBe(false);
+    });
+  });
+
   describe('every option with a siblingProperties has a `property` that matches a known option', () => {
     const opts = getOptions();
     const optionNames = new Set(opts.map((o) => o.name));

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1377,6 +1377,15 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
   },
   {
+    name: 'registryStrategy',
+    description:
+      'Strategy to use when multiple registryUrls are available for a datasource lookup.',
+    type: 'string',
+    allowedValues: ['first', 'hunt', 'merge'],
+    cli: false,
+    env: false,
+  },
+  {
     name: 'extractVersion',
     description:
       "A regex (`re2`) to extract a version from a datasource's raw version string.",

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -1,6 +1,7 @@
 import type { Category, PlatformId } from '../constants/index.ts';
 import type { LogLevelRemap } from '../logger/types.ts';
 import type { ManagerName } from '../manager-list.generated.ts';
+import type { RegistryStrategy } from '../modules/datasource/types.ts';
 import type { CustomManager } from '../modules/manager/custom/types.ts';
 import type { RepoSortMethod, SortMethod } from '../modules/platform/types.ts';
 import type {
@@ -138,6 +139,7 @@ export interface RenovateSharedConfig {
   pruneBranchAfterAutomerge?: boolean;
   rangeStrategy?: RangeStrategy;
   rebaseLabel?: string;
+  registryStrategy?: RegistryStrategy;
   rebaseWhen?: string;
   recreateClosed?: boolean;
   recreateWhen?: RecreateWhen;

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -1002,6 +1002,57 @@ describe('modules/datasource/index', () => {
           });
         });
       });
+
+      describe('config registryStrategy overrides datasource default', () => {
+        class MergeDatasource extends DummyDatasource {
+          override readonly registryStrategy = 'merge';
+        }
+
+        beforeEach(() => {
+          datasources.set(
+            datasource,
+            new MergeDatasource({
+              'https://reg1.com': { releases: [{ version: '1.0.0' }] },
+              'https://reg2.com': { releases: [{ version: '2.0.0' }] },
+            }),
+          );
+        });
+
+        it('config first overrides datasource merge', async () => {
+          const res = await getPkgReleases({
+            datasource,
+            packageName,
+            registryStrategy: 'first',
+            defaultRegistryUrls: ['https://reg1.com', 'https://reg2.com'],
+          });
+          expect(res).toMatchObject({
+            releases: [{ version: '1.0.0' }],
+          });
+        });
+
+        it('config hunt overrides datasource merge', async () => {
+          const res = await getPkgReleases({
+            datasource,
+            packageName,
+            registryStrategy: 'hunt',
+            defaultRegistryUrls: ['https://reg1.com', 'https://reg2.com'],
+          });
+          expect(res).toMatchObject({
+            releases: [{ version: '1.0.0' }],
+          });
+        });
+
+        it('uses datasource merge when config does not override', async () => {
+          const res = await getPkgReleases({
+            datasource,
+            packageName,
+            defaultRegistryUrls: ['https://reg1.com', 'https://reg2.com'],
+          });
+          expect(res).toMatchObject({
+            releases: [{ version: '1.0.0' }, { version: '2.0.0' }],
+          });
+        });
+      });
     });
   });
 });


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As part of future changes in Renovate 444, we'll change the default
`registryStrategy` for the Maven Datasource, as a way to prevent
overload on their infrastructure.


<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
