### PR TITLE
fix(workers/repository): preserve global config overrides when requireConfig=ignored

### DIFF
--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -411,6 +411,30 @@ describe('workers/repository/init/merge', () => {
       ).toBeDefined();
     });
 
+    it('preserves global config overrides over preset defaults when requireConfig=ignored', async () => {
+      // Regression test: when requireConfig=ignored and the global config has
+      // extends + an explicit override, the override must not be lost to preset
+      // re-expansion in the repo-config pipeline.
+      migrateAndValidate.migrateAndValidate.mockResolvedValue({
+        warnings: [],
+        errors: [],
+      });
+      migrate.migrateConfig.mockImplementation((c) => ({
+        isMigrated: false,
+        migratedConfig: c,
+      }));
+      GlobalConfig.set({ requireConfig: 'ignored' });
+      // config:recommended pulls in :dependencyDashboard which sets dependencyDashboard=true.
+      // The global config explicitly sets it to false — that must survive.
+      const res = await mergeRenovateConfig({
+        ...config,
+        requireConfig: 'ignored',
+        extends: [':dependencyDashboard'],
+        dependencyDashboard: false,
+      });
+      expect(res.dependencyDashboard).toBe(false);
+    });
+
     it('sets npmToken to npmrc when it is not inside encrypted', async () => {
       scm.getFileList.mockResolvedValue(['package.json', '.renovaterc.json']);
       fs.readLocalFile.mockResolvedValue(

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -253,7 +253,15 @@ export async function mergeRenovateConfig(
     returnConfig = mergeChildConfig(returnConfig, resolvedRepoEntryWithSecrets);
   }
 
-  if (isNonEmptyArray(returnConfig.extends)) {
+  // When requireConfig=ignored, no repo file is read, so resolvedRepoConfig is
+  // always empty. Copying global extends into it causes preset re-expansion
+  // without the global overrides present, making them lose to preset defaults.
+  // Keep extends in returnConfig instead; the final resolveConfigPresets call
+  // below will expand them with all global overrides intact.
+  if (
+    isNonEmptyArray(returnConfig.extends) &&
+    getInheritedOrGlobal('requireConfig') !== 'ignored'
+  ) {
     resolvedRepoConfig.extends = [
       ...coerceArray(returnConfig.extends),
       ...coerceArray(resolvedRepoConfig.extends),


### PR DESCRIPTION
## Changes

When a global Renovate config uses `extends` alongside explicit overrides:

```json5
{
  extends: ["config:recommended"],
  dependencyDashboard: false,
}
```

…and sets `requireConfig: "ignored"`, the explicit overrides have no effect.
Renovate still creates Dependency Dashboard issues despite `dependencyDashboard: false`.

**Root cause:** In `mergeRenovateConfig()`, lines 256–261 copy `extends` from the
global `returnConfig` into an empty `resolvedRepoConfig` (no repo file is read when
`requireConfig=ignored`). `resolveConfigPresets` then expands `config:recommended`
without any global overrides present, so `dependencyDashboard` comes out `true`.
`mergeChildConfig(returnConfig, resolvedConfig)` then lets this preset-expanded child
overwrite the global parent, discarding the override.

**Fix:** Skip copying `extends` into `resolvedRepoConfig` when `requireConfig=ignored`.
This keeps `extends` in `returnConfig`, where the final `resolveConfigPresets` call
(line 327) expands them with all global overrides already present and correctly applied
on top. The guard is scoped to `requireConfig=ignored` only; the normal flow (with a
repo file) is unchanged.

- `lib/workers/repository/init/merge.ts`: Skip copying global `extends` into
  `resolvedRepoConfig` when `requireConfig=ignored`
- `lib/workers/repository/init/merge.spec.ts`: Add regression test — global
  `dependencyDashboard: false` must survive preset expansion when `requireConfig=ignored`

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Code, tests, and PR description written with Claude Code (Anthropic claude-sonnet).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>