### PR TITLE
ci: add auto label for "please follow our PR template"

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -756,3 +756,15 @@
         - This is not be the intended behaviour, and is generally not recommended by Renovate maintainers. We only accept it if the packages strictly need to be updated together.
 
     It is worth both the author of the PR and the reviewer confirming that this is the intended behaviour.
+
+'auto:pr-template':
+  comment: >
+    Hi there,
+
+    We notice that the Pull Request you've created doesn't quite follow our template.
+
+    Please update the PR description to follow our template.
+
+    This improves the maintainers' time to triage, as key information is clearly indicated in the format we expect.
+
+    Thanks, the Renovate team


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Despite it being in our `AGENTS.md` and when creating a PR, it seems
like users and/or agents are actively ignoring it.

To reduce the manual typing we need to add as maintainers/collaborators,
we can add an automagic label (https://github.com/renovatebot/renovate/pulls?q=is%3Apr+is%3Aopen+label%3Aauto%3Apr-template).


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
