### PR TITLE
feat(presets/workaround): aospTagVersioning

### DIFF
--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -347,7 +347,8 @@ export const presets: Record<string, Preset> = {
         matchManagers: ['git-submodules'],
         matchDatasources: ['git-refs'],
         matchSourceUrls: ['https://android.googlesource.com/**'],
-        versioning: 'regex:^android-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_r(?<build>\\d+)$',
+        versioning:
+          'regex:^android-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_r(?<build>\\d+)$',
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -29,6 +29,18 @@ export const presets: Record<string, Preset> = {
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
+  aospTagVersioning: {
+    description: 'Use regex versioning for AOSP submodule tags.',
+    packageRules: [
+      {
+        matchDatasources: ['git-refs'],
+        matchManagers: ['git-submodules'],
+        matchSourceUrls: ['https://android.googlesource.com/**'],
+        versioning:
+          'regex:^android-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_r(?<build>\\d+)$',
+      },
+    ],
+  },
   bitnamiDockerImageVersioning: {
     description: 'Use custom regex versioning for bitnami images',
     packageRules: [
@@ -337,18 +349,6 @@ export const presets: Record<string, Preset> = {
         matchDatasources: ['docker'],
         matchDepNames: ['ubuntu'],
         versioning: 'ubuntu',
-      },
-    ],
-  },
-  aospTagVersioning: {
-    description: 'Use regex versioning for AOSP submodule tags.',
-    packageRules: [
-      {
-        matchManagers: ['git-submodules'],
-        matchDatasources: ['git-refs'],
-        matchSourceUrls: ['https://android.googlesource.com/**'],
-        versioning:
-          'regex:^android-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_r(?<build>\\d+)$',
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -25,6 +25,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:rke2KubernetesVersioning',
       'workarounds:libericaJdkDockerVersioning',
       'workarounds:ubuntuDockerVersioning',
+      'workarounds:aospTagVersioning',
     ],
     ignoreDeps: [], // Hack to improve onboarding PR description
   },
@@ -336,6 +337,17 @@ export const presets: Record<string, Preset> = {
         matchDatasources: ['docker'],
         matchDepNames: ['ubuntu'],
         versioning: 'ubuntu',
+      },
+    ],
+  },
+  aospTagVersioning: {
+    description: 'Use regex versioning for AOSP submodule tags.',
+    packageRules: [
+      {
+        matchManagers: ['git-submodules'],
+        matchDatasources: ['git-refs'],
+        matchSourceUrls: ['https://android.googlesource.com/**'],
+        versioning: 'regex:^android-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)_r(?<build>\\d+)$',
       },
     ],
   },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Workaround for AOSP tag styles.

## Context

- Refs #43618.

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository https://github.com/JakeWharton/dalvik-dx/blob/56a66b58734b6e1222894756813fc5054dcebfea/.gitmodules#L3-L4
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JakeWharton/dalvik-dx

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
