### PR TITLE
refactor(gerrit): use schema validated `getJson` instead of `getJsonUnchecked` 

### DIFF
--- a/lib/modules/platform/gerrit/client.spec.ts
+++ b/lib/modules/platform/gerrit/client.spec.ts
@@ -7,9 +7,9 @@ import { client } from './client.ts';
 import type {
   GerritChange,
   GerritChangeMessageInfo,
-  GerritFindPRConfig,
   GerritMergeableInfo,
-} from './types.ts';
+} from './schema.ts';
+import type { GerritFindPRConfig } from './types.ts';
 import { MIN_GERRIT_VERSION } from './utils.ts';
 
 const gerritEndpointUrl = 'https://dev.gerrit.com/renovate/';
@@ -178,12 +178,15 @@ describe('modules/platform/gerrit/client', () => {
           .query((query) => query?.q?.includes(expectedQueryPart) ?? false)
           .reply(
             200,
-            gerritRestResponse([{ _number: 1 }, { _number: 2 }]),
+            gerritRestResponse([
+              gerritChange({ _number: 1 }),
+              gerritChange({ _number: 2 }),
+            ]),
             jsonResultHeader,
           );
         await expect(client.findChanges('repo', config)).resolves.toEqual([
-          { _number: 1 },
-          { _number: 2 },
+          gerritChange({ _number: 1 }),
+          gerritChange({ _number: 2 }),
         ]);
       },
     );
@@ -193,14 +196,18 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .get('/a/changes/')
         .query((query) => query.n === '1')
-        .reply(200, gerritRestResponse([{ _number: 1 }]), jsonResultHeader);
+        .reply(
+          200,
+          gerritRestResponse([gerritChange({ _number: 1 })]),
+          jsonResultHeader,
+        );
       await expect(
         client.findChanges('repo', {
           branchName: 'dependency-xyz',
           singleChange: true,
           pageLimit: 5, // should be ignored
         }),
-      ).resolves.toEqual([{ _number: 1 }]);
+      ).resolves.toEqual([gerritChange({ _number: 1 })]);
     });
 
     it('sets query.n as 50 if pageLimit is not provided', async () => {
@@ -208,12 +215,16 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .get('/a/changes/')
         .query((query) => query.n === '50')
-        .reply(200, gerritRestResponse([{ _number: 1 }]), jsonResultHeader);
+        .reply(
+          200,
+          gerritRestResponse([gerritChange({ _number: 1 })]),
+          jsonResultHeader,
+        );
       await expect(
         client.findChanges('repo', {
           branchName: 'dependency-xyz',
         }),
-      ).resolves.toEqual([{ _number: 1 }]);
+      ).resolves.toEqual([gerritChange({ _number: 1 })]);
     });
 
     it('sets query.n with pageLimit if provided', async () => {
@@ -221,13 +232,17 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .get('/a/changes/')
         .query((query) => query.n === '5')
-        .reply(200, gerritRestResponse([{ _number: 1 }]), jsonResultHeader);
+        .reply(
+          200,
+          gerritRestResponse([gerritChange({ _number: 1 })]),
+          jsonResultHeader,
+        );
       await expect(
         client.findChanges('repo', {
           branchName: 'dependency-xyz',
           pageLimit: 5,
         }),
-      ).resolves.toEqual([{ _number: 1 }]);
+      ).resolves.toEqual([gerritChange({ _number: 1 })]);
     });
 
     it('sets query.S with startOffset if provided', async () => {
@@ -235,13 +250,17 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .get('/a/changes/')
         .query((query) => query.S === '5')
-        .reply(200, gerritRestResponse([{ _number: 1 }]), jsonResultHeader);
+        .reply(
+          200,
+          gerritRestResponse([gerritChange({ _number: 1 })]),
+          jsonResultHeader,
+        );
       await expect(
         client.findChanges('repo', {
           branchName: 'dependency-xyz',
           startOffset: 5,
         }),
-      ).resolves.toEqual([{ _number: 1 }]);
+      ).resolves.toEqual([gerritChange({ _number: 1 })]);
     });
 
     it('sets query.S as 0 if startOffset is not provided', async () => {
@@ -249,12 +268,16 @@ describe('modules/platform/gerrit/client', () => {
         .scope(gerritEndpointUrl)
         .get('/a/changes/')
         .query((query) => query.S === '0')
-        .reply(200, gerritRestResponse([{ _number: 1 }]), jsonResultHeader);
+        .reply(
+          200,
+          gerritRestResponse([gerritChange({ _number: 1 })]),
+          jsonResultHeader,
+        );
       await expect(
         client.findChanges('repo', {
           branchName: 'dependency-xyz',
         }),
-      ).resolves.toEqual([{ _number: 1 }]);
+      ).resolves.toEqual([gerritChange({ _number: 1 })]);
     });
 
     it('handles pagination automatically', async () => {
@@ -265,8 +288,8 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            { _number: 1 },
-            { _number: 2, _more_changes: true },
+            gerritChange({ _number: 1 }),
+            gerritChange({ _number: 2, _more_changes: true }),
           ]),
           jsonResultHeader,
         )
@@ -275,8 +298,8 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            { _number: 3 },
-            { _number: 4, _more_changes: true },
+            gerritChange({ _number: 3 }),
+            gerritChange({ _number: 4, _more_changes: true }),
           ]),
           jsonResultHeader,
         )
@@ -284,7 +307,10 @@ describe('modules/platform/gerrit/client', () => {
         .query((query) => query.n === '2' && query.S === '4')
         .reply(
           200,
-          gerritRestResponse([{ _number: 5 }, { _number: 6 }]),
+          gerritRestResponse([
+            gerritChange({ _number: 5 }),
+            gerritChange({ _number: 6 }),
+          ]),
           jsonResultHeader,
         );
       await expect(
@@ -293,12 +319,12 @@ describe('modules/platform/gerrit/client', () => {
           pageLimit: 2, // to keep the test short
         }),
       ).resolves.toEqual([
-        { _number: 1 },
-        { _number: 2 },
-        { _number: 3 },
-        { _number: 4 },
-        { _number: 5 },
-        { _number: 6 },
+        gerritChange({ _number: 1 }),
+        gerritChange({ _number: 2 }),
+        gerritChange({ _number: 3 }),
+        gerritChange({ _number: 4 }),
+        gerritChange({ _number: 5 }),
+        gerritChange({ _number: 6 }),
       ]);
     });
 
@@ -310,8 +336,8 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            { _number: 3 },
-            { _number: 4, _more_changes: true },
+            gerritChange({ _number: 3 }),
+            gerritChange({ _number: 4, _more_changes: true }),
           ]),
           jsonResultHeader,
         )
@@ -319,7 +345,10 @@ describe('modules/platform/gerrit/client', () => {
         .query((query) => query.n === '2' && query.S === '4')
         .reply(
           200,
-          gerritRestResponse([{ _number: 5 }, { _number: 6 }]),
+          gerritRestResponse([
+            gerritChange({ _number: 5 }),
+            gerritChange({ _number: 6 }),
+          ]),
           jsonResultHeader,
         );
       await expect(
@@ -329,10 +358,10 @@ describe('modules/platform/gerrit/client', () => {
           startOffset: 2,
         }),
       ).resolves.toEqual([
-        { _number: 3 },
-        { _number: 4 },
-        { _number: 5 },
-        { _number: 6 },
+        gerritChange({ _number: 3 }),
+        gerritChange({ _number: 4 }),
+        gerritChange({ _number: 5 }),
+        gerritChange({ _number: 6 }),
       ]);
     });
 
@@ -344,8 +373,8 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            { _number: 1 },
-            { _number: 2, _more_changes: true },
+            gerritChange({ _number: 1 }),
+            gerritChange({ _number: 2, _more_changes: true }),
           ]),
           jsonResultHeader,
         );
@@ -355,7 +384,10 @@ describe('modules/platform/gerrit/client', () => {
           noPagination: true,
           pageLimit: 2,
         }),
-      ).resolves.toEqual([{ _number: 1 }, { _number: 2 }]);
+      ).resolves.toEqual([
+        gerritChange({ _number: 1 }),
+        gerritChange({ _number: 2 }),
+      ]);
     });
 
     it('sets query.o when requestDetails is provided', async () => {
@@ -367,19 +399,23 @@ describe('modules/platform/gerrit/client', () => {
             Array.isArray(query.o) &&
             query.o.toString() === ['LABELS', 'MESSAGES'].toString(),
         )
-        .reply(200, gerritRestResponse([{ _number: 3 }]), jsonResultHeader);
+        .reply(
+          200,
+          gerritRestResponse([gerritChange({ _number: 3 })]),
+          jsonResultHeader,
+        );
       await expect(
         client.findChanges('repo', {
           branchName: 'dependency-xyz',
           requestDetails: ['LABELS', 'MESSAGES'],
         }),
-      ).resolves.toEqual([{ _number: 3 }]);
+      ).resolves.toEqual([gerritChange({ _number: 3 })]);
     });
   });
 
   describe('getChange()', () => {
     it('get', async () => {
-      const change = partial<GerritChange>({});
+      const change = gerritChange({ _number: 123456 });
       httpMock
         .scope(gerritEndpointUrl)
         .get('/a/changes/123456?o=CURRENT_REVISION&o=COMMIT_FOOTERS')
@@ -472,7 +508,7 @@ describe('modules/platform/gerrit/client', () => {
     });
 
     it('returns single change when only one found', async () => {
-      const change = partial<GerritChange>({
+      const change = gerritChange({
         _number: 123,
         branch: 'main',
       });
@@ -490,11 +526,11 @@ describe('modules/platform/gerrit/client', () => {
     });
 
     it('returns first change when multiple found without targetBranch', async () => {
-      const change1 = partial<GerritChange>({
+      const change1 = gerritChange({
         _number: 111,
         branch: 'main',
       });
-      const change2 = partial<GerritChange>({
+      const change2 = gerritChange({
         _number: 222,
         branch: 'develop',
       });
@@ -512,11 +548,11 @@ describe('modules/platform/gerrit/client', () => {
     });
 
     it('returns matching change when targetBranch specified and match found', async () => {
-      const change1 = partial<GerritChange>({
+      const change1 = gerritChange({
         _number: 111,
         branch: 'main',
       });
-      const change2 = partial<GerritChange>({
+      const change2 = gerritChange({
         _number: 222,
         branch: 'develop',
       });
@@ -535,11 +571,11 @@ describe('modules/platform/gerrit/client', () => {
     });
 
     it('returns first change when targetBranch specified but no match found', async () => {
-      const change1 = partial<GerritChange>({
+      const change1 = gerritChange({
         _number: 111,
         branch: 'main',
       });
-      const change2 = partial<GerritChange>({
+      const change2 = gerritChange({
         _number: 222,
         branch: 'develop',
       });
@@ -574,14 +610,14 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            partial<GerritChangeMessageInfo>({ message: 'msg1' }),
-            partial<GerritChangeMessageInfo>({ message: 'msg2' }),
+            partial<GerritChangeMessageInfo>({ id: '1', message: 'msg1' }),
+            partial<GerritChangeMessageInfo>({ id: '2', message: 'msg2' }),
           ]),
           jsonResultHeader,
         );
       await expect(client.getMessages(123456)).resolves.toEqual([
-        { message: 'msg1' },
-        { message: 'msg2' },
+        { id: '1', message: 'msg1' },
+        { id: '2', message: 'msg2' },
       ]);
     });
   });
@@ -647,8 +683,11 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            partial<GerritChangeMessageInfo>({ message: 'msg1' }),
-            partial<GerritChangeMessageInfo>({ message: 'the message' }),
+            partial<GerritChangeMessageInfo>({ id: '1', message: 'msg1' }),
+            partial<GerritChangeMessageInfo>({
+              id: '2',
+              message: 'the message',
+            }),
           ]),
           jsonResultHeader,
         );
@@ -689,7 +728,11 @@ describe('modules/platform/gerrit/client', () => {
         .reply(
           200,
           gerritRestResponse([
-            partial<GerritChangeMessageInfo>({ message: 'msg1', tag: 'TAG' }),
+            partial<GerritChangeMessageInfo>({
+              id: '1',
+              message: 'msg1',
+              tag: 'TAG',
+            }),
           ]),
           jsonResultHeader,
         );
@@ -805,6 +848,19 @@ describe('modules/platform/gerrit/client', () => {
     });
   });
 });
+
+function gerritChange(overrides: Partial<GerritChange> = {}): GerritChange {
+  return {
+    branch: 'main',
+    change_id: 'I0123456789abcdef',
+    subject: 'subject',
+    status: 'NEW',
+    created: '2024-01-01 00:00:00.000000000',
+    hashtags: [],
+    _number: 0,
+    ...overrides,
+  };
+}
 
 function gerritRestResponse(body: any): any {
   return `)]}'\n${JSON.stringify(body)}`;

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -6,6 +6,15 @@ import { logger } from '../../../logger/index.ts';
 import { GerritHttp } from '../../../util/http/gerrit.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
 import { getQueryString } from '../../../util/url.ts';
+import {
+  GerritBranchInfoSchema,
+  GerritChangeMessagesSchema,
+  GerritChangeSchema,
+  GerritChangesSchema,
+  GerritMergeableInfoSchema,
+  GerritProjectInfoSchema,
+  GerritReposSchema,
+} from './schema.ts';
 import type {
   GerritAccountInfo,
   GerritBranchInfo,
@@ -44,17 +53,18 @@ class GerritClient {
   }
 
   async getRepos(): Promise<string[]> {
-    const res = await this.gerritHttp.getJsonUnchecked<string[]>(
+    const res = await this.gerritHttp.getJson(
       'a/projects/?type=CODE&state=ACTIVE',
+      GerritReposSchema,
     );
     return Object.keys(res.body);
   }
 
   async getProjectInfo(repository: string): Promise<GerritProjectInfo> {
-    const projectInfo =
-      await this.gerritHttp.getJsonUnchecked<GerritProjectInfo>(
-        `a/projects/${encodeURIComponent(repository)}`,
-      );
+    const projectInfo = await this.gerritHttp.getJson(
+      `a/projects/${encodeURIComponent(repository)}`,
+      GerritProjectInfoSchema,
+    );
     if (projectInfo.body.state !== 'ACTIVE') {
       throw new Error(REPOSITORY_ARCHIVED);
     }
@@ -62,8 +72,9 @@ class GerritClient {
   }
 
   async getBranchInfo(repository: string): Promise<GerritBranchInfo> {
-    const branchInfo = await this.gerritHttp.getJsonUnchecked<GerritBranchInfo>(
+    const branchInfo = await this.gerritHttp.getJson(
       `a/projects/${encodeURIComponent(repository)}/branches/HEAD`,
+      GerritBranchInfoSchema,
     );
     return branchInfo.body;
   }
@@ -125,22 +136,23 @@ class GerritClient {
     while (true) {
       query.S = allChanges.length + startOffset;
       const queryString = `q=${filters.join('+')}&${getQueryString(query)}`;
-      const changes = await this.gerritHttp.getJsonUnchecked<GerritChange[]>(
+      const changes = await this.gerritHttp.getJson(
         `a/changes/?${queryString}`,
+        GerritChangesSchema,
       );
 
       logger.trace(
         `findChanges(${queryString},start=${query.S},limit=${query.n}) => ${changes.body.length}`,
       );
 
-      const lastChange = changes.body.at(-1);
+      const lastChange = changes.body.at(-1) as GerritChange | undefined;
       let hasMoreChanges = false;
       if (lastChange?._more_changes) {
         hasMoreChanges = true;
         delete lastChange._more_changes;
       }
 
-      allChanges.push(...changes.body);
+      allChanges.push(...(changes.body as GerritChange[]));
 
       if (
         findPRConfig.singleChange ||
@@ -159,17 +171,18 @@ class GerritClient {
     requestDetails?: GerritRequestDetail[],
   ): Promise<GerritChange> {
     const queryString = getQueryString({ o: requestDetails });
-    const changes = await this.gerritHttp.getJsonUnchecked<GerritChange>(
+    const changes = await this.gerritHttp.getJson(
       `a/changes/${changeNumber}?${queryString}`,
+      GerritChangeSchema,
     );
-    return changes.body;
+    return changes.body as GerritChange;
   }
 
   async getMergeableInfo(change: GerritChange): Promise<GerritMergeableInfo> {
-    const mergeable =
-      await this.gerritHttp.getJsonUnchecked<GerritMergeableInfo>(
-        `a/changes/${change._number}/revisions/current/mergeable`,
-      );
+    const mergeable = await this.gerritHttp.getJson(
+      `a/changes/${change._number}/revisions/current/mergeable`,
+      GerritMergeableInfoSchema,
+    );
     return mergeable.body;
   }
 
@@ -190,10 +203,11 @@ class GerritClient {
   }
 
   async getMessages(changeNumber: number): Promise<GerritChangeMessageInfo[]> {
-    const messages = await this.gerritHttp.getJsonUnchecked<
-      GerritChangeMessageInfo[]
-    >(`a/changes/${changeNumber}/messages`);
-    return messages.body;
+    const messages = await this.gerritHttp.getJson(
+      `a/changes/${changeNumber}/messages`,
+      GerritChangeMessagesSchema,
+    );
+    return messages.body as GerritChangeMessageInfo[];
   }
 
   async addMessage(

--- a/lib/modules/platform/gerrit/client.ts
+++ b/lib/modules/platform/gerrit/client.ts
@@ -6,24 +6,19 @@ import { logger } from '../../../logger/index.ts';
 import { GerritHttp } from '../../../util/http/gerrit.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
 import { getQueryString } from '../../../util/url.ts';
+import type { GerritAccountInfo, GerritChangeMessageInfo } from './schema.ts';
 import {
-  GerritBranchInfoSchema,
-  GerritChangeMessagesSchema,
-  GerritChangeSchema,
-  GerritChangesSchema,
-  GerritMergeableInfoSchema,
-  GerritProjectInfoSchema,
-  GerritReposSchema,
-} from './schema.ts';
-import type {
-  GerritAccountInfo,
   GerritBranchInfo,
   GerritChange,
-  GerritChangeMessageInfo,
-  GerritFindPRConfig,
-  GerritHashtagsInput,
+  GerritChangeMessages,
+  GerritChanges,
   GerritMergeableInfo,
   GerritProjectInfo,
+  GerritRepos,
+} from './schema.ts';
+import type {
+  GerritFindPRConfig,
+  GerritHashtagsInput,
   GerritRequestDetail,
 } from './types.ts';
 import {
@@ -55,7 +50,7 @@ class GerritClient {
   async getRepos(): Promise<string[]> {
     const res = await this.gerritHttp.getJson(
       'a/projects/?type=CODE&state=ACTIVE',
-      GerritReposSchema,
+      GerritRepos,
     );
     return Object.keys(res.body);
   }
@@ -63,7 +58,7 @@ class GerritClient {
   async getProjectInfo(repository: string): Promise<GerritProjectInfo> {
     const projectInfo = await this.gerritHttp.getJson(
       `a/projects/${encodeURIComponent(repository)}`,
-      GerritProjectInfoSchema,
+      GerritProjectInfo,
     );
     if (projectInfo.body.state !== 'ACTIVE') {
       throw new Error(REPOSITORY_ARCHIVED);
@@ -74,7 +69,7 @@ class GerritClient {
   async getBranchInfo(repository: string): Promise<GerritBranchInfo> {
     const branchInfo = await this.gerritHttp.getJson(
       `a/projects/${encodeURIComponent(repository)}/branches/HEAD`,
-      GerritBranchInfoSchema,
+      GerritBranchInfo,
     );
     return branchInfo.body;
   }
@@ -138,21 +133,21 @@ class GerritClient {
       const queryString = `q=${filters.join('+')}&${getQueryString(query)}`;
       const changes = await this.gerritHttp.getJson(
         `a/changes/?${queryString}`,
-        GerritChangesSchema,
+        GerritChanges,
       );
 
       logger.trace(
         `findChanges(${queryString},start=${query.S},limit=${query.n}) => ${changes.body.length}`,
       );
 
-      const lastChange = changes.body.at(-1) as GerritChange | undefined;
+      const lastChange = changes.body.at(-1);
       let hasMoreChanges = false;
       if (lastChange?._more_changes) {
         hasMoreChanges = true;
         delete lastChange._more_changes;
       }
 
-      allChanges.push(...(changes.body as GerritChange[]));
+      allChanges.push(...changes.body);
 
       if (
         findPRConfig.singleChange ||
@@ -173,15 +168,15 @@ class GerritClient {
     const queryString = getQueryString({ o: requestDetails });
     const changes = await this.gerritHttp.getJson(
       `a/changes/${changeNumber}?${queryString}`,
-      GerritChangeSchema,
+      GerritChange,
     );
-    return changes.body as GerritChange;
+    return changes.body;
   }
 
   async getMergeableInfo(change: GerritChange): Promise<GerritMergeableInfo> {
     const mergeable = await this.gerritHttp.getJson(
       `a/changes/${change._number}/revisions/current/mergeable`,
-      GerritMergeableInfoSchema,
+      GerritMergeableInfo,
     );
     return mergeable.body;
   }
@@ -205,9 +200,9 @@ class GerritClient {
   async getMessages(changeNumber: number): Promise<GerritChangeMessageInfo[]> {
     const messages = await this.gerritHttp.getJson(
       `a/changes/${changeNumber}/messages`,
-      GerritChangeMessagesSchema,
+      GerritChangeMessages,
     );
-    return messages.body as GerritChangeMessageInfo[];
+    return messages.body;
   }
 
   async addMessage(

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -13,7 +13,7 @@ import type {
   GerritLabelTypeInfo,
   GerritProjectInfo,
   GerritRevisionInfo,
-} from './types.ts';
+} from './schema.ts';
 import {
   REQUEST_DETAILS_FOR_PRS,
   TAG_PULL_REQUEST_BODY,

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -31,8 +31,8 @@ import { repoFingerprint } from '../util.ts';
 import { smartTruncate } from '../utils/pr-body.ts';
 import { readOnlyIssueBody } from '../utils/read-only-issue-body.ts';
 import { client } from './client.ts';
+import type { GerritLabelTypeInfo, GerritProjectInfo } from './schema.ts';
 import { configureScm, pushForReview } from './scm.ts';
-import type { GerritLabelTypeInfo, GerritProjectInfo } from './types.ts';
 import {
   MAX_GERRIT_COMMENT_SIZE,
   REQUEST_DETAILS_FOR_PRS,

--- a/lib/modules/platform/gerrit/schema.ts
+++ b/lib/modules/platform/gerrit/schema.ts
@@ -1,0 +1,94 @@
+import { z } from 'zod/v4';
+import { LooseArray } from '../../../util/schema-utils/index.ts';
+
+export const GerritAccountInfoSchema = z.object({
+  _account_id: z.number(),
+  username: z.string().optional(),
+});
+
+export const GerritLabelInfoSchema = z.object({
+  approved: GerritAccountInfoSchema.optional(),
+  rejected: GerritAccountInfoSchema.optional(),
+  blocking: z.boolean().optional(),
+});
+
+export const GerritActionInfoSchema = z.object({
+  method: z.string().optional(),
+  enabled: z.boolean().optional(),
+});
+
+export const GerritRevisionInfoSchema = z.object({
+  uploader: GerritAccountInfoSchema.optional(),
+  ref: z.string().optional(),
+  created: z.string().optional(),
+  actions: z.record(z.string(), GerritActionInfoSchema).optional(),
+  commit_with_footers: z.string().optional(),
+});
+
+export const GerritChangeMessageInfoSchema = z.object({
+  id: z.string().optional(),
+  message: z.string(),
+  tag: z.string().optional(),
+});
+
+export const GerritChangeSchema = z.object({
+  branch: z.string().optional(),
+  change_id: z.string().optional(),
+  subject: z.string().optional(),
+  status: z.enum(['NEW', 'MERGED', 'ABANDONED']).optional(),
+  created: z.string().optional(),
+  hashtags: z.array(z.string()).optional(),
+  submittable: z.boolean().optional(),
+  _number: z.number().optional(),
+  labels: z.record(z.string(), GerritLabelInfoSchema).optional(),
+  reviewers: z
+    .object({
+      REVIEWER: LooseArray(GerritAccountInfoSchema).optional(),
+    })
+    .optional(),
+  messages: LooseArray(GerritChangeMessageInfoSchema).optional(),
+  current_revision: z.string().optional(),
+  revisions: z.record(z.string(), GerritRevisionInfoSchema).optional(),
+  problems: z.array(z.unknown()).optional(),
+  _more_changes: z.boolean().optional(),
+});
+
+export const GerritChangesSchema = LooseArray(GerritChangeSchema);
+
+export const GerritLabelTypeInfoSchema = z.object({
+  values: z.record(z.coerce.number(), z.string()),
+  default_value: z.number(),
+});
+
+export const GerritProjectInfoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  state: z.enum(['ACTIVE', 'READ_ONLY', 'HIDDEN']).optional(),
+  labels: z.record(z.string(), GerritLabelTypeInfoSchema).optional(),
+});
+
+export const GerritBranchInfoSchema = z.object({
+  ref: z.string(),
+  revision: z.string(),
+});
+
+export const GerritMergeableInfoSchema = z.object({
+  submit_type: z.enum([
+    'MERGE_IF_NECESSARY',
+    'FAST_FORWARD_ONLY',
+    'REBASE_IF_NECESSARY',
+    'REBASE_ALWAYS',
+    'MERGE_ALWAYS',
+    'CHERRY_PICK',
+  ]),
+  mergeable: z.boolean(),
+});
+
+export const GerritReposSchema = z.record(
+  z.string(),
+  z.object({}).passthrough(),
+);
+
+export const GerritChangeMessagesSchema = LooseArray(
+  GerritChangeMessageInfoSchema,
+);

--- a/lib/modules/platform/gerrit/schema.ts
+++ b/lib/modules/platform/gerrit/schema.ts
@@ -1,78 +1,94 @@
 import { z } from 'zod/v4';
 import { LooseArray } from '../../../util/schema-utils/index.ts';
 
-export const GerritAccountInfoSchema = z.object({
+/**
+ * The Schemas for the Gerrit API Responses ({@link https://gerrit-review.googlesource.com/Documentation/rest-api.html | REST-API})
+ * minimized to only needed properties.
+ *
+ * @packageDocumentation
+ */
+
+export const GerritAccountInfo = z.object({
   _account_id: z.number(),
   username: z.string().optional(),
 });
+export type GerritAccountInfo = z.infer<typeof GerritAccountInfo>;
 
-export const GerritLabelInfoSchema = z.object({
-  approved: GerritAccountInfoSchema.optional(),
-  rejected: GerritAccountInfoSchema.optional(),
+export const GerritLabelInfo = z.object({
+  approved: GerritAccountInfo.optional(),
+  rejected: GerritAccountInfo.optional(),
   blocking: z.boolean().optional(),
 });
+export type GerritLabelInfo = z.infer<typeof GerritLabelInfo>;
 
-export const GerritActionInfoSchema = z.object({
+export const GerritActionInfo = z.object({
   method: z.string().optional(),
   enabled: z.boolean().optional(),
 });
+export type GerritActionInfo = z.infer<typeof GerritActionInfo>;
 
-export const GerritRevisionInfoSchema = z.object({
-  uploader: GerritAccountInfoSchema.optional(),
-  ref: z.string().optional(),
-  created: z.string().optional(),
-  actions: z.record(z.string(), GerritActionInfoSchema).optional(),
+export const GerritRevisionInfo = z.object({
+  uploader: GerritAccountInfo,
+  ref: z.string(),
+  created: z.string(),
+  actions: z.record(z.string(), GerritActionInfo).optional(),
   commit_with_footers: z.string().optional(),
 });
+export type GerritRevisionInfo = z.infer<typeof GerritRevisionInfo>;
 
-export const GerritChangeMessageInfoSchema = z.object({
-  id: z.string().optional(),
+export const GerritChangeMessageInfo = z.object({
+  id: z.string(),
   message: z.string(),
   tag: z.string().optional(),
 });
+export type GerritChangeMessageInfo = z.infer<typeof GerritChangeMessageInfo>;
 
-export const GerritChangeSchema = z.object({
-  branch: z.string().optional(),
-  change_id: z.string().optional(),
-  subject: z.string().optional(),
-  status: z.enum(['NEW', 'MERGED', 'ABANDONED']).optional(),
-  created: z.string().optional(),
-  hashtags: z.array(z.string()).optional(),
+export const GerritChange = z.object({
+  branch: z.string(),
+  change_id: z.string(),
+  subject: z.string(),
+  status: z.enum(['NEW', 'MERGED', 'ABANDONED']),
+  created: z.string(),
+  hashtags: z.array(z.string()),
   submittable: z.boolean().optional(),
-  _number: z.number().optional(),
-  labels: z.record(z.string(), GerritLabelInfoSchema).optional(),
+  _number: z.number(),
+  labels: z.record(z.string(), GerritLabelInfo).optional(),
   reviewers: z
     .object({
-      REVIEWER: LooseArray(GerritAccountInfoSchema).optional(),
+      REVIEWER: LooseArray(GerritAccountInfo).optional(),
     })
     .optional(),
-  messages: LooseArray(GerritChangeMessageInfoSchema).optional(),
+  messages: LooseArray(GerritChangeMessageInfo).optional(),
   current_revision: z.string().optional(),
-  revisions: z.record(z.string(), GerritRevisionInfoSchema).optional(),
+  revisions: z.record(z.string(), GerritRevisionInfo).optional(),
   problems: z.array(z.unknown()).optional(),
   _more_changes: z.boolean().optional(),
 });
+export type GerritChange = z.infer<typeof GerritChange>;
 
-export const GerritChangesSchema = LooseArray(GerritChangeSchema);
+export const GerritChanges = LooseArray(GerritChange);
 
-export const GerritLabelTypeInfoSchema = z.object({
+export const GerritLabelTypeInfo = z.object({
   values: z.record(z.coerce.number(), z.string()),
   default_value: z.number(),
 });
+export type GerritLabelTypeInfo = z.infer<typeof GerritLabelTypeInfo>;
 
-export const GerritProjectInfoSchema = z.object({
+export const GerritProjectInfo = z.object({
   id: z.string(),
   name: z.string(),
   state: z.enum(['ACTIVE', 'READ_ONLY', 'HIDDEN']).optional(),
-  labels: z.record(z.string(), GerritLabelTypeInfoSchema).optional(),
+  labels: z.record(z.string(), GerritLabelTypeInfo).optional(),
 });
+export type GerritProjectInfo = z.infer<typeof GerritProjectInfo>;
 
-export const GerritBranchInfoSchema = z.object({
+export const GerritBranchInfo = z.object({
   ref: z.string(),
   revision: z.string(),
 });
+export type GerritBranchInfo = z.infer<typeof GerritBranchInfo>;
 
-export const GerritMergeableInfoSchema = z.object({
+export const GerritMergeableInfo = z.object({
   submit_type: z.enum([
     'MERGE_IF_NECESSARY',
     'FAST_FORWARD_ONLY',
@@ -83,12 +99,8 @@ export const GerritMergeableInfoSchema = z.object({
   ]),
   mergeable: z.boolean(),
 });
+export type GerritMergeableInfo = z.infer<typeof GerritMergeableInfo>;
 
-export const GerritReposSchema = z.record(
-  z.string(),
-  z.object({}).passthrough(),
-);
+export const GerritRepos = z.record(z.string(), z.object({}).loose());
 
-export const GerritChangeMessagesSchema = LooseArray(
-  GerritChangeMessageInfoSchema,
-);
+export const GerritChangeMessages = LooseArray(GerritChangeMessageInfo);

--- a/lib/modules/platform/gerrit/scm.spec.ts
+++ b/lib/modules/platform/gerrit/scm.spec.ts
@@ -2,17 +2,17 @@ import { DateTime } from 'luxon';
 import { git, partial } from '~test/util.ts';
 import type { LongCommitSha } from '../../../util/git/types.ts';
 import { client as _client } from './client.ts';
+import type {
+  GerritAccountInfo,
+  GerritChange,
+  GerritRevisionInfo,
+} from './schema.ts';
 import {
   GerritScm,
   configureScm,
   pendingChangeBranches,
   pushForReview,
 } from './scm.ts';
-import type {
-  GerritAccountInfo,
-  GerritChange,
-  GerritRevisionInfo,
-} from './types.ts';
 
 vi.mock('./client.ts');
 const clientMock = vi.mocked(_client);

--- a/lib/modules/platform/gerrit/types.ts
+++ b/lib/modules/platform/gerrit/types.ts
@@ -27,30 +27,6 @@ export interface GerritFindPRConfig extends FindPRConfig {
   startOffset?: number;
 }
 
-/**
- * The Interfaces for the Gerrit API Responses ({@link https://gerrit-review.googlesource.com/Documentation/rest-api.html | REST-API})
- * minimized to only needed properties.
- *
- * @packageDocumentation
- */
-
-export interface GerritProjectInfo {
-  id: string;
-  name: string;
-  state?: 'ACTIVE' | 'READ_ONLY' | 'HIDDEN';
-  labels?: Record<string, GerritLabelTypeInfo>;
-}
-
-export interface GerritLabelTypeInfo {
-  values: Record<number, string>;
-  default_value: number;
-}
-
-export interface GerritBranchInfo {
-  ref: string;
-  revision: string;
-}
-
 export type GerritChangeStatus = 'NEW' | 'MERGED' | 'ABANDONED';
 
 export type GerritRequestDetail =
@@ -62,88 +38,6 @@ export type GerritRequestDetail =
   | 'CURRENT_ACTIONS'
   | 'CURRENT_REVISION'
   | 'COMMIT_FOOTERS';
-
-export interface GerritChange {
-  branch: string;
-  change_id: string;
-  subject: string;
-  status: GerritChangeStatus;
-  created: string;
-  hashtags: string[];
-  /** Requires o=SUBMITTABLE. */
-  submittable?: boolean;
-  _number: number;
-  /** Requires o=LABELS. */
-  labels?: Record<string, GerritLabelInfo>;
-  /** Requires o=LABELS. */
-  reviewers?: {
-    REVIEWER?: GerritAccountInfo[];
-  };
-  /** Requires o=MESSAGES. */
-  messages?: GerritChangeMessageInfo[];
-  /** Requires o=CURRENT_REVISION. */
-  current_revision?: string;
-  /**
-   * All patch sets of this change as a map that maps the commit ID of the patch set to a RevisionInfo entity.
-   * Requires o=CURRENT_REVISION.
-   */
-  revisions?: Record<string, GerritRevisionInfo>;
-  /**
-   * Potential consistency issues with the change (not related to labels).
-   * Requires o=CHECKS. */
-  problems?: unknown[];
-  /**
-   *  Whether the query would deliver more results if not limited.
-   *  Only set on the last change that is returned, except when there are no more changes.
-   */
-  _more_changes?: boolean;
-}
-
-export interface GerritRevisionInfo {
-  uploader: GerritAccountInfo;
-  /** The Git reference for the patch set. */
-  ref: string;
-  created: string;
-  /** Requires o=CURRENT_ACTIONS. */
-  actions?: Record<string, GerritActionInfo>;
-  /** Requires o=COMMIT_FOOTERS. */
-  commit_with_footers?: string;
-}
-
-export interface GerritChangeMessageInfo {
-  id: string;
-  message: string;
-  tag?: string;
-}
-
-export interface GerritLabelInfo {
-  approved?: GerritAccountInfo;
-  rejected?: GerritAccountInfo;
-  /** If true, the label blocks submit operation. If not set, the default is false. */
-  blocking?: boolean;
-}
-
-export interface GerritActionInfo {
-  method?: string;
-  enabled?: boolean;
-}
-
-export interface GerritAccountInfo {
-  _account_id: number;
-  /** Requires o=DETAILED_ACCOUNTS. */
-  username?: string;
-}
-
-export interface GerritMergeableInfo {
-  submit_type:
-    | 'MERGE_IF_NECESSARY'
-    | 'FAST_FORWARD_ONLY'
-    | 'REBASE_IF_NECESSARY'
-    | 'REBASE_ALWAYS'
-    | 'MERGE_ALWAYS'
-    | 'CHERRY_PICK';
-  mergeable: boolean;
-}
 
 export interface GerritHashtagsInput {
   add?: string[] | null;

--- a/lib/modules/platform/gerrit/utils.spec.ts
+++ b/lib/modules/platform/gerrit/utils.spec.ts
@@ -7,10 +7,10 @@ import type {
   GerritAccountInfo,
   GerritChange,
   GerritChangeMessageInfo,
-  GerritChangeStatus,
   GerritLabelTypeInfo,
   GerritRevisionInfo,
-} from './types.ts';
+} from './schema.ts';
+import type { GerritChangeStatus } from './types.ts';
 import * as utils from './utils.ts';
 import { mapBranchStatusToLabel } from './utils.ts';
 

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -7,12 +7,8 @@ import { regEx } from '../../../util/regex.ts';
 import { joinUrlParts, parseUrl } from '../../../util/url.ts';
 import { hashBody } from '../pr-body.ts';
 import type { GitUrlOption, Pr } from '../types.ts';
-import type {
-  GerritChange,
-  GerritChangeStatus,
-  GerritLabelTypeInfo,
-  GerritRequestDetail,
-} from './types.ts';
+import type { GerritChange, GerritLabelTypeInfo } from './schema.ts';
+import type { GerritChangeStatus, GerritRequestDetail } from './types.ts';
 
 export const MIN_GERRIT_VERSION = '3.0.0';
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

- replaces `getJsonUnchecked` with `getJson`
- the new schemas follow strictly the interfaces defined before

<!-- Describe what behavior is changed by this PR. -->

## Context

07/13

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
