### PR TITLE
fix(config-migration): always reset migration info

### DIFF
--- a/lib/workers/repository/config-migration/index.spec.ts
+++ b/lib/workers/repository/config-migration/index.spec.ts
@@ -101,4 +101,14 @@ describe('workers/repository/config-migration/index', () => {
     expect(branchList).toBeEmptyArray();
     expect(ensureConfigMigrationPr).toHaveBeenCalledTimes(0);
   });
+
+  it('always resets MigratedDataFactory even when an error is thrown', async () => {
+    vi.mocked(checkConfigMigrationBranch).mockRejectedValue(
+      new Error('unexpected error'),
+    );
+    await expect(configMigration(config, [])).rejects.toThrow(
+      'unexpected error',
+    );
+    expect(MigratedDataFactory.reset).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/workers/repository/config-migration/index.ts
+++ b/lib/workers/repository/config-migration/index.ts
@@ -20,37 +20,36 @@ export async function configMigration(
     return { result: 'no-migration' };
   }
 
-  const migratedConfigData = await MigratedDataFactory.getAsync();
-  if (!migratedConfigData) {
-    logger.debug('Config does not need migration');
+  try {
+    const migratedConfigData = await MigratedDataFactory.getAsync();
+    if (!migratedConfigData) {
+      logger.debug('Config does not need migration');
+      return { result: 'no-migration' };
+    }
+
+    const res = await checkConfigMigrationBranch(config, migratedConfigData);
+
+    // migration needed but not demanded by user
+    if (res.result === 'no-migration-branch') {
+      return { result: 'add-checkbox' };
+    }
+
+    branchList.push(res.migrationBranch);
+
+    const pr = await ensureConfigMigrationPr(config, migratedConfigData);
+
+    // only happens incase a migration pr was created by another user
+    // for other cases in which a PR could not be found or created: we log warning and throw error from within the ensureConfigMigrationPr fn
+    if (!pr) {
+      return { result: 'add-checkbox' };
+    }
+
+    return {
+      result:
+        res.result === 'migration-branch-exists' ? 'pr-exists' : 'pr-modified',
+      prNumber: pr.number,
+    };
+  } finally {
     MigratedDataFactory.reset();
-    return { result: 'no-migration' };
   }
-
-  const res = await checkConfigMigrationBranch(config, migratedConfigData);
-
-  // migration needed but not demanded by user
-  if (res.result === 'no-migration-branch') {
-    MigratedDataFactory.reset();
-    return { result: 'add-checkbox' };
-  }
-
-  branchList.push(res.migrationBranch);
-
-  const pr = await ensureConfigMigrationPr(config, migratedConfigData);
-
-  // only happens incase a migration pr was created by another user
-  // for other cases in which a PR could not be found or created: we log warning and throw error from within the ensureConfigMigrationPr fn
-  if (!pr) {
-    MigratedDataFactory.reset();
-    return { result: 'add-checkbox' };
-  }
-
-  MigratedDataFactory.reset();
-
-  return {
-    result:
-      res.result === 'migration-branch-exists' ? 'pr-exists' : 'pr-modified',
-    prNumber: pr.number,
-  };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes
- Wrap the `MigratedDataFactory` singleton in try/finally so `reset()` is called for both normal flow and errors.
<!-- Describe what behavior is changed by this PR. -->

## Context

Ref: https://github.com/renovatebot/renovate/discussions/43625

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
