### PR TITLE
fix(manager/flux): extract both commit and branch for GitRepository

### DIFF
--- a/lib/modules/manager/flux/extract.spec.ts
+++ b/lib/modules/manager/flux/extract.spec.ts
@@ -691,6 +691,37 @@ describe('modules/manager/flux/extract', () => {
       });
     });
 
+    it('extracts GitRepository with both commit and branch', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          apiVersion: source.toolkit.fluxcd.io/v1beta1
+          kind: GitRepository
+          metadata:
+            name: renovate-repo
+            namespace: renovate-system
+          spec:
+            ref:
+              commit: adf1fce
+              branch: hotfix/39.264.1
+            url: https://github.com/renovatebot/renovate
+        `,
+        'test.yaml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            currentDigest: 'adf1fce',
+            currentValue: 'hotfix/39.264.1',
+            datasource: GitRefsDatasource.id,
+            depName: 'renovate-repo',
+            packageName: 'https://github.com/renovatebot/renovate',
+            replaceString: 'adf1fce',
+            sourceUrl: 'https://github.com/renovatebot/renovate',
+          },
+        ],
+      });
+    });
+
     it('extracts GitRepository with a tag from github with ssh', () => {
       const result = extractPackageFile(
         codeBlock`

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -351,6 +351,9 @@ function resolveResourceManifest(
           if (isHttpUrl(gitUrl)) {
             dep.sourceUrl = gitUrl.replace(/\.git$/, '');
           }
+          if (resource.spec.ref?.branch) {
+            dep.currentValue = resource.spec.ref.branch;
+          }
         } else if (resource.spec.ref?.tag) {
           dep.currentValue = resource.spec.ref.tag;
           resolveGitRepositoryPerSourceTag(dep, resource.spec.url);

--- a/lib/modules/manager/flux/readme.md
+++ b/lib/modules/manager/flux/readme.md
@@ -49,6 +49,7 @@ In this example, a `HelmRelease` whose `spec.chart.spec.sourceRef.name` is `podi
 Renovate can update `git` references from `GitRepository` resources.
 
 The `flux` manager only updates `GitRepository` fields that have a `tag` or `commit` key.
+When `commit` is being updated, if a `branch` key is also present, only commits from that branch will be considered.
 
 ### Kustomization support
 

--- a/lib/modules/manager/flux/schema.ts
+++ b/lib/modules/manager/flux/schema.ts
@@ -65,6 +65,7 @@ export const GitRepository = KubernetesResource.extend({
       .object({
         tag: z.string().optional(),
         commit: z.string().optional(),
+        branch: z.string().optional(),
       })
       .optional(),
   }),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR fixes update checking when using both commit and branch for the Flux manager for GitRepository. Flux has a specific behavior when both are specified. To quote the CRD description of the field `commit`:

> This can be combined with Branch to shallow clone the branch, in which the commit is expected to exist.

Without this PR, Renovate ignores `branch` and just tries to upgrade `commit` to the latest in the _default branch_ . If `branch: another-branch` is specified, this leads to an invalid combination (a commit that does not exist on `another-branch`) as far as Flux is concerned.

Therefore, I'm proposing this PR as a bug fix. Feel free to disagree and we can talk over an issue if needed.

(This is different from #29768, where if both tag and digest is specified on `OCIRepository`, Flux specifies that digest takes precedence. Without #41882, Renovate can produce undesirable manifests but they're still valid as far as Flux is concerned.)

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

I only tested this against a private repository but I can summarize the result.

Without this PR, Renovate suggests the snippet below. This happens regardless of whether `commit` is already the latest commit on `my-branch`.

```
branch: my-branch
commit: <latest commit from main, not my-branch>
```

With this PR, Renovate suggests below, or no suggested update at all if `commit` is already the latest commit on `my-branch`.

```
branch: my-branch
commit: <latest commit from my-branch>
```

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
