### PR TITLE
fix(workers/repository): correctly render `schedule` for vulnerability alerts

### DIFF
--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -91,6 +91,26 @@ describe('workers/repository/update/pr/body/config-description', () => {
       expect(res).toContain(expected);
     });
 
+    // because the merging of `force` should have happened before this function, this clarifies that ?
+    it('does not take into account `force`', () => {
+      const res = getPrConfigDescription({
+        ...config,
+        force: {
+          schedule: ['before 6am on Monday', 'after 3pm on Tuesday'],
+          automergeSchedule: ['after 6pm on Friday'],
+        },
+      });
+
+      const expected = codeBlock`
+        - Branch creation
+          - At any time (no schedule defined)
+        - Automerge
+          - At any time (no schedule defined)
+      `;
+
+      expect(res).toContain(expected);
+    });
+
     it('summarizes cron schedules (for automergeSchedule)', () => {
       const res = getPrConfigDescription({
         ...config,

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -80,7 +80,15 @@ describe('workers/repository/update/pr/body/config-description', () => {
 
     it('renders undefined schedule', () => {
       const res = getPrConfigDescription(config);
-      expect(res).toContain(`At any time (no schedule defined)`);
+
+      const expected = codeBlock`
+        - Branch creation
+          - At any time (no schedule defined)
+        - Automerge
+          - At any time (no schedule defined)
+      `;
+
+      expect(res).toContain(expected);
     });
 
     it('summarizes cron schedules (for automergeSchedule)', () => {

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -91,6 +91,23 @@ describe('workers/repository/update/pr/body/config-description', () => {
       expect(res).toContain(expected);
     });
 
+    it('renders empty schedule', () => {
+      const res = getPrConfigDescription({
+        ...config,
+        // for instance when set on a vulnerability alert overrides the
+        schedule: [],
+      });
+
+      const expected = codeBlock`
+        - Branch creation
+          - At any time (no schedule defined)
+        - Automerge
+          - At any time (no schedule defined)
+      `;
+
+      expect(res).toContain(expected);
+    });
+
     // because the merging of `force` should have happened before this function, this clarifies that ?
     it('does not take into account `force`', () => {
       const res = getPrConfigDescription({

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -57,7 +57,7 @@ function scheduleToString(
   timezone: string | undefined,
 ): string {
   const scheduleLines = [];
-  if (schedule && schedule[0] !== 'at any time') {
+  if (schedule?.length && schedule[0] !== 'at any time') {
     const r = getReadableCronSchedule(schedule);
     if (r) {
       scheduleLines.push(...r);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Otherwise we see [i.e.](https://github.com/JamieTanna-Mend-testing/renovate-discussions-43304/pull/1)

- Branch creation
  - ""
- Automerge
  - At any time (no schedule defined)

\+ some additional tests

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
