### PR TITLE
fix(manager/flux): pin tag-only OCIRepository digests to spec.ref.digest

### DIFF
--- a/lib/modules/manager/flux/extract.spec.ts
+++ b/lib/modules/manager/flux/extract.spec.ts
@@ -2,6 +2,7 @@ import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type { RepoGlobalConfig } from '../../../config/types.ts';
+import { compile } from '../../../util/template/index.ts';
 import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { GitRefsDatasource } from '../../datasource/git-refs/index.ts';
@@ -57,16 +58,79 @@ describe('modules/manager/flux/extract', () => {
           },
           {
             autoReplaceStringTemplate:
-              '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
             currentDigest: undefined,
             currentValue: 'v1.8.2',
             datasource: DockerDatasource.id,
             depName: 'ghcr.io/kyverno/manifests/kyverno',
             packageName: 'ghcr.io/kyverno/manifests/kyverno',
-            replaceString: 'v1.8.2',
+            replaceString: 'tag: v1.8.2',
           },
         ],
       });
+      const ociDep = result?.deps.find(
+        (dep) => dep.depName === 'ghcr.io/kyverno/manifests/kyverno',
+      );
+      expect(
+        compile(
+          ociDep!.autoReplaceStringTemplate!,
+          { newValue: 'v2.0.0' },
+          false,
+        ),
+      ).toBe('tag: v2.0.0');
+      expect(
+        compile(
+          ociDep!.autoReplaceStringTemplate!,
+          { newValue: 'v2.0.0', newDigest: 'sha256:abcd' },
+          false,
+        ),
+      ).toBe('tag: v2.0.0\n    digest: sha256:abcd');
+    });
+
+    it('keeps HelmRelease values image replacement in inline tag@digest format', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          ${fixtureHelmSource}
+          ---
+          apiVersion: helm.toolkit.fluxcd.io/v2
+          kind: HelmRelease
+          metadata:
+            name: sealed-secrets
+            namespace: kube-system
+          spec:
+            chart:
+              spec:
+                chart: sealed-secrets
+                sourceRef:
+                  kind: HelmRepository
+                  name: sealed-secrets
+                version: "2.0.2"
+            values:
+              image:
+                repository: ghcr.io/example/app
+                tag: v1.2.3
+        `,
+        'test.yaml',
+      );
+      expect(result?.deps).toContainEqual(
+        expect.objectContaining({
+          depName: 'ghcr.io/example/app',
+          currentValue: 'v1.2.3',
+          autoReplaceStringTemplate:
+            '{{newValue}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          replaceString: 'v1.2.3',
+        }),
+      );
+      const imageDep = result?.deps.find(
+        (dep) => dep.depName === 'ghcr.io/example/app',
+      );
+      expect(
+        compile(
+          imageDep!.autoReplaceStringTemplate!,
+          { newValue: 'v1.2.4', newDigest: 'sha256:abcd' },
+          false,
+        ),
+      ).toBe('v1.2.4@sha256:abcd');
     });
 
     it.each`
@@ -477,13 +541,13 @@ describe('modules/manager/flux/extract', () => {
         deps: [
           {
             autoReplaceStringTemplate:
-              '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
             currentDigest: undefined,
             currentValue: 'v1.8.2',
             depName: 'ghcr.io/kyverno/manifests/kyverno',
             packageName: 'ghcr.io/kyverno/manifests/kyverno',
             datasource: DockerDatasource.id,
-            replaceString: 'v1.8.2',
+            replaceString: 'tag: v1.8.2',
           },
         ],
       });
@@ -882,13 +946,137 @@ describe('modules/manager/flux/extract', () => {
         deps: [
           {
             autoReplaceStringTemplate:
-              '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
             currentValue: 'v1.8.2',
             currentDigest: undefined,
             depName: 'ghcr.io/kyverno/manifests/kyverno',
             packageName: 'ghcr.proxy.test/some/path/kyverno/manifests/kyverno',
             datasource: DockerDatasource.id,
-            replaceString: 'v1.8.2',
+            replaceString: 'tag: v1.8.2',
+          },
+        ],
+      });
+    });
+
+    it('extracts OCIRepository with a quoted tag', () => {
+      const result = extractPackageFile(
+        codeBlock`
+        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        kind: OCIRepository
+        metadata:
+          name: kyverno-controller
+          namespace: flux-system
+        spec:
+          ref:
+            tag: "v1.8.2"
+          url: oci://ghcr.io/kyverno/manifests/kyverno
+      `,
+        'test.yaml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            autoReplaceStringTemplate:
+              'tag: "{{newValue}}"{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.8.2',
+            depName: 'ghcr.io/kyverno/manifests/kyverno',
+            packageName: 'ghcr.io/kyverno/manifests/kyverno',
+            datasource: DockerDatasource.id,
+            replaceString: 'tag: "v1.8.2"',
+          },
+        ],
+      });
+    });
+
+    it('extracts OCIRepository with a tag and preserves 4-space ref indentation', () => {
+      const result = extractPackageFile(
+        codeBlock`
+        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        kind: OCIRepository
+        metadata:
+            name: kyverno-controller
+            namespace: flux-system
+        spec:
+            ref:
+                tag: v1.8.2
+            url: oci://ghcr.io/kyverno/manifests/kyverno
+      `,
+        'test.yaml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            autoReplaceStringTemplate:
+              'tag: {{newValue}}{{#if newDigest}}\n        digest: {{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.8.2',
+            depName: 'ghcr.io/kyverno/manifests/kyverno',
+            packageName: 'ghcr.io/kyverno/manifests/kyverno',
+            datasource: DockerDatasource.id,
+            replaceString: 'tag: v1.8.2',
+          },
+        ],
+      });
+    });
+
+    it('extracts OCIRepository with a tag when ref is after url', () => {
+      const result = extractPackageFile(
+        codeBlock`
+        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        kind: OCIRepository
+        metadata:
+          name: kyverno-controller
+          namespace: flux-system
+        spec:
+          url: oci://ghcr.io/kyverno/manifests/kyverno
+          ref:
+            tag: v1.8.2
+      `,
+        'test.yaml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            autoReplaceStringTemplate:
+              'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.8.2',
+            depName: 'ghcr.io/kyverno/manifests/kyverno',
+            packageName: 'ghcr.io/kyverno/manifests/kyverno',
+            datasource: DockerDatasource.id,
+            replaceString: 'tag: v1.8.2',
+          },
+        ],
+      });
+    });
+
+    it('extracts OCIRepository with a tag and preserves CRLF newlines in replacement template', () => {
+      const result = extractPackageFile(
+        [
+          'apiVersion: source.toolkit.fluxcd.io/v1beta2',
+          'kind: OCIRepository',
+          'metadata:',
+          '  name: kyverno-controller',
+          'spec:',
+          '  url: oci://ghcr.io/kyverno/manifests/kyverno',
+          '  ref:',
+          '    tag: v1.8.2',
+          '',
+        ].join('\r\n'),
+        'test.yaml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            autoReplaceStringTemplate:
+              'tag: {{newValue}}{{#if newDigest}}\r\n    digest: {{newDigest}}{{/if}}',
+            currentDigest: undefined,
+            currentValue: 'v1.8.2',
+            depName: 'ghcr.io/kyverno/manifests/kyverno',
+            packageName: 'ghcr.io/kyverno/manifests/kyverno',
+            datasource: DockerDatasource.id,
+            replaceString: 'tag: v1.8.2',
           },
         ],
       });
@@ -922,7 +1110,7 @@ describe('modules/manager/flux/extract', () => {
       });
     });
 
-    it('extracts OCIRepository with a tag that contains a digest', () => {
+    it('repairs OCIRepository with a tag that contains an inline digest by emitting a separate digest line', () => {
       const result = extractPackageFile(
         codeBlock`
         apiVersion: source.toolkit.fluxcd.io/v1beta2
@@ -941,7 +1129,7 @@ describe('modules/manager/flux/extract', () => {
         deps: [
           {
             autoReplaceStringTemplate:
-              '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
             currentDigest:
               'sha256:761c3189c482d0f1f0ad3735ca05c4c398cae201d2169f6645280c7b7b2ce6fc',
             currentValue: 'v1.8.2',
@@ -949,7 +1137,7 @@ describe('modules/manager/flux/extract', () => {
             packageName: 'ghcr.io/kyverno/manifests/kyverno',
             datasource: DockerDatasource.id,
             replaceString:
-              'v1.8.2@sha256:761c3189c482d0f1f0ad3735ca05c4c398cae201d2169f6645280c7b7b2ce6fc',
+              'tag: v1.8.2@sha256:761c3189c482d0f1f0ad3735ca05c4c398cae201d2169f6645280c7b7b2ce6fc',
           },
         ],
       });
@@ -1166,13 +1354,13 @@ describe('modules/manager/flux/extract', () => {
         deps: [
           {
             autoReplaceStringTemplate:
-              '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+              'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
             currentDigest: undefined,
             currentValue: 'v1.0.0',
             datasource: DockerDatasource.id,
             depName: 'ghcr.io/other/repo',
             packageName: 'ghcr.io/other/repo',
-            replaceString: 'v1.0.0',
+            replaceString: 'tag: v1.0.0',
           },
           {
             autoReplaceStringTemplate: expect.stringMatching(
@@ -1277,6 +1465,35 @@ describe('modules/manager/flux/extract', () => {
             replaceString: expect.stringMatching(
               /tag: v1\.8\.2\n\s*digest: sha256:761c3189c482d0f1f0ad3735ca05c4c398cae201d2169f6645280c7b7b2ce6fc/,
             ),
+          },
+        ],
+      });
+    });
+
+    it('skips OCIRepository with tag-only ref when tag value is a YAML alias', () => {
+      const result = extractPackageFile(
+        codeBlock`
+        x-tag: &mytag v1.8.2
+        apiVersion: source.toolkit.fluxcd.io/v1beta2
+        kind: OCIRepository
+        metadata:
+          name: kyverno-controller
+        spec:
+          url: oci://ghcr.io/kyverno/manifests/kyverno
+          ref:
+            tag: *mytag
+        `,
+        'test.yaml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            currentDigest: undefined,
+            currentValue: 'v1.8.2',
+            datasource: DockerDatasource.id,
+            depName: 'ghcr.io/kyverno/manifests/kyverno',
+            packageName: 'ghcr.io/kyverno/manifests/kyverno',
+            skipReason: 'invalid-value',
           },
         ],
       });
@@ -1454,13 +1671,13 @@ describe('modules/manager/flux/extract', () => {
           deps: [
             {
               autoReplaceStringTemplate:
-                '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+                'tag: {{newValue}}{{#if newDigest}}\n    digest: {{newDigest}}{{/if}}',
               currentDigest: undefined,
               currentValue: 'v1.8.2',
               depName: 'ghcr.io/kyverno/manifests/kyverno',
               packageName: 'ghcr.io/kyverno/manifests/kyverno',
               datasource: DockerDatasource.id,
-              replaceString: 'v1.8.2',
+              replaceString: 'tag: v1.8.2',
             },
           ],
           packageFile: 'lib/modules/manager/flux/__fixtures__/ociSource.yaml',

--- a/lib/modules/manager/flux/extract.spec.ts
+++ b/lib/modules/manager/flux/extract.spec.ts
@@ -1470,7 +1470,7 @@ describe('modules/manager/flux/extract', () => {
       });
     });
 
-    it('skips OCIRepository with tag-only ref when tag value is a YAML alias', () => {
+    it('extracts OCIRepository with tag-only ref when tag value is a YAML alias without digest pinning', () => {
       const result = extractPackageFile(
         codeBlock`
         x-tag: &mytag v1.8.2
@@ -1488,12 +1488,13 @@ describe('modules/manager/flux/extract', () => {
       expect(result).toEqual({
         deps: [
           {
+            autoReplaceStringTemplate: '{{newValue}}',
             currentDigest: undefined,
             currentValue: 'v1.8.2',
             datasource: DockerDatasource.id,
             depName: 'ghcr.io/kyverno/manifests/kyverno',
             packageName: 'ghcr.io/kyverno/manifests/kyverno',
-            skipReason: 'invalid-value',
+            replaceString: 'v1.8.2',
           },
         ],
       });

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -1,5 +1,6 @@
 import { isString } from '@sindresorhus/is';
 import {
+  type Document,
   type Scalar,
   type YAMLMap,
   isMap,
@@ -189,9 +190,12 @@ function resolveSystemManifest(
 /**
  * Returns all `spec.ref` map nodes for OCIRepository resources matching `resourceName`.
  */
-function findOCIRefNodes(content: string, resourceName: string): YAMLMap[] {
+function findOCIRefNodes(
+  docs: Document.Parsed[],
+  resourceName: string,
+): YAMLMap[] {
   const refNodes: YAMLMap[] = [];
-  for (const doc of parseAllDocuments(content, { strict: false })) {
+  for (const doc of docs) {
     const docContents = doc.contents;
     if (!isMap(docContents)) {
       continue;
@@ -221,10 +225,11 @@ function findOCIRefNodes(content: string, resourceName: string): YAMLMap[] {
 }
 
 function extractOCIRefTagAndDigestRange(
+  docs: Document.Parsed[],
   content: string,
   resourceName: string,
 ): { replaceString: string; tagFirst: boolean } | null {
-  for (const refNode of findOCIRefNodes(content, resourceName)) {
+  for (const refNode of findOCIRefNodes(docs, resourceName)) {
     let tagKey: Scalar | undefined;
     let tagValue: Scalar | undefined;
     let digestKey: Scalar | undefined;
@@ -263,10 +268,11 @@ function extractOCIRefTagAndDigestRange(
 }
 
 function extractOCIRefTagRange(
+  docs: Document.Parsed[],
   content: string,
   resourceName: string,
 ): { replaceString: string; indentation: string } | null {
-  for (const refNode of findOCIRefNodes(content, resourceName)) {
+  for (const refNode of findOCIRefNodes(docs, resourceName)) {
     for (const item of refNode.items) {
       if (
         isPair(item) &&
@@ -296,6 +302,7 @@ function resolveResourceManifest(
   registryAliases: Record<string, string> | undefined,
   content: string,
 ): PackageDependency[] {
+  let docs: Document.Parsed[] | undefined;
   const deps: PackageDependency[] = [];
   for (const resource of manifest.resources) {
     switch (resource.kind) {
@@ -417,6 +424,7 @@ function resolveResourceManifest(
           combinedDep.currentValue = resource.spec.ref.tag;
 
           const refRange = extractOCIRefTagAndDigestRange(
+            (docs ??= parseAllDocuments(content, { strict: false })),
             content,
             resource.metadata.name,
           );
@@ -454,6 +462,7 @@ function resolveResourceManifest(
             registryAliases,
           );
           const refTagRange = extractOCIRefTagRange(
+            (docs ??= parseAllDocuments(content, { strict: false })),
             content,
             resource.metadata.name,
           );

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -1,5 +1,12 @@
 import { isString } from '@sindresorhus/is';
-import { type YAMLMap, isMap, isPair, isScalar, parseAllDocuments } from 'yaml';
+import {
+  type Scalar,
+  type YAMLMap,
+  isMap,
+  isPair,
+  isScalar,
+  parseAllDocuments,
+} from 'yaml';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
@@ -218,36 +225,36 @@ function extractOCIRefTagAndDigestRange(
   resourceName: string,
 ): { replaceString: string; tagFirst: boolean } | null {
   for (const refNode of findOCIRefNodes(content, resourceName)) {
-    let tagKeyRange: [number, number, number] | null = null;
-    let tagValueEnd: number | null = null;
-    let digestKeyRange: [number, number, number] | null = null;
-    let digestValueEnd: number | null = null;
+    let tagKey: Scalar | undefined;
+    let tagValue: Scalar | undefined;
+    let digestKey: Scalar | undefined;
+    let digestValue: Scalar | undefined;
 
     for (const item of refNode.items) {
       if (!isPair(item) || !isScalar(item.key)) {
         continue;
       }
       if (item.key.value === 'tag' && isScalar(item.value)) {
-        tagKeyRange = item.key.range ?? null;
-        tagValueEnd = item.value.range?.[1] ?? null;
+        tagKey = item.key;
+        tagValue = item.value;
       } else if (item.key.value === 'digest' && isScalar(item.value)) {
-        digestKeyRange = item.key.range ?? null;
-        digestValueEnd = item.value.range?.[1] ?? null;
+        digestKey = item.key;
+        digestValue = item.value;
       }
     }
 
     if (
-      !tagKeyRange ||
-      tagValueEnd === null ||
-      !digestKeyRange ||
-      digestValueEnd === null
+      !tagKey?.range ||
+      !tagValue?.range ||
+      !digestKey?.range ||
+      !digestValue?.range
     ) {
       continue;
     }
 
-    const tagFirst = tagKeyRange[0] < digestKeyRange[0];
-    const start = tagFirst ? tagKeyRange[0] : digestKeyRange[0];
-    const end = tagFirst ? digestValueEnd : tagValueEnd;
+    const tagFirst = tagKey.range[0] < digestKey.range[0];
+    const start = tagFirst ? tagKey.range[0] : digestKey.range[0];
+    const end = tagFirst ? digestValue.range[1] : tagValue.range[1];
 
     return { replaceString: content.slice(start, end), tagFirst };
   }
@@ -265,10 +272,12 @@ function extractOCIRefTagRange(
         isPair(item) &&
         isScalar(item.key) &&
         item.key.value === 'tag' &&
-        isScalar(item.value)
+        isScalar(item.value) &&
+        item.key.range &&
+        item.value.range
       ) {
-        const keyStart = item.key.range![0];
-        const valueEnd = item.value.range![1];
+        const keyStart = item.key.range[0];
+        const valueEnd = item.value.range[1];
         const lineStart = content.lastIndexOf('\n', keyStart - 1) + 1;
         return {
           replaceString: content.slice(keyStart, valueEnd),

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -267,17 +267,8 @@ function extractOCIRefTagRange(
         item.key.value === 'tag' &&
         isScalar(item.value)
       ) {
-        const keyStart = item.key.range?.[0];
-        const valueEnd = item.value.range?.[1];
-        if (
-          keyStart === undefined ||
-          valueEnd === undefined ||
-          !isString(item.value.value) ||
-          item.value.value.trim() === ''
-        ) {
-          /* v8 ignore next: defensive guard - zod schema filters non-string tags upstream */
-          continue;
-        }
+        const keyStart = item.key.range![0];
+        const valueEnd = item.value.range![1];
         const lineStart = content.lastIndexOf('\n', keyStart - 1) + 1;
         return {
           replaceString: content.slice(keyStart, valueEnd),

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -476,9 +476,10 @@ function resolveResourceManifest(
           } else {
             logger.debug(
               { file: manifest.file, name: resource.metadata.name },
-              'Unable to locate tag node for replacement (may be YAML alias or alias reference), skipping replacement',
+              'Unable to locate tag node for replacement (may be YAML alias or alias reference), digest pinning will not be possible',
             );
-            dep.skipReason = 'invalid-value';
+            dep.replaceString = resource.spec.ref.tag;
+            dep.autoReplaceStringTemplate = '{{newValue}}';
           }
           deps.push(dep);
         } else {

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -1,5 +1,5 @@
 import { isString } from '@sindresorhus/is';
-import { isMap, isPair, isScalar, parseAllDocuments } from 'yaml';
+import { type YAMLMap, isMap, isPair, isScalar, parseAllDocuments } from 'yaml';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
@@ -179,10 +179,11 @@ function resolveSystemManifest(
   ];
 }
 
-function extractOCIRefRange(
-  content: string,
-  resourceName: string,
-): { replaceString: string; tagFirst: boolean } | null {
+/**
+ * Returns all `spec.ref` map nodes for OCIRepository resources matching `resourceName`.
+ */
+function findOCIRefNodes(content: string, resourceName: string): YAMLMap[] {
+  const refNodes: YAMLMap[] = [];
   for (const doc of parseAllDocuments(content, { strict: false })) {
     const docContents = doc.contents;
     if (!isMap(docContents)) {
@@ -204,10 +205,19 @@ function extractOCIRefRange(
       continue;
     }
     const refNode = specNode.get('ref');
-    if (!isMap(refNode)) {
-      continue;
+    if (isMap(refNode)) {
+      refNodes.push(refNode);
     }
+  }
 
+  return refNodes;
+}
+
+function extractOCIRefTagAndDigestRange(
+  content: string,
+  resourceName: string,
+): { replaceString: string; tagFirst: boolean } | null {
+  for (const refNode of findOCIRefNodes(content, resourceName)) {
     let tagKeyRange: [number, number, number] | null = null;
     let tagValueEnd: number | null = null;
     let digestKeyRange: [number, number, number] | null = null;
@@ -218,11 +228,11 @@ function extractOCIRefRange(
         continue;
       }
       if (item.key.value === 'tag' && isScalar(item.value)) {
-        tagKeyRange = item.key.range;
-        tagValueEnd = item.value.range[1];
+        tagKeyRange = item.key.range ?? null;
+        tagValueEnd = item.value.range?.[1] ?? null;
       } else if (item.key.value === 'digest' && isScalar(item.value)) {
-        digestKeyRange = item.key.range;
-        digestValueEnd = item.value.range[1];
+        digestKeyRange = item.key.range ?? null;
+        digestValueEnd = item.value.range?.[1] ?? null;
       }
     }
 
@@ -240,6 +250,41 @@ function extractOCIRefRange(
     const end = tagFirst ? digestValueEnd : tagValueEnd;
 
     return { replaceString: content.slice(start, end), tagFirst };
+  }
+
+  return null;
+}
+
+function extractOCIRefTagRange(
+  content: string,
+  resourceName: string,
+): { replaceString: string; indentation: string } | null {
+  for (const refNode of findOCIRefNodes(content, resourceName)) {
+    for (const item of refNode.items) {
+      if (
+        isPair(item) &&
+        isScalar(item.key) &&
+        item.key.value === 'tag' &&
+        isScalar(item.value)
+      ) {
+        const keyStart = item.key.range?.[0];
+        const valueEnd = item.value.range?.[1];
+        if (
+          keyStart === undefined ||
+          valueEnd === undefined ||
+          !isString(item.value.value) ||
+          item.value.value.trim() === ''
+        ) {
+          /* v8 ignore next: defensive guard - zod schema filters non-string tags upstream */
+          continue;
+        }
+        const lineStart = content.lastIndexOf('\n', keyStart - 1) + 1;
+        return {
+          replaceString: content.slice(keyStart, valueEnd),
+          indentation: content.slice(lineStart, keyStart),
+        };
+      }
+    }
   }
 
   return null;
@@ -371,7 +416,10 @@ function resolveResourceManifest(
           // Set currentValue to the tag so the docker datasource can look up the image's new digest
           combinedDep.currentValue = resource.spec.ref.tag;
 
-          const refRange = extractOCIRefRange(content, resource.metadata.name);
+          const refRange = extractOCIRefTagAndDigestRange(
+            content,
+            resource.metadata.name,
+          );
           if (refRange) {
             combinedDep.replaceString = refRange.replaceString;
             if (refRange.tagFirst) {
@@ -405,9 +453,24 @@ function resolveResourceManifest(
             false,
             registryAliases,
           );
-          dep.autoReplaceStringTemplate =
-            '{{#if newValue}}{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}';
-          dep.replaceString = resource.spec.ref.tag;
+          const refTagRange = extractOCIRefTagRange(
+            content,
+            resource.metadata.name,
+          );
+          if (refTagRange) {
+            dep.replaceString = refTagRange.replaceString;
+            const newline = content.includes('\r\n') ? '\r\n' : '\n';
+            dep.autoReplaceStringTemplate = `${refTagRange.replaceString.replace(
+              resource.spec.ref.tag,
+              '{{newValue}}',
+            )}{{#if newDigest}}${newline}${refTagRange.indentation}digest: {{newDigest}}{{/if}}`;
+          } else {
+            logger.debug(
+              { file: manifest.file, name: resource.metadata.name },
+              'Unable to locate tag node for replacement (may be YAML alias or alias reference), skipping replacement',
+            );
+            dep.skipReason = 'invalid-value';
+          }
           deps.push(dep);
         } else {
           const dep = getDep(container, false, registryAliases);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Updates the Flux manager so `OCIRepository` resources with tag-only refs get proper digest-pinning suggestions by writing `spec.ref.digest` rather than incorrectly suggesting `tag@sha256:...` style values in `spec.ref.tag`.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42082
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

I opened a discussion here before starting since I didn't see the original issue but it didn't generate any new conversation: https://github.com/renovatebot/renovate/discussions/43505

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used GitHub Copilot with opus 4.6 high reasoning to write the majority of the code in this change, but spent a decent amount of my own time steering it to iterate on the results until it reached a state I felt comfortable signing my name to and submitting for others to review. This is my first contribution to the project so AI was useful for orienting myself.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->