### PR TITLE
test(config): ensure no `default` options require migrating

### DIFF
--- a/lib/config/options/index.spec.ts
+++ b/lib/config/options/index.spec.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { isNullOrUndefined } from '@sindresorhus/is';
 import * as manager from '../../modules/manager/index.ts';
 import * as platform from '../../modules/platform/index.ts';
+import { migrateConfig } from '../migration.ts';
 import { getOptions } from './index.ts';
 
 vi.unmock('../../modules/platform/index.ts');
@@ -177,6 +178,24 @@ describe('config/options/index', () => {
           }
         }
       }
+    }
+  });
+
+  describe('every option with a default must not need migrating', () => {
+    const opts = getOptions();
+
+    for (const option of opts.filter((o) => o.default)) {
+      const defaultConfig = {
+        [option.name]: option.default,
+      };
+      const { isMigrated, migratedConfig } = migrateConfig(defaultConfig);
+      it(`${option.name}'s default config should not need any migrations`, () => {
+        expect(defaultConfig).toEqual(migratedConfig);
+        expect(isMigrated).toBeFalse();
+        // expect(isMigrated,
+        //   `${option.name}'s default config needs to be migrated: \n${JSON.stringify(migratedConfig, null, 2)}`
+        // ).toBeFalse()
+      });
     }
   });
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As a follow-up to #43804, we can make sure that our configuration no
longer needs migrations.

If there are migrations needed, we can see the resulting configuration
and amend it.

This will fail until #43804 is rebased on top of it

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
