### PR TITLE
feat(datasource/docker): add opt-in metadata timestamps

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1603,6 +1603,20 @@ Presets which consist only of other presets have their own description omitted f
 
 Add to this object if you wish to define rules that apply only to PRs that update digests.
 
+## `dockerReleaseTimestampSource`
+
+This option controls whether Docker release timestamps may fall back to OCI image metadata when registry-controlled timestamps are unavailable.
+
+Supported values:
+
+- `registry`: Use only registry-controlled timestamps, such as Docker Hub's `tag_last_pushed`
+- `metadata`: For non-Docker-Hub registries, fall back to the OCI manifest `org.opencontainers.image.created` annotation, then the image config `created` field
+
+The `metadata` fallback is opt-in because OCI image metadata is controlled by the image publisher or build system, not the registry.
+Anyone who can publish an image can spoof these values, and reproducible-build tooling may rewrite them to deterministic values rather than publish times.
+
+Use `metadata` only when you accept this trade-off, for example with private registries, pull-through caches, or public OCI registries that do not expose a supported registry timestamp.
+
 ## `draftPR`
 
 If you want the PRs created by Renovate to be considered as drafts rather than normal PRs, you could add this property to your `renovate.json`:

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -212,34 +212,52 @@ The below is a non-exhaustive list of public registries which support release ti
 
 <!-- markdownlint-disable MD060 -->
 
-| Datasource           | Registry URL                                       | Supported | Notes                                                            |
-| -------------------- | -------------------------------------------------- | --------- | ---------------------------------------------------------------- |
-| `crate`              | `https://crates.io`                                | ✅        |                                                                  |
-| `rubygems`           | `https://rubygems.org`                             | ✅        |                                                                  |
-| `docker`             | `https://index.docker.io`                          | ✅        |                                                                  |
-| `docker`             | (not Docker Hub)                                   | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38656)    |
-| `docker`             | `https://ghcr.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/39064)    |
-| `docker`             | `https://quay.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38572)    |
-| `github-releases`    | `https://github.com`                               | ✅        |                                                                  |
-| `terraform-module`   | `https://registry.terraform.io`                    | ✅        |                                                                  |
-| `terraform-module`   | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                |
-| `terraform-provider` | `https://registry.terraform.io`                    | ✅        |                                                                  |
-| `terraform-provider` | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                |
-| `github-tags`        | `https://github.com`                               | ✅        |                                                                  |
-| `go`                 | `https://proxy.golang.org,`                        | ✅        |                                                                  |
-| `golang-version`     | `https://raw.githubusercontent.com/golang/website` | ✅        |                                                                  |
-| `maven`              | `https://repo1.maven.org/maven2`                   | ✅        |                                                                  |
-| `node-version`       | `https://nodejs.org/dist`                          | ✅        |                                                                  |
-| `npm`                | `https://registry.npmjs.org`                       | ✅        |                                                                  |
-| `nuget`              | `https://api.nuget.org/v3/index.json`              | ✅        |                                                                  |
-| `pypi`               | `https://pypi.org/pypi/`                           | ✅        |                                                                  |
-| `ruby-version`       | `https://www.ruby-lang.org`                        | ✅        |                                                                  |
-| `jsr`                | `https://jsr.io`                                   | ✅        | For packages without explicit timestamps, defaults to 2025-09-18 |
+| Datasource           | Registry URL                                       | Supported | Notes                                                                                                                     |
+| -------------------- | -------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `crate`              | `https://crates.io`                                | ✅        |                                                                                                                           |
+| `rubygems`           | `https://rubygems.org`                             | ✅        |                                                                                                                           |
+| `docker`             | `https://index.docker.io`                          | ✅        | Uses Docker Hub `tag_last_pushed`                                                                                         |
+| `docker`             | (not Docker Hub)                                   | 🟡        | Registry-controlled timestamps are not generally available. See [Docker metadata timestamps](#docker-metadata-timestamps) |
+| `docker`             | `https://ghcr.io`                                  | 🟡        | See [Docker metadata timestamps](#docker-metadata-timestamps)                                                             |
+| `docker`             | `https://quay.io`                                  | 🟡        | See [Docker metadata timestamps](#docker-metadata-timestamps)                                                             |
+| `github-releases`    | `https://github.com`                               | ✅        |                                                                                                                           |
+| `terraform-module`   | `https://registry.terraform.io`                    | ✅        |                                                                                                                           |
+| `terraform-module`   | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                                                                         |
+| `terraform-provider` | `https://registry.terraform.io`                    | ✅        |                                                                                                                           |
+| `terraform-provider` | `https://registry.opentofu.org`                    | ✅        | Queries `api.opentofu.org` for release timestamps                                                                         |
+| `github-tags`        | `https://github.com`                               | ✅        |                                                                                                                           |
+| `go`                 | `https://proxy.golang.org,`                        | ✅        |                                                                                                                           |
+| `golang-version`     | `https://raw.githubusercontent.com/golang/website` | ✅        |                                                                                                                           |
+| `maven`              | `https://repo1.maven.org/maven2`                   | ✅        |                                                                                                                           |
+| `node-version`       | `https://nodejs.org/dist`                          | ✅        |                                                                                                                           |
+| `npm`                | `https://registry.npmjs.org`                       | ✅        |                                                                                                                           |
+| `nuget`              | `https://api.nuget.org/v3/index.json`              | ✅        |                                                                                                                           |
+| `pypi`               | `https://pypi.org/pypi/`                           | ✅        |                                                                                                                           |
+| `ruby-version`       | `https://www.ruby-lang.org`                        | ✅        |                                                                                                                           |
+| `jsr`                | `https://jsr.io`                                   | ✅        | For packages without explicit timestamps, defaults to 2025-09-18                                                          |
 
 It is _likely_ that if you are using a public registry (i.e. `registry.npmjs.org`, `repo1.maven.org`, etc) the release timestamp data will be present.
 We welcome user contributions to this table.
 
 If you use a custom registry, for instance as a pull-through cache, [additional configuration may be required](#how-do-i-add-timestamp-data-to-custom-registries).
+
+#### Docker metadata timestamps
+
+Docker Hub release timestamps come from Docker Hub's registry-controlled `tag_last_pushed` field.
+This is the default and preferred source for Docker release timestamps.
+
+For other Docker and OCI registries, the OCI Distribution API does not generally expose a registry-controlled publish timestamp.
+If you enable [`dockerReleaseTimestampSource=metadata`](../configuration-options.md#dockerreleasetimestampsource), Renovate can use publisher-controlled OCI metadata as a fallback for non-Docker-Hub registries:
+
+1. `org.opencontainers.image.created` on the image manifest
+2. `created` in the image config blob
+
+This fallback is opt-in because the values are controlled by the image publisher or build system, not the registry.
+They may be spoofed by anyone who can publish the image, and they may be intentionally rewritten by reproducible-build tooling such as `SOURCE_DATE_EPOCH`.
+That means metadata timestamps are less suitable when `minimumReleaseAge` is intended to protect against a compromised image publishing pipeline.
+
+The fallback can still be useful for private registries, pull-through caches, GHCR, Quay, GCR, and other registries where no supported registry timestamp exists.
+Renovate only checks the newest Docker releases for metadata timestamps to avoid excessive manifest and blob requests.
 
 If you are using a custom registry, or unsure about a public registry, you can confirm this using Renovate's debug logs by looking for the `packageFiles with updates` debug log line, which may contain a `releaseTimestamp` field in dependency updates:
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3434,6 +3434,16 @@ const options: Readonly<RenovateOptions>[] = [
     experimentalIssues: [41485],
   },
   {
+    name: 'dockerReleaseTimestampSource',
+    description:
+      'Controls whether Docker release timestamps may fall back to client-controlled OCI image metadata when registry-controlled timestamps are unavailable.',
+    type: 'string',
+    default: 'registry',
+    allowedValues: ['registry', 'metadata'],
+    experimental: true,
+    experimentalIssues: [37196, 38656, 38659],
+  },
+  {
     name: 'dockerMaxPages',
     description:
       'By default, Renovate fetches up to 20 pages of Docker tags from registries. But you can set your own limit with this config option.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -329,6 +329,7 @@ export type ConstraintsFilter = 'strict' | 'none';
 export type MinimumReleaseAgeBehaviour =
   | 'timestamp-required'
   | 'timestamp-optional';
+export type DockerReleaseTimestampSource = 'registry' | 'metadata';
 
 export const allowedStatusCheckStrings = [
   'minimumReleaseAge',
@@ -468,6 +469,7 @@ export interface RenovateConfig
 
   checkedBranches?: string[];
   customizeDashboard?: Record<string, string>;
+  dockerReleaseTimestampSource?: DockerReleaseTimestampSource;
 
   statusCheckNames?: Record<StatusCheckKey, string | null>;
   /**

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1621,6 +1621,52 @@ describe('modules/datasource/docker/index', () => {
       expect(res?.releases).toHaveLength(1);
     });
 
+    it('sets releaseTimestamp from OCI manifest created annotation for non-Docker-Hub registries', async () => {
+      const created = '2024-01-02T03:04:05.000Z';
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/chart/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/chart/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .twice()
+        .reply(200, '', {})
+        .get('/acme/chart/manifests/1.0.0')
+        .twice()
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'sha256:123',
+            mediaType: 'application/vnd.cncf.helm.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.created': created,
+            'org.opencontainers.image.source': 'https://github.com/acme/chart',
+          },
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        packageName: 'ghcr.io/acme/chart',
+      });
+
+      expect(res).toMatchObject({
+        registryUrl: 'https://ghcr.io',
+        lookupName: 'acme/chart',
+        releases: [
+          {
+            version: '1.0.0',
+            releaseTimestamp: created,
+          },
+        ],
+        sourceUrl: 'https://github.com/acme/chart',
+      });
+    });
+
     it('uses quay api', async () => {
       const tags = [{ name: '5.0.12' }];
       httpMock

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1621,7 +1621,40 @@ describe('modules/datasource/docker/index', () => {
       expect(res?.releases).toHaveLength(1);
     });
 
-    it('sets releaseTimestamp from OCI manifest created annotation for non-Docker-Hub registries', async () => {
+    it('does not set releaseTimestamp from OCI metadata by default', async () => {
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/chart/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/chart/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .reply(200, '', {})
+        .get('/acme/chart/manifests/1.0.0')
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'sha256:123',
+            mediaType: 'application/vnd.cncf.helm.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.created': '2024-01-02T03:04:05.000Z',
+            'org.opencontainers.image.source': 'https://github.com/acme/chart',
+          },
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        packageName: 'ghcr.io/acme/chart',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+
+    it('sets releaseTimestamp from OCI manifest created annotation when metadata timestamps are enabled', async () => {
       const created = '2024-01-02T03:04:05.000Z';
       const tags = ['1.0.0'];
       httpMock
@@ -1651,6 +1684,7 @@ describe('modules/datasource/docker/index', () => {
       const res = await getPkgReleases({
         datasource: DockerDatasource.id,
         currentValue: '0.9.0',
+        dockerReleaseTimestampSource: 'metadata',
         packageName: 'ghcr.io/acme/chart',
       });
 
@@ -1665,6 +1699,247 @@ describe('modules/datasource/docker/index', () => {
         ],
         sourceUrl: 'https://github.com/acme/chart',
       });
+    });
+
+    it('falls back to OCI image config created timestamp when metadata timestamps are enabled', async () => {
+      const created = '2024-02-03T04:05:06.000Z';
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .times(4)
+        .reply(200, '', {})
+        .get('/acme/app/manifests/1.0.0')
+        .twice()
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'sha256:config',
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+        })
+        .get('/acme/app/blobs/sha256:config')
+        .twice()
+        .reply(200, {
+          architecture: 'amd64',
+          created,
+          config: {
+            Labels: {
+              'org.opencontainers.image.source': 'https://github.com/acme/app',
+            },
+          },
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        dockerReleaseTimestampSource: 'metadata',
+        packageName: 'ghcr.io/acme/app',
+      });
+
+      expect(res).toMatchObject({
+        releases: [
+          {
+            version: '1.0.0',
+            releaseTimestamp: created,
+          },
+        ],
+        sourceUrl: 'https://github.com/acme/app',
+      });
+    });
+
+    it('prefers OCI manifest created annotation over image config created timestamp', async () => {
+      const annotationCreated = '2024-02-03T04:05:06.000Z';
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .twice()
+        .reply(200, '', {})
+        .get('/acme/app/manifests/1.0.0')
+        .twice()
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'sha256:config',
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.created': annotationCreated,
+            'org.opencontainers.image.revision': 'abc123',
+            'org.opencontainers.image.source': 'https://github.com/acme/app',
+          },
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        dockerReleaseTimestampSource: 'metadata',
+        packageName: 'ghcr.io/acme/app',
+      });
+
+      expect(res?.releases).toMatchObject([
+        {
+          version: '1.0.0',
+          releaseTimestamp: annotationCreated,
+        },
+      ]);
+    });
+
+    it('uses OCI image config created timestamp if manifest created annotation is invalid', async () => {
+      const created = '2024-03-04T05:06:07.000Z';
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .times(4)
+        .reply(200, '', {})
+        .get('/acme/app/manifests/1.0.0')
+        .twice()
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'sha256:config',
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.created': 'not-a-timestamp',
+          },
+        })
+        .get('/acme/app/blobs/sha256:config')
+        .twice()
+        .reply(200, {
+          architecture: 'amd64',
+          created,
+          config: {
+            Labels: {
+              'org.opencontainers.image.source': 'https://github.com/acme/app',
+            },
+          },
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        dockerReleaseTimestampSource: 'metadata',
+        packageName: 'ghcr.io/acme/app',
+      });
+
+      expect(res?.releases).toMatchObject([
+        {
+          version: '1.0.0',
+          releaseTimestamp: created,
+        },
+      ]);
+    });
+
+    it('ignores invalid OCI metadata timestamps', async () => {
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .thrice()
+        .reply(200, '', {})
+        .get('/acme/app/manifests/1.0.0')
+        .twice()
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: 'sha256:config',
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.created': 'not-a-timestamp',
+            'org.opencontainers.image.revision': 'abc123',
+            'org.opencontainers.image.source': 'https://github.com/acme/app',
+          },
+        })
+        .get('/acme/app/blobs/sha256:config')
+        .reply(200, {
+          architecture: 'amd64',
+          created: '0001-01-01T00:00:00Z',
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        dockerReleaseTimestampSource: 'metadata',
+        packageName: 'ghcr.io/acme/app',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+
+    it('limits OCI metadata timestamp lookups to the newest releases', async () => {
+      const tags = [...range(0, 20)].map((index) => `1.0.${index}`);
+      let scope = httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/acme/app/tags/list?n=10000')
+        .reply(200, { tags }, {})
+        .get('/')
+        .times(21)
+        .reply(200, '', {});
+
+      for (const tag of tags.slice(1)) {
+        scope = scope.get(`/acme/app/manifests/${tag}`).reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.manifest.v1+json',
+          config: {
+            digest: `sha256:${tag}`,
+            mediaType: 'application/vnd.oci.image.config.v1+json',
+          },
+          annotations: {
+            'org.opencontainers.image.created': '2024-01-02T03:04:05.000Z',
+          },
+        });
+      }
+
+      scope.get('/acme/app/manifests/1.0.20').reply(200, {
+        schemaVersion: 2,
+        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+        config: {
+          digest: 'sha256:1.0.20',
+          mediaType: 'application/vnd.oci.image.config.v1+json',
+        },
+        annotations: {
+          'org.opencontainers.image.revision': 'abc123',
+          'org.opencontainers.image.source': 'https://github.com/acme/app',
+        },
+      });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        currentValue: '0.9.0',
+        dockerReleaseTimestampSource: 'metadata',
+        packageName: 'ghcr.io/acme/app',
+      });
+
+      expect(res?.releases[0]).toEqual({ version: '1.0.0' });
+      expect(
+        res?.releases.slice(1).every((release) => release.releaseTimestamp),
+      ).toBeTrue();
     });
 
     it('uses quay api', async () => {

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -77,7 +77,7 @@ const defaultConfig = {
 };
 
 const ociCreatedLabel = 'org.opencontainers.image.created';
-const maxOciCreatedTimestampLookups = 20;
+const maxMetadataTimestampLookups = 20;
 
 export class DockerDatasource extends Datasource {
   static readonly id = dockerDatasourceId;
@@ -90,7 +90,7 @@ export class DockerDatasource extends Datasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'Docker Hub release timestamps are determined from the `tag_last_pushed` field in the results. Other OCI registries may use the `org.opencontainers.image.created` manifest annotation for the newest releases. **NOTE**: Currently, Docker Hub digests will receive the same release timestamp as the `tag_last_pushed`, which means that digests may appear newer than they are - see https://github.com/renovatebot/renovate/issues/38659';
+    'Docker Hub release timestamps are determined from the `tag_last_pushed` field in the results. Other registries only receive release timestamps from OCI image metadata if `dockerReleaseTimestampSource=metadata` is enabled. **NOTE**: Currently, Docker Hub digests will receive the same release timestamp as the `tag_last_pushed`, which means that digests may appear newer than they are - see https://github.com/renovatebot/renovate/issues/38659';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
     'The source URL is determined from the `org.opencontainers.image.source` and `org.label-schema.vcs-url` labels present in the metadata of the **latest stable** image found on the Docker registry.';
@@ -1130,7 +1130,7 @@ export class DockerDatasource extends Datasource {
     );
   }
 
-  private async getOciCreatedReleaseTimestamp(
+  private async getMetadataReleaseTimestamp(
     registryHost: string,
     dockerRepository: string,
     tag: string,
@@ -1141,21 +1141,36 @@ export class DockerDatasource extends Datasource {
         dockerRepository,
         tag,
       );
-      if (!manifest || !('annotations' in manifest)) {
+      if (!manifest) {
         return null;
       }
 
-      return asTimestamp(manifest.annotations?.[ociCreatedLabel]);
+      if ('annotations' in manifest) {
+        const annotationTimestamp = asTimestamp(
+          manifest.annotations?.[ociCreatedLabel],
+        );
+        if (annotationTimestamp) {
+          return annotationTimestamp;
+        }
+      }
+
+      const configResponse = await this.getImageConfig(
+        registryHost,
+        dockerRepository,
+        manifest.config.digest,
+      );
+
+      return asTimestamp(configResponse?.body.created);
     } catch (err) {
       logger.debug(
         { registryHost, dockerRepository, tag, err },
-        'Could not determine OCI created release timestamp',
+        'Could not determine Docker metadata release timestamp',
       );
       return null;
     }
   }
 
-  private async addOciCreatedReleaseTimestamps(
+  private async addMetadataReleaseTimestamps(
     registryHost: string,
     dockerRepository: string,
     releases: Release[],
@@ -1166,12 +1181,12 @@ export class DockerDatasource extends Datasource {
 
     const releasesToCheck = releases
       .filter((release) => !release.releaseTimestamp)
-      .slice(-maxOciCreatedTimestampLookups);
+      .slice(-maxMetadataTimestampLookups);
 
     await pMap(
       releasesToCheck,
       async (release) => {
-        const releaseTimestamp = await this.getOciCreatedReleaseTimestamp(
+        const releaseTimestamp = await this.getMetadataReleaseTimestamp(
           registryHost,
           dockerRepository,
           release.version,
@@ -1199,6 +1214,7 @@ export class DockerDatasource extends Datasource {
    */
   private async _getReleases({
     currentValue,
+    dockerReleaseTimestampSource,
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
@@ -1219,8 +1235,8 @@ export class DockerDatasource extends Datasource {
       )
         .transform((tags) => tags.map((version) => ({ version })))
         .transform(async (releases) =>
-          currentValue
-            ? await this.addOciCreatedReleaseTimestamps(
+          currentValue && dockerReleaseTimestampSource === 'metadata'
+            ? await this.addMetadataReleaseTimestamps(
                 registryHost,
                 dockerRepository,
                 releases,

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -9,6 +9,7 @@ import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-pro
 import { HttpError } from '../../../util/http/index.ts';
 import type { HttpResponse } from '../../../util/http/types.ts';
 import { hasKey } from '../../../util/object.ts';
+import { map as pMap } from '../../../util/promises.ts';
 import { type AsyncResult, Result } from '../../../util/result.ts';
 import { isDockerDigest } from '../../../util/string-match.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
@@ -75,6 +76,9 @@ const defaultConfig = {
   },
 };
 
+const ociCreatedLabel = 'org.opencontainers.image.created';
+const maxOciCreatedTimestampLookups = 20;
+
 export class DockerDatasource extends Datasource {
   static readonly id = dockerDatasourceId;
 
@@ -86,7 +90,7 @@ export class DockerDatasource extends Datasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'Only supported on Docker Hub: The release timestamp is determined from the `tag_last_pushed` field in the results. **NOTE**: Currently, digests will receive the same release timestamp as the `tag_last_pushed`, which means that digests may appear newer than they are - see https://github.com/renovatebot/renovate/issues/38659';
+    'Docker Hub release timestamps are determined from the `tag_last_pushed` field in the results. Other OCI registries may use the `org.opencontainers.image.created` manifest annotation for the newest releases. **NOTE**: Currently, Docker Hub digests will receive the same release timestamp as the `tag_last_pushed`, which means that digests may appear newer than they are - see https://github.com/renovatebot/renovate/issues/38659';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
     'The source URL is determined from the `org.opencontainers.image.source` and `org.label-schema.vcs-url` labels present in the metadata of the **latest stable** image found on the Docker registry.';
@@ -1126,6 +1130,62 @@ export class DockerDatasource extends Datasource {
     );
   }
 
+  private async getOciCreatedReleaseTimestamp(
+    registryHost: string,
+    dockerRepository: string,
+    tag: string,
+  ): Promise<Release['releaseTimestamp'] | null> {
+    try {
+      const manifest = await this.getManifest(
+        registryHost,
+        dockerRepository,
+        tag,
+      );
+      if (!manifest || !('annotations' in manifest)) {
+        return null;
+      }
+
+      return asTimestamp(manifest.annotations?.[ociCreatedLabel]);
+    } catch (err) {
+      logger.debug(
+        { registryHost, dockerRepository, tag, err },
+        'Could not determine OCI created release timestamp',
+      );
+      return null;
+    }
+  }
+
+  private async addOciCreatedReleaseTimestamps(
+    registryHost: string,
+    dockerRepository: string,
+    releases: Release[],
+  ): Promise<Release[]> {
+    if (registryHost === DOCKER_HUB) {
+      return releases;
+    }
+
+    const releasesToCheck = releases
+      .filter((release) => !release.releaseTimestamp)
+      .slice(-maxOciCreatedTimestampLookups);
+
+    await pMap(
+      releasesToCheck,
+      async (release) => {
+        const releaseTimestamp = await this.getOciCreatedReleaseTimestamp(
+          registryHost,
+          dockerRepository,
+          release.version,
+        );
+        if (releaseTimestamp) {
+          release.releaseTimestamp = releaseTimestamp;
+        }
+      },
+      { concurrency: 5 },
+    );
+
+    return releases;
+  }
+
   /**
    * docker.getReleases
    *
@@ -1138,6 +1198,7 @@ export class DockerDatasource extends Datasource {
    * This function will filter only tags that contain a semver version
    */
   private async _getReleases({
+    currentValue,
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
@@ -1155,7 +1216,17 @@ export class DockerDatasource extends Datasource {
       Result.wrapNullable(
         this.getTags(registryHost, dockerRepository),
         'tags-error' as const,
-      ).transform((tags) => tags.map((version) => ({ version })));
+      )
+        .transform((tags) => tags.map((version) => ({ version })))
+        .transform(async (releases) =>
+          currentValue
+            ? await this.addOciCreatedReleaseTimestamps(
+                registryHost,
+                dockerRepository,
+                releases,
+              )
+            : releases,
+        );
 
     const getDockerHubTags = (): TagsResultType =>
       Result.wrapNullable(

--- a/lib/modules/datasource/docker/readme.md
+++ b/lib/modules/datasource/docker/readme.md
@@ -13,4 +13,20 @@ Here's an example from our `renovate/renovate` Dockerfile:
 LABEL org.opencontainers.image.source="https://github.com/renovatebot/renovate"
 ```
 
+## Release timestamps
+
+Renovate uses registry-controlled Docker Hub `tag_last_pushed` values as Docker release timestamps by default.
+Other Docker and OCI registries often do not expose registry-controlled publish timestamps through the OCI Distribution API.
+
+If you enable `dockerReleaseTimestampSource=metadata`, Renovate can also use client-controlled OCI image metadata for non-Docker-Hub registries.
+Renovate checks the `org.opencontainers.image.created` manifest annotation first, then the image config `created` field.
+This can make `minimumReleaseAge` usable for registries such as GHCR, Quay, GCR, private registries, and pull-through caches that do not expose a supported registry timestamp.
+
+These metadata timestamps are weaker than registry-controlled timestamps because image publishers, build systems, or an attacker with publish access can set them to arbitrary values.
+Some projects also rewrite image `created` timestamps for reproducible builds, so the value may be deterministic rather than a publish time.
+Keep the default `dockerReleaseTimestampSource=registry` if you use `minimumReleaseAge` as a strict supply-chain safety control.
+Only enable `metadata` when you accept this trade-off.
+
+To avoid excessive registry calls, Renovate only attempts metadata timestamp lookups for the newest Docker releases during a lookup.
+
 If you use [Harbor](https://goharbor.io/) as a proxy cache for Docker Hub, then you must use Harbor version `2.5.0` or higher.

--- a/lib/modules/datasource/docker/schema.ts
+++ b/lib/modules/datasource/docker/schema.ts
@@ -40,6 +40,7 @@ const OciPlatform = z
 export const OciImageConfig = z.object({
   // This is required by the spec, but probably not present in the wild.
   architecture: z.string().nullish(),
+  created: z.string().nullish(),
   config: z.object({ Labels: z.record(z.string()).nullish() }).nullish(),
 });
 export type OciImageConfig = z.infer<typeof OciImageConfig>;

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -1,6 +1,7 @@
 import type {
   ConstraintsFilter,
   CustomDatasourceConfig,
+  DockerReleaseTimestampSource,
 } from '../../config/types.ts';
 import type { ModuleApi } from '../../types/index.ts';
 import type {
@@ -42,6 +43,7 @@ export interface GetReleasesConfig {
    */
   constraintsVersioning?: Partial<Record<AdditionalConstraintName, string>>;
   constraintsFiltering?: ConstraintsFilter;
+  dockerReleaseTimestampSource?: DockerReleaseTimestampSource;
 }
 
 export interface GetPkgReleasesConfig {
@@ -61,6 +63,7 @@ export interface GetPkgReleasesConfig {
   replacementName?: string;
   replacementVersion?: string;
   constraintsFiltering?: ConstraintsFilter;
+  dockerReleaseTimestampSource?: DockerReleaseTimestampSource;
   /**
    * Any specific overrides for the versioning for the `AdditionalConstraintName`s.
    */


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR keeps Renovate's default OCI release timestamp behavior registry-controlled, while adding an explicit opt-in path for registries that do not expose supported publish timestamps for container images.

The new experimental `dockerReleaseTimestampSource=metadata` option allows non-Docker-Hub OCI registries to use client-controlled OCI metadata as a best-effort `releaseTimestamp` fallback:

1. Docker Hub remains unchanged and uses the registry-controlled `tag_last_pushed` value.
2. Non-Docker-Hub registries use metadata only when `dockerReleaseTimestampSource=metadata` is configured.
3. Metadata lookup checks `org.opencontainers.image.created` on the resolved image manifest first.
4. If the manifest annotation is absent or invalid, lookup falls back to the image config blob `created` field.
5. Invalid metadata timestamps are ignored.
6. Metadata lookup is bounded to the newest Docker releases to avoid unbounded manifest/blob requests.

Because OCI annotations and image config fields are publisher/build-system controlled, this PR keeps metadata timestamps opt-in instead of silently weakening `minimumReleaseAge` for all users.

Related issues:

Refs #37196  
Refs #38656  
Refs #38659

https://github.com/project-zot/zui/pull/502#issue-3881457672

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

> It doesn't close the previously referred issues and discussions because the security concern is not directly addressed, but it does provide a decent workaround for stalling PR's.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). --- Github Copilot with ChatGPT 5.5. (Logs available on request)
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
