### PR TITLE
fix(workers/repository): don't re-process `init` error

### DIFF
--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -44,7 +44,7 @@ import { OnboardingState } from './onboarding/common.ts';
 import { ensureOnboardingPr } from './onboarding/pr/index.ts';
 import type { ExtractResult } from './process/extract-update.ts';
 import { extractDependencies, updateRepo } from './process/index.ts';
-import type { ProcessResult, RepositoryResult } from './result.ts';
+import type { ProcessResult } from './result.ts';
 import { processResult } from './result.ts';
 
 // istanbul ignore next
@@ -55,14 +55,13 @@ export async function renovateRepository(
   splitInit();
 
   let repoResult: ProcessResult | undefined;
-  const { config, localDir, errorRes } = await instrument(
+  const { config, localDir, error } = await instrument(
     'init',
     async (): Promise<{
       config: RenovateConfig;
       localDir: string;
-      errorRes?: string;
+      error?: Error;
     }> => {
-      let errorRes: RepositoryResult | undefined;
       let config = GlobalConfig.set(
         applySecretsAndVariablesToConfig({
           config: repoConfig,
@@ -85,7 +84,7 @@ export async function renovateRepository(
         addSplit('init');
       } catch (err) /* istanbul ignore next */ {
         setMeta({ repository: config.repository });
-        errorRes = await handleError(config, err);
+        const errorRes = await handleError(config, err);
         const pruneWhenErrors = [
           REPOSITORY_DISABLED_BY_CONFIG,
           REPOSITORY_FORKED,
@@ -95,9 +94,11 @@ export async function renovateRepository(
           await pruneStaleBranches(config, []);
         }
         repoResult = processResult(config, errorRes);
+
+        return { config, localDir, error: err };
       }
 
-      return { config, localDir, errorRes };
+      return { config, localDir };
     },
     {
       attributes: {
@@ -106,89 +107,93 @@ export async function renovateRepository(
     },
   );
 
-  try {
-    // only continue if init stage was successful
-    if (errorRes) {
-      throw new Error(errorRes);
-    }
+  // only continue if init stage was successful
+  if (error === undefined) {
+    try {
+      const performExtract =
+        config.repoIsOnboarded! ||
+        !OnboardingState.onboardingCacheValid ||
+        OnboardingState.prUpdateRequested;
+      const extractResult = performExtract
+        ? await extractDependencies(config)
+        : emptyExtract();
+      addExtractionStats(config, extractResult);
 
-    const performExtract =
-      config.repoIsOnboarded! ||
-      !OnboardingState.onboardingCacheValid ||
-      OnboardingState.prUpdateRequested;
-    const extractResult = performExtract
-      ? await extractDependencies(config)
-      : emptyExtract();
-    addExtractionStats(config, extractResult);
+      const { branches, branchList, packageFiles } = extractResult;
 
-    const { branches, branchList, packageFiles } = extractResult;
-
-    if (config.semanticCommits === 'auto') {
-      config.semanticCommits = await detectSemanticCommits();
-    }
-
-    if (
-      GlobalConfig.get('dryRun') !== 'lookup' &&
-      GlobalConfig.get('dryRun') !== 'extract'
-    ) {
-      await instrument(
-        'onboarding',
-        () => ensureOnboardingPr(config, packageFiles, branches),
-        {
-          attributes: {
-            [ATTR_RENOVATE_SPLIT]: 'onboarding',
-          },
-        },
-      );
-      addSplit('onboarding');
-      const res = await instrument(
-        'update',
-        () => updateRepo(config, branches),
-        {
-          attributes: {
-            [ATTR_RENOVATE_SPLIT]: 'update',
-          },
-        },
-      );
-      setMeta({ repository: config.repository });
-      addSplit('update');
-      if (performExtract) {
-        await setBranchCache(branches); // update branch cache if performed extraction
+      if (config.semanticCommits === 'auto') {
+        config.semanticCommits = await detectSemanticCommits();
       }
-      if (res === 'automerged') {
-        if (canRetry) {
-          logger.info('Restarting repository job after automerge result');
-          const recursiveRes = await renovateRepository(repoConfig, false);
-          return recursiveRes;
-        }
-        logger.debug(`Automerged but already retried once`);
-      } else {
-        const configMigrationRes = await configMigration(config, branchList);
-        await ensureDependencyDashboard(
-          config,
-          branches,
-          packageFiles,
-          configMigrationRes,
+
+      if (
+        GlobalConfig.get('dryRun') !== 'lookup' &&
+        GlobalConfig.get('dryRun') !== 'extract'
+      ) {
+        await instrument(
+          'onboarding',
+          () => ensureOnboardingPr(config, packageFiles, branches),
+          {
+            attributes: {
+              [ATTR_RENOVATE_SPLIT]: 'onboarding',
+            },
+          },
         );
+        addSplit('onboarding');
+        const res = await instrument(
+          'update',
+          () => updateRepo(config, branches),
+          {
+            attributes: {
+              [ATTR_RENOVATE_SPLIT]: 'update',
+            },
+          },
+        );
+        setMeta({ repository: config.repository });
+        addSplit('update');
+        if (performExtract) {
+          await setBranchCache(branches); // update branch cache if performed extraction
+        }
+        if (res === 'automerged') {
+          if (canRetry) {
+            logger.info('Restarting repository job after automerge result');
+            const recursiveRes = await renovateRepository(repoConfig, false);
+            return recursiveRes;
+          }
+          logger.debug(`Automerged but already retried once`);
+        } else {
+          const configMigrationRes = await configMigration(config, branchList);
+          await ensureDependencyDashboard(
+            config,
+            branches,
+            packageFiles,
+            configMigrationRes,
+          );
+        }
+        await finalizeRepo(config, branchList, repoConfig);
+        // TODO #22198
+        repoResult = processResult(config, res!);
       }
-      await finalizeRepo(config, branchList, repoConfig);
-      // TODO #22198
-      repoResult = processResult(config, res!);
+      printRepositoryProblems(config.repository);
+    } catch (err) /* istanbul ignore next */ {
+      setMeta({ repository: config.repository });
+      const errorRes = await handleError(config, err);
+      const pruneWhenErrors = [
+        REPOSITORY_DISABLED_BY_CONFIG,
+        REPOSITORY_FORKED,
+        REPOSITORY_NO_CONFIG,
+      ];
+      if (pruneWhenErrors.includes(errorRes)) {
+        await pruneStaleBranches(config, []);
+      }
+      repoResult = processResult(config, errorRes);
     }
-    printRepositoryProblems(config.repository);
-  } catch (err) /* istanbul ignore next */ {
-    setMeta({ repository: config.repository });
-    const errorRes = await handleError(config, err);
-    const pruneWhenErrors = [
-      REPOSITORY_DISABLED_BY_CONFIG,
-      REPOSITORY_FORKED,
-      REPOSITORY_NO_CONFIG,
-    ];
-    if (pruneWhenErrors.includes(errorRes)) {
-      await pruneStaleBranches(config, []);
-    }
-    repoResult = processResult(config, errorRes);
+  } else {
+    logger.debug(
+      { error },
+      'Skipping the rest to the Renovate run due to error in `init` phase',
+    );
   }
+
   if (localDir && !repoConfig.persistRepoData) {
     try {
       await deleteLocalFile('.');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When the `init` phase encounters an error, we're currently processing it
twice.

This leads to "Action Required" Issues losing any error context (as only
the `errorRes`, not the full `error` is returned), making them much less
useful.

We can refactor to:

- not duplicate the handling
- pass around the full `error` so we can log it outside of the `init`
  phase

As noted in #43558, and seen by some Mend customers.

This appears to be an inadvertent regression introduced in #38764

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/invalid-config/issues/1

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
