### PR TITLE
feat(presets): support fetching `.jsonc` files

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -8,7 +8,7 @@ description: Renovate's support for ESLint-like shareable configs
 This page describes how to configure your shared presets.
 Read the [Key concepts, presets](./key-concepts/presets.md) page to learn more about presets in general.
 
-Shareable config presets must use the JSON or JSON5 formats, other formats are not supported.
+Shareable config presets must use the JSON, JSONC or JSON5 formats, other formats are not supported.
 
 !!! tip
   Describe what your preset does in the `"description"` field or add comments as Renovate supports `JSONC` syntax within its preset files.
@@ -46,6 +46,7 @@ If you wish to have an alternative file name, you need to specify it (e.g. `gith
 | ------------------------------------------- | -------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
 | GitHub default                              | `github>abc/foo`                 | `default` | `https://github.com/abc/foo` | `default.json`  | Default branch |
 | GitHub with preset name                     | `github>abc/foo:xyz`             | `xyz`     | `https://github.com/abc/foo` | `xyz.json`      | Default branch |
+| GitHub with preset name (JSONC)             | `github>abc/foo:xyz.jsonc`       | `xyz`     | `https://github.com/abc/foo` | `xyz.jsonc`     | Default branch |
 | GitHub with preset name (JSON5)             | `github>abc/foo:xyz.json5`       | `xyz`     | `https://github.com/abc/foo` | `xyz.json5`     | Default branch |
 | GitHub with preset name and path            | `github>abc/foo//path/xyz`       | `xyz`     | `https://github.com/abc/foo` | `path/xyz.json` | Default branch |
 | GitHub default with a tag                   | `github>abc/foo#1.2.3`           | `default` | `https://github.com/abc/foo` | `default.json`  | `1.2.3`        |
@@ -59,6 +60,7 @@ If you wish to have an alternative file name, you need to specify it (e.g. `gith
 | ------------------------------------------- | -------------------------------- | --------- | ---------------------------- | --------------- | -------------- |
 | GitLab default                              | `gitlab>abc/foo`                 | `default` | `https://gitlab.com/abc/foo` | `default.json`  | Default branch |
 | GitLab with preset name                     | `gitlab>abc/foo:xyz`             | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | Default branch |
+| GitLab with preset name (JSONC)             | `gitlab>abc/foo:xyz.jsonc`       | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.jsonc`     | Default branch |
 | GitLab with preset name (JSON5)             | `gitlab>abc/foo:xyz.json5`       | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json5`     | Default branch |
 | GitLab default with a tag                   | `gitlab>abc/foo#1.2.3`           | `default` | `https://gitlab.com/abc/foo` | `default.json`  | `1.2.3`        |
 | GitLab with preset name with a tag          | `gitlab>abc/foo:xyz#1.2.3`       | `xyz`     | `https://gitlab.com/abc/foo` | `xyz.json`      | `1.2.3`        |

--- a/lib/config/presets/forgejo/index.spec.ts
+++ b/lib/config/presets/forgejo/index.spec.ts
@@ -50,6 +50,23 @@ describe('config/presets/forgejo/index', () => {
       expect(res).toEqual({ from: 'api' });
     });
 
+    it('returns JSONC', async () => {
+      httpMock
+        .scope(forgejoApiHost)
+        .get(`${basePath}/some-filename.jsonc`)
+        .reply(200, {
+          content: toBase64('{"from": /* secret! */ "api"}'),
+        });
+
+      const res = await forgejo.fetchJSONFile(
+        'some/repo',
+        'some-filename.jsonc',
+        forgejoApiHost,
+        null,
+      );
+      expect(res).toEqual({ from: 'api' });
+    });
+
     it('throws external host error', async () => {
       httpMock
         .scope(forgejoApiHost)

--- a/lib/config/presets/gitea/index.spec.ts
+++ b/lib/config/presets/gitea/index.spec.ts
@@ -50,6 +50,23 @@ describe('config/presets/gitea/index', () => {
       expect(res).toEqual({ from: 'api' });
     });
 
+    it('returns JSONC', async () => {
+      httpMock
+        .scope(giteaApiHost)
+        .get(`${basePath}/some-filename.jsonc`)
+        .reply(200, {
+          content: toBase64('{"from": /* secret! */ "api"}'),
+        });
+
+      const res = await gitea.fetchJSONFile(
+        'some/repo',
+        'some-filename.jsonc',
+        giteaApiHost,
+        null,
+      );
+      expect(res).toEqual({ from: 'api' });
+    });
+
     it('throws external host error', async () => {
       httpMock
         .scope(giteaApiHost)

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -140,6 +140,20 @@ describe('config/presets/github/index', () => {
       expect(content).toEqual({ foo: 'bar' });
     });
 
+    it('should query preset within the file when .jsonc extension provided', async () => {
+      httpMock
+        .scope(githubApiHost)
+        .get(`${basePath}/somefile.jsonc`)
+        .reply(200, {
+          content: toBase64('{"foo":/* nothing to see here */"bar"}'),
+        });
+      const content = await github.getPreset({
+        repo: 'some/repo',
+        presetName: 'somefile.jsonc',
+      });
+      expect(content).toEqual({ foo: 'bar' });
+    });
+
     it('should query subpreset', async () => {
       httpMock
         .scope(githubApiHost)

--- a/lib/config/presets/http/index.spec.ts
+++ b/lib/config/presets/http/index.spec.ts
@@ -27,6 +27,17 @@ describe('config/presets/http/index', () => {
       expect(await http.getPreset({ repo })).toEqual({ foo: 'bar' });
     });
 
+    it('should return parsed JSONC', async () => {
+      httpMock
+        .scope('https://my.server/')
+        .get('/test-preset.jsonc')
+        .reply(200, '{ "foo": "bar" } // comment');
+
+      const repo = 'https://my.server/test-preset.jsonc';
+
+      expect(await http.getPreset({ repo })).toEqual({ foo: 'bar' });
+    });
+
     it('throws if fails to parse', async () => {
       httpMock.scope(host).get(filePath).reply(200, 'not json');
 

--- a/lib/config/presets/util.spec.ts
+++ b/lib/config/presets/util.spec.ts
@@ -44,14 +44,12 @@ describe('config/presets/util', () => {
       ['default.json', 'default.json'],
       ['renovate.json', 'renovate.json'],
       ['renovate.json5', 'renovate.json5'],
+      ['renovate.jsonc', 'renovate.jsonc'],
 
       // the .json suffix is added if there is no `.json` or `.json5` suffix
       ['some-path', 'some-path.json'],
       ['some-path.', 'some-path..json'],
       ['some-path.js', 'some-path.js.json'],
-
-      // as JSONC is unsupported
-      ['renovate.jsonc', 'renovate.jsonc.json'],
     ])('when filename is %s, %s is fetched', async (input, expected) => {
       fetch.mockResolvedValueOnce({});
 

--- a/lib/config/presets/util.spec.ts
+++ b/lib/config/presets/util.spec.ts
@@ -38,6 +38,34 @@ describe('config/presets/util', () => {
     ).toEqual({ foo: true });
   });
 
+  describe('handles different filenames', () => {
+    it.each([
+      ['default', 'default.json'],
+      ['default.json', 'default.json'],
+      ['renovate.json', 'renovate.json'],
+      ['renovate.json5', 'renovate.json5'],
+
+      // the .json suffix is added if there is no `.json` or `.json5` suffix
+      ['some-path', 'some-path.json'],
+      ['some-path.', 'some-path..json'],
+      ['some-path.js', 'some-path.js.json'],
+
+      // as JSONC is unsupported
+      ['renovate.jsonc', 'renovate.jsonc.json'],
+    ])('when filename is %s, %s is fetched', async (input, expected) => {
+      fetch.mockResolvedValueOnce({});
+
+      await fetchPreset({ ...config, filePreset: input, fetch });
+
+      expect(fetch).toHaveBeenCalledWith(
+        config.repo,
+        expected,
+        'endpoint/',
+        undefined,
+      );
+    });
+  });
+
   it('fails', async () => {
     fetch.mockRejectedValueOnce(new Error('fails'));
     await expect(fetchPreset({ ...config, fetch })).rejects.toThrow('fails');

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -61,7 +61,7 @@ export async function fetchPreset({
     jsonContent = await fetch(
       repo,
       buildFilePath(
-        regEx(/\.json5?$/).test(fileName) ? fileName : `${fileName}.json`,
+        regEx(/\.json[5c]?$/).test(fileName) ? fileName : `${fileName}.json`,
       ),
       endpoint,
       tag,


### PR DESCRIPTION
## Changes

Similar to #43677, as we now support a
`.jsonc` file for configuration, we should make sure that we can also
use it for a preset.

We can also add additional tests across a few presets to make sure that
we have sufficient coverage.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
