### PR TITLE
chore(lib/util): log header names when request fails

### DIFF
--- a/lib/util/http/got.spec.ts
+++ b/lib/util/http/got.spec.ts
@@ -36,6 +36,9 @@ describe('util/http/got', () => {
             method: 'GET',
             responseType: 'text',
             noAuth: true,
+            headers: {
+              Authorization: 'Bearer please-do-not-log',
+            },
           },
           [],
         ),
@@ -46,6 +49,9 @@ describe('util/http/got', () => {
     ).rejects.toThrow();
 
     expect(logger.logger.debug).toHaveBeenCalledWith(
+      {
+        requestHeaderNames: ['authorization'],
+      },
       expect.stringMatching(
         /^GET https:\/\/example\.com\/test = \(code=\w+, statusCode=-1 retryCount=\d+, duration=-?\d+\)$/,
       ),

--- a/lib/util/http/got.spec.ts
+++ b/lib/util/http/got.spec.ts
@@ -22,6 +22,36 @@ describe('util/http/got', () => {
     );
   });
 
+  it('logs debug line when request error occurs', async () => {
+    httpMock
+      .scope('https://example.com')
+      .get('/test')
+      .replyWithError('connection error');
+
+    await expect(
+      fetch(
+        'https://example.com/test',
+        normalize(
+          {
+            method: 'GET',
+            responseType: 'text',
+            noAuth: true,
+          },
+          [],
+        ),
+        {
+          queueMs: 0,
+        },
+      ),
+    ).rejects.toThrow();
+
+    expect(logger.logger.debug).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^GET https:\/\/example\.com\/test = \(code=\w+, statusCode=-1 retryCount=\d+, duration=-?\d+\)$/,
+      ),
+    );
+  });
+
   it('does a flat clone of options', async () => {
     httpMock.scope('https://example.com').get('/test').reply(200, 'ok');
 

--- a/lib/util/http/got.ts
+++ b/lib/util/http/got.ts
@@ -55,7 +55,12 @@ export async function fetch(
       const method = options.method.toUpperCase();
       const code = coerceString(error.code, 'UNKNOWN');
       const retryCount = coerceNumber(error.request?.retryCount, -1);
+      // not truly "canonical" form for the headers, but close enough for this purpose
+      const requestHeaderNames = Object.keys(options.headers ?? {}).map((h) =>
+        h.toLowerCase(),
+      );
       logger.debug(
+        { requestHeaderNames },
         `${method} ${url} = (code=${code}, statusCode=${statusCode} retryCount=${retryCount}, duration=${duration})`,
       );
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When a request fails, and we DEBUG log an indication of the failed
request, it's currently difficult to understand whether a request had
the right headers that may have been needed.

To provide more information to a user who is debugging, we can log the
header names.

This does not log the full header values, only the names, which should
be non-sensitive.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
