### PR TITLE
fix(config): mark relevant options with `patternMatch`

### DIFF
--- a/lib/config/__snapshots__/validation.spec.ts.snap
+++ b/lib/config/__snapshots__/validation.spec.ts.snap
@@ -196,6 +196,14 @@ exports[`config/validation > validateConfig(config) > returns custom deprecation
 exports[`config/validation > validateConfig(config) > returns nested errors 1`] = `
 [
   {
+    "message": "Failed to parse regex pattern for packageRules[0].matchPackageNames: !/abc ([a-z]+) ([a-z]+))/",
+    "topic": "Configuration Error",
+  },
+  {
+    "message": "Failed to parse regex pattern for packageRules[0].matchPackageNames: /abc ([a-z]+) ([a-z]+))/",
+    "topic": "Configuration Error",
+  },
+  {
     "message": "Invalid configuration option: foo",
     "topic": "Configuration Error",
   },
@@ -209,6 +217,10 @@ exports[`config/validation > validateConfig(config) > returns nested errors 1`] 
   },
   {
     "message": "Invalid regExp for packageRules[0].matchPackageNames: \`/abc ([a-z]+) ([a-z]+))/\`",
+    "topic": "Configuration Error",
+  },
+  {
+    "message": "packageRules[0].matchPackageNames: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.",
     "topic": "Configuration Error",
   },
 ]

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -126,6 +126,7 @@ const options: Readonly<RenovateOptions>[] = [
     subType: 'string',
     default: [],
     globalOnly: true,
+    patternMatch: true,
   },
   {
     name: 'bumpVersions',
@@ -1160,6 +1161,7 @@ const options: Readonly<RenovateOptions>[] = [
     allowString: true,
     default: null,
     globalOnly: true,
+    patternMatch: true,
   },
   {
     name: 'autodiscoverNamespaces',
@@ -1220,6 +1222,7 @@ const options: Readonly<RenovateOptions>[] = [
     subType: 'string',
     stage: 'package',
     cli: false,
+    patternMatch: true,
   },
   {
     name: 'useBaseBranchConfig',
@@ -1284,6 +1287,7 @@ const options: Readonly<RenovateOptions>[] = [
     subType: 'string',
     stage: 'repository',
     default: [],
+    patternMatch: true,
   },
   {
     name: 'ignorePaths',
@@ -1294,6 +1298,7 @@ const options: Readonly<RenovateOptions>[] = [
     subType: 'string',
     stage: 'repository',
     default: ['**/node_modules/**', '**/bower_components/**'],
+    patternMatch: true,
   },
   {
     name: 'excludeCommitPaths',
@@ -1303,6 +1308,7 @@ const options: Readonly<RenovateOptions>[] = [
     subType: 'string',
     default: [],
     advancedUse: true,
+    patternMatch: true,
   },
   {
     name: 'executionTimeout',
@@ -1464,6 +1470,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchRepositories',
@@ -1491,6 +1498,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchManagers',
@@ -1518,6 +1526,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchDepTypes',
@@ -1531,6 +1540,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchPackageNames',
@@ -1544,6 +1554,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchDepNames',
@@ -1557,6 +1568,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchCurrentValue',
@@ -1568,6 +1580,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchCurrentVersion',
@@ -1590,6 +1603,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'sourceUrl',
@@ -1622,6 +1636,7 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchRegistryUrls',
@@ -1734,17 +1749,19 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchFileNames',
     description:
-      'List of strings to do an exact match against package and lock files with full path. Only works inside a `packageRules` object.',
+      'List of patterns to match against package and lock file paths. Valid only within a `packageRules` object.',
     type: 'array',
     subType: 'string',
     stage: 'repository',
     parents: ['packageRules'],
     cli: false,
     env: false,
+    patternMatch: true,
   },
   {
     name: 'matchJsonata',

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -441,6 +441,11 @@ describe('config/validation', () => {
       expect(errors).toEqual([
         {
           topic: 'Configuration Error',
+          message:
+            'Failed to parse regex pattern for baseBranchPatterns: /***$}{]][/',
+        },
+        {
+          topic: 'Configuration Error',
           message: 'Invalid regExp for baseBranchPatterns: `/***$}{]][/`',
         },
       ]);
@@ -472,7 +477,7 @@ describe('config/validation', () => {
         config,
       );
       expect(warnings).toHaveLength(0);
-      expect(errors).toHaveLength(4);
+      expect(errors).toHaveLength(7);
       expect(errors).toMatchSnapshot();
     });
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As part of future changes, we want to perform strict validation on
the `allowedValues` for all config options as part of Config Validation.

Before we do this, per #40805, we should make sure that the config
options are all marked accordingly.

The list of relevant config options that support pattern matching has
been determined by Claude Opus.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40805
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation


## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
