### PR TITLE
docs(docs): remove usage of `prettier-ignore` in site generation

### DIFF
--- a/tools/docs/config.ts
+++ b/tools/docs/config.ts
@@ -215,8 +215,7 @@ function stringifyArrays(el: Record<string, any>): void {
 
 function genExperimentalMsg(el: Record<string, any>): string {
   const ghIssuesUrl = 'https://github.com/renovatebot/renovate/issues/';
-  let warning =
-    '\n<!-- prettier-ignore -->\n!!! warning "This feature is flagged as experimental"\n';
+  let warning = '\n!!! warning "This feature is flagged as experimental"\n';
 
   if (el.experimentalDescription) {
     warning += indent`${1}${el.experimentalDescription}`;
@@ -238,12 +237,11 @@ function genExperimentalMsg(el: Record<string, any>): string {
 }
 
 function genTemplatingMsg(): string {
-  return `\n<!-- prettier-ignore -->\n!!! tip "This option supports Renovate's template syntax"\n${indent`${1}See [templates](templates.md) for available variables and helpers.`}\n`;
+  return `\n!!! tip "This option supports Renovate's template syntax"\n${indent`${1}See [templates](templates.md) for available variables and helpers.`}\n`;
 }
 
 function genDeprecationMsg(el: Record<string, any>): string {
-  let warning =
-    '\n<!-- prettier-ignore -->\n!!! warning "This feature has been deprecated"\n';
+  let warning = '\n!!! warning "This feature has been deprecated"\n';
 
   if (el.deprecationMsg) {
     warning += indent`${1}${el.deprecationMsg}`;
@@ -495,8 +493,5 @@ export async function generateConfig(dist: string, bot = false): Promise<void> {
 }
 
 function generateAdvancedUse(): string {
-  return (
-    '\n<!-- prettier-ignore -->\n!!! warning\n' +
-    '  For advanced use only! Use at your own risk!\n'
-  );
+  return '!!! warning\n' + '  For advanced use only! Use at your own risk!\n';
 }

--- a/tools/docs/manager-mise-supported-plugins.ts
+++ b/tools/docs/manager-mise-supported-plugins.ts
@@ -93,7 +93,7 @@ function generateCombinedTooling(): string {
   const maybeCount = allTools.filter((t) => t.supported === 'maybe').length;
   const unsupportedCount = allTools.filter((t) => t.supported === false).length;
 
-  content = `<!-- prettier-ignore -->\n!!! note\n  Renovate syncs the supported registry data with mise, and is periodically updated (currently using \`${parsedMiseRegistry.meta.version}\`.<br>Over time, this support may change and short tool names may be added / removed as per upstream mise.\n`;
+  content = `!!! note\n  Renovate syncs the supported registry data with mise, and is periodically updated (currently using \`${parsedMiseRegistry.meta.version}\`.<br>Over time, this support may change and short tool names may be added / removed as per upstream mise.\n`;
 
   content += `Renovate's \`mise\` manager can version the following tool short names.\nOut of ${total} known tools: ${supportedCount} supported, ${maybeCount} possibly supported, ${unsupportedCount} unsupported.\n`;
 

--- a/tools/docs/platforms.ts
+++ b/tools/docs/platforms.ts
@@ -26,7 +26,6 @@ export async function generatePlatforms(
       md += '\n\n';
 
       md += codeBlock`
-        <!-- prettier-ignore -->
         !!! warning "This feature is flagged as experimental"
           Experimental features might be changed or even removed at any time.
       `;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Removes the dynamic usages of `<!-- prettier-ignore -->` in site generation code. 

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/43615

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: renovatebot/renovate

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
