### PR TITLE
test(linter):  zod schema and infered type naming rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -70,6 +70,7 @@
     "renovate/enforce-ts-extension": "error",
     "renovate/no-new-url": "error",
     "renovate/no-tools-import": "error",
+    "renovate/zod-schema-naming": "error",
 
     "typescript/await-thenable": "error",
     "typescript/no-floating-promises": "error",

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -16,7 +16,7 @@ import * as git from '../../../util/git/index.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { getPkgReleases } from '../index.ts';
 import { CrateDatasource } from './index.ts';
-import type { RegistryConfigSchema } from './schema.ts';
+import type { RegistryConfig } from './schema.ts';
 
 vi.unmock('../../../util/mutex.ts');
 const createSimpleGit = vi.mocked(git.createSimpleGit);
@@ -28,7 +28,7 @@ const CRATES_IO_REGISTRY_URL_PARSED = 'https://index.crates.io/';
 
 const datasource = CrateDatasource.id;
 
-const cratesIoConfig: RegistryConfigSchema = {
+const cratesIoConfig: RegistryConfig = {
   dl: DL_BASE_URL,
   api: API_BASE_URL,
 };

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -21,7 +21,7 @@ import type {
   Release,
   ReleaseResult,
 } from '../types.ts';
-import { RegistryConfigSchema, ReleaseTimestamp } from './schema.ts';
+import { RegistryConfig, ReleaseTimestamp } from './schema.ts';
 import type {
   CrateMetadata,
   CrateRecord,
@@ -161,9 +161,9 @@ export class CrateDatasource extends Datasource {
    */
   private async fetchRegistryConfig(
     info: RegistryInfo,
-  ): Promise<RegistryConfigSchema | null> {
+  ): Promise<RegistryConfig | null> {
     const cacheKey = `crate-datasource/registry-config/${info.rawUrl}`;
-    const cached = memCache.get<RegistryConfigSchema>(cacheKey);
+    const cached = memCache.get<RegistryConfig>(cacheKey);
     if (cached) {
       return cached;
     }
@@ -172,7 +172,7 @@ export class CrateDatasource extends Datasource {
       try {
         const configPath = upath.join(info.clonePath, 'config.json');
         const content = await readCacheFile(configPath, 'utf8');
-        const parsed = Json.pipe(RegistryConfigSchema).parse(content);
+        const parsed = Json.pipe(RegistryConfig).parse(content);
         memCache.set(cacheKey, parsed);
         return parsed;
       } catch {
@@ -184,10 +184,7 @@ export class CrateDatasource extends Datasource {
     } else {
       try {
         const configUrl = joinUrlParts(info.rawUrl, 'config.json');
-        const { body } = await this.http.getJson(
-          configUrl,
-          RegistryConfigSchema,
-        );
+        const { body } = await this.http.getJson(configUrl, RegistryConfig);
         memCache.set(cacheKey, body);
         return body;
       } catch {

--- a/lib/modules/datasource/crate/schema.ts
+++ b/lib/modules/datasource/crate/schema.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod/v4';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
 
-export const RegistryConfigSchema = z.object({
+export const RegistryConfig = z.object({
   dl: z.string(),
   api: z.string().optional(),
 });
-export type RegistryConfigSchema = z.infer<typeof RegistryConfigSchema>;
+export type RegistryConfig = z.infer<typeof RegistryConfig>;
 
 export const ReleaseTimestamp = z
   .object({

--- a/lib/modules/datasource/elm-package/index.ts
+++ b/lib/modules/datasource/elm-package/index.ts
@@ -5,7 +5,7 @@ import { joinUrlParts } from '../../../util/url.ts';
 import * as elmVersioning from '../../versioning/elm/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
-import { ElmPackageReleasesSchema } from './schema.ts';
+import { ElmPackageReleases } from './schema.ts';
 
 export class ElmPackageDatasource extends Datasource {
   static readonly id = 'elm-package';
@@ -45,7 +45,7 @@ export class ElmPackageDatasource extends Datasource {
     );
 
     const { val: result, err } = await this.http
-      .getJsonSafe(pkgUrl, ElmPackageReleasesSchema)
+      .getJsonSafe(pkgUrl, ElmPackageReleases)
       .onError((err) => {
         logger.debug(
           {

--- a/lib/modules/datasource/elm-package/schema.ts
+++ b/lib/modules/datasource/elm-package/schema.ts
@@ -6,7 +6,7 @@ import type { ReleaseResult } from '../types.ts';
  * Response from package.elm-lang.org/packages/{author}/{package}/releases.json
  * Maps version strings to Unix timestamps
  */
-export const ElmPackageReleasesSchema = z
+export const ElmPackageReleases = z
   .record(z.string(), z.number())
   .refine((obj) => Object.keys(obj).length > 0, 'No releases found')
   .transform((releases): ReleaseResult => {

--- a/lib/modules/datasource/helm/index.ts
+++ b/lib/modules/datasource/helm/index.ts
@@ -4,7 +4,6 @@ import { ensureTrailingSlash } from '../../../util/url.ts';
 import * as helmVersioning from '../../versioning/helm/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
-import type { HelmRepositoryData } from './schema.ts';
 import { HelmRepository } from './schema.ts';
 
 export class HelmDatasource extends Datasource {
@@ -31,7 +30,7 @@ export class HelmDatasource extends Datasource {
 
   private async _getRepositoryData(
     helmRepository: string,
-  ): Promise<HelmRepositoryData> {
+  ): Promise<HelmRepository> {
     const { val, err } = await this.http
       .getYamlSafe(
         'index.yaml',
@@ -47,7 +46,7 @@ export class HelmDatasource extends Datasource {
     return val;
   }
 
-  getRepositoryData(helmRepository: string): Promise<HelmRepositoryData> {
+  getRepositoryData(helmRepository: string): Promise<HelmRepository> {
     return withCache(
       {
         namespace: `datasource-${HelmDatasource.id}`,

--- a/lib/modules/datasource/helm/schema.ts
+++ b/lib/modules/datasource/helm/schema.ts
@@ -80,4 +80,4 @@ export const HelmRepository = z
   })
   .transform(({ entries }) => entries);
 
-export type HelmRepositoryData = z.infer<typeof HelmRepository>;
+export type HelmRepository = z.infer<typeof HelmRepository>;

--- a/lib/modules/manager/composer/schema.ts
+++ b/lib/modules/manager/composer/schema.ts
@@ -53,7 +53,7 @@ export const Repo = z.discriminatedUnion('type', [
   PathRepo,
   PackageRepo,
 ]);
-export type Repo = z.infer<typeof ComposerRepo>;
+export type Repo = z.infer<typeof Repo>;
 
 export const NamedRepo = z.discriminatedUnion('type', [
   ComposerRepo,

--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -34,7 +34,7 @@ function actionSchema(
   return z
     .object({
       uses: matchAction(name),
-      with: withSchema ?? VersionValSchema,
+      with: withSchema ?? VersionVal,
     })
     .transform(
       ({ with: { val, ...meta } }): PackageDependency => ({
@@ -83,11 +83,11 @@ function valSchema(key: string): z.ZodType<{ val: string | undefined }> {
     .transform((val) => ({ val: val[key] }));
 }
 
-const VersionValSchema = z
+const VersionVal = z
   .object({ version: z.string().optional() })
   .transform((val) => ({ val: val.version }));
 
-const InstallBinaryWithSchema = z
+const InstallBinaryWith = z
   .object({ repo: z.string(), tag: z.string() })
   .transform(({ repo, tag }) => ({ packageName: repo, val: tag }));
 
@@ -135,7 +135,7 @@ export const communityActions: Record<string, CommunityActionConfig> = {
   'jaxxstorm/action-install-gh-release': {
     datasource: GithubReleasesDatasource.id,
     packageName: '', // determined from `repo` input
-    withSchema: InstallBinaryWithSchema,
+    withSchema: InstallBinaryWith,
   },
   'oven-sh/setup-bun': {
     datasource: NpmDatasource.id,
@@ -171,7 +171,7 @@ export const communityActions: Record<string, CommunityActionConfig> = {
   'sigoden/install-binary': {
     datasource: GithubReleasesDatasource.id,
     packageName: '', // determined from `repo` input
-    withSchema: InstallBinaryWithSchema,
+    withSchema: InstallBinaryWith,
   },
   'zizmorcore/zizmor-action': {
     datasource: DockerDatasource.id,

--- a/lib/modules/manager/vendir/extract.ts
+++ b/lib/modules/manager/vendir/extract.ts
@@ -12,16 +12,15 @@ import type {
   PackageFileContent,
 } from '../types.ts';
 import type {
-  GitRefDefinition,
-  GithubReleaseDefinition,
-  HelmChartDefinition,
-  HttpReleaseDefinition,
-  VendirDefinition,
+  GitRef,
+  GithubRelease,
+  HelmChart,
+  HttpRelease,
 } from './schema.ts';
 import { Vendir } from './schema.ts';
 
 export function extractHelmChart(
-  helmChart: HelmChartDefinition,
+  helmChart: HelmChart,
   aliases?: Record<string, string>,
 ): PackageDependency {
   if (isOCIRegistry(helmChart.repository.url)) {
@@ -48,9 +47,7 @@ export function extractHelmChart(
   };
 }
 
-export function extractGitSource(
-  gitSource: GitRefDefinition,
-): PackageDependency {
+export function extractGitSource(gitSource: GitRef): PackageDependency {
   const httpUrl = getHttpUrl(gitSource.url);
   return {
     depName: httpUrl,
@@ -61,7 +58,7 @@ export function extractGitSource(
 }
 
 export function extractGithubReleaseSource(
-  githubRelease: GithubReleaseDefinition,
+  githubRelease: GithubRelease,
 ): PackageDependency {
   return {
     depName: githubRelease.slug,
@@ -73,7 +70,7 @@ export function extractGithubReleaseSource(
 }
 
 export function extractHttpReleaseSource(
-  httpRelease: HttpReleaseDefinition,
+  httpRelease: HttpRelease,
 ): PackageDependency {
   return {
     packageName: httpRelease.url,
@@ -86,7 +83,7 @@ export function extractHttpReleaseSource(
 export function parseVendir(
   content: string,
   packageFile?: string,
-): VendirDefinition | null {
+): Vendir | null {
   try {
     return parseSingleYaml(content, {
       customSchema: Vendir,

--- a/lib/modules/manager/vendir/schema.ts
+++ b/lib/modules/manager/vendir/schema.ts
@@ -66,8 +66,8 @@ export const Vendir = VendirResource.extend({
   ),
 });
 
-export type VendirDefinition = z.infer<typeof Vendir>;
-export type HelmChartDefinition = z.infer<typeof HelmChart>;
-export type GitRefDefinition = z.infer<typeof GitRef>;
-export type GithubReleaseDefinition = z.infer<typeof GithubRelease>;
-export type HttpReleaseDefinition = z.infer<typeof HttpRelease>;
+export type Vendir = z.infer<typeof Vendir>;
+export type HelmChart = z.infer<typeof HelmChart>;
+export type GitRef = z.infer<typeof GitRef>;
+export type GithubRelease = z.infer<typeof GithubRelease>;
+export type HttpRelease = z.infer<typeof HttpRelease>;

--- a/lib/modules/platform/gitlab/pr-cache.ts
+++ b/lib/modules/platform/gitlab/pr-cache.ts
@@ -8,7 +8,7 @@ import type {
 } from '../../../util/http/gitlab.ts';
 import { regEx } from '../../../util/regex.ts';
 import { getQueryString } from '../../../util/url.ts';
-import { GitLabMergeRequestsSchema } from './schema.ts';
+import { GitLabMergeRequests } from './schema.ts';
 import type { GitlabPr, GitlabPrCacheData } from './types.ts';
 import { prInfo } from './utils.ts';
 
@@ -141,7 +141,7 @@ export class GitlabPrCache {
     const { body: items } = await http.getJson(
       `/projects/${this.repo}/merge_requests?${query}`,
       opts,
-      GitLabMergeRequestsSchema,
+      GitLabMergeRequests,
     );
 
     if (items.length) {

--- a/lib/modules/platform/gitlab/schema.ts
+++ b/lib/modules/platform/gitlab/schema.ts
@@ -10,14 +10,14 @@ export const LastPipelineId = z
   })
   .transform(({ last_pipeline }) => last_pipeline.id);
 
-const GitlabUserSchema = z.object({
+const GitlabUser = z.object({
   id: z.number(),
   username: z.string(),
 });
 
-const LongCommitShaSchema = z.string().transform((val) => val as LongCommitSha);
+const LongCommitSha = z.string().transform((val) => val as LongCommitSha);
 
-export const GitLabMergeRequestSchema = z.object({
+export const GitLabMergeRequest = z.object({
   iid: z.number(),
   title: z.string(),
   description: z.string().nullable(),
@@ -28,18 +28,18 @@ export const GitLabMergeRequestSchema = z.object({
   updated_at: z.string(),
   diverged_commits_count: z.number().optional(),
   merge_status: z.string().optional(),
-  assignee: GitlabUserSchema.nullish(),
-  assignees: LooseArray(GitlabUserSchema).catch([]),
-  reviewers: LooseArray(GitlabUserSchema).catch([]),
+  assignee: GitlabUser.nullish(),
+  assignees: LooseArray(GitlabUser).catch([]),
+  reviewers: LooseArray(GitlabUser).catch([]),
   labels: z.array(z.string()).optional(),
-  sha: LongCommitShaSchema.nullish(),
+  sha: LongCommitSha.nullish(),
   head_pipeline: z
     .object({
       status: z.string(),
-      sha: LongCommitShaSchema,
+      sha: LongCommitSha,
     })
     .nullish(),
 });
 
-export const GitLabMergeRequestsSchema = z.array(GitLabMergeRequestSchema);
-export type GitLabMergeRequest = z.infer<typeof GitLabMergeRequestSchema>;
+export const GitLabMergeRequests = z.array(GitLabMergeRequest);
+export type GitLabMergeRequest = z.infer<typeof GitLabMergeRequest>;

--- a/lib/modules/platform/scm-manager/schema.ts
+++ b/lib/modules/platform/scm-manager/schema.ts
@@ -8,36 +8,33 @@ export const User = z.object({
 });
 export type User = z.infer<typeof User>;
 
-export const DefaultBranchSchema = z.object({
+export const DefaultBranch = z.object({
   defaultBranch: z.string(),
 });
 
-export const LinkSchema = z.object({
+export const Link = z.object({
   href: z.string(),
   name: z.string().optional().nullable(),
   templated: z.boolean().optional().nullable(),
 });
-export type Link = z.infer<typeof LinkSchema>;
+export type Link = z.infer<typeof Link>;
 
-export const LinksSchema = z.record(
-  z.string(),
-  z.union([LinkSchema, z.array(LinkSchema)]),
-);
-export type Links = z.infer<typeof LinksSchema>;
+export const Links = z.record(z.string(), z.union([Link, z.array(Link)]));
+export type Links = z.infer<typeof Links>;
 
-export const PrStateSchema = z.enum(['DRAFT', 'OPEN', 'REJECTED', 'MERGED']);
-export type PrState = z.infer<typeof PrStateSchema>;
+export const PrState = z.enum(['DRAFT', 'OPEN', 'REJECTED', 'MERGED']);
+export type PrState = z.infer<typeof PrState>;
 
-export const PrMergeMethodSchema = z.enum([
+export const PrMergeMethod = z.enum([
   'MERGE_COMMIT',
   'REBASE',
   'FAST_FORWARD_IF_POSSIBLE',
   'FAST_FORWARD_ONLY',
   'SQUASH',
 ]);
-export type PrMergeMethod = z.infer<typeof PrMergeMethodSchema>;
+export type PrMergeMethod = z.infer<typeof PrMergeMethod>;
 
-export const PullRequestSchema = z.object({
+export const PullRequest = z.object({
   id: z.string(),
   author: z
     .object({
@@ -61,7 +58,7 @@ export const PullRequestSchema = z.object({
   description: z.string().optional().nullable(),
   creationDate: z.string(),
   lastModified: z.string().optional().nullable(),
-  status: PrStateSchema,
+  status: PrState,
   reviewer: z
     .array(
       z.object({
@@ -78,46 +75,46 @@ export const PullRequestSchema = z.object({
     todo: z.number(),
     done: z.number(),
   }),
-  _links: LinksSchema,
+  _links: Links,
   _embedded: z.object({
     defaultConfig: z.object({
-      mergeStrategy: PrMergeMethodSchema,
+      mergeStrategy: PrMergeMethod,
       deleteBranchOnMerge: z.boolean(),
     }),
   }),
 });
-export type PullRequest = z.infer<typeof PullRequestSchema>;
+export type PullRequest = z.infer<typeof PullRequest>;
 
-const RepoTypeSchema = z.enum(['git', 'svn', 'hg']);
+const RepoType = z.enum(['git', 'svn', 'hg']);
 
-export const RepoSchema = z.object({
+export const Repo = z.object({
   contact: z.string().optional().nullable(),
   creationDate: z.string().optional().nullable(),
   description: z.string().optional().nullable(),
   lastModified: z.string().optional().nullable(),
   namespace: z.string(),
   name: z.string(),
-  type: RepoTypeSchema,
+  type: RepoType,
   archived: z.boolean(),
   exporting: z.boolean(),
   healthCheckRunning: z.boolean(),
-  _links: LinksSchema,
+  _links: Links,
 });
-export type Repo = z.infer<typeof RepoSchema>;
+export type Repo = z.infer<typeof Repo>;
 
-const PagedSchema = z.object({
+const Paged = z.object({
   page: z.number(),
   pageTotal: z.number(),
 });
 
-export const PagedPullRequestSchema = PagedSchema.extend({
+export const PagedPullRequest = Paged.extend({
   _embedded: z.object({
-    pullRequests: z.array(PullRequestSchema),
+    pullRequests: z.array(PullRequest),
   }),
 });
 
-export const PagedRepoSchema = PagedSchema.extend({
+export const PagedRepo = Paged.extend({
   _embedded: z.object({
-    repositories: z.array(RepoSchema),
+    repositories: z.array(Repo),
   }),
 });

--- a/lib/modules/platform/scm-manager/scm-manager-helper.ts
+++ b/lib/modules/platform/scm-manager/scm-manager-helper.ts
@@ -1,11 +1,11 @@
 import { ScmManagerHttp } from '../../../util/http/scm-manager.ts';
-import type { Link, PullRequest, Repo } from './schema.ts';
+import type { Link } from './schema.ts';
 import {
-  DefaultBranchSchema,
-  PagedPullRequestSchema,
-  PagedRepoSchema,
-  PullRequestSchema,
-  RepoSchema,
+  DefaultBranch,
+  PagedPullRequest,
+  PagedRepo,
+  PullRequest,
+  Repo,
   User,
 } from './schema.ts';
 import type {
@@ -55,7 +55,7 @@ export async function getRepo(repoPath: string): Promise<Repo> {
     {
       headers: { accept: CONTENT_TYPES.REPOSITORY },
     },
-    RepoSchema,
+    Repo,
   );
   return response.body;
 }
@@ -66,7 +66,7 @@ export async function getAllRepos(): Promise<Repo[]> {
     {
       headers: { accept: CONTENT_TYPES.REPOSITORIES },
     },
-    PagedRepoSchema,
+    PagedRepo,
   );
 
   return response.body._embedded.repositories;
@@ -79,7 +79,7 @@ export async function getDefaultBranch(repo: Repo): Promise<string> {
     {
       headers: { accept: CONTENT_TYPES.GIT_CONFIG },
     },
-    DefaultBranchSchema,
+    DefaultBranch,
   );
 
   return response.body.defaultBranch;
@@ -96,7 +96,7 @@ export async function getAllRepoPrs(
     {
       headers: { accept: CONTENT_TYPES.PULLREQUESTS },
     },
-    PagedPullRequestSchema,
+    PagedPullRequest,
   );
   return response.body._embedded.pullRequests;
 }
@@ -110,7 +110,7 @@ export async function getRepoPr(
     {
       headers: { accept: CONTENT_TYPES.PULLREQUEST },
     },
-    PullRequestSchema,
+    PullRequest,
   );
 
   return response.body;
@@ -136,7 +136,7 @@ export async function createScmPr(
     {
       headers: { accept: CONTENT_TYPES.PULLREQUEST },
     },
-    PullRequestSchema,
+    PullRequest,
   );
 
   return getCreatedPrResponse.body;

--- a/lib/modules/versioning/index.spec.ts
+++ b/lib/modules/versioning/index.spec.ts
@@ -22,7 +22,7 @@ describe('modules/versioning/index', () => {
   it('matches the API contract', async () => {
     const versionings = allVersioning.getVersionings();
 
-    const VersioningApiSchema = z
+    const VersioningApi = z
       .string()
       .refine((name) => versionings.has(name), {
         error: 'Allowed in config but does not exist in the API',
@@ -61,13 +61,11 @@ describe('modules/versioning/index', () => {
 
     const config = getOptions().find(({ name }) => name === 'versioning');
 
-    const ValidVersioningSchema = z
+    const ValidVersioning = z
       .object({ allowedValues: z.string().array() })
       .transform(({ allowedValues }) => allowedValues)
-      .pipe(VersioningApiSchema.array());
+      .pipe(VersioningApi.array());
 
-    await expect(
-      ValidVersioningSchema.parseAsync(config),
-    ).resolves.toBeDefined();
+    await expect(ValidVersioning.parseAsync(config)).resolves.toBeDefined();
   });
 });

--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -6,8 +6,7 @@ import { hash } from '../../../hash.ts';
 import { safeStringify } from '../../../stringify.ts';
 import { CACHE_REVISION } from '../common.ts';
 import { cleanupHttpCache } from '../http-cache.ts';
-import type { RepoCacheRecord } from '../schema.ts';
-import { RepoCacheV13 } from '../schema.ts';
+import { RepoCacheRecord } from '../schema.ts';
 import type { RepoCache, RepoCacheData } from '../types.ts';
 
 export abstract class RepoCacheBase implements RepoCache {
@@ -65,7 +64,7 @@ export abstract class RepoCacheBase implements RepoCache {
         return;
       }
 
-      const cacheV13 = RepoCacheV13.safeParse(oldCache);
+      const cacheV13 = RepoCacheRecord.safeParse(oldCache);
       if (cacheV13.success) {
         await this.restore(cacheV13.data);
         logger.debug('Repository cache is restored from revision 13');

--- a/lib/util/cache/repository/schema.ts
+++ b/lib/util/cache/repository/schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod/v4';
 import { Json } from '../../schema-utils/index.ts';
 
-export const RepoCacheV13 = Json.pipe(
+export const RepoCacheRecord = Json.pipe(
   z
     .object({
       repository: z.string().min(1),
@@ -13,4 +13,4 @@ export const RepoCacheV13 = Json.pipe(
     .strict(),
 );
 
-export type RepoCacheRecord = z.infer<typeof RepoCacheV13>;
+export type RepoCacheRecord = z.infer<typeof RepoCacheRecord>;

--- a/lib/util/emoji.ts
+++ b/lib/util/emoji.ts
@@ -27,14 +27,14 @@ const EmojiShortcodes = Json.pipe(
     z.union([z.string().transform((val) => [val]), z.array(z.string())]),
   ),
 );
-type EmojiShortcodeMapping = z.infer<typeof EmojiShortcodes>;
+type EmojiShortcodes = z.infer<typeof EmojiShortcodes>;
 
-const patchedEmojis: EmojiShortcodeMapping = {
+const patchedEmojis: EmojiShortcodes = {
   '26A0-FE0F': ['warning'], // Colorful warning (⚠️) instead of black and white (⚠)
   '2139-FE0F': ['information_source'], // Colorful info (ℹ️) instead of black and white (ℹ)
 };
 
-function initMapping(mapping: EmojiShortcodeMapping): void {
+function initMapping(mapping: EmojiShortcodes): void {
   for (const [hex, shortcodes] of Object.entries(mapping)) {
     const mainShortcode = `:${shortcodes[0]}:`;
 

--- a/lib/util/schema-utils/index.spec.ts
+++ b/lib/util/schema-utils/index.spec.ts
@@ -539,11 +539,11 @@ describe('util/schema-utils/index', () => {
 
   describe('logging utils', () => {
     it('logs debug message and returns fallback value', () => {
-      const Schema = z
+      const Str = z
         .string()
         .catch(withDebugMessage('default string', 'Debug message'));
 
-      const result = Schema.parse(42);
+      const result = Str.parse(42);
 
       expect(result).toBe('default string');
 
@@ -554,11 +554,11 @@ describe('util/schema-utils/index', () => {
     });
 
     it('logs trace message and returns fallback value', () => {
-      const Schema = z
+      const Str = z
         .string()
         .catch(withTraceMessage('default string', 'Trace message'));
 
-      const result = Schema.parse(42);
+      const result = Str.parse(42);
 
       expect(result).toBe('default string');
 
@@ -691,18 +691,18 @@ describe('util/schema-utils/index', () => {
     });
 
     it('can be combined with other schema types', () => {
-      const Schema = z.object({
+      const Obj = z.object({
         data: NotCircular.pipe(z.any()),
       });
 
-      expect(Schema.parse({ data: { a: 1, b: 2 } })).toEqual({
+      expect(Obj.parse({ data: { a: 1, b: 2 } })).toEqual({
         data: { a: 1, b: 2 },
       });
 
       const obj: any = { a: 1 };
       obj.self = obj;
 
-      expect(Schema.safeParse({ data: obj })).toMatchObject({
+      expect(Obj.safeParse({ data: obj })).toMatchObject({
         success: false,
         error: {
           issues: [

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -610,14 +610,14 @@ export class Vulnerabilities {
   }
 
   static evaluateCvssVector(vector: string): [string, string] {
-    const CvssJsonSchema = z.object({
+    const CvssJson = z.object({
       baseScore: z.number().default(0.0),
       baseSeverity: z.string().toUpperCase().default('UNKNOWN'),
     });
 
     try {
       const parsedCvssScore: CvssVector<any> | null = fromVector(vector);
-      const res = CvssJsonSchema.parse(parsedCvssScore?.createJsonSchema());
+      const res = CvssJson.parse(parsedCvssScore?.createJsonSchema());
 
       return [res.baseScore.toFixed(1), res.baseSeverity];
     } catch {

--- a/tools/check/coverage.ts
+++ b/tools/check/coverage.ts
@@ -15,7 +15,7 @@ const CoverageEntry = z.object({
 
 const CoverageJson = z.record(z.string(), CoverageEntry);
 
-type CoverageData = z.infer<typeof CoverageJson>;
+type CoverageJson = z.infer<typeof CoverageJson>;
 
 function groupConsecutiveNumbers(numbers: number[]): string[] {
   if (numbers.length === 0) {
@@ -43,7 +43,7 @@ function groupConsecutiveNumbers(numbers: number[]): string[] {
 
 async function loadCoverageFile(
   coverageDir: string,
-): Promise<CoverageData | null> {
+): Promise<CoverageJson | null> {
   const coverageFile = upath.resolve(coverageDir, 'coverage-final.json');
   if (!(await fs.pathExists(coverageFile))) {
     return null;
@@ -61,9 +61,9 @@ async function loadCoverageFile(
 }
 
 function normalizeCoveragePaths(
-  data: CoverageData,
-): Map<string, CoverageData[string]> {
-  const normalized = new Map<string, CoverageData[string]>();
+  data: CoverageJson,
+): Map<string, CoverageJson[string]> {
+  const normalized = new Map<string, CoverageJson[string]>();
   for (const [key, value] of Object.entries(data)) {
     normalized.set(upath.normalize(key), value);
   }
@@ -76,7 +76,7 @@ function isSourceFile(path: string): boolean {
 
 function extractFileCoverage(
   file: string,
-  coverage: Map<string, CoverageData[string]>,
+  coverage: Map<string, CoverageJson[string]>,
 ): CoverageInfo | null {
   const absPath = upath.resolve(process.cwd(), file);
   const entry = coverage.get(absPath);
@@ -124,7 +124,7 @@ function extractFileCoverage(
 
 export async function loadCoverage(
   coverageDir: string,
-): Promise<Map<string, CoverageData[string]> | null> {
+): Promise<Map<string, CoverageJson[string]> | null> {
   const data = await loadCoverageFile(coverageDir);
   if (!data) {
     return null;
@@ -133,7 +133,7 @@ export async function loadCoverage(
 }
 
 export function getCoverageForFiles(
-  coverage: Map<string, CoverageData[string]>,
+  coverage: Map<string, CoverageJson[string]>,
   files: string[],
 ): CoverageInfo[] {
   const results: CoverageInfo[] = [];
@@ -150,7 +150,7 @@ export function getCoverageForFiles(
 }
 
 export function getCoverageForDir(
-  coverage: Map<string, CoverageData[string]>,
+  coverage: Map<string, CoverageJson[string]>,
   dir: string,
 ): CoverageInfo[] {
   const absDir = `${upath.resolve(process.cwd(), dir)}/`;

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -2,6 +2,7 @@ import enforceTsExtension from './rules/enforce-ts-extension.js';
 import noNewUrl from './rules/no-new-url.js';
 import noToolsImport from './rules/no-tools-import.js';
 import testRootDescribe from './rules/test-root-describe.js';
+import zodSchemaNaming from './rules/zod-schema-naming.js';
 
 export default {
   meta: {
@@ -12,5 +13,6 @@ export default {
     'no-new-url': noNewUrl,
     'no-tools-import': noToolsImport,
     'test-root-describe': testRootDescribe,
+    'zod-schema-naming': zodSchemaNaming,
   },
 };

--- a/tools/lint/rules/zod-schema-naming.js
+++ b/tools/lint/rules/zod-schema-naming.js
@@ -1,0 +1,142 @@
+/**
+ * Walk the init expression to its leftmost identifier by unwrapping
+ * CallExpression.callee and MemberExpression.object chains.
+ * @param {import('estree').Expression | import('estree').Super} node
+ * @returns {string | null}
+ */
+function getLeftmostIdentifier(node) {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  if (node.type === 'CallExpression') {
+    return getLeftmostIdentifier(node.callee);
+  }
+  if (node.type === 'MemberExpression') {
+    return getLeftmostIdentifier(node.object);
+  }
+  return null;
+}
+
+/**
+ * Minimal shapes of the TypeScript AST nodes inspected by Check B. oxc emits a
+ * typescript-eslint-compatible AST, but these nodes are absent from ESLint's
+ * estree typings and oxlint does not export its own node types, so the fields
+ * this rule reads are described here.
+ *
+ * @typedef {{ type: string, name: string }} TSName
+ * @typedef {{ type: string, left: TSName, right: TSName }} TSQualifiedName
+ * @typedef {{ type: string, exprName?: TSName }} TSTypeQuery
+ * @typedef {{ params: TSTypeQuery[] }} TSTypeArgs
+ * @typedef {{ type: string, typeName: TSQualifiedName, typeArguments?: TSTypeArgs, typeParameters?: TSTypeArgs }} TSTypeReference
+ * @typedef {{ id: import('estree').Identifier, typeAnnotation?: TSTypeReference }} TSTypeAliasDeclaration
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    messages: {
+      noSchemaSuffix:
+        'Zod schema should not use a `Schema` suffix; name it `{{name}}` instead.',
+      mismatchedInferType:
+        "Inferred type should share its schema's name (expected `type {{name}} = ...`).",
+    },
+  },
+  create(context) {
+    /** @type {string | null} */
+    let zodBinding = null;
+    /** @type {Set<string>} */
+    const schemaNames = new Set();
+
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'zod' && node.source.value !== 'zod/v4') {
+          return;
+        }
+        for (const specifier of node.specifiers) {
+          if (
+            specifier.type === 'ImportSpecifier' &&
+            specifier.imported.type === 'Identifier' &&
+            specifier.imported.name === 'z'
+          ) {
+            zodBinding = specifier.local.name;
+          }
+        }
+      },
+
+      VariableDeclarator(node) {
+        if (!zodBinding || !node.init || node.id.type !== 'Identifier') {
+          return;
+        }
+        const leftmost = getLeftmostIdentifier(node.init);
+        if (!leftmost) {
+          return;
+        }
+        if (leftmost !== zodBinding && !schemaNames.has(leftmost)) {
+          return;
+        }
+
+        const name = node.id.name;
+        schemaNames.add(name);
+
+        if (!name.endsWith('Schema')) {
+          return;
+        }
+        context.report({
+          node: node.id,
+          messageId: 'noSchemaSuffix',
+          data: { name: name.slice(0, -6) },
+        });
+      },
+
+      /** @param {unknown} node */
+      TSTypeAliasDeclaration(node) {
+        if (!zodBinding) {
+          return;
+        }
+        const decl = /** @type {TSTypeAliasDeclaration} */ (node);
+        const { typeAnnotation } = decl;
+        if (typeAnnotation?.type !== 'TSTypeReference') {
+          return;
+        }
+
+        // Match z.infer<...> — TSQualifiedName where left = zodBinding, right = 'infer'
+        const refTypeName = typeAnnotation.typeName;
+        if (
+          refTypeName.type !== 'TSQualifiedName' ||
+          refTypeName.left.type !== 'Identifier' ||
+          refTypeName.left.name !== zodBinding ||
+          refTypeName.right.type !== 'Identifier' ||
+          refTypeName.right.name !== 'infer'
+        ) {
+          return;
+        }
+
+        // oxc emits `typeArguments`; keep `typeParameters` as a fallback for other serializers.
+        const typeArgs =
+          typeAnnotation.typeArguments ?? typeAnnotation.typeParameters;
+        if (typeArgs?.params.length !== 1) {
+          return;
+        }
+
+        const [typeArg] = typeArgs.params;
+        if (typeArg.type !== 'TSTypeQuery' || !typeArg.exprName) {
+          return;
+        }
+        const { exprName } = typeArg;
+        if (exprName.type !== 'Identifier') {
+          return;
+        }
+
+        const schemaName = exprName.name;
+        if (decl.id.name !== schemaName) {
+          context.report({
+            node: decl.id,
+            messageId: 'mismatchedInferType',
+            data: { name: schemaName },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds an eslint / oxlint rule to enforce that the Zod schemas do NOT have a `Schema` suffix according to [our dev docs](https://github.com/renovatebot/renovate/blob/main/docs/development/zod.md#name-schemas-without-any-schema-suffix). 
This rule also enforces that the Schema and inferred types have to be named the same way

Adapted the code base based on the new linting errors found

<!-- Describe what behavior is changed by this PR. -->

## Context

Having gotten this wrong multiple times in the past PRs and we are not consistent in the current codebase


Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
