### PR TITLE
fix(pep621): support flat `index-url` and `extra-index-url` for uv credential injection

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -339,6 +339,106 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
       ]);
     });
+
+    it('uses flat index-url as default registry', () => {
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://custom.example.com/pypi/simple"
+      `)!;
+
+      const dependencies = [
+        { depName: 'dep1', packageName: 'dep1' },
+        { depName: 'dep2', packageName: 'dep2' },
+      ];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          depName: 'dep1',
+          registryUrls: ['https://custom.example.com/pypi/simple'],
+          packageName: 'dep1',
+        },
+        {
+          depName: 'dep2',
+          registryUrls: ['https://custom.example.com/pypi/simple'],
+          packageName: 'dep2',
+        },
+      ]);
+    });
+
+    it('uses flat extra-index-url as implicit indexes', () => {
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        extra-index-url = [
+          "https://private.example.com/pypi/simple",
+        ]
+      `)!;
+
+      const dependencies = [{ depName: 'dep1', packageName: 'dep1' }];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          depName: 'dep1',
+          registryUrls: [
+            'https://private.example.com/pypi/simple',
+            'https://pypi.org/pypi/',
+          ],
+          packageName: 'dep1',
+        },
+      ]);
+    });
+
+    it('uses flat index-url and extra-index-url together', () => {
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://cdproxy.example.com/pypi/simple"
+        extra-index-url = [
+          "https://private.example.com/pypi/simple",
+        ]
+      `)!;
+
+      const dependencies = [{ depName: 'dep1', packageName: 'dep1' }];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          depName: 'dep1',
+          registryUrls: [
+            'https://private.example.com/pypi/simple',
+            'https://cdproxy.example.com/pypi/simple',
+          ],
+          packageName: 'dep1',
+        },
+      ]);
+    });
+
+    it('flat index-url is ignored when [[tool.uv.index]] has a default', () => {
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://flat-default.example.com/pypi/simple"
+
+        [[tool.uv.index]]
+        name = "structured"
+        url = "https://structured.example.com/pypi/simple"
+        default = true
+      `)!;
+
+      const dependencies = [{ depName: 'dep1', packageName: 'dep1' }];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          depName: 'dep1',
+          registryUrls: ['https://structured.example.com/pypi/simple'],
+          packageName: 'dep1',
+        },
+      ]);
+    });
   });
 
   describe('extractLockedVersions()', () => {
@@ -887,6 +987,506 @@ describe('modules/manager/pep621/processors/uv', () => {
           cmd: 'uv lock --upgrade',
           options: {
             cwd: '/tmp/github/some/repo/folder',
+          },
+        },
+      ]);
+    });
+
+    it('injects credentials for flat extra-index-url', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.add({
+        matchHost: 'https://private.example.com',
+        hostType: 'pypi',
+        username: 'user',
+        password: 'pass',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+          datasource: PypiDatasource.id,
+          registryUrls: [
+            'https://private.example.com/pypi/simple',
+            'https://pypi.org/pypi/',
+          ],
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        extra-index-url = [
+          "https://private.example.com/pypi/simple",
+        ]
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: {
+              UV_EXTRA_INDEX_URL:
+                'https://user:pass@private.example.com/pypi/simple',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('injects credentials for flat extra-index-url on lockFileMaintenance', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.add({
+        matchHost: 'https://private.example.com',
+        hostType: 'pypi',
+        username: 'user',
+        password: 'pass',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        extra-index-url = [
+          "https://private.example.com/pypi/simple",
+        ]
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: { isLockFileMaintenance: true },
+          updatedDeps: [],
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade',
+          options: {
+            env: {
+              UV_EXTRA_INDEX_URL:
+                'https://user:pass@private.example.com/pypi/simple',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('injects credentials for flat index-url as UV_INDEX_URL', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.add({
+        matchHost: 'https://cdproxy.example.com',
+        hostType: 'pypi',
+        username: 'user',
+        password: 'pass',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+          datasource: PypiDatasource.id,
+          registryUrls: ['https://cdproxy.example.com/pypi/simple'],
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://cdproxy.example.com/pypi/simple"
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: {
+              UV_INDEX_URL: 'https://user:pass@cdproxy.example.com/pypi/simple',
+              UV_EXTRA_INDEX_URL: '',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('does not set UV_INDEX_URL when [[tool.uv.index]] overrides the default', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.add({
+        matchHost: 'https://structured.example.com',
+        hostType: 'pypi',
+        username: 'user',
+        password: 'pass',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+          datasource: PypiDatasource.id,
+          registryUrls: ['https://structured.example.com/pypi/simple'],
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://flat.example.com/pypi/simple"
+
+        [[tool.uv.index]]
+        name = "structured"
+        url = "https://structured.example.com/pypi/simple"
+        default = true
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: expect.not.objectContaining({
+              UV_INDEX_URL: expect.anything(),
+            }),
+          },
+        },
+      ]);
+    });
+
+    it('injects only username into UV_INDEX_URL when password is absent', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.clear();
+      hostRules.add({
+        matchHost: 'https://username-only.example.com',
+        hostType: 'pypi',
+        username: 'user',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://username-only.example.com/pypi/simple"
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: {
+              UV_INDEX_URL:
+                'https://user@username-only.example.com/pypi/simple',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('injects only password into UV_INDEX_URL when username is absent', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.clear();
+      hostRules.add({
+        matchHost: 'https://password-only.example.com',
+        hostType: 'pypi',
+        password: 'pass',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://password-only.example.com/pypi/simple"
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: {
+              UV_INDEX_URL:
+                'https://:pass@password-only.example.com/pypi/simple',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('does not add flat extra-index-url to UV_EXTRA_INDEX_URL when already in [[tool.uv.index]]', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      hostRules.clear();
+      hostRules.add({
+        matchHost: 'https://dedup.example.com',
+        hostType: 'pypi',
+        username: 'user',
+        password: 'pass',
+      });
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        extra-index-url = ["https://dedup.example.com/pypi/simple"]
+
+        [[tool.uv.index]]
+        name = "dedup"
+        url = "https://dedup.example.com/pypi/simple"
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      // The URL is already covered by [[tool.uv.index]], so the flat extra-index-url
+      // entry is deduplicated and UV_EXTRA_INDEX_URL is empty.
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: {
+              UV_EXTRA_INDEX_URL: '',
+              UV_INDEX_DEDUP_USERNAME: 'user',
+              UV_INDEX_DEDUP_PASSWORD: 'pass',
+            },
+          },
+        },
+      ]);
+    });
+
+    it('does not set UV_INDEX_URL when index-url has no matching credentials', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('uv.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }],
+      });
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '0.2.35' }],
+      });
+
+      const updatedDeps = [
+        {
+          packageName: 'dep1',
+          depType: depTypes.dependencies,
+        },
+      ];
+      const pyproject = parsePyProject(codeBlock`
+        [tool.uv]
+        index-url = "https://no-creds.example.com/simple"
+      `)!;
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'pyproject.toml',
+          newPackageFileContent: '',
+          config: {},
+          updatedDeps,
+        },
+        pyproject,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'uv.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'uv lock --upgrade-package dep1',
+          options: {
+            env: expect.not.objectContaining({
+              UV_INDEX_URL: expect.anything(),
+            }),
           },
         },
       ]);

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -47,9 +47,23 @@ export class UvProcessor extends BasePyProjectProcessor {
     const defaultIndex = uv.index?.find(
       (index) => index.default && !index.explicit,
     );
-    const implicitIndexUrls = uv.index
-      ?.filter((index) => !index.explicit && index.name !== defaultIndex?.name)
-      ?.map(({ url }) => url);
+
+    // flat 'index-url' is equivalent to a non-explicit default [[tool.uv.index]] entry
+    const flatDefaultUrl =
+      !defaultIndex && !hasExplicitDefault ? uv['index-url'] : undefined;
+
+    const indexImplicitUrls =
+      uv.index
+        ?.filter(
+          (index) => !index.explicit && index.name !== defaultIndex?.name,
+        )
+        ?.map(({ url }) => url) ?? [];
+
+    // flat 'extra-index-url' entries are equivalent to non-explicit, non-default [[tool.uv.index]] entries
+    const implicitIndexUrls = [
+      ...indexImplicitUrls,
+      ...(uv['extra-index-url'] ?? []),
+    ];
 
     const devDependencies = uv['dev-dependencies'];
     if (devDependencies) {
@@ -58,7 +72,12 @@ export class UvProcessor extends BasePyProjectProcessor {
 
     // https://docs.astral.sh/uv/concepts/dependencies/#dependency-sources
     // Skip sources that do not make sense to handle (e.g. path).
-    if (uv.sources || defaultIndex || implicitIndexUrls) {
+    if (
+      uv.sources ||
+      defaultIndex ||
+      flatDefaultUrl ||
+      implicitIndexUrls.length > 0
+    ) {
       for (const dep of deps) {
         /* v8 ignore next 3 -- needs test */
         if (!dep.packageName) {
@@ -109,9 +128,12 @@ export class UvProcessor extends BasePyProjectProcessor {
           } else if (defaultIndex) {
             // There is a default index configured, so use it.
             dep.registryUrls = [defaultIndex.url];
+          } else if (flatDefaultUrl) {
+            // flat index-url acts as the default
+            dep.registryUrls = [flatDefaultUrl];
           }
 
-          if (implicitIndexUrls?.length) {
+          if (implicitIndexUrls.length > 0) {
             // If there are implicit indexes, check them first and fall back
             // to the default.
             dep.registryUrls = implicitIndexUrls.concat(
@@ -199,6 +221,7 @@ export class UvProcessor extends BasePyProjectProcessor {
         ...getGitEnvironmentVariables(['pep621']),
         ...(await getUvExtraIndexUrl(project, updateArtifact.updatedDeps)),
         ...(await getUvIndexCredentials(project)),
+        ...(await getUvIndexUrl(project)),
       };
       const execOptions: ExecOptions = {
         cwdFile: packageFileName,
@@ -319,13 +342,28 @@ async function getUvExtraIndexUrl(
       // Check if the registry URL is not the default one and not already configured
       const configuredIndexUrls =
         project.tool?.uv?.index?.map(({ url }) => url) ?? [];
+      const flatDefaultUrl = project.tool?.uv?.['index-url'];
       return (
         registryUrl !== PypiDatasource.defaultURL &&
-        !configuredIndexUrls.includes(registryUrl)
+        !configuredIndexUrls.includes(registryUrl) &&
+        registryUrl !== flatDefaultUrl
       );
     });
 
   const registryUrls = new Set(pyPiRegistryUrls);
+
+  // Also include URLs from flat 'extra-index-url' directly.
+  // This covers lockFileMaintenance (empty updatedDeps) and cases where
+  // extra-index-url is not yet reflected in dep.registryUrls.
+  const configuredIndexUrls = new Set(
+    project.tool?.uv?.index?.map(({ url }) => url) ?? [],
+  );
+  for (const url of project.tool?.uv?.['extra-index-url'] ?? []) {
+    if (!configuredIndexUrls.has(url)) {
+      registryUrls.add(url);
+    }
+  }
+
   const extraIndexUrls: string[] = [];
 
   for (const registryUrl of registryUrls) {
@@ -350,6 +388,37 @@ async function getUvExtraIndexUrl(
   return {
     UV_EXTRA_INDEX_URL: extraIndexUrls.join(' '),
   };
+}
+
+async function getUvIndexUrl(project: PyProject): Promise<NodeJS.ProcessEnv> {
+  const indexUrl = project.tool?.uv?.['index-url'];
+  // Only handle flat index-url if no [[tool.uv.index]] entry overrides the default
+  const hasIndexDefault = project.tool?.uv?.index?.some(
+    (index) => index.default,
+  );
+  if (!indexUrl || hasIndexDefault) {
+    return {};
+  }
+
+  const parsedUrl = parseUrl(indexUrl);
+  /* v8 ignore if -- needs test */
+  if (!parsedUrl) {
+    return {};
+  }
+
+  const { username, password } = await getUsernamePassword(parsedUrl);
+  if (!username && !password) {
+    return {};
+  }
+
+  if (username) {
+    parsedUrl.username = username;
+  }
+  if (password) {
+    parsedUrl.password = password;
+  }
+
+  return { UV_INDEX_URL: parsedUrl.toString() };
 }
 
 async function getUvIndexCredentials(

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -168,6 +168,10 @@ const UvConfig = z.object({
       }),
     )
     .optional(),
+  // https://docs.astral.sh/uv/reference/settings/#index-url
+  'index-url': z.string().optional(),
+  // https://docs.astral.sh/uv/reference/settings/#extra-index-url
+  'extra-index-url': z.array(z.string()).optional(),
 });
 
 export const ProjectSection = z.object({


### PR DESCRIPTION
## Changes

The `UvConfig` Zod schema was silently dropping `index-url` and `extra-index-url` from `[tool.uv]`, meaning:

- `dep.registryUrls` was never populated with those URLs, so datasource version lookups hit the wrong registry
- `getUvExtraIndexUrl()` had nothing to inject credentials into
- `uv lock` ran unauthenticated against private registries

This PR:
- Adds `index-url` and `extra-index-url` to the `UvConfig` schema
- Populates `dep.registryUrls` from them in `process()`, mirroring the `[[tool.uv.index]]` behaviour
- Injects `UV_EXTRA_INDEX_URL` with embedded credentials from `extra-index-url` entries, including for `lockFileMaintenance` runs with empty `updatedDeps`
- Injects `UV_INDEX_URL` with embedded credentials from `index-url`, unless overridden by a `[[tool.uv.index]]` default entry

## Context

- [x] This doesn't close an existing Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). Code and tests were generated with GitHub Copilot (Claude Sonnet 4.6) and reviewed by the PR author.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests