### PR TITLE
fix(datasource/npm): tolerate non-string `time` entries in packument

### DIFF
--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -703,6 +703,51 @@ describe('modules/datasource/npm/get', () => {
       );
     });
 
+    it('returns releases when `time` contains non-string entries', async () => {
+      // JFrog Artifactory emits `"unpublished": null` under `time`, which
+      // previously caused the whole packument to fail schema validation.
+      httpMock
+        .scope('https://example.com')
+        .get('/some-package')
+        .reply(200, {
+          name: 'some-package',
+          'dist-tags': { latest: '1.1.0' },
+          versions: { '1.0.0': {}, '1.1.0': {} },
+          time: {
+            unpublished: null,
+            created: '2026-01-22T23:58:45.285Z',
+            modified: '2026-06-02T00:59:50.138Z',
+            '1.0.0': '2026-01-23T01:23:37.982Z',
+            '1.1.0': '2026-04-15T18:50:36.431Z',
+          },
+        });
+
+      const dep = await getDependency(
+        http,
+        'https://example.com',
+        'some-package',
+      );
+
+      expect(dep?.releases).toEqual([
+        {
+          version: '1.0.0',
+          releaseTimestamp: '2026-01-23T01:23:37.982Z',
+          attestation: false,
+          dependencies: undefined,
+          devDependencies: undefined,
+          gitRef: undefined,
+        },
+        {
+          version: '1.1.0',
+          releaseTimestamp: '2026-04-15T18:50:36.431Z',
+          attestation: false,
+          dependencies: undefined,
+          devDependencies: undefined,
+          gitRef: undefined,
+        },
+      ]);
+    });
+
     it('returns unexpired cache', async () => {
       vi.setSystemTime('2024-06-15T00:14:59.999Z');
       packageCache.get.mockResolvedValue({

--- a/lib/modules/datasource/npm/schema.spec.ts
+++ b/lib/modules/datasource/npm/schema.spec.ts
@@ -68,6 +68,38 @@ describe('modules/datasource/npm/schema', () => {
     });
   });
 
+  it('drops non-string `time` entries (e.g. Artifactory `unpublished: null`)', () => {
+    const result = NpmResponse.parse({
+      name: 'mypackage',
+      'dist-tags': { latest: '1.1.0' },
+      versions: { '1.0.0': {}, '1.1.0': {} },
+      time: {
+        unpublished: null,
+        created: '2026-01-22T23:58:45.285Z',
+        modified: '2026-06-02T00:59:50.138Z',
+        '1.0.0': '2026-01-23T01:23:37.982Z',
+        '1.1.0': '2026-04-15T18:50:36.431Z',
+      },
+    });
+    expect(result.time).toEqual({
+      created: '2026-01-22T23:58:45.285Z',
+      modified: '2026-06-02T00:59:50.138Z',
+      '1.0.0': '2026-01-23T01:23:37.982Z',
+      '1.1.0': '2026-04-15T18:50:36.431Z',
+    });
+  });
+
+  it('drops non-string `time` entries for the cached packument', () => {
+    const result = CachedPackument.parse({
+      time: {
+        unpublished: null,
+        '1.0.0': '2026-01-23T01:23:37.982Z',
+      },
+      versions: { '1.0.0': {} },
+    });
+    expect(result.time).toEqual({ '1.0.0': '2026-01-23T01:23:37.982Z' });
+  });
+
   describe('NpmResponseSchema', () => {
     it('parses a full npm registry response and preserves extra version fields', () => {
       const input = {

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -16,6 +16,24 @@ const Distribution = z.object({
   attestations: Attestations.optional(),
 });
 
+/**
+ * The packument `time` field maps each published version to its release
+ * timestamp, alongside metadata keys such as `created`, `modified`, and
+ * `unpublished`. Some registries (e.g. JFrog Artifactory) emit non-string
+ * values like `"unpublished": null`, which must not invalidate the whole
+ * packument. Drop any non-string entries so consumers only ever see
+ * version→timestamp strings.
+ */
+const PackumentTime = z
+  .record(z.string(), z.unknown())
+  .transform((time) =>
+    Object.fromEntries(
+      Object.entries(time).filter(
+        (entry): entry is [string, string] => typeof entry[1] === 'string',
+      ),
+    ),
+  );
+
 export const NpmResponseVersion = z.object({
   repository: Repository.optional(),
   homepage: z.string().optional().catch(undefined),
@@ -35,7 +53,7 @@ export const CachedPackument = z.object({
   versions: z.record(z.string(), NpmResponseVersion).optional(),
   repository: Repository.optional(),
   homepage: z.string().optional(),
-  time: z.record(z.string(), z.string()).optional(),
+  time: PackumentTime.optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });
 
@@ -53,7 +71,7 @@ export const NpmResponse = z.object({
   versions: z.record(z.string(), NpmResponseVersionLoose).optional(),
   repository: Repository.optional(),
   homepage: z.string().optional(),
-  time: z.record(z.string(), z.string()).optional(),
+  time: PackumentTime.optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });
 

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { LooseRecord } from '../../../util/schema-utils/index.ts';
 
 const Repository = z.union([
   z.string(),
@@ -15,24 +16,6 @@ const Attestations = z.object({
 const Distribution = z.object({
   attestations: Attestations.optional(),
 });
-
-/**
- * The packument `time` field maps each published version to its release
- * timestamp, alongside metadata keys such as `created`, `modified`, and
- * `unpublished`. Some registries (e.g. JFrog Artifactory) emit non-string
- * values like `"unpublished": null`, which must not invalidate the whole
- * packument. Drop any non-string entries so consumers only ever see
- * version→timestamp strings.
- */
-const PackumentTime = z
-  .record(z.string(), z.unknown())
-  .transform((time) =>
-    Object.fromEntries(
-      Object.entries(time).filter(
-        (entry): entry is [string, string] => typeof entry[1] === 'string',
-      ),
-    ),
-  );
 
 export const NpmResponseVersion = z.object({
   repository: Repository.optional(),
@@ -53,7 +36,9 @@ export const CachedPackument = z.object({
   versions: z.record(z.string(), NpmResponseVersion).optional(),
   repository: Repository.optional(),
   homepage: z.string().optional(),
-  time: PackumentTime.optional(),
+  // `LooseRecord` drops non-string entries (e.g. Artifactory's
+  // `"unpublished": null`) instead of invalidating the whole packument.
+  time: LooseRecord(z.string()).optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });
 
@@ -71,7 +56,7 @@ export const NpmResponse = z.object({
   versions: z.record(z.string(), NpmResponseVersionLoose).optional(),
   repository: Repository.optional(),
   homepage: z.string().optional(),
-  time: PackumentTime.optional(),
+  time: LooseRecord(z.string()).optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

JFrog Artifactory npm registries emit `"unpublished": null` under the packument `time` field. Since the schema declared `time` values as `z.string()`, the `null` failed validation and Zod rejected the entire packument, so every package lookup returned no-result.

Strip non-string `time` entries via a shared `PackumentTime` transform so a stray metadata key cannot invalidate the whole packument, while keeping the real version->timestamp entries the datasource relies on.

The problem I am trying to solve was introduced with #43699 by @secustor, first included with 43.210.2. 

Note: I've got no control over Artifactory, and I intend to report this as an issue to them. Anyone who has had JFrog Artifactory knows that they are extremely slow to respond to these kinds of issues.

I have tested this change against my artifactory instance and it seems to do the trick.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: The repository is not public, I'm sorry.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
