### PR TITLE
fix(conda/pypi): allow nullable strings

### DIFF
--- a/lib/modules/datasource/conda/index.spec.ts
+++ b/lib/modules/datasource/conda/index.spec.ts
@@ -76,6 +76,27 @@ describe('modules/datasource/conda/index', () => {
       expect(res).toBeNull();
     });
 
+    it('handles null html_url and dev_url without throwing', async () => {
+      const packageName = 'pytest';
+      httpMock
+        .scope('https://api.anaconda.org/package/conda-forge')
+        .get(`/${packageName}`)
+        .reply(200, {
+          html_url: null,
+          dev_url: null,
+          versions: ['1.0.0'],
+          files: [],
+        });
+      const res = await getPkgReleases({
+        registryUrls: ['https://api.anaconda.org/package/conda-forge'],
+        datasource,
+        packageName,
+      });
+      expect(res).toMatchObject({ releases: [{ version: '1.0.0' }] });
+      expect(res?.homepage).toBeUndefined();
+      expect(res?.sourceUrl).toBeUndefined();
+    });
+
     it('supports multiple custom datasource urls', async () => {
       const packageName = 'pytest';
       httpMock

--- a/lib/modules/datasource/conda/schema.ts
+++ b/lib/modules/datasource/conda/schema.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod/v4';
-import { LooseArray } from '../../../util/schema-utils/index.ts';
+import { LooseArray, Nullish } from '../../../util/schema-utils/index.ts';
 
 export const CondaFile = z.object({
   version: z.string(),
-  upload_time: z.string().optional(),
+  upload_time: Nullish(z.string()),
 });
 
 export const CondaPackage = z.object({
-  html_url: z.string().optional(),
-  dev_url: z.string().optional(),
+  html_url: Nullish(z.string()),
+  dev_url: Nullish(z.string()),
   files: LooseArray(CondaFile).optional(),
   versions: z.array(z.string()).optional(),
 });

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -156,6 +156,7 @@ export class PypiDatasource extends Datasource {
         const lower = name.toLowerCase();
 
         if (
+          projectUrl &&
           !dependency.sourceUrl &&
           (lower.startsWith('repo') ||
             lower === 'code' ||

--- a/lib/modules/datasource/pypi/schema.spec.ts
+++ b/lib/modules/datasource/pypi/schema.spec.ts
@@ -55,7 +55,7 @@ describe('modules/datasource/pypi/schema', () => {
         releases: {},
       };
       const result = PypiResponse.parse(input);
-      expect(result?.info?.home_page).toBeNull();
+      expect(result?.info?.home_page).toBeUndefined();
       expect(result?.info?.project_urls?.Repository).toBe(
         input.info.project_urls.Repository,
       );

--- a/lib/modules/datasource/pypi/schema.spec.ts
+++ b/lib/modules/datasource/pypi/schema.spec.ts
@@ -21,7 +21,7 @@ describe('modules/datasource/pypi/schema', () => {
           ],
           '2.27.0': [
             {
-              requires_python: null, // null is allowed
+              requires_python: null,
               upload_time: '2021-11-16T12:00:00',
               yanked: true,
             },
@@ -31,7 +31,16 @@ describe('modules/datasource/pypi/schema', () => {
       const result = PypiResponse.parse(input);
       expect(result?.info?.name).toBe('requests');
       expect(result?.releases?.['2.28.0']?.[0].requires_python).toBe('>=3.7');
-      expect(result?.releases?.['2.27.0']?.[0].requires_python).toBeNull();
+      expect(result?.releases?.['2.27.0']?.[0].requires_python).toBeUndefined();
+    });
+
+    it('normalizes null home_page to undefined', () => {
+      const input = {
+        info: { name: 'pkg', home_page: null },
+        releases: {},
+      };
+      const result = PypiResponse.parse(input);
+      expect(result?.info?.home_page).toBeUndefined();
     });
 
     it('throws for genuinely invalid input (no error swallowing)', () => {

--- a/lib/modules/datasource/pypi/schema.ts
+++ b/lib/modules/datasource/pypi/schema.ts
@@ -1,9 +1,10 @@
 import { z } from 'zod/v4';
+import { Nullish } from '../../../util/schema-utils/index.ts';
 
 export const PypiRelease = z.object({
-  requires_python: z.string().nullish(),
-  upload_time: z.string().optional(),
-  yanked: z.boolean().optional(),
+  requires_python: Nullish(z.string()),
+  upload_time: Nullish(z.string()),
+  yanked: Nullish(z.boolean()).default(false),
 });
 
 export type PypiRelease = z.infer<typeof PypiRelease>;
@@ -11,9 +12,9 @@ export type PypiRelease = z.infer<typeof PypiRelease>;
 export const PypiResponse = z.object({
   info: z
     .object({
-      name: z.string().optional(),
-      home_page: z.string().optional().nullish(),
-      project_urls: z.record(z.string(), z.string()).optional(),
+      name: Nullish(z.string()),
+      home_page: Nullish(z.string()),
+      project_urls: z.record(z.string(), Nullish(z.string())).optional(),
     })
     .optional(),
   releases: z.record(z.string(), z.array(PypiRelease)).optional(),

--- a/lib/util/schema-utils/index.spec.ts
+++ b/lib/util/schema-utils/index.spec.ts
@@ -10,6 +10,7 @@ import {
   LooseRecord,
   MultidocYaml,
   NotCircular,
+  Nullish,
   Toml,
   UtcDate,
   Yaml,
@@ -138,6 +139,28 @@ describe('util/schema-utils/index', () => {
           },
         ],
       });
+    });
+  });
+
+  describe('Nullish', () => {
+    it('converts null to undefined', () => {
+      const s = z.object({ a: Nullish(z.string()) });
+      expect(s.parse({ a: null })).toEqual({});
+    });
+
+    it('converts undefined to undefined (key absent)', () => {
+      const s = z.object({ a: Nullish(z.string()) });
+      expect(s.parse({})).toEqual({});
+    });
+
+    it('preserves valid string values', () => {
+      const s = z.object({ a: Nullish(z.string()) });
+      expect(s.parse({ a: 'hello' })).toEqual({ a: 'hello' });
+    });
+
+    it('rejects wrong types', () => {
+      const s = Nullish(z.string());
+      expect(() => s.parse(42)).toThrow();
     });
   });
 

--- a/lib/util/schema-utils/index.ts
+++ b/lib/util/schema-utils/index.ts
@@ -187,6 +187,20 @@ export function LooseRecord<
   });
 }
 
+/**
+ * Accepts `null`, `undefined`, or an absent key and normalizes all to
+ * `undefined`. Keeps the output type as `T | undefined` (never `null`), so
+ * assignment into non-nullable targets needs no `?? undefined` coalescing.
+ */
+export function Nullish<Schema extends z.ZodTypeAny>(
+  schema: Schema,
+): z.ZodOptional<z.ZodType<z.output<Schema> | undefined>> {
+  return schema
+    .nullable()
+    .transform((value) => value ?? undefined)
+    .optional();
+}
+
 export const Json = z.string().transform((str, ctx): unknown => {
   try {
     return JSON.parse(str);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Changes all string and boolean schema values to the `Nullish` helper which allows values to be `undefined` ( by not being present or actively set ) as well set to `null` and standardize it to `undefined`. 

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/discussions/43819
https://github.com/renovatebot/renovate/pull/43814

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
