### PR TITLE
test(datasource/pypi): cover null and missing home_page

### DIFF
--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -278,6 +278,31 @@ describe('modules/datasource/pypi/index', () => {
       expect(result?.changelogUrl).toBe(info.project_urls.changelog);
     });
 
+    it('finds urls from project_urls when home_page is null', async () => {
+      const info = {
+        name: 'flexget',
+        home_page: null,
+        project_urls: {
+          Forum: 'https://discuss.flexget.com',
+          Homepage: 'https://flexget.com',
+          changelog: 'https://github.com/Flexget/wiki/blob/master/ChangeLog.md',
+          'Issue Tracker': 'https://github.com/Flexget/Flexget/issues',
+          Repository: 'https://github.com/Flexget/Flexget',
+        },
+      };
+      httpMock
+        .scope(baseUrl)
+        .get('/flexget/json')
+        .reply(200, { ...JSON.parse(res1), info });
+      const result = await getPkgReleases({
+        datasource,
+        packageName: 'flexget',
+      });
+      expect(result?.homepage).toBeUndefined();
+      expect(result?.sourceUrl).toBe(info.project_urls.Repository);
+      expect(result?.changelogUrl).toBe(info.project_urls.changelog);
+    });
+
     it('excludes gh sponsors url from project_urls', async () => {
       const info = {
         name: 'flexget',

--- a/lib/modules/datasource/pypi/schema.spec.ts
+++ b/lib/modules/datasource/pypi/schema.spec.ts
@@ -34,6 +34,36 @@ describe('modules/datasource/pypi/schema', () => {
       expect(result?.releases?.['2.27.0']?.[0].requires_python).toBeNull();
     });
 
+    it('parses a PyPI JSON response with a null home_page', () => {
+      const input = {
+        info: {
+          name: 'mypackage',
+          home_page: null,
+          project_urls: {
+            Repository: 'https://github.com/example/mypackage',
+          },
+        },
+        releases: {},
+      };
+      const result = PypiResponse.parse(input);
+      expect(result?.info?.home_page).toBeNull();
+      expect(result?.info?.project_urls?.Repository).toBe(
+        input.info.project_urls.Repository,
+      );
+    });
+
+    it('parses a PyPI JSON response with a missing home_page', () => {
+      const input = {
+        info: {
+          name: 'mypackage',
+        },
+        releases: {},
+      };
+      const result = PypiResponse.parse(input);
+      expect(result?.info?.home_page).toBeUndefined();
+      expect(result?.info?.name).toBe(input.info.name);
+    });
+
     it('throws for genuinely invalid input (no error swallowing)', () => {
       expect(() => PypiResponse.parse('not-an-object')).toThrow();
     });


### PR DESCRIPTION
Add regression tests for the fix that allows a null or missing home_page in PyPI JSON responses (#43814). Covers both the schema parser and the datasource, asserting that homepage is left unset and sourceUrl/changelogUrl fall back to project_urls when home_page is null.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
- [x] The changes are tests-only

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
