### PR TITLE
feat(config): support explicit `.jsonc` file

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -43,7 +43,8 @@ Renovate stops the search after it finds the first match.
 
 !!! note
   Renovate supports `JSONC` for `.json` files and any config files without file extension (e.g. `.renovaterc`).
-  We also recommend you prefer using `JSONC` within a `.json` file to using a `.json5` file if you want to add comments.
+  We also recommend you prefer using a `.jsonc` file if you want to add comments to your configuration, instead of a `.json5` file.
+  Using an explicit `.jsonc` file is preferred over using a `.json` file with comments, as it can cause issues with editors and syntax highlighting.
 
 Renovate always uses the config from the repository's default branch, even if that configuration specifies `baseBranchPatterns`.
 Renovate does not read/override the config from within each base branch if present.

--- a/lib/config/app-strings.spec.ts
+++ b/lib/config/app-strings.spec.ts
@@ -34,6 +34,15 @@ describe('config/app-strings', () => {
     const filenames = getConfigFileNames('gitea');
     expect(filenames.includes('.github/renovate.json')).toBeFalse();
     expect(filenames.includes('.gitea/renovate.json')).toBeTrue();
+
+    const platformSpecificFilenames = filenames.filter((v) =>
+      v.startsWith('.gitea/'),
+    );
+    expect(platformSpecificFilenames).toEqual([
+      '.gitea/renovate.json',
+      '.gitea/renovate.json5',
+    ]);
+
     expect(
       getConfigFileNames('github').includes('.github/renovate.json'),
     ).toBeTrue();

--- a/lib/config/app-strings.spec.ts
+++ b/lib/config/app-strings.spec.ts
@@ -17,16 +17,19 @@ describe('config/app-strings', () => {
     expect(filenames.includes('def')).toBeTrue();
   });
 
-  it('expands brace patterns for json and json5 filenames', () => {
+  it('expands brace patterns for json, jsonc and json5 filenames', () => {
     const filenames = getConfigFileNames();
 
     expect(filenames.includes('renovate.json')).toBeTrue();
+    expect(filenames.includes('renovate.jsonc')).toBeTrue();
     expect(filenames.includes('renovate.json5')).toBeTrue();
     expect(filenames.includes('.renovaterc.json')).toBeTrue();
+    expect(filenames.includes('.renovaterc.jsonc')).toBeTrue();
     expect(filenames.includes('.renovaterc.json5')).toBeTrue();
 
-    expect(filenames.includes('renovate.json{,5}')).toBeFalse();
+    expect(filenames.includes('renovate.json{,c,5}')).toBeFalse();
 
+    expect(filenames.includes('package.jsonc')).toBeFalse();
     expect(filenames.includes('package.json5')).toBeFalse();
   });
 
@@ -40,6 +43,7 @@ describe('config/app-strings', () => {
     );
     expect(platformSpecificFilenames).toEqual([
       '.gitea/renovate.json',
+      '.gitea/renovate.jsonc',
       '.gitea/renovate.json5',
     ]);
 
@@ -54,9 +58,11 @@ describe('config/app-strings', () => {
     expect(filenames.includes('.local/renovate.json')).toBeFalse();
     expect(filenames).toEqual([
       'renovate.json',
+      'renovate.jsonc',
       'renovate.json5',
       '.renovaterc',
       '.renovaterc.json',
+      '.renovaterc.jsonc',
       '.renovaterc.json5',
       'package.json',
     ]);

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -4,11 +4,11 @@ import type { PlatformId } from '../constants/index.ts';
 import { regEx } from '../util/regex.ts';
 
 const configFilePatterns = [
-  'renovate.json{,5}',
-  '.github/renovate.json{,5}',
-  '.gitlab/renovate.json{,5}',
+  'renovate.json{,c,5}',
+  '.github/renovate.json{,c,5}',
+  '.gitlab/renovate.json{,c,5}',
   '.renovaterc',
-  '.renovaterc.json{,5}',
+  '.renovaterc.json{,c,5}',
   'package.json',
 ];
 
@@ -24,7 +24,7 @@ export function getConfigFileNames(platform?: PlatformId): string[] {
   let filteredConfigFileNames = [...configFileNames];
 
   if (isNonEmptyString(platform)) {
-    const platfromRe = regEx('\\.(?<platform>.*)\\/renovate\\.json[5]?$');
+    const platfromRe = regEx('\\.(?<platform>.*)\\/renovate\\.json[c5]?$');
     filteredConfigFileNames = configFileNames.filter((filename) => {
       const matchResult = platfromRe.exec(filename);
       if (!matchResult) {
@@ -38,6 +38,7 @@ export function getConfigFileNames(platform?: PlatformId): string[] {
 
     if (!['github', 'gitlab'].includes(platform) && platform !== 'local') {
       filteredConfigFileNames.push(`.${platform}/renovate.json`);
+      filteredConfigFileNames.push(`.${platform}/renovate.jsonc`);
       filteredConfigFileNames.push(`.${platform}/renovate.json5`);
     }
   }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #40868, and a follow-up to #36141, we should explicitly look
for a `.jsonc` file in the repository.

Replaces #41143, #36630

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
