### PR TITLE
fix(docker): handle maxResults error on auth probe for ECR repo

### DIFF
--- a/lib/modules/datasource/docker/common.spec.ts
+++ b/lib/modules/datasource/docker/common.spec.ts
@@ -149,6 +149,78 @@ describe('modules/datasource/docker/common', () => {
       ).rejects.toThrow(PAGE_NOT_FOUND_ERROR);
     });
 
+    it('falls back to base /v2/ auth probe when tags URL returns 405 ECR maxResults error', async () => {
+      httpMock
+        .scope('https://my.local.registry')
+        .get('/v2/repo/tags/list?n=10000')
+        .reply(
+          405,
+          {
+            errors: [
+              {
+                code: 'UNSUPPORTED',
+                message:
+                  "Invalid parameter at 'maxResults' failed to satisfy constraint: 'Member must have value less than or equal to 1000'",
+              },
+            ],
+          },
+          { 'docker-distribution-api-version': 'registry/2.0' },
+        )
+        .get('/v2/')
+        .reply(200, '');
+
+      const headers = await getAuthHeaders(
+        http,
+        'https://my.local.registry',
+        'repo',
+        'https://my.local.registry/v2/repo/tags/list?n=10000',
+      );
+
+      expect(headers).toEqual({});
+    });
+
+    it('falls back to base /v2/ auth probe and negotiates token when 405 ECR maxResults error is received', async () => {
+      httpMock
+        .scope('https://my.local.registry')
+        .get('/v2/repo/tags/list?n=10000')
+        .reply(
+          405,
+          {
+            errors: [
+              {
+                code: 'UNSUPPORTED',
+                message:
+                  "Invalid parameter at 'maxResults' failed to satisfy constraint: 'Member must have value less than or equal to 1000'",
+              },
+            ],
+          },
+          { 'docker-distribution-api-version': 'registry/2.0' },
+        )
+        .get('/v2/', undefined, { badheaders: ['authorization'] })
+        .reply(401, '', {
+          'www-authenticate':
+            'Bearer realm="https://my.local.registry/oauth2/token",service="my.local.registry"',
+        })
+        .get(
+          '/oauth2/token?service=my.local.registry&scope=repository:repo:pull',
+        )
+        .reply(200, { token: 'some-token' });
+
+      const headers = await getAuthHeaders(
+        http,
+        'https://my.local.registry',
+        'repo',
+        'https://my.local.registry/v2/repo/tags/list?n=10000',
+      );
+
+      // do not inline, otherwise we get false positive from codeql
+      expect(headers).toMatchInlineSnapshot(`
+        {
+          "authorization": "Bearer some-token",
+        }
+      `);
+    });
+
     it('returns "authType token" if both provided', async () => {
       httpMock
         .scope('https://my.local.registry')

--- a/lib/modules/datasource/docker/common.spec.ts
+++ b/lib/modules/datasource/docker/common.spec.ts
@@ -204,7 +204,7 @@ describe('modules/datasource/docker/common', () => {
         .get(
           '/oauth2/token?service=my.local.registry&scope=repository:repo:pull',
         )
-        .reply(200, { token: 'some-token' });
+        .reply(200, { token: 'abc' });
 
       const headers = await getAuthHeaders(
         http,
@@ -213,10 +213,9 @@ describe('modules/datasource/docker/common', () => {
         'https://my.local.registry/v2/repo/tags/list?n=10000',
       );
 
-      // do not inline, otherwise we get false positive from codeql
       expect(headers).toMatchInlineSnapshot(`
         {
-          "authorization": "Bearer some-token",
+          "authorization": "Bearer abc",
         }
       `);
     });

--- a/lib/modules/datasource/docker/common.spec.ts
+++ b/lib/modules/datasource/docker/common.spec.ts
@@ -213,11 +213,7 @@ describe('modules/datasource/docker/common', () => {
         'https://my.local.registry/v2/repo/tags/list?n=10000',
       );
 
-      expect(headers).toMatchInlineSnapshot(`
-        {
-          "authorization": "Bearer abc",
-        }
-      `);
+      expect(headers).toEqual({ authorization: 'Bearer abc' });
     });
 
     it('returns "authType token" if both provided', async () => {

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -80,7 +80,7 @@ export async function getAuthHeaders(
     // n>1000 with 405 even on the auth-probe request.  Fall back to probing the base
     // /v2/ endpoint so getAuthHeaders can still obtain a valid token; the main fetch
     // loop already retries with n=1000 when it encounters this same error.
-    if (isECRMaxResultsResponse(apiCheckResponse as HttpResponse<any>)) {
+    if (isECRMaxResultsResponse(apiCheckResponse)) {
       logger.debug(
         { apiCheckUrl },
         'Registry rejected n>1000 on auth probe; retrying auth check via base /v2/ endpoint',

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -28,7 +28,7 @@ import {
 } from '../../../util/url.ts';
 import { api as dockerVersioning } from '../../versioning/docker/index.ts';
 import { getGoogleAuthToken } from '../util.ts';
-import { ecrRegex, getECRAuthToken } from './ecr.ts';
+import { ecrRegex, getECRAuthToken, isECRMaxResultsResponse } from './ecr.ts';
 import { googleRegex } from './google.ts';
 import type { OciHelmConfig } from './schema.ts';
 import type { RegistryRepository } from './types.ts';
@@ -75,6 +75,17 @@ export async function getAuthHeaders(
       logger.debug(`Page Not Found ${apiCheckUrl}`);
       // throw error up to be caught and potentially retried with library/ prefix
       throw new Error(PAGE_NOT_FOUND_ERROR);
+    }
+    // Some ECR-compatible private registries (e.g. corporate Docker proxies) reject
+    // n>1000 with 405 even on the auth-probe request.  Fall back to probing the base
+    // /v2/ endpoint so getAuthHeaders can still obtain a valid token; the main fetch
+    // loop already retries with n=1000 when it encounters this same error.
+    if (isECRMaxResultsResponse(apiCheckResponse as HttpResponse<any>)) {
+      logger.debug(
+        { apiCheckUrl },
+        'Registry rejected n>1000 on auth probe; retrying auth check via base /v2/ endpoint',
+      );
+      return getAuthHeaders(http, registryHost, dockerRepository);
     }
     if (
       apiCheckResponse.statusCode !== 401 ||

--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -52,14 +52,18 @@ export async function getECRAuthToken(
   return null;
 }
 
-export function isECRMaxResultsError(err: HttpError): boolean {
-  const resp = err.response as HttpResponse<any> | undefined;
+// https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeRepositories.html#ECR-DescribeRepositories-request-maxResults
+export function isECRMaxResultsResponse(resp: HttpResponse<any>): boolean {
   return !!(
-    resp?.statusCode === 405 &&
+    resp.statusCode === 405 &&
     resp.headers?.['docker-distribution-api-version'] &&
-    // https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeRepositories.html#ECR-DescribeRepositories-request-maxResults
     resp.body?.errors?.[0]?.message?.includes(
       'Member must have value less than or equal to 1000',
     )
   );
+}
+
+export function isECRMaxResultsError(err: HttpError): boolean {
+  const resp = err.response as HttpResponse<any> | undefined;
+  return !!resp && isECRMaxResultsResponse(resp);
 }

--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -64,6 +64,6 @@ export function isECRMaxResultsResponse(resp: HttpResponse<any>): boolean {
 }
 
 export function isECRMaxResultsError(err: HttpError): boolean {
-  const resp = err.response as HttpResponse<any> | undefined;
+  const resp = err.response as HttpResponse<unknown> | undefined;
   return !!resp && isECRMaxResultsResponse(resp);
 }

--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -53,11 +53,12 @@ export async function getECRAuthToken(
 }
 
 // https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeRepositories.html#ECR-DescribeRepositories-request-maxResults
-export function isECRMaxResultsResponse(resp: HttpResponse<any>): boolean {
+export function isECRMaxResultsResponse(resp: HttpResponse<unknown>): boolean {
+  const body = resp.body as { errors?: { message?: string }[] } | undefined;
   return !!(
     resp.statusCode === 405 &&
     resp.headers?.['docker-distribution-api-version'] &&
-    resp.body?.errors?.[0]?.message?.includes(
+    body?.errors?.[0]?.message?.includes(
       'Member must have value less than or equal to 1000',
     )
   );

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1915,6 +1915,72 @@ describe('modules/datasource/docker/index', () => {
         });
       });
 
+      it('resolves requests to ECR proxy when auth probe itself returns 405 maxResults error', async () => {
+        const maxResultsErrorBody = {
+          errors: [
+            {
+              code: 'UNSUPPORTED',
+              message:
+                "Invalid parameter at 'maxResults' failed to satisfy constraint: 'Member must have value less than or equal to 1000'",
+            },
+          ],
+        };
+
+        httpMock
+          .scope('https://ecr-proxy.company.com/v2')
+          // auth probe for tags URL → 405 (triggers fallback to /v2/ base)
+          .get('/node/tags/list?n=10000')
+          .reply(405, maxResultsErrorBody, {
+            'Docker-Distribution-Api-Version': 'registry/2.0',
+          })
+          // fallback auth probe via base /v2/ → 200 (no auth needed)
+          .get('/')
+          .reply(200)
+          // actual tag fetch → 405 (triggers isECRMaxResultsError retry with n=1000)
+          .get('/node/tags/list?n=10000')
+          .reply(405, maxResultsErrorBody, {
+            'Docker-Distribution-Api-Version': 'registry/2.0',
+          })
+          .get('/node/tags/list?n=1000')
+          .reply(200, { tags: ['some'] }, {})
+          // auth probe for manifest fetch
+          .get('/')
+          .reply(200)
+          .get('/node/manifests/some')
+          .reply(200, {
+            schemaVersion: 2,
+            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+            config: {
+              digest: 'some-config-digest',
+              mediaType: 'application/vnd.docker.container.image.v1+json',
+            },
+          })
+          // auth probe for blob fetch
+          .get('/')
+          .reply(200)
+          .get('/node/blobs/some-config-digest')
+          .reply(200, {
+            architecture: 'amd64',
+            config: {
+              Labels: {
+                'org.opencontainers.image.source':
+                  'https://github.com/renovatebot/renovate',
+              },
+            },
+          });
+        expect(
+          await getPkgReleases({
+            datasource: DockerDatasource.id,
+            packageName: 'ecr-proxy.company.com/node',
+          }),
+        ).toEqual({
+          lookupName: 'node',
+          registryUrl: 'https://ecr-proxy.company.com',
+          releases: [],
+          sourceUrl: 'https://github.com/renovatebot/renovate',
+        });
+      });
+
       it('returns null when it receives ECR max results error more than once', async () => {
         const maxResultsErrorBody = {
           errors: [


### PR DESCRIPTION
Some private Docker registries that front ECR reject `n=10000` on the tags URL even during the auth-probe request, returning a 405 with the ECR-style "Member must have value less than or equal to 1000" error body. `getAuthHeaders` had no handler for this case and returned null, so the lookup aborted before the main fetch loop's existing n=1000 retry could fire.

Fix: extract `isECRMaxResultsResponse` from `isECRMaxResultsError` in ecr.ts and use it in `getAuthHeaders` to detect the 405 pattern. When matched, fall back to probing the base `/v2/` endpoint for auth, then let the existing `isECRMaxResultsError` retry in the tag-fetch loop handle the n=1000 fallback.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Improves handling of ECR proxies

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
