### PR TITLE
fix(manager/circleci): parse config files as YAML 1.1

### DIFF
--- a/lib/modules/manager/circleci/extract.spec.ts
+++ b/lib/modules/manager/circleci/extract.spec.ts
@@ -332,5 +332,55 @@ describe('modules/manager/circleci/extract', () => {
         ],
       });
     });
+
+    it('extracts deps from configs with multiple merge keys per mapping', () => {
+      // YAML 1.2 rejects a mapping with two `<<` keys as a duplicate key and
+      // the entire file is skipped. CircleCI itself parses these files as
+      // YAML 1.1, where merge keys are valid and additive, so Renovate must
+      // do the same to avoid silently missing every dep in the file.
+      const res = extractPackageFile(codeBlock`
+        version: 2.1
+
+        aliases:
+          - &node-base
+            docker:
+              - image: node:18
+          - &node-env
+            environment:
+              NODE_ENV: production
+
+        orbs:
+          python: circleci/python@2.1.1
+
+        jobs:
+          build:
+            <<: *node-base
+            <<: *node-env
+            steps:
+              - checkout
+      `);
+
+      expect(res?.deps).toEqual([
+        {
+          currentValue: '2.1.1',
+          datasource: 'orb',
+          depName: 'python',
+          depType: 'orb',
+          packageName: 'circleci/python',
+          versioning: 'npm',
+        },
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest: undefined,
+          currentValue: '18',
+          datasource: 'docker',
+          depName: 'node',
+          packageName: 'node',
+          depType: 'docker',
+          replaceString: 'node:18',
+        },
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -49,7 +49,10 @@ export function extractPackageFile(
   config?: ExtractConfig,
 ): PackageFileContent | null {
   const { val: parsed, err } = Result.wrap(() =>
-    CircleCiFile.parse(parseSingleYaml(content)),
+    // Parse as YAML 1.1 so anchor merge keys (`<<`) work, matching CircleCI's
+    // own behavior. Under YAML 1.2 a mapping with multiple `<<` keys is
+    // rejected as a duplicate key, which causes the whole file to be skipped.
+    CircleCiFile.parse(parseSingleYaml(content, { version: '1.1' })),
   ).unwrap();
 
   if (err) {

--- a/lib/modules/manager/circleci/readme.md
+++ b/lib/modules/manager/circleci/readme.md
@@ -2,6 +2,24 @@ The `circleci` manager extracts both `docker` as well as `orb` datasources from 
 
 If you need to change the versioning format, read the [versioning](../../versioning/index.md) documentation to learn more.
 
+### YAML aliases and merge keys
+
+Renovate parses CircleCI config files as YAML 1.2.
+Merge keys (`<<`) are a [YAML 1.1](https://yaml.org/type/merge.html) feature and are not part of YAML 1.2.
+A config that relies on merge keys can therefore fail to parse — for example, a mapping with more than one `<<` key is rejected as a duplicate key under YAML 1.2.
+When parsing fails, Renovate skips the entire file and misses every `docker` and `orb` dependency in it.
+
+To keep merge keys working, add a `%YAML 1.1` directive as the first line of the file:
+
+```yaml
+%YAML 1.1
+---
+version: 2.1
+# ... rest of your config
+```
+
+CircleCI itself processes merge keys regardless of the directive, so this does not change how your pipeline runs.
+
 ### Private orbs
 
 To get private orbs working you should:

--- a/lib/modules/manager/circleci/readme.md
+++ b/lib/modules/manager/circleci/readme.md
@@ -2,24 +2,6 @@ The `circleci` manager extracts both `docker` as well as `orb` datasources from 
 
 If you need to change the versioning format, read the [versioning](../../versioning/index.md) documentation to learn more.
 
-### YAML aliases and merge keys
-
-Renovate parses CircleCI config files as YAML 1.2.
-Merge keys (`<<`) are a [YAML 1.1](https://yaml.org/type/merge.html) feature and are not part of YAML 1.2.
-A config that relies on merge keys can therefore fail to parse — for example, a mapping with more than one `<<` key is rejected as a duplicate key under YAML 1.2.
-When parsing fails, Renovate skips the entire file and misses every `docker` and `orb` dependency in it.
-
-To keep merge keys working, add a `%YAML 1.1` directive as the first line of the file:
-
-```yaml
-%YAML 1.1
----
-version: 2.1
-# ... rest of your config
-```
-
-CircleCI itself processes merge keys regardless of the directive, so this does not change how your pipeline runs.
-
 ### Private orbs
 
 To get private orbs working you should:


### PR DESCRIPTION
## Description

The `circleci` manager parsed config files as YAML 1.2, but CircleCI's own config processor uses YAML 1.1. When a config relies on YAML 1.1 features the parse fails, Renovate skips the entire file, and every `docker` and `orb` dep in it is silently dropped.

The most common trigger is a mapping with more than one `<<` merge key, which YAML 1.2 rejects as a duplicate key. CircleCI is fine with it.

This PR passes `{ version: '1.1' }` to `parseSingleYaml`, which:

- enables anchor merge keys (`<<`) natively
- swaps to the YAML 1.1 implicit-type schema, matching how CircleCI itself parses the file
- adds a regression test that covers the duplicate-merge-key case (the test asserts the deps list, not just that parsing didn't throw — the original bug was a *silent* skip, not a thrown error)

The previous revision of this PR documented a `%YAML 1.1` directive workaround; per review feedback (thanks @jamietanna and @secustor) the readme addition is reverted in favor of the actual fix.

Context: discussion #35786.