### PR TITLE
feat(manager/nuget): default `rangeStrategy` to bump

### DIFF
--- a/lib/modules/manager/nuget/index.ts
+++ b/lib/modules/manager/nuget/index.ts
@@ -21,7 +21,7 @@ export const defaultConfig = {
     '/(^|/)dotnet-tools\\.json$/',
     '/(^|/)global\\.json$/',
   ],
-  // after Renovate xxx, this is required to make sure that NuGet's treatment of "bare versions" as a range does not lead to a lack of dependency updates
+  // after Renovate 43.208.2, this is required to make sure that NuGet's treatment of "bare versions" as a range does not lead to a lack of dependency updates
   // NOTE that in the next major version, this will be removed, and users will need to decide whether to re-enable this
   rangeStrategy: 'bump',
 };

--- a/lib/modules/manager/nuget/index.ts
+++ b/lib/modules/manager/nuget/index.ts
@@ -21,6 +21,7 @@ export const defaultConfig = {
     '/(^|/)dotnet-tools\\.json$/',
     '/(^|/)global\\.json$/',
   ],
+  rangeStrategy: 'bump', // this is done inorder to handle nuget's treatment of bare versions as range
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/nuget/index.ts
+++ b/lib/modules/manager/nuget/index.ts
@@ -21,7 +21,9 @@ export const defaultConfig = {
     '/(^|/)dotnet-tools\\.json$/',
     '/(^|/)global\\.json$/',
   ],
-  rangeStrategy: 'bump', // this is done inorder to handle nuget's treatment of bare versions as range
+  // after Renovate xxx, this is required to make sure that NuGet's treatment of "bare versions" as a range does not lead to a lack of dependency updates
+  // NOTE that in the next major version, this will be removed, and users will need to decide whether to re-enable this
+  rangeStrategy: 'bump',
 };
 
 export const supportedDatasources = [

--- a/lib/modules/manager/nuget/readme.md
+++ b/lib/modules/manager/nuget/readme.md
@@ -25,7 +25,7 @@ But, you need to add those files manually to the `managerFilePatterns` as they a
 
 ### Disabling updates for pinned versions
 
-In NuGet, when you use versions like `Version="1.2.3"` then it means "1.2.3 or greater, up to v2"
+In NuGet, when you use versions like `Version="1.2.3"` then it means "1.2.3 or greater" (an open-ended minimum, with no upper bound).
 When you use versions like `Version="[1.2.3]"` then it means "exactly 1.2.3".
 
 If you would like Renovate to disable updating of exact versions (warning: you might end up years out of date and not realize it) then here is an example configuration to achieve that:
@@ -42,6 +42,32 @@ If you would like Renovate to disable updating of exact versions (warning: you m
   ]
 }
 ```
+
+### Getting updates for non-pinned (bare) versions
+
+Because a bare version such as `Version="1.2.3"` is an _open-ended minimum_ (`1.2.3` or greater), it is a range rather than a single version.
+The default `rangeStrategy` of `auto` resolves to `replace` for NuGet, and `replace` cannot produce an update for an open-ended minimum: every newer release already satisfies "1.2.3 or greater", so there is nothing to replace.
+The result is that Renovate detects no updates for these dependencies and closes any existing update PRs.
+
+To keep receiving updates for bare versions, set `rangeStrategy` to `bump`.
+With `bump`, Renovate raises the minimum to the newest release (for example `1.2.3` to `1.5.0`):
+
+```json
+{
+  "packageRules": [
+    {
+      "description": "Bump bare NuGet versions to the latest release",
+      "matchManagers": ["nuget"],
+      "rangeStrategy": "bump"
+    }
+  ]
+}
+```
+
+!!! note
+  This is a change in behavior.
+  Earlier versions of Renovate anchored the "current version" directly to the value in your project file, so bare versions received updates under any `rangeStrategy`.
+  Renovate no longer treats a range (including a bare NuGet version) as the current version, so the `rangeStrategy` now decides the outcome: use `bump` to restore the previous update behavior.
 
 ### Workload restore
 

--- a/lib/modules/manager/nuget/readme.md
+++ b/lib/modules/manager/nuget/readme.md
@@ -45,7 +45,7 @@ If you would like Renovate to disable updating of exact versions (warning: you m
 
 ### Getting updates for non-pinned (bare) versions
 
-Because a bare version such as `Version="1.2.3"` is an _open-ended minimum_ (`1.2.3` or greater), it is a range rather than a single version.
+Per [NuGet's versioning rules](https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges), a bare version such as `Version="1.2.3"` is an _open-ended minimum_ (`1.2.3` or greater) — so it is NuGet, not Renovate, that treats this as a range rather than a single version.
 The default `rangeStrategy` of `auto` resolves to `replace` for NuGet, and `replace` cannot produce an update for an open-ended minimum: every newer release already satisfies "1.2.3 or greater", so there is nothing to replace.
 The result is that Renovate detects no updates for these dependencies and closes any existing update PRs.
 
@@ -67,7 +67,7 @@ With `bump`, Renovate raises the minimum to the newest release (for example `1.2
 !!! note
   This is a change in behavior.
   Earlier versions of Renovate anchored the "current version" directly to the value in your project file, so bare versions received updates under any `rangeStrategy`.
-  Renovate no longer treats a range (including a bare NuGet version) as the current version, so the `rangeStrategy` now decides the outcome: use `bump` to restore the previous update behavior.
+  Since Renovate `43.208.2`, Renovate no longer treats a range (including a bare NuGet version) as the current version, so the `rangeStrategy` now decides the outcome: use `bump` to restore the previous update behavior.
 
 ### Workload restore
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

1. Keep bare version treated as range as per Nuget docs: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning?tabs=semver20sort#version-ranges
2. Default the `rangeStrategy=bump` for nuget version so existing users who rely on bare versions getting updated keep the old behavior

<!-- Describe what behavior is changed by this PR. -->

## Context

Ref: https://github.com/renovatebot/renovate/discussions/43762

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). (for docs)
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/koosvanw/renovate-nuget-regression-repro

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
