### PR TITLE
ci: normalize admonition indentation using mkdocs-admonition

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -19,8 +19,8 @@ The bot first checks all the files in the `configFileNames` array before checkin
   Storing the Renovate configuration in a `package.json` file is deprecated and support may be removed in the future.
 
 !!! note
-   Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
-   We also recommend you prefer using `JSONC` within a `.json` file to using a `.json5` file if you want to add comments.
+  Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
+  We also recommend you prefer using `JSONC` within a `.json` file to using a `.json5` file if you want to add comments.
 
 When Renovate runs on a repository, it tries to find the configuration files in the order listed above.
 Renovate stops the search after it finds the first match.
@@ -4082,7 +4082,7 @@ Example:
 ```
 
 !!! note
-   `dataFileTemplate` is ignored if there is no `commands` configured.
+  `dataFileTemplate` is ignored if there is no `commands` configured.
 
 ### `postUpgradeTasks.executionMode`
 
@@ -4751,7 +4751,7 @@ When this option is set, Renovate won't attempt to update artifacts such as lock
   When this option is used in package rules, along with grouped upgrades, artifact updating will only be skipped if every upgrade in the grouped branch wants to skip it.
 
 !!! warning
-    When artifact updates are skipped and the `packageManager` field in `package.json` is updated, the new version will not contain a hash. The hash is only applied when artifacts are updated. For example, a value of `packageManager: "yarn@3.0.0+sha224.deadbeef"` would be updated to just `packageManager: "yarn@3.1.0"` rather than `packageManager: "yarn@3.1.0+sha224.f0cacc1a"`.
+  When artifact updates are skipped and the `packageManager` field in `package.json` is updated, the new version will not contain a hash. The hash is only applied when artifacts are updated. For example, a value of `packageManager: "yarn@3.0.0+sha224.deadbeef"` would be updated to just `packageManager: "yarn@3.1.0"` rather than `packageManager: "yarn@3.1.0+sha224.f0cacc1a"`.
 
 ## `skipInstalls`
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -12,7 +12,7 @@ Do _not_ put the self-hosted config options listed on this page in your "reposit
 The config options below _must_ be configured in the bot/admin config, so in either a environment variable, CLI option, or a special file like `config.js`.
 
 !!! note
-   Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
+  Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
 
 For information about how to configure Renovate with a `config.js` see the [Using `config.js` documentation](./getting-started/running.md#using-configjs).
 
@@ -1056,8 +1056,8 @@ When this feature is enabled, resolved presets will be cached in Renovate's pack
 TTL is 15 minutes by default, and it is adjustable in [cacheTtlOverride](#cachettloverride).
 
 !!! warning
-   Doing so improves efficiency because shared presets don't need to be reloaded/resolved for every repository, however it also means that private presets can be "leaked" between repositories.
-   You should only enable this when all repositories are trusted, such as a corporate environment.
+  Doing so improves efficiency because shared presets don't need to be reloaded/resolved for every repository, however it also means that private presets can be "leaked" between repositories.
+  You should only enable this when all repositories are trusted, such as a corporate environment.
 
 ## `privateKey`
 

--- a/lib/data/readme.md
+++ b/lib/data/readme.md
@@ -21,10 +21,10 @@ The `monorepo.json` file has all the monorepo presets.
 Monorepo presets group related packages, so they are updated with a single Renovate PR.
 
 !!! note
-    We only accept monorepos when packages are released together.
-    So they should have all the same version or they strictly need to be merged together.
-    Otherwise those groupings would cause [immortal](https://docs.renovatebot.com/key-concepts/pull-requests/#immortal-prs) PR's.
-    Please add that information with links to source for validation.
+  We only accept monorepos when packages are released together.
+  So they should have all the same version or they strictly need to be merged together.
+  Otherwise those groupings would cause [immortal](https://docs.renovatebot.com/key-concepts/pull-requests/#immortal-prs) PR's.
+  Please add that information with links to source for validation.
 
 ### Ways to group packages
 

--- a/tools/prettier/plugins/mkdocs-admonitions/index.mjs
+++ b/tools/prettier/plugins/mkdocs-admonitions/index.mjs
@@ -23,6 +23,26 @@ const COLLISION_GUARD = 'mkdocs-admonition:';
 // Matches both spaced (<!-- prettier-ignore -->) and compact (<!--prettier-ignore-->) forms.
 const PRETTIER_IGNORE_RE = /^<!--\s*prettier-ignore\s*-->$/;
 
+/** @param {string[]} bodyLines */
+function normalizeBodyIndent(bodyLines) {
+  let minIndent = Infinity;
+  for (const line of bodyLines) {
+    if (line.trim() === '') {
+      continue;
+    }
+    const m = /^(\s*)/.exec(line);
+    if (m) {
+      minIndent = Math.min(minIndent, m[1].length);
+    }
+  }
+  if (minIndent === Infinity || minIndent === 2) {
+    return bodyLines;
+  }
+  return bodyLines.map((line) =>
+    line.trim() === '' ? '' : `  ${line.slice(minIndent)}`,
+  );
+}
+
 /** @param {string} text */
 function maskAdmonitions(text) {
   const lines = text.split('\n');
@@ -67,26 +87,24 @@ function maskAdmonitions(text) {
         peekIdx++;
       }
       if (peekIdx < lines.length && ADMONITION_HEADER.test(lines[peekIdx])) {
-        const blockLines = [line]; // <!-- prettier-ignore -->
+        const prefixLines = [line]; // <!-- prettier-ignore -->
         i++;
         while (i < peekIdx) {
-          blockLines.push(lines[i]); // blank lines between ignore and !!!
+          prefixLines.push(lines[i]); // blank lines between ignore and !!!
           i++;
         }
-        // Fall through into the shared admonition-body consumption below
-        blockLines.push(lines[i]); // !!! header
+        prefixLines.push(lines[i]); // !!! header
         i++;
+        const bodyLines = [];
         while (i < lines.length && BODY_LINE.test(lines[i])) {
-          blockLines.push(lines[i]);
+          bodyLines.push(lines[i]);
           i++;
         }
-        while (
-          blockLines.length > 1 &&
-          blockLines[blockLines.length - 1] === ''
-        ) {
-          blockLines.pop();
+        while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') {
+          bodyLines.pop();
           i--;
         }
+        const blockLines = [...prefixLines, ...normalizeBodyIndent(bodyLines)];
         const n = placeholders.length;
         placeholders.push(blockLines.join('\n'));
         masked.push(`<!--mkdocs-admonition:${n}-->`);
@@ -95,25 +113,23 @@ function maskAdmonitions(text) {
     }
 
     if (ADMONITION_HEADER.test(line)) {
-      const blockLines = [line];
       i++;
+      const bodyLines = [];
 
       // Greedily consume body: blank lines and 2+-space-indented lines
       while (i < lines.length && BODY_LINE.test(lines[i])) {
-        blockLines.push(lines[i]);
+        bodyLines.push(lines[i]);
         i++;
       }
 
       // Strip trailing blank lines to avoid double-blank in prettier output;
       // they will be re-emitted to the masked stream as normal blank lines.
-      while (
-        blockLines.length > 1 &&
-        blockLines[blockLines.length - 1] === ''
-      ) {
-        blockLines.pop();
+      while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') {
+        bodyLines.pop();
         i--;
       }
 
+      const blockLines = [line, ...normalizeBodyIndent(bodyLines)];
       const n = placeholders.length;
       placeholders.push(blockLines.join('\n'));
       masked.push(`<!--mkdocs-admonition:${n}-->`);

--- a/tools/prettier/plugins/mkdocs-admonitions/index.spec.mjs
+++ b/tools/prettier/plugins/mkdocs-admonitions/index.spec.mjs
@@ -41,30 +41,6 @@ describe('mkdocs-admonitions prettier plugin', () => {
     await expect(fmt(input)).resolves.toBe(input);
   });
 
-  it('normalizes 3-space body to 2-space', async () => {
-    const input = block`
-      !!! note
-         Body with three spaces.
-    `;
-    const expected = block`
-      !!! note
-        Body with three spaces.
-    `;
-    await expect(fmt(input)).resolves.toBe(expected);
-  });
-
-  it('normalizes 5-space body to 2-space', async () => {
-    const input = block`
-      !!! note
-           Renovate supports \`JSONC\` for \`.json\` files.
-    `;
-    const expected = block`
-      !!! note
-        Renovate supports \`JSONC\` for \`.json\` files.
-    `;
-    await expect(fmt(input)).resolves.toBe(expected);
-  });
-
   it('normalizes multi-line body with internal blank line from 4 to 2 spaces', async () => {
     const input = block`
       !!! note
@@ -164,34 +140,6 @@ describe('mkdocs-admonitions prettier plugin', () => {
     const expected = block`
       ???+ tip
         This is open by default.
-    `;
-    await expect(fmt(input)).resolves.toBe(expected);
-  });
-
-  it('normalizes ??? collapsible with quoted title body from 4 to 2 spaces', async () => {
-    const input = block`
-      ??? warning "Custom Title"
-          Content here.
-    `;
-    const expected = block`
-      ??? warning "Custom Title"
-        Content here.
-    `;
-    await expect(fmt(input)).resolves.toBe(expected);
-  });
-
-  it('normalizes ???+ collapsible multi-line body from 4 to 2 spaces', async () => {
-    const input = block`
-      ???+ note "Title"
-          First paragraph.
-
-          Second paragraph.
-    `;
-    const expected = block`
-      ???+ note "Title"
-        First paragraph.
-
-        Second paragraph.
     `;
     await expect(fmt(input)).resolves.toBe(expected);
   });

--- a/tools/prettier/plugins/mkdocs-admonitions/index.spec.mjs
+++ b/tools/prettier/plugins/mkdocs-admonitions/index.spec.mjs
@@ -21,12 +21,16 @@ function block(strings, ...values) {
 }
 
 describe('mkdocs-admonitions prettier plugin', () => {
-  it('preserves simple !!! note with 4-space body', async () => {
+  it('normalizes 4-space body to 2-space', async () => {
     const input = block`
       !!! note
           This is the body.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      !!! note
+        This is the body.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
   it('preserves 2-space-indented body (mirrors typst/readme.md)', async () => {
@@ -37,38 +41,56 @@ describe('mkdocs-admonitions prettier plugin', () => {
     await expect(fmt(input)).resolves.toBe(input);
   });
 
-  it('preserves 3-space-indented body (mirrors configuration-options.md)', async () => {
+  it('normalizes 3-space body to 2-space', async () => {
     const input = block`
       !!! note
          Body with three spaces.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      !!! note
+        Body with three spaces.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
-  it('preserves 5-space-indented body (mirrors self-hosted-configuration.md)', async () => {
+  it('normalizes 5-space body to 2-space', async () => {
     const input = block`
       !!! note
            Renovate supports \`JSONC\` for \`.json\` files.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      !!! note
+        Renovate supports \`JSONC\` for \`.json\` files.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
-  it('preserves multi-line body with internal blank line', async () => {
+  it('normalizes multi-line body with internal blank line from 4 to 2 spaces', async () => {
     const input = block`
       !!! note
           First paragraph.
 
           Second paragraph.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      !!! note
+        First paragraph.
+
+        Second paragraph.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
-  it('preserves !!! warning with quoted title', async () => {
+  it('normalizes body of !!! warning with quoted title from 4 to 2 spaces', async () => {
     const input = block`
       !!! warning "Custom Title"
           Content here.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      !!! warning "Custom Title"
+        Content here.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
   it('preserves empty-body admonition', async () => {
@@ -102,7 +124,7 @@ describe('mkdocs-admonitions prettier plugin', () => {
       More text.
     `;
     const output = await fmt(input);
-    expect(output).toContain('!!! note\n    Body.');
+    expect(output).toContain('!!! note\n  Body.');
     // Prettier normalizes the paragraph's extra spaces
     expect(output).not.toContain('Some   extra   spaces.');
     expect(output).toContain('Some extra spaces.');
@@ -118,42 +140,74 @@ describe('mkdocs-admonitions prettier plugin', () => {
           Other.
     `;
     const output = await fmt(input);
-    expect(output).toContain('!!! note\n    Body.');
-    expect(output).toContain('!!! tip\n    Other.');
+    expect(output).toContain('!!! note\n  Body.');
+    expect(output).toContain('!!! tip\n  Other.');
   });
 
-  it('preserves ??? collapsible admonition (closed by default)', async () => {
+  it('normalizes ??? collapsible admonition body from 4 to 2 spaces', async () => {
     const input = block`
       ??? note
           This is collapsible.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      ??? note
+        This is collapsible.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
-  it('preserves ???+ collapsible admonition (open by default)', async () => {
+  it('normalizes ???+ collapsible admonition body from 4 to 2 spaces', async () => {
     const input = block`
       ???+ tip
           This is open by default.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      ???+ tip
+        This is open by default.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
-  it('preserves ??? collapsible with quoted title', async () => {
+  it('normalizes ??? collapsible with quoted title body from 4 to 2 spaces', async () => {
     const input = block`
       ??? warning "Custom Title"
           Content here.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      ??? warning "Custom Title"
+        Content here.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
-  it('preserves ???+ collapsible with multi-line body', async () => {
+  it('normalizes ???+ collapsible multi-line body from 4 to 2 spaces', async () => {
     const input = block`
       ???+ note "Title"
           First paragraph.
 
           Second paragraph.
     `;
-    await expect(fmt(input)).resolves.toBe(input);
+    const expected = block`
+      ???+ note "Title"
+        First paragraph.
+
+        Second paragraph.
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
+  });
+
+  it('preserves relative indent of nested content while normalizing base to 2 spaces', async () => {
+    const input = block`
+      !!! note
+          outer
+              inner
+    `;
+    const expected = block`
+      !!! note
+        outer
+            inner
+    `;
+    await expect(fmt(input)).resolves.toBe(expected);
   });
 
   it('throws when source contains collision guard string', async () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Update the `mkdocs-admonitions` to enforce a 2 space indent after admonitions

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/43615#discussion_r3309740331

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
