### PR TITLE
feat(mise): extract task tools

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1308,4 +1308,89 @@ describe('modules/manager/mise/extract', () => {
       ]);
     });
   });
+
+  // https://mise.jdx.dev/tasks/task-configuration.html#task-properties
+  describe('extractPackageFile() with tasks', () => {
+    const RUST_197 = { depName: 'rust', currentValue: '1.97.0' };
+    const ZOXIDE = { depName: 'cargo:zoxide', currentValue: '0.9.6' };
+
+    it.each([
+      {
+        description: 'inline tools table on a task',
+        content: codeBlock`
+          [tasks.build]
+          run = "cargo build"
+          tools = {rust = "1.97.0"}
+        `,
+        expectedDeps: [RUST_197],
+      },
+      {
+        description: 'dotted key tools under [tasks.build]',
+        content: codeBlock`
+          [tasks.build]
+          tools.rust = "1.97.0"
+        `,
+        expectedDeps: [RUST_197],
+      },
+      {
+        description: 'subtable [tasks.<name>.tools]',
+        content: codeBlock`
+          [tasks.build.tools]
+          rust = "1.97.0"
+          "cargo:zoxide" = "0.9.6"
+        `,
+        expectedDeps: [RUST_197, ZOXIDE],
+      },
+      {
+        description: 'top level and task tools',
+        content: codeBlock`
+          [tools]
+          rust = "1.97.0"
+
+          [tasks.lint.tools]
+          rust = "1.80.0"
+        `,
+        expectedDeps: [RUST_197, { ...RUST_197, currentValue: '1.80.0' }],
+      },
+      {
+        description: 'inline table task with top level tools',
+        content: codeBlock`
+          [tools]
+          rust = "1.97.0"
+
+          [tasks]
+          build = { run = "cargo build" }
+        `,
+        expectedDeps: [RUST_197],
+      },
+      {
+        description: 'string shorthand task with top level tools',
+        content: codeBlock`
+          [tools]
+          rust = "1.97.0"
+
+          [tasks]
+          build = "echo 'rust is a must'"
+        `,
+        expectedDeps: [RUST_197],
+      },
+      {
+        description: 'array shorthand task with top level tools',
+        content: codeBlock`
+          [tools]
+          rust = "1.97.0"
+
+          [tasks]
+          test = ["echo '🦀🦀🦀'"]
+        `,
+        expectedDeps: [RUST_197],
+      },
+    ])(
+      'extracts task tools - $description',
+      async ({ content, expectedDeps }) => {
+        const result = await extractPackageFile(content, miseFilename);
+        expect(result).toMatchObject({ deps: expectedDeps });
+      },
+    );
+  });
 });

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -58,23 +58,13 @@ export async function extractPackageFile(
   const deps: PackageDependency[] = [];
 
   for (const [name, toolData] of Object.entries(misefile.tools)) {
-    const version = parseVersion(toolData);
-    // Parse the tool options in the tool name
-    const { name: depName, options: optionsInName } =
-      optionInToolNameRegex.exec(name.trim())!.groups!;
-    const delimiterIndex = name.indexOf(':');
-    const backend = depName.substring(0, delimiterIndex);
-    const toolName = depName.substring(delimiterIndex + 1);
-    const options = parseOptions(
-      optionsInName,
-      isNonEmptyObject(toolData) ? toolData : {},
-    );
-    const toolConfig =
-      version === null
-        ? null
-        : getToolConfig(backend, toolName, version, options);
-    const dep = createDependency(depName, version, toolConfig);
-    deps.push(dep);
+    deps.push(extractToolEntry(name, toolData));
+  }
+
+  for (const taskData of Object.values(misefile.tasks)) {
+    for (const [name, toolData] of Object.entries(taskData.tools ?? {})) {
+      deps.push(extractToolEntry(name, toolData));
+    }
   }
 
   if (!deps.length) {
@@ -257,6 +247,25 @@ function getConfigFromTooling(
       ? toolDefinition.config(version)
       : toolDefinition.config) ?? null
   ); // Ensure null is returned instead of undefined
+}
+
+function extractToolEntry(name: string, toolData: MiseTool): PackageDependency {
+  const version = parseVersion(toolData);
+  const { name: depName, options: optionsInName } = optionInToolNameRegex.exec(
+    name.trim(),
+  )!.groups!;
+  const delimiterIndex = depName.indexOf(':');
+  const backend = depName.substring(0, delimiterIndex);
+  const toolName = depName.substring(delimiterIndex + 1);
+  const options = parseOptions(
+    optionsInName,
+    isNonEmptyObject(toolData) ? toolData : {},
+  );
+  const toolConfig =
+    version === null
+      ? null
+      : getToolConfig(backend, toolName, version, options);
+  return createDependency(depName, version, toolConfig);
 }
 
 function createDependency(

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -11,6 +11,10 @@ Renovate supports all standard mise configuration file patterns:
 - Environment-specific variants (e.g., `mise.production.toml`, `.mise.dev.toml`)
 - Local variants (e.g., `mise.local.toml`, `.mise.local.toml`)
 
+### Supported tool locations
+
+Renovate supports top level [`tools`](https://mise.jdx.dev/configuration.html#tools-dev-tools) and [`tasks.*.tools`](https://mise.jdx.dev/tasks/task-configuration.html#tools) keys.
+
 ### Lock file support
 
 Renovate supports mise lock files (`mise.lock`).

--- a/lib/modules/manager/mise/schema.spec.ts
+++ b/lib/modules/manager/mise/schema.spec.ts
@@ -7,11 +7,11 @@ describe('modules/manager/mise/schema', () => {
       const content = codeBlock`
         min_version = "2024.11.1"
       `;
-      expect(MiseFile.parse(content)).toEqual({ tools: {} });
+      expect(MiseFile.parse(content)).toEqual({ tools: {}, tasks: {} });
     });
 
     it('defaults tools to empty object for empty TOML', () => {
-      expect(MiseFile.parse('')).toEqual({ tools: {} });
+      expect(MiseFile.parse('')).toEqual({ tools: {}, tasks: {} });
     });
 
     it('parses [tools] when present', () => {
@@ -21,6 +21,7 @@ describe('modules/manager/mise/schema', () => {
       `;
       expect(MiseFile.parse(content)).toEqual({
         tools: { node: '20' },
+        tasks: {},
       });
     });
   });

--- a/lib/modules/manager/mise/schema.ts
+++ b/lib/modules/manager/mise/schema.ts
@@ -25,9 +25,17 @@ const MiseTool = z.union([
 ]);
 export type MiseTool = z.infer<typeof MiseTool>;
 
+const MiseTask = z
+  .object({
+    tools: z.record(z.string(), MiseTool).optional(),
+  })
+  .passthrough()
+  .catch({});
+
 export const MiseFile = Toml.pipe(
   z.object({
     tools: z.record(z.string(), MiseTool).default({}),
+    tasks: z.record(z.string(), MiseTask).default({}),
   }),
 );
 export type MiseFile = z.infer<typeof MiseFile>;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Extracts mise tools from the `tasks.*.tools` map. See https://mise.jdx.dev/tasks/task-configuration.html#tools

As of now, only tools under the top level `tools` are recognized

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Via https://github.com/renovatebot/renovate/discussions/43718

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used claude sonnet to generate code for tests and verify that I covered each relevant mise task setup 

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

I'm not sure this requires a documentation change, but I'm glad to do so if preferred. These are still tools, just in a different spot than currently recognized

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
