### PR TITLE
fix(config): remove deprecated rebaseStalePrs from lockFileMaintenance default

### DIFF
--- a/lib/config/__snapshots__/index.spec.ts.snap
+++ b/lib/config/__snapshots__/index.spec.ts.snap
@@ -11,7 +11,6 @@ exports[`config/index > mergeChildConfig(parentConfig, childConfig) > merges 1`]
   "prBodyDefinitions": {
     "Change": "All locks refreshed",
   },
-  "rebaseStalePrs": true,
   "recreateWhen": "always",
   "schedule": [
     "on monday",

--- a/lib/config/__snapshots__/index.spec.ts.snap
+++ b/lib/config/__snapshots__/index.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`config/index > mergeChildConfig(parentConfig, childConfig) > merges 1`]
   "prBodyDefinitions": {
     "Change": "All locks refreshed",
   },
+  "rebaseWhen": "behind-base-branch",
   "recreateWhen": "always",
   "schedule": [
     "on monday",

--- a/lib/config/__snapshots__/index.spec.ts.snap
+++ b/lib/config/__snapshots__/index.spec.ts.snap
@@ -11,7 +11,6 @@ exports[`config/index > mergeChildConfig(parentConfig, childConfig) > merges 1`]
   "prBodyDefinitions": {
     "Change": "All locks refreshed",
   },
-  "rebaseWhen": "behind-base-branch",
   "recreateWhen": "always",
   "schedule": [
     "on monday",

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2526,7 +2526,6 @@ const options: Readonly<RenovateOptions>[] = [
     default: {
       enabled: false,
       recreateWhen: 'always',
-      rebaseWhen: 'behind-base-branch',
       branchTopic: 'lock-file-maintenance',
       commitMessageAction: 'Lock file maintenance',
       commitMessageTopic: null,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2526,7 +2526,6 @@ const options: Readonly<RenovateOptions>[] = [
     default: {
       enabled: false,
       recreateWhen: 'always',
-      rebaseStalePrs: true,
       branchTopic: 'lock-file-maintenance',
       commitMessageAction: 'Lock file maintenance',
       commitMessageTopic: null,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2526,6 +2526,7 @@ const options: Readonly<RenovateOptions>[] = [
     default: {
       enabled: false,
       recreateWhen: 'always',
+      rebaseWhen: 'behind-base-branch',
       branchTopic: 'lock-file-maintenance',
       commitMessageAction: 'Lock file maintenance',
       commitMessageTopic: null,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

`rebaseStalePrs` was removed in favour of `rebaseWhen` (#5547), so the `rebaseStalePrs: true` carried in the `lockFileMaintenance` default is dead, and it makes the documented default fail validation when copied (`Invalid configuration option: lockFileMaintenance.rebaseStalePrs`). This removes it; the default keeps tracking the global `rebaseWhen`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was written primarily by Claude (Claude Code, Opus 4.8): the code change, the snapshot update, and this description were AI-generated, then reviewed and directed by me. PR replies on this thread are also AI-drafted and human-reviewed.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (code inspection; the updated snapshot test is exercised by CI)
