### PR TITLE
feat(presets): link to Octochangelog for updates to Renovate itself

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -1242,6 +1242,7 @@ describe('config/presets/index', () => {
           'helpers:gitlabDigestChangelogs',
           'helpers:goXPackagesChangelogLink',
           'helpers:goXPackagesNameLink',
+          'helpers:renovateChangelog',
         ],
       });
     });

--- a/lib/config/presets/internal/config.preset.ts
+++ b/lib/config/presets/internal/config.preset.ts
@@ -41,6 +41,7 @@ export const presets: Record<string, Preset> = {
       'helpers:gitlabDigestChangelogs',
       'helpers:goXPackagesChangelogLink',
       'helpers:goXPackagesNameLink',
+      'helpers:renovateChangelog',
     ],
   },
   semverAllMonthly: {

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -141,6 +141,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         matchSourceUrls: ['https://github.com/renovatebot/renovate'],
+        matchUpdateTypes: ['major', 'minor', 'patch'],
         prBodyDefinitions: {
           Change:
             '[`{{{displayFrom}}}` → `{{{displayTo}}}`](https://octochangelog.com/compare?repo=renovatebot%2Frenovate&from={{ currentVersion }}&to={{ newVersion }})',

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -135,4 +135,17 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
+  renovateChangelog: {
+    description:
+      "Provide a link to octochangelog's improved breakdown for Renovate's changelogs",
+    packageRules: [
+      {
+        matchSourceUrls: ['https://github.com/renovatebot/renovate'],
+        prBodyDefinitions: {
+          Change:
+            '[`{{{displayFrom}}}` → `{{{displayTo}}}`](https://octochangelog.com/compare?repo=renovatebot%2Frenovate&from={{ currentVersion }}&to={{ newVersion }})',
+        },
+      },
+    ],
+  },
 };


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Related to #41809, and a recommendation I personally have for folks
updating their version of Renovate via Renovate, we can use
Octochangelog to provide a nicer breakdown of Renovate CLI release
notes, grouping them by headers i.e. "Features" and "Bug Fixes" across
all version(s) being updated.

This overrides the default link i.e.

```
https://app.renovatebot.com/package-diff?name=renovate&from=43.198.0&to=43.206.1
```

to:

```
https://octochangelog.com/compare?repo=renovatebot%2Frenovate&from=43.198.0&to=43.206.1
```

As this is a strong recommendation, we add it into `config:recommended`.

<!-- Describe what behavior is changed by this PR. -->
## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

- https://github.com/JamieTanna-Mend-testing/renovate-changelog/pull/3
- https://github.com/JamieTanna-Mend-testing/renovate-changelog/pull/4

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
