### PR TITLE
test(workers/repository): simplify config hash tests for onboarding

### DIFF
--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -9,6 +9,7 @@ import { REPOSITORY_CLOSED_ONBOARDING } from '../../../../constants/error-messag
 import { logger } from '../../../../logger/index.ts';
 import type { PackageFile } from '../../../../modules/manager/types.ts';
 import type { Pr } from '../../../../modules/platform/index.ts';
+import { hashBody } from '../../../../modules/platform/pr-body.ts';
 import * as memCache from '../../../../util/cache/memory/index.ts';
 import type { BranchConfig } from '../../../types.ts';
 import { OnboardingState } from '../common.ts';
@@ -20,8 +21,36 @@ describe('workers/repository/onboarding/pr/index', () => {
     let packageFiles: Record<string, PackageFile[]>;
     let branches: BranchConfig[];
 
+    // NOTE that when the test below fails, these will need to be updated
+    const ONBOARDING_PR_BODY_HASH_WITH_REBASE =
+      '3864212140a13f6ddfaf19c2c812187369a6b00e680a0ac443b4d23539317c41';
+    const ONBOARDING_PR_BODY_HASH_WITHOUT_REBASE =
+      '1280e47eeebf596351163aef6d1367d083276b37bcc97fb3b05c4b4312ef357a';
+
+    // NOTE that if you're intentionally changing the onboarding PR's contents, these hashes will change - update them above
+    describe('generates a consistent hash of the body', () => {
+      it('when the rebase checkbox is present', async () => {
+        config.onboardingRebaseCheckbox = true;
+        OnboardingState.prUpdateRequested = true;
+
+        await ensureOnboardingPr(config, packageFiles, branches);
+        const prBody = platform.createPr.mock.calls[0][0].prBody;
+
+        expect(hashBody(prBody)).toBe(ONBOARDING_PR_BODY_HASH_WITH_REBASE);
+      });
+
+      it('when the rebase checkbox is not present', async () => {
+        config.onboardingRebaseCheckbox = false;
+
+        await ensureOnboardingPr(config, packageFiles, branches);
+        const prBody = platform.createPr.mock.calls[0][0].prBody;
+
+        expect(hashBody(prBody)).toBe(ONBOARDING_PR_BODY_HASH_WITHOUT_REBASE);
+      });
+    });
+
     const bodyStruct = {
-      hash: '3864212140a13f6ddfaf19c2c812187369a6b00e680a0ac443b4d23539317c41',
+      hash: ONBOARDING_PR_BODY_HASH_WITH_REBASE,
     };
 
     beforeEach(() => {
@@ -213,8 +242,7 @@ describe('workers/repository/onboarding/pr/index', () => {
       'returns if PR does not need updating' +
         '(onboardingRebaseCheckbox="$onboardingRebaseCheckbox")',
       async ({ onboardingRebaseCheckbox }) => {
-        const hash =
-          '1280e47eeebf596351163aef6d1367d083276b37bcc97fb3b05c4b4312ef357a'; // no rebase checkbox PR hash
+        const hash = ONBOARDING_PR_BODY_HASH_WITHOUT_REBASE;
         config.onboardingRebaseCheckbox = onboardingRebaseCheckbox;
         OnboardingState.prUpdateRequested = true; // case 'false' is tested in "breaks early when onboarding"
         platform.getBranchPr.mockResolvedValue(


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As part of future changes, we'll be making further tweaks to how the
onboarding PR is generated.

However, recent changes to the onboarding PR has proved that the
generation of the hash is quite awkward to work with.

We can use Claude Sonnet's help to refactor this and introduce a test
that helps us understand what the new hashes should be if there are
changes.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
