### PR TITLE
feat(manager/sveltos): add Sveltos ClusterPromotion

### DIFF
--- a/lib/modules/manager/sveltos/dep-types.ts
+++ b/lib/modules/manager/sveltos/dep-types.ts
@@ -13,4 +13,8 @@ export const knownDepTypes = [
     depType: 'EventTrigger',
     description: 'A Sveltos `EventTrigger` resource',
   },
+  {
+    depType: 'ClusterPromotion',
+    description: 'A Sveltos `ClusterPromotion` resource',
+  },
 ] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/sveltos/extract.spec.ts
+++ b/lib/modules/manager/sveltos/extract.spec.ts
@@ -167,6 +167,36 @@ spec:
     chartName:        oci://custom-registry:443/charts/vault-sidecar
     chartVersion:     0.5.0
 `;
+const validClusterPromotion = codeBlock`
+---
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterPromotion
+metadata:
+  name: baseline
+spec:
+  profileSpec:
+    helmCharts:
+    - repositoryURL:    https://prometheus-community.github.io/helm-charts
+      repositoryName:   prometheus-community
+      chartName:        prometheus-community/prometheus
+      chartVersion:     "23.4.0"
+    - repositoryURL:    https://kyverno.github.io/kyverno/
+      repositoryName:   kyverno
+      chartName:        kyverno/kyverno
+      chartVersion:     "v3.2.5"
+---
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterPromotion
+metadata:
+  name: vault
+spec:
+  profileSpec:
+    helmCharts:
+    - repositoryURL:    oci://registry-1.docker.io/bitnamicharts/vault
+      repositoryName:   oci-vault
+      chartName:        oci://registry-1.docker.io/bitnamicharts/vault
+      chartVersion:     0.7.2
+`;
 const malformedProfiles = codeBlock`
 ---
 # malformed eventtrigger as the source is null
@@ -204,6 +234,20 @@ apiVersion: config.projectsveltos.io/v1beta1
 kind: Profile
 spec:
   helmCharts: null
+---
+# malformed clusterPromotion as the sources array is empty
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterPromotion
+spec:
+  profileSpec:
+    helmCharts: []
+---
+# malformed clusterPromotion as the source is null
+apiVersion: config.projectsveltos.io/v1beta1
+kind: ClusterPromotion
+spec:
+  profileSpec:
+    helmCharts: null
 `;
 const randomManifest = codeBlock`
 apiVersion: apps/v1
@@ -466,6 +510,42 @@ describe('modules/manager/sveltos/extract', () => {
             packageName: 'docker.proxy.test/some/path/bitnamicharts/vault',
             datasource: 'docker',
             depType: 'ClusterProfile',
+          },
+        ],
+      });
+    });
+
+    it('supports clusterpromotions', () => {
+      const result = extractPackageFile(
+        validClusterPromotion,
+        'clusterpromotions.yml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            currentValue: '23.4.0',
+            datasource: 'helm',
+            depType: 'ClusterPromotion',
+            depName: 'prometheus-community/prometheus',
+            packageName: 'prometheus',
+            registryUrls: [
+              'https://prometheus-community.github.io/helm-charts',
+            ],
+          },
+          {
+            currentValue: 'v3.2.5',
+            datasource: 'helm',
+            depType: 'ClusterPromotion',
+            depName: 'kyverno/kyverno',
+            packageName: 'kyverno',
+            registryUrls: ['https://kyverno.github.io/kyverno/'],
+          },
+          {
+            currentValue: '0.7.2',
+            datasource: 'docker',
+            depType: 'ClusterPromotion',
+            depName: 'oci://registry-1.docker.io/bitnamicharts/vault',
+            packageName: 'registry-1.docker.io/bitnamicharts/vault',
           },
         ],
       });

--- a/lib/modules/manager/sveltos/extract.ts
+++ b/lib/modules/manager/sveltos/extract.ts
@@ -75,7 +75,12 @@ function processAppSpec(
 
   const depType = definition.kind;
 
-  for (const source of coerceArray(definition.spec?.helmCharts)) {
+  const helmCharts =
+    definition.kind === 'ClusterPromotion'
+      ? definition.spec?.profileSpec?.helmCharts
+      : definition.spec?.helmCharts;
+
+  for (const source of coerceArray(helmCharts)) {
     const dep = processHelmCharts(source, config?.registryAliases);
     if (dep) {
       dep.depType = depType;

--- a/lib/modules/manager/sveltos/readme.md
+++ b/lib/modules/manager/sveltos/readme.md
@@ -38,8 +38,9 @@ You must set your own `managerFilePatterns` rules, so Renovate knows which `*.ya
 
 You can use these `depTypes` for fine-grained control, for example to disable parts of the Sveltos manager.
 
-| Resource                                                                                             | `depType`        |
-| :--------------------------------------------------------------------------------------------------- | :--------------- |
-| [Cluster Profiles](https://projectsveltos.github.io/sveltos/addons/clusterprofile/)                  | `ClusterProfile` |
-| [Profiles](https://projectsveltos.github.io/sveltos/addons/profile/)                                 | `Profile`        |
-| [EventTrigger](https://projectsveltos.github.io/sveltos/events/addon_event_deployment/#eventtrigger) | `EventTrigger`   |
+| Resource                                                                                             | `depType`          |
+| :--------------------------------------------------------------------------------------------------- | :----------------- |
+| [Cluster Profiles](https://projectsveltos.github.io/sveltos/addons/clusterprofile/)                  | `ClusterProfile`   |
+| [Profiles](https://projectsveltos.github.io/sveltos/addons/profile/)                                 | `Profile`          |
+| [EventTrigger](https://projectsveltos.github.io/sveltos/events/addon_event_deployment/#eventtrigger) | `EventTrigger`     |
+| [ClusterPromotion](https://projectsveltos.github.io/sveltos/addons/clusterpromotion/)                | `ClusterPromotion` |

--- a/lib/modules/manager/sveltos/schema.ts
+++ b/lib/modules/manager/sveltos/schema.ts
@@ -34,10 +34,22 @@ export const EventTrigger = KubernetesResource.extend({
   spec: SveltosHelmSpec,
 });
 
+export const ClusterPromotionSpec = z.object({
+  profileSpec: SveltosHelmSpec.optional(),
+});
+export type ClusterPromotionSpec = z.infer<typeof ClusterPromotionSpec>;
+
+export const ClusterPromotion = KubernetesResource.extend({
+  apiVersion: z.string().startsWith('config.projectsveltos.io/'),
+  kind: z.literal('ClusterPromotion'),
+  spec: ClusterPromotionSpec,
+});
+
 // Create a union schema for ProfileDefinition
 export const ProfileDefinition = z.union([
   Profile,
   ClusterProfile,
   EventTrigger,
+  ClusterPromotion,
 ]);
 export type ProfileDefinition = z.infer<typeof ProfileDefinition>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
