### PR TITLE
fix(rust-version): cache bust `manifests.txt` to avoid stale CDN responses

### DIFF
--- a/lib/modules/datasource/rust-version/index.spec.ts
+++ b/lib/modules/datasource/rust-version/index.spec.ts
@@ -1,5 +1,7 @@
+import { isString } from '@sindresorhus/is';
 import * as httpMock from '~test/http-mock.ts';
 import { logger } from '~test/util.ts';
+import { regEx } from '../../../util/regex.ts';
 import { getPkgReleases } from '../index.ts';
 import { RustVersionDatasource } from './index.ts';
 
@@ -17,6 +19,7 @@ static.rust-lang.org/dist/2025-11-24/channel-rust-beta.toml`;
       httpMock
         .scope('https://static.rust-lang.org')
         .get('/manifests.txt')
+        .query((query) => isString(query.t) && regEx(/^\d+$/).test(query.t))
         .reply(200, manifestsContent);
 
       const res = await getPkgReleases({
@@ -52,6 +55,7 @@ static.rust-lang.org/dist/2024-10-19/channel-rust-1.82.0.toml`;
       httpMock
         .scope('https://static.rust-lang.org')
         .get('/manifests.txt')
+        .query((query) => isString(query.t) && regEx(/^\d+$/).test(query.t))
         .reply(200, manifestsContent);
 
       const res = await getPkgReleases({
@@ -74,6 +78,7 @@ static.rust-lang.org/dist/2024-10-17/channel-rust-1.82.0.toml`;
       httpMock
         .scope('https://static.rust-lang.org')
         .get('/manifests.txt')
+        .query((query) => isString(query.t) && regEx(/^\d+$/).test(query.t))
         .reply(200, manifestsContent);
 
       const res = await getPkgReleases({
@@ -99,6 +104,7 @@ static.rust-lang.org/dist/2024-10-17/channel-rust-1.82.0.toml`;
       httpMock
         .scope('https://static.rust-lang.org')
         .get('/manifests.txt')
+        .query((query) => isString(query.t) && regEx(/^\d+$/).test(query.t))
         .reply(200, manifestsContent);
 
       const res = await getPkgReleases({
@@ -119,6 +125,7 @@ static.rust-lang.org/dist/2024-10-17/channel-rust-1.82.0.toml`;
       httpMock
         .scope('https://static.rust-lang.org')
         .get('/manifests.txt')
+        .query((query) => isString(query.t) && regEx(/^\d+$/).test(query.t))
         .reply(500);
 
       await expect(

--- a/lib/modules/datasource/rust-version/index.ts
+++ b/lib/modules/datasource/rust-version/index.ts
@@ -53,6 +53,11 @@ export class RustVersionDatasource extends Datasource {
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const url = new URL('manifests.txt', registryUrl);
 
+    // Bust the CDN cache, which can serve a stale `manifests.txt` for up to a
+    // day. Renovate's package cache still controls how often we fetch, so this
+    // only fires on a cache miss.
+    url.searchParams.set('t', Date.now().toString());
+
     let parsedResults: ParsedManifestUrl[];
     try {
       parsedResults = await this.getManifests(url);


### PR DESCRIPTION
## Changes

The CDN in front of `static.rust-lang.org` can serve a stale `manifests.txt` for up to a day, which hides newly released versions from the `rust-version` datasource. This was investigated in dependabot/dependabot-core#13583, where it was traced to inconsistent CDN edge propagation of `manifests.txt`. It affects stable releases too, not just nightly: at the moment 1.96.0 is missing from https://static.rust-lang.org/manifests.txt, but shows up in e.g. https://static.rust-lang.org/manifests.txt?t=123.

This appends a timestamp query param (`?t=<unix-ms>`) to the `manifests.txt` fetch so each request falls through to origin. Renovate's package cache (`withCache`) still controls how often we fetch, since `_getReleases` is only invoked on a cache miss, so the bust fires at most once per cache window and never adds load beyond Renovate's own TTL.

This mirrors the fix in dependabot-core (dependabot/dependabot-core#13604).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The code and tests were written by Claude Code (Claude Opus 4.8) under my review and direction.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
