### PR TITLE
fix(types): allow `gitUrl` in global config

### DIFF
--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -34,6 +34,7 @@ export class GlobalConfig {
     'executionTimeout',
     'exposeAllEnv',
     'gitTimeout',
+    'gitUrl',
     'githubTokenWarn',
     'httpCacheTtlDays',
     'ignorePrAuthor',

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -34,7 +34,6 @@ export class GlobalConfig {
     'executionTimeout',
     'exposeAllEnv',
     'gitTimeout',
-    'gitUrl',
     'githubTokenWarn',
     'httpCacheTtlDays',
     'ignorePrAuthor',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -397,7 +397,6 @@ export interface RenovateConfig
   forkToken?: string;
 
   gitAuthor?: string;
-  gitUrl?: GitUrlOption;
 
   hostRules?: HostRule[];
 
@@ -511,6 +510,7 @@ export interface CustomDatasourceConfig {
  */
 export interface AllConfig
   extends RenovateConfig, GlobalOnlyConfigLegacy, RepoGlobalConfig {
+  gitUrl?: GitUrlOption;
   password?: string;
   token?: string;
   username?: string;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -2,7 +2,11 @@ import type { Category, PlatformId } from '../constants/index.ts';
 import type { LogLevelRemap } from '../logger/types.ts';
 import type { ManagerName } from '../manager-list.generated.ts';
 import type { CustomManager } from '../modules/manager/custom/types.ts';
-import type { RepoSortMethod, SortMethod } from '../modules/platform/types.ts';
+import type {
+  GitUrlOption,
+  RepoSortMethod,
+  SortMethod,
+} from '../modules/platform/types.ts';
 import type {
   AutoMergeType,
   HostRule,
@@ -249,6 +253,7 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   executionTimeout?: number;
   exposeAllEnv?: boolean;
   gitTimeout?: number;
+  gitUrl?: GitUrlOption;
   githubTokenWarn?: boolean;
   includeMirrors?: boolean;
   localDir?: string;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -253,7 +253,6 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   executionTimeout?: number;
   exposeAllEnv?: boolean;
   gitTimeout?: number;
-  gitUrl?: GitUrlOption;
   githubTokenWarn?: boolean;
   includeMirrors?: boolean;
   localDir?: string;
@@ -398,6 +397,7 @@ export interface RenovateConfig
   forkToken?: string;
 
   gitAuthor?: string;
+  gitUrl?: GitUrlOption;
 
   hostRules?: HostRule[];
 

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2353,7 +2353,6 @@ describe('config/validation', () => {
         };
         const { warnings } = await configValidation.validateConfig(
           'global',
-          // @ts-expect-error: contains invalid values
           config,
         );
         expect(warnings).toEqual([


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

When testing https://github.com/renovatebot/renovate/pull/43651 I noticed that TypeScript was flagging `gitUrl` in my global config. This PR fixes the type so that doesn't happen.

- https://docs.renovatebot.com/self-hosted-configuration/#giturl

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
