### PR TITLE
fix(config/validation): remove custom validation for `allowedValues`

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2457,13 +2457,7 @@ describe('config/validation', () => {
         'global',
         config,
       );
-      expect(warnings).toEqual([
-        {
-          message:
-            'Invalid value `invalid` for `binarySource`. The allowed values are docker, global, install, hermit.',
-          topic: 'Configuration Error',
-        },
-      ]);
+      expect(warnings).toBeEmptyArray();
       expect(errors).toMatchObject([
         {
           message:
@@ -2481,13 +2475,7 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toEqual([
-          {
-            message:
-              'Invalid value `invalid` for `binarySource`. The allowed values are docker, global, install, hermit.',
-            topic: 'Configuration Error',
-          },
-        ]);
+        expect(warnings).toBeEmptyArray();
         expect(errors).toMatchObject([
           {
             message:
@@ -2521,13 +2509,7 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toEqual([
-          {
-            message:
-              'Invalid value `invalid` for `requireConfig`. The allowed values are required, optional, ignored.',
-            topic: 'Configuration Error',
-          },
-        ]);
+        expect(warnings).toBeEmptyArray();
         expect(errors).toMatchObject([
           {
             message:
@@ -2544,13 +2526,7 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toEqual([
-          {
-            message:
-              'Invalid value `invalid` for `dryRun`. The allowed values are extract, lookup, full.',
-            topic: 'Configuration Error',
-          },
-        ]);
+        expect(warnings).toBeEmptyArray();
         expect(errors).toMatchObject([
           {
             message:
@@ -2567,13 +2543,7 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toEqual([
-          {
-            message:
-              'Invalid value `invalid` for `repositoryCache`. The allowed values are enabled, disabled, reset.',
-            topic: 'Configuration Error',
-          },
-        ]);
+        expect(warnings).toBeEmptyArray();
         expect(errors).toMatchObject([
           {
             message:
@@ -2660,12 +2630,7 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toMatchObject([
-          {
-            message:
-              'Invalid value `invalid` for `gitUrl`. The allowed values are default, ssh, endpoint.',
-          },
-        ]);
+        expect(warnings).toBeEmptyArray();
         expect(errors).toMatchObject([
           {
             message:
@@ -2735,16 +2700,6 @@ describe('config/validation', () => {
           message:
             'Configuration option `checkedBranches` should be a list (Array).',
           topic: 'Configuration Error',
-        },
-        {
-          topic: 'Configuration Error',
-          message:
-            'Invalid value `1` for `mergeConfidenceDatasources`. The allowed values are go, maven, npm, nuget, packagist, pypi, rubygems.',
-        },
-        {
-          topic: 'Configuration Error',
-          message:
-            'Invalid value for `gitNoVerify`. The allowed values are commit, push.',
         },
       ]);
       expect(errors).toMatchObject([

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -988,6 +988,10 @@ describe('config/validation', () => {
       expect(errors).toMatchInlineSnapshot(`
         [
           {
+            "message": "Invalid customManagers[0].customType: customType had a value \`"unknown"\` which was not part of the allowedValues: ["jsonata","regex"]",
+            "topic": "Configuration Error",
+          },
+          {
             "message": "Invalid customType: unknown. Key is not a custom manager",
             "topic": "Configuration Error",
           },
@@ -2460,7 +2464,12 @@ describe('config/validation', () => {
           topic: 'Configuration Error',
         },
       ]);
-      expect(errors).toBeEmptyArray();
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid binarySource: binarySource had a value `"invalid"` which was not part of the allowedValues: ["global","docker","install","hermit"]',
+        },
+      ]);
     });
 
     describe('validates string type options', () => {
@@ -2479,7 +2488,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid binarySource: binarySource had a value `"invalid"` which was not part of the allowedValues: ["global","docker","install","hermit"]',
+          },
+        ]);
       });
 
       it('baseDir', async () => {
@@ -2514,7 +2528,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid requireConfig: requireConfig had a value `"invalid"` which was not part of the allowedValues: ["required","optional","ignored"]',
+          },
+        ]);
       });
 
       it('dryRun', async () => {
@@ -2532,7 +2551,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid dryRun: dryRun had a value `"invalid"` which was not part of the allowedValues: ["extract","lookup","full"]',
+          },
+        ]);
       });
 
       it('repositoryCache', async () => {
@@ -2550,7 +2574,12 @@ describe('config/validation', () => {
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid repositoryCache: repositoryCache had a value `"invalid"` which was not part of the allowedValues: ["disabled","enabled","reset"]',
+          },
+        ]);
       });
 
       it('onboardingConfigFileName', async () => {
@@ -2631,14 +2660,19 @@ describe('config/validation', () => {
           'global',
           config,
         );
-        expect(warnings).toEqual([
+        expect(warnings).toMatchObject([
           {
             message:
               'Invalid value `invalid` for `gitUrl`. The allowed values are default, ssh, endpoint.',
+          },
+        ]);
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid gitUrl: gitUrl had a value `"invalid"` which was not part of the allowedValues: ["default","ssh","endpoint"]',
             topic: 'Configuration Error',
           },
         ]);
-        expect(errors).toBeEmptyArray();
       });
     });
 
@@ -2708,12 +2742,18 @@ describe('config/validation', () => {
             'Invalid value `1` for `mergeConfidenceDatasources`. The allowed values are go, maven, npm, nuget, packagist, pypi, rubygems.',
         },
         {
+          topic: 'Configuration Error',
           message:
             'Invalid value for `gitNoVerify`. The allowed values are commit, push.',
+        },
+      ]);
+      expect(errors).toMatchObject([
+        {
+          message:
+            'Invalid gitNoVerify: gitNoVerify had invalid values `["invalid"]` which are not part of the allowedValues: ["commit","push"]',
           topic: 'Configuration Error',
         },
       ]);
-      expect(errors).toBeEmptyArray();
     });
 
     it('validates object type options', async () => {
@@ -2998,6 +3038,100 @@ describe('config/validation', () => {
           topic: 'Configuration Error',
         },
       ]);
+    });
+
+    describe('allowedValues are validated', () => {
+      it('with repo config', async () => {
+        const config: Partial<RenovateConfig> = {
+          // for a single value
+          // @ts-expect-error: contains invalid values
+          mode: 'not-valid',
+          // for an array
+          postUpdateOptions: ['invalid', 'another'],
+          hostRules: [
+            {
+              // this is allowed, as it's the default value
+              artifactAuth: null,
+            },
+          ],
+          packageRules: [
+            // valid and a regex: versioning scheme
+            {
+              matchDepNames: ['/.*/'],
+              versioning: 'regex:^(?<major>1)',
+            },
+            // valid and part of allowedValues
+            {
+              matchDepNames: ['/.*/'],
+              versioning: 'maven',
+            },
+            // invalid, using an unknown option
+            {
+              matchDepNames: ['/.*/'],
+              versioning: 'not-ever-valid-scheme',
+            },
+          ],
+          bumpVersions: [
+            {
+              filePatterns: [],
+              matchStrings: [],
+              bumpType: '{{#if isPatch}}patch{{else}}minor{{/if}}',
+            },
+          ],
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'repo',
+          config,
+          true,
+        );
+        expect(warnings).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid mode: mode had a value `"not-valid"` which was not part of the allowedValues: ["full","silent"]',
+            topic: 'Configuration Error',
+          },
+          {
+            message:
+              'Invalid packageRules[2].versioning: versioning had invalid value `"not-ever-valid-scheme"`. versioning can only be a known versioning scheme, or be a string starting with `regex:` for custom regular expression versioning',
+            topic: 'Configuration Error',
+          },
+          {
+            message:
+              'Invalid postUpdateOptions: postUpdateOptions had invalid values `["invalid","another"]` which are not part of the allowedValues: ["bundlerConservative","composerWithAll","composerNoMinimalChanges","dotnetWorkloadRestore","gomodMassage","gomodTidy","gomodTidy1.17","gomodTidyE","gomodUpdateImportPaths","gomodSkipVendor","gomodVendor","goGenerate","helmUpdateSubChartArchives","kustomizeInflateHelmCharts","npmDedupe","npmInstallTwice","pnpmDedupe","yarnDedupeFewer","yarnDedupeHighest"]',
+            topic: 'Configuration Error',
+          },
+        ]);
+      });
+
+      it('with global config', async () => {
+        const config: Partial<AllConfig> = {
+          // for a single value
+          // @ts-expect-error: contains invalid values
+          autodiscoverRepoOrder: 'middle-out',
+
+          // for an array
+          // @ts-expect-error: contains invalid values
+          allowedUnsafeExecutions: ['some', 'value'],
+
+          // TODO nested
+        };
+        const { warnings, errors } = await configValidation.validateConfig(
+          'global',
+          config,
+        );
+        expect(warnings).toBeEmptyArray();
+        expect(errors).toMatchObject([
+          {
+            message:
+              'Invalid allowedUnsafeExecutions: allowedUnsafeExecutions had invalid values `["some","value"]` which are not part of the allowedValues: ["bazelModDeps","goGenerate","gradleWrapper","mise"]',
+          },
+          {
+            message:
+              'Invalid autodiscoverRepoOrder: autodiscoverRepoOrder had a value `"middle-out"` which was not part of the allowedValues: ["asc","desc"]',
+          },
+        ]);
+      });
     });
 
     describe('cacheTtlOverride', () => {

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -43,7 +43,6 @@ import { GlobalConfig } from './global.ts';
 import { migrateConfig } from './migration.ts';
 import { getOptions } from './options/index.ts';
 import { resolveConfigPresets } from './presets/index.ts';
-import { supportedDatasources } from './presets/internal/merge-confidence.preset.ts';
 import { parsePreset } from './presets/parse.ts';
 import type {
   AllConfig,
@@ -986,46 +985,6 @@ async function validateGlobalConfig(
               },
             ).join(', ')}.`,
           });
-        } else if (
-          key === 'repositoryCache' &&
-          !['enabled', 'disabled', 'reset'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['enabled', 'disabled', 'reset'].join(', ')}.`,
-          });
-        } else if (
-          key === 'dryRun' &&
-          !['extract', 'lookup', 'full'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['extract', 'lookup', 'full'].join(', ')}.`,
-          });
-        } else if (
-          key === 'binarySource' &&
-          !['docker', 'global', 'install', 'hermit'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['docker', 'global', 'install', 'hermit'].join(', ')}.`,
-          });
-        } else if (
-          key === 'requireConfig' &&
-          !['required', 'optional', 'ignored'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['required', 'optional', 'ignored'].join(', ')}.`,
-          });
-        } else if (
-          key === 'gitUrl' &&
-          !['default', 'ssh', 'endpoint'].includes(val)
-        ) {
-          warnings.push({
-            topic: 'Configuration Error',
-            message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['default', 'ssh', 'endpoint'].join(', ')}.`,
-          });
         }
 
         if (
@@ -1065,30 +1024,6 @@ async function validateGlobalConfig(
               currentPath: currentPath!,
             }),
           );
-        }
-        if (key === 'gitNoVerify') {
-          const allowedValues = ['commit', 'push'];
-          for (const value of val as string[]) {
-            // v8 ignore else -- TODO: add test #40625
-            if (!allowedValues.includes(value)) {
-              warnings.push({
-                topic: 'Configuration Error',
-                message: `Invalid value for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
-              });
-            }
-          }
-        }
-        if (key === 'mergeConfidenceDatasources') {
-          const allowedValues = supportedDatasources;
-          for (const value of val as string[]) {
-            // v8 ignore else -- TODO: add test #40625
-            if (!allowedValues.includes(value)) {
-              warnings.push({
-                topic: 'Configuration Error',
-                message: `Invalid value \`${value}\` for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
-              });
-            }
-          }
         }
       } else {
         warnings.push({

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -922,6 +922,8 @@ export async function validateConfig(
         }
       }
     }
+
+    validateAllowedValues(key, val, currentPath, errors);
   }
 
   function sortAll(a: ValidationMessage, b: ValidationMessage): number {
@@ -1153,6 +1155,8 @@ async function validateGlobalConfig(
       }
     }
   }
+
+  validateAllowedValues(key, val, currentPath, errors);
 }
 
 function getPossibleConfigFileNames({
@@ -1168,4 +1172,45 @@ function getPossibleConfigFileNames({
   }
 
   return filenames;
+}
+
+function validateAllowedValues(
+  key: string,
+  val: any,
+  currentPath: string | undefined,
+  errors: ValidationMessage[],
+): void {
+  const option = options.find((o) => o.name === key);
+  if (!option) {
+    return;
+  }
+
+  const allowedValues = option?.allowedValues;
+  if (allowedValues?.length) {
+    if (val === null && option.default === null) {
+      // do nothing
+    } else if (isArray(val, isString)) {
+      const invalidOptions = val.filter((v) => !allowedValues.includes(v));
+      if (invalidOptions.length) {
+        errors.push({
+          topic: 'Configuration Error',
+          message: `Invalid ${currentPath}: ${option.name} had invalid values \`${JSON.stringify(invalidOptions)}\` which are not part of the allowedValues: ${JSON.stringify(option.allowedValues)}`,
+        });
+      }
+    } else if (isString(val)) {
+      if (key === 'versioning') {
+        if (!allowedValues.includes(val) && !val.startsWith('regex:')) {
+          errors.push({
+            topic: 'Configuration Error',
+            message: `Invalid ${currentPath}: ${option.name} had invalid value \`${JSON.stringify(val)}\`. ${option.name} can only be a known versioning scheme, or be a string starting with \`regex:\` for custom regular expression versioning`,
+          });
+        }
+      } else if (!allowedValues.includes(val) && !option.supportsTemplating) {
+        errors.push({
+          topic: 'Configuration Error',
+          message: `Invalid ${currentPath}: ${option.name} had a value \`${JSON.stringify(val)}\` which was not part of the allowedValues: ${JSON.stringify(option.allowedValues)}`,
+        });
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Instead of using custom code to handle this for a subset of options, we
can instead make sure that we're using the shared
`validateAllowedValues` function.

Although this does reduce some of the more human-readable custom worded
messages, this keeps things more consistent and scalable as options are
added.

<!-- Describe what behavior is changed by this PR. -->
## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
