### PR TITLE
ci: do not allow nested tenary operators

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -57,6 +57,7 @@
     "no-unassigned-vars": "error",
     "prefer-template": "error",
     "prefer-arrow-callback": ["error", { "allowUnboundThis": false }],
+    "no-nested-ternary": "error",
 
     "renovate/enforce-ts-extension": "error",
     "renovate/no-new-url": "error",

--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -77,17 +77,22 @@ async function validate(
     const added = styleText('green', '+ ');
     const removed = styleText('red', '- ');
     const msg = changedObjects
-      .flatMap((part) =>
-        part.value
+      .flatMap((part) => {
+        let linePrefix: string;
+        if (part.added) {
+          linePrefix = added;
+        } else if (part.removed) {
+          linePrefix = removed;
+        } else {
+          linePrefix = '  ';
+        }
+        return part.value
           .split('\n')
           .filter(isNonEmptyStringAndNotWhitespace)
           .map((line) =>
-            line.replace(
-              regEx(/^(?<ws> *)/),
-              `${part.added ? added : part.removed ? removed : '  '}$<ws>`,
-            ),
-          ),
-      )
+            line.replace(regEx(/^(?<ws> *)/), `${linePrefix}$<ws>`),
+          );
+      })
       .join('\n');
     logger.warn(`Config migration diff:\n${msg}`);
     if (strict) {

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -3,6 +3,7 @@ import { logger } from '../../../logger/index.ts';
 import { isSkipComment } from '../../../util/ignore.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
+import type { StaticTooling } from './upgradeable-tooling.ts';
 import { upgradeableTooling } from './upgradeable-tooling.ts';
 
 export function extractPackageFile(content: string): PackageFileContent | null {
@@ -21,11 +22,13 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     const version = groups.version.trim();
 
     const toolConfig = upgradeableTooling[depName];
-    const toolDefinition = toolConfig
-      ? typeof toolConfig.config === 'function'
-        ? toolConfig.config(version)
-        : toolConfig.config
-      : undefined;
+    let toolDefinition: StaticTooling | undefined;
+    if (toolConfig) {
+      toolDefinition =
+        typeof toolConfig.config === 'function'
+          ? toolConfig.config(version)
+          : toolConfig.config;
+    }
 
     if (toolDefinition) {
       const dep: PackageDependency = {

--- a/lib/modules/manager/npm/update/dependency/pnpm.ts
+++ b/lib/modules/manager/npm/update/dependency/pnpm.ts
@@ -56,11 +56,16 @@ export function updatePnpmWorkspaceDependency({
   const usesImplicitDefaultCatalog = parsedContents.catalog !== undefined;
   const isCatalogUpdate = catalogName && depType !== pnpmWorkspaceOverrides;
 
-  const oldVersion = isCatalogUpdate
-    ? catalogName === 'default' && usesImplicitDefaultCatalog
-      ? parsedContents.catalog?.[depName!]
-      : parsedContents.catalogs?.[catalogName]?.[depName!]
-    : parsedContents.overrides?.[depName!];
+  let oldVersion: string | undefined;
+  if (isCatalogUpdate) {
+    if (catalogName === 'default' && usesImplicitDefaultCatalog) {
+      oldVersion = parsedContents.catalog?.[depName!];
+    } else {
+      oldVersion = parsedContents.catalogs?.[catalogName]?.[depName!];
+    }
+  } else {
+    oldVersion = parsedContents.overrides?.[depName!];
+  }
 
   if (oldVersion === newValue) {
     logger.trace('Version is already updated');

--- a/lib/modules/manager/npm/update/dependency/yarn.ts
+++ b/lib/modules/manager/npm/update/dependency/yarn.ts
@@ -47,12 +47,15 @@ export function updateYarnrcCatalogDependency({
     return null;
   }
 
-  const oldVersion =
-    catalogName === 'default'
-      ? parsedContents.catalog?.[depName!]
-      : isObject(parsedContents.catalogs?.[catalogName]) && isString(depName)
-        ? parsedContents.catalogs?.[catalogName][depName]
-        : undefined;
+  let oldVersion: string | undefined;
+  if (catalogName === 'default') {
+    oldVersion = parsedContents.catalog?.[depName!];
+  } else if (
+    isObject(parsedContents.catalogs?.[catalogName]) &&
+    isString(depName)
+  ) {
+    oldVersion = parsedContents.catalogs?.[catalogName][depName];
+  }
 
   if (oldVersion === newValue) {
     logger.trace('Version is already updated');

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -461,12 +461,14 @@ function rangeToStr(fullRange: Range[] | null): string | null {
 
 function tokensToStr(tokens: Token[]): string {
   return tokens.reduce((result: string, token: Token) => {
-    const prefix =
-      token.prefix === PREFIX_DOT
-        ? '.'
-        : token.prefix === PREFIX_HYPHEN
-          ? '-'
-          : token.prefix;
+    let prefix: string;
+    if (token.prefix === PREFIX_DOT) {
+      prefix = '.';
+    } else if (token.prefix === PREFIX_HYPHEN) {
+      prefix = '-';
+    } else {
+      prefix = token.prefix;
+    }
     return `${result}${prefix}${token.val}`;
   }, '');
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Do not allow nested ternaries as they are general not easy to read
<!-- Describe what behavior is changed by this PR. -->

## Context

Seen on https://github.com/renovatebot/renovate/pull/43491

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
