### PR TITLE
fix(manager/npm): use packageName for pnpm override minimumReleaseAgeExclude

### DIFF
--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -387,6 +387,40 @@ minimumReleaseAgeExclude:
       ]);
     });
 
+    it('uses packageName for minimumReleaseAgeExclude when override key has a version constraint', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 10080`,
+      ); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            depName: 'qs@<6.14.1',
+            packageName: 'qs',
+            currentValue: '6.14.2',
+            newVersion: '6.15.0',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents:
+              'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  # Renovate security update: qs@6.15.0\n  - qs@6.15.0\n',
+          },
+        },
+      ]);
+    });
+
     it('updates pnpm workspace - appends new minimumReleaseAgeExclude setting', async () => {
       fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
       fs.localPathExists.mockResolvedValueOnce(true);

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -188,6 +188,9 @@ async function updatePnpmWorkspace(
     let excludeNode = doc.getIn(['minimumReleaseAgeExclude']) as YAMLSeq | null;
     // v8 ignore next -- TODO: add test #40625
     const newVersion = upgrade.newVersion ?? upgrade.newValue;
+    // pnpm override keys can carry a version constraint (e.g. `qs@<6.14.1`),
+    // so use the parsed packageName to avoid malformed excludes like `qs@<6.14.1@6.15.0`
+    const excludeName = upgrade.packageName ?? upgrade.depName;
 
     /* v8 ignore if -- should not happen, adding for type narrowing*/
     if (excludeNode && !isSeq(excludeNode)) {
@@ -197,8 +200,8 @@ async function updatePnpmWorkspace(
     if (!excludeNode) {
       logger.debug('Adding new exclude block');
       excludeNode = doc.createNode([]) as YAMLSeq;
-      const newItem = doc.createNode(`${upgrade.depName}@${newVersion}`);
-      newItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+      const newItem = doc.createNode(`${excludeName}@${newVersion}`);
+      newItem.commentBefore = ` Renovate security update: ${excludeName}@${newVersion}`;
       excludeNode.items.push(newItem);
       doc.set('minimumReleaseAgeExclude', excludeNode);
       updated = true;
@@ -206,7 +209,7 @@ async function updatePnpmWorkspace(
     }
 
     const { item: matchedItem, allExcluded } = getMatchedItem(
-      upgrade.depName!,
+      excludeName!,
       excludeNode.items,
     );
 
@@ -216,12 +219,12 @@ async function updatePnpmWorkspace(
 
     if (isScalar<string>(matchedItem)) {
       // if we have a comment before the list, which includes the dependency
-      if (excludeNode?.commentBefore?.includes(`${upgrade.depName}@`)) {
+      if (excludeNode?.commentBefore?.includes(`${excludeName}@`)) {
         // and it doesn't already have the version included in it
         if (
           !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
             excludeNode.commentBefore,
-            upgrade.depName,
+            excludeName,
             newVersion,
           )
         ) {
@@ -238,7 +241,7 @@ async function updatePnpmWorkspace(
         if (
           !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
             matchedItem.commentBefore,
-            upgrade.depName,
+            excludeName,
             newVersion,
           )
         ) {
@@ -247,14 +250,14 @@ async function updatePnpmWorkspace(
           updated = true;
         }
       } else {
-        matchedItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+        matchedItem.commentBefore = ` Renovate security update: ${excludeName}@${newVersion}`;
         updated = true;
       }
 
       if (
         !minimumReleaseAgeExcludeIncludesDepNameAndVersion(
           matchedItem.value,
-          upgrade.depName,
+          excludeName,
           newVersion,
         )
       ) {
@@ -263,8 +266,8 @@ async function updatePnpmWorkspace(
       }
     } else {
       // add new entry
-      const newItem = doc.createNode(`${upgrade.depName}@${newVersion}`);
-      newItem.commentBefore = ` Renovate security update: ${upgrade.depName}@${newVersion}`;
+      const newItem = doc.createNode(`${excludeName}@${newVersion}`);
+      newItem.commentBefore = ` Renovate security update: ${excludeName}@${newVersion}`;
 
       excludeNode.items.push(newItem);
       updated = true;


### PR DESCRIPTION
## Changes

Fix malformed `minimumReleaseAgeExclude` entries when a pnpm `overrides` key carries a version constraint (e.g. `qs@<6.14.1`).

Previously the full override key was used as the dep name, producing invalid entries like `qs@<6.14.1@6.15.0` ("Invalid versions union") which blocked lockfile regeneration for security updates. The exclude entry now uses the parsed `packageName`, yielding `qs@6.15.0`.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Used Claude Code (Claude Opus 4.8) to diagnose the bug, scope the fix in `lib/modules/manager/npm/artifacts.ts`, and add a regression test.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests
