### PR TITLE
docs(manger/github-actions): reword "community actions" section

### DIFF
--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -102,8 +102,24 @@ For example, normally the `^` syntax is not used in `go` or `python`, but it's s
 Depending on your use case, you may need to change `versioning` manually.
 If you find a use case which you think Renovate could/should automatically detect and support without manual configuration, please raise a Discussion to suggest it.
 
-### commonly used community actions
+### Updating `with:` values in commonly used Community-maintained GitHub Actions
 
-Renovate also supports some commonly used community actions:
+Third-party GitHub Actions will commonly specify a version of a given tool using a `with:` block, such as:
+
+GitHub Actions maintained by the wider community have `with:` blocks such as:
+
+```yaml
+steps:
+- uses: astral-sh/setup-uv@v8.1.0
+  with:
+    version: '0.4.x'
+
+- uses: 'denoland/setup-deno@v2',
+  with:
+    deno-version: '2.4.0'
+```
+
+Renovate supports extracting some of these input(s) from the following Actions, and performing automagic dependency updates accordingly.
+The following third-party Actions have support for their `with:` blocks:
 
 <!-- Autogenerate in https://github.com/renovatebot/renovate -->

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -1,23 +1,54 @@
+import { codeBlock } from 'common-tags';
+import { z } from 'zod/v4';
 import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/community.ts';
 import { communityActions } from '../../../../lib/modules/manager/github-actions/community.ts';
 import { readFile, updateFile } from '../../../utils/index.ts';
 import { replaceContent } from '../../utils.ts';
 
-function generateTool({ depName, packageName }: CommunityActionConfig): string {
-  if (!depName && !packageName) {
-    // some actions determine the depName and packageName dynamically
-    return '';
+function getWithSchemaFields(
+  schema: CommunityActionConfig['withSchema'],
+): string[] {
+  if (!schema) {
+    return ['version'];
   }
-  return ` ([\`${depName ?? packageName}\`](https://github.com/${packageName}))`;
+  // `z.object({...}).transform(...)` produces a ZodPipe in Zod v4, where
+  // `def.in` is the source ZodObject. Walk through any pipes until we hit it.
+  let current: z.ZodType = schema;
+  while ('in' in current.def) {
+    current = current.def.in as z.ZodType;
+  }
+  if (current instanceof z.ZodObject) {
+    return Object.keys(current.shape);
+  }
+  return ['version'];
 }
 
-function generateTooling(): string {
-  return Object.entries(communityActions)
-    .map(
-      ([name, cfg]) =>
-        `- [\`${name}\`](https://github.com/${name})${generateTool(cfg)}`,
-    )
-    .join('\n');
+function determineDependencyToUpdate({
+  depName,
+  packageName,
+}: CommunityActionConfig): string {
+  if (!depName && !packageName) {
+    // some actions determine the depName and packageName dynamically
+    return '(determined from `with` input(s))';
+  }
+
+  return `[\`${depName ?? packageName}\`](https://github.com/${packageName})`;
+}
+
+function generateToolingTable(): string {
+  let table = codeBlock`
+    | Action | \`with\` input(s) used | Dependency |
+    | --- | --- | --- |
+    `;
+  table += '\n';
+
+  for (const [name, cfg] of Object.entries(communityActions)) {
+    const withFields = getWithSchemaFields(cfg.withSchema);
+
+    table += `| [\`${name}\`](https://github.com/${name}) | \`${withFields.join('`, `')}\` | ${determineDependencyToUpdate(cfg)} |\n`;
+  }
+
+  return table;
 }
 
 export async function generateManagerGithubActionsCommunity(
@@ -25,7 +56,7 @@ export async function generateManagerGithubActionsCommunity(
 ): Promise<void> {
   const indexFileName = `${dist}/modules/manager/github-actions/index.md`;
   let indexContent = await readFile(indexFileName);
-  indexContent = replaceContent(indexContent, generateTooling());
+  indexContent = replaceContent(indexContent, generateToolingTable());
   await updateFile(
     `${dist}/modules/manager/github-actions/index.md`,
     indexContent,

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -5,6 +5,7 @@ import { replaceContent } from '../../utils.ts';
 
 function generateTool({ depName, packageName }: CommunityActionConfig): string {
   if (!depName && !packageName) {
+    // some actions determine the depName and packageName dynamically
     return '';
   }
   return ` ([\`${depName ?? packageName}\`](https://github.com/${packageName}))`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As some follow-ups to #43821, we
can slightly reword the intro to add some more information about what
these target.

Also:

To provide further clarity on how each of the Actions' `with`s are used,
we can make this more explicit in our autogenerated docs, providing:

- which field(s) are extracted, taken from their Zod schema (with help
  from Claude Opus to extract this)
- note the dependency updating, and where it may be determined from the
  given `withSchema`
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

<img width="752" height="1593" alt="Screenshot 2026-06-05 at 13 27 03" src="https://github.com/user-attachments/assets/67b5b7e2-f5e8-4095-9cef-9f03d0359291" />


## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
