### PR TITLE
refactor(schema-utils): add DeepNullish and use it for conda pypi

### DIFF
--- a/docs/development/zod.md
+++ b/docs/development/zod.md
@@ -287,6 +287,64 @@ const Versions = LooseArray(
 );
 ```
 
+### Use `Nullish` and `DeepNullish` to handle null as absent
+
+External APIs sometimes return `null` for fields that are conceptually absent rather than intentionally null.
+`Nullish` and `DeepNullish` normalise this by converting `null` (and `undefined`) to `undefined`, which Zod then treats as absent.
+
+#### `Nullish` — single field
+
+Wrap one field with `Nullish` when only that field needs to accept `null`:
+
+```ts
+const Release = z.object({
+  version: z.string(),
+  releaseTimestamp: Nullish(z.string()),
+});
+
+Release.parse({ version: '1.0.0', releaseTimestamp: null });
+// => { version: '1.0.0' }  (releaseTimestamp absent)
+```
+
+#### `DeepNullish` — whole schema at once
+
+When an API returns `null` in many optional fields, applying `Nullish` to each one individually is tedious.
+`DeepNullish` walks the schema at build time and replaces every `.optional()` field with `Nullish` semantics in one call.
+
+Prefer `DeepNullish` over manual `Nullish` wrapping when the schema has multiple optional fields:
+
+```ts
+const Release = DeepNullish(
+  z.object({
+    version: z.string(),
+    releaseTimestamp: z.string().optional(),
+    gitRef: z.string().optional(),
+  }),
+);
+
+Release.parse({ version: '1.0.0', releaseTimestamp: null, gitRef: null });
+// => { version: '1.0.0' }
+```
+
+`DeepNullish` also recurses into the **output side** of `pipe` / transform nodes, so it works directly with `Json.pipe(…)`:
+
+```ts
+const Release = DeepNullish(
+  Json.pipe(
+    z.object({
+      version: z.string(),
+      releaseTimestamp: z.string().optional(),
+    }),
+  ),
+);
+
+Release.parse('{"version":"1.0.0","releaseTimestamp":null}');
+// => { version: '1.0.0' }
+```
+
+!!! note
+  Intentional `.nullable()` fields are preserved — `null` is kept, not stripped.
+
 ### Combining with `Result` class
 
 The `Result` (and `AsyncResult`) class represents the result of an operation, like `Result.ok(200)` or `Result.err(404)`.

--- a/lib/modules/datasource/conda/schema.ts
+++ b/lib/modules/datasource/conda/schema.ts
@@ -1,16 +1,20 @@
 import { z } from 'zod/v4';
-import { LooseArray, Nullish } from '../../../util/schema-utils/index.ts';
+import { DeepNullish, LooseArray } from '../../../util/schema-utils/index.ts';
 
-export const CondaFile = z.object({
-  version: z.string(),
-  upload_time: Nullish(z.string()),
-});
+export const CondaFile = DeepNullish(
+  z.object({
+    version: z.string(),
+    upload_time: z.string().optional(),
+  }),
+);
 
-export const CondaPackage = z.object({
-  html_url: Nullish(z.string()),
-  dev_url: Nullish(z.string()),
-  files: LooseArray(CondaFile).optional(),
-  versions: z.array(z.string()).optional(),
-});
+export const CondaPackage = DeepNullish(
+  z.object({
+    html_url: z.string().optional(),
+    dev_url: z.string().optional(),
+    files: LooseArray(CondaFile).optional(),
+    versions: z.array(z.string()).optional(),
+  }),
+);
 
 export type CondaPackage = z.infer<typeof CondaPackage>;

--- a/lib/modules/datasource/pypi/schema.ts
+++ b/lib/modules/datasource/pypi/schema.ts
@@ -1,23 +1,27 @@
 import { z } from 'zod/v4';
-import { Nullish } from '../../../util/schema-utils/index.ts';
+import { DeepNullish } from '../../../util/schema-utils/index.ts';
 
-export const PypiRelease = z.object({
-  requires_python: Nullish(z.string()),
-  upload_time: Nullish(z.string()),
-  yanked: Nullish(z.boolean()).default(false),
-});
+export const PypiRelease = DeepNullish(
+  z.object({
+    requires_python: z.string().optional(),
+    upload_time: z.string().optional(),
+    yanked: z.boolean().optional().default(false),
+  }),
+);
 
 export type PypiRelease = z.infer<typeof PypiRelease>;
 
-export const PypiResponse = z.object({
-  info: z
-    .object({
-      name: Nullish(z.string()),
-      home_page: Nullish(z.string()),
-      project_urls: z.record(z.string(), Nullish(z.string())).optional(),
-    })
-    .optional(),
-  releases: z.record(z.string(), z.array(PypiRelease)).optional(),
-});
+export const PypiResponse = DeepNullish(
+  z.object({
+    info: z
+      .object({
+        name: z.string().optional(),
+        home_page: z.string().optional(),
+        project_urls: z.record(z.string(), z.string().optional()).optional(),
+      })
+      .optional(),
+    releases: z.record(z.string(), z.array(PypiRelease)).optional(),
+  }),
+);
 
 export type PypiResponse = z.infer<typeof PypiResponse>;

--- a/lib/util/schema-utils/index.spec.ts
+++ b/lib/util/schema-utils/index.spec.ts
@@ -263,7 +263,7 @@ describe('util/schema-utils/index', () => {
     });
 
     describe('Loose* schemas remain opaque (closure boundary)', () => {
-      it('LooseArray element optionals are not rewritten', () => {
+      it('LooseArray element optionals are not rewritten, but cleaned up', () => {
         const s = DeepNullish(
           LooseArray(z.object({ b: z.string().optional() })),
         );
@@ -271,11 +271,14 @@ describe('util/schema-utils/index', () => {
         expect(s.parse([{ b: 'x' }])).toEqual([{ b: 'x' }]);
       });
 
-      it('LooseRecord value optionals are not rewritten', () => {
+      it('LooseRecord value optionals are not rewritten, but cleaned up', () => {
         const s = DeepNullish(
           LooseRecord(z.object({ b: z.string().optional() })),
         );
         expect(s.parse({ k: { b: null } })).toEqual({});
+        expect(s.parse({ k: { b: null }, j: { b: '' } })).toEqual({
+          j: { b: '' },
+        });
         expect(s.parse({ k: { b: 'x' } })).toEqual({ k: { b: 'x' } });
       });
     });

--- a/lib/util/schema-utils/index.spec.ts
+++ b/lib/util/schema-utils/index.spec.ts
@@ -2,6 +2,7 @@ import { codeBlock } from 'common-tags';
 import { z } from 'zod/v4';
 import { logger } from '~test/util.ts';
 import {
+  DeepNullish,
   Ini,
   Json,
   Json5,
@@ -162,6 +163,142 @@ describe('util/schema-utils/index', () => {
       const s = Nullish(z.string());
       expect(() => s.parse(42)).toThrow();
     });
+  });
+
+  describe('DeepNullish', () => {
+    describe('optional leaf', () => {
+      const s = DeepNullish(z.object({ a: z.string().optional() }));
+
+      it.each`
+        input             | expected
+        ${{ a: null }}    | ${{}}
+        ${{}}             | ${{}}
+        ${{ a: 'hello' }} | ${{ a: 'hello' }}
+      `('parses $input', ({ input, expected }) => {
+        expect(s.parse(input)).toEqual(expected);
+      });
+
+      it('rejects wrong types', () => {
+        expect(() => s.parse({ a: 42 })).toThrow();
+      });
+    });
+
+    it.each`
+      input                         | expected
+      ${{ outer: { inner: null } }} | ${{ outer: {} }}
+      ${{ outer: null }}            | ${{}}
+    `('recurses into nested objects: $input', ({ input, expected }) => {
+      const s = DeepNullish(
+        z.object({
+          outer: z.object({ inner: z.string().optional() }).optional(),
+        }),
+      );
+      expect(s.parse(input)).toEqual(expected);
+    });
+
+    it('recurses into record valueType', () => {
+      const s = DeepNullish(z.record(z.string(), z.string().optional()));
+      const result = s.parse({ key: null });
+      expect(result.key).toBeUndefined();
+    });
+
+    it('recurses into array element', () => {
+      const s = DeepNullish(z.array(z.string().optional()));
+      expect(s.parse([null, 'hello'])).toEqual([undefined, 'hello']);
+    });
+
+    it.each`
+      input                   | expected
+      ${{ val: { a: null } }} | ${{ val: {} }}
+      ${{ val: { a: 'x' } }}  | ${{ val: { a: 'x' } }}
+      ${{ val: 42 }}          | ${{ val: 42 }}
+    `('recurses into union options: $input', ({ input, expected }) => {
+      const s = DeepNullish(
+        z.object({
+          val: z.union([z.object({ a: z.string().optional() }), z.number()]),
+        }),
+      );
+      expect(s.parse(input)).toEqual(expected);
+    });
+
+    it.each`
+      input          | expected
+      ${{}}          | ${{ y: false }}
+      ${{ y: null }} | ${{ y: false }}
+      ${{ y: true }} | ${{ y: true }}
+    `('handles default over optional: $input', ({ input, expected }) => {
+      const s = DeepNullish(
+        z.object({ y: z.boolean().optional().default(false) }),
+      );
+      expect(s.parse(input)).toEqual(expected);
+    });
+
+    it.each`
+      input             | expected
+      ${{ a: null }}    | ${{ a: null }}
+      ${{ a: 'hello' }} | ${{ a: 'hello' }}
+    `(
+      'preserves nullable fields (null not stripped): $input',
+      ({ input, expected }) => {
+        const s = DeepNullish(z.object({ a: z.nullable(z.string()) }));
+        expect(s.parse(input)).toEqual(expected);
+      },
+    );
+
+    describe('recurses into pipe output side', () => {
+      const s = DeepNullish(Json.pipe(z.object({ a: z.string().optional() })));
+
+      it('parses valid input', () => {
+        expect(s.parse('{"a":"x"}')).toEqual({ a: 'x' });
+      });
+
+      it('strips optional inside pipe', () => {
+        expect(s.parse('{"a":null}')).toEqual({});
+        expect(s.parse('{}')).toEqual({});
+      });
+
+      it('still rejects invalid JSON', () => {
+        expect(s.safeParse('{{{')).toMatchObject({ success: false });
+      });
+    });
+
+    describe('Loose* schemas remain opaque (closure boundary)', () => {
+      it('LooseArray element optionals are not rewritten', () => {
+        const s = DeepNullish(
+          LooseArray(z.object({ b: z.string().optional() })),
+        );
+        expect(s.parse([{ b: null }])).toEqual([]);
+        expect(s.parse([{ b: 'x' }])).toEqual([{ b: 'x' }]);
+      });
+
+      it('LooseRecord value optionals are not rewritten', () => {
+        const s = DeepNullish(
+          LooseRecord(z.object({ b: z.string().optional() })),
+        );
+        expect(s.parse({ k: { b: null } })).toEqual({});
+        expect(s.parse({ k: { b: 'x' } })).toEqual({ k: { b: 'x' } });
+      });
+    });
+
+    it('passes through leaf types unchanged', () => {
+      expect(DeepNullish(z.string()).parse('hello')).toBe('hello');
+    });
+
+    it('rejects wrong types on leaf', () => {
+      expect(() => DeepNullish(z.string()).parse(42)).toThrow();
+    });
+
+    it.each`
+      input          | expected
+      ${{ a: null }} | ${{}}
+      ${{ a: 'x' }}  | ${{ a: 'x' }}
+    `(
+      'is idempotent when schema already uses Nullish: $input',
+      ({ input, expected }) => {
+        const s = DeepNullish(z.object({ a: Nullish(z.string()) }));
+        expect(s.parse(input)).toEqual(expected);
+      },
+    );
   });
 
   describe('Json', () => {
@@ -593,45 +730,37 @@ describe('util/schema-utils/index', () => {
   });
 
   describe('NotCircular', () => {
-    it('allows non-circular primitive values', () => {
-      const Schema = NotCircular.pipe(z.any());
+    const Schema = NotCircular.pipe(z.any());
 
-      expect(Schema.parse(undefined)).toBeUndefined();
-      expect(Schema.parse(null)).toBeNull();
-      expect(Schema.parse(123)).toBe(123);
-      expect(Schema.parse('string')).toBe('string');
-      expect(Schema.parse(true)).toBe(true);
+    it.each`
+      value
+      ${undefined}
+      ${null}
+      ${123}
+      ${'string'}
+      ${true}
+    `('allows non-circular primitive $value', ({ value }) => {
+      expect(Schema.parse(value)).toBe(value);
     });
 
-    it('allows non-circular arrays', () => {
-      const Schema = NotCircular.pipe(z.any());
-
-      expect(Schema.parse([1, 2, 3])).toEqual([1, 2, 3]);
-      expect(Schema.parse([{ a: 1 }, { b: 2 }])).toEqual([{ a: 1 }, { b: 2 }]);
-      expect(
-        Schema.parse([
-          [1, 2],
-          [3, 4],
-        ]),
-      ).toEqual([
-        [1, 2],
-        [3, 4],
-      ]);
+    it.each`
+      value
+      ${[1, 2, 3]}
+      ${[{ a: 1 }, { b: 2 }]}
+      ${[[1, 2], [3, 4]]}
+    `('allows non-circular array $value', ({ value }) => {
+      expect(Schema.parse(value)).toEqual(value);
     });
 
-    it('allows non-circular objects', () => {
-      const Schema = NotCircular.pipe(z.any());
-
-      expect(Schema.parse({ a: 1, b: 2 })).toEqual({ a: 1, b: 2 });
-      expect(Schema.parse({ a: { b: 1 }, c: { d: 2 } })).toEqual({
-        a: { b: 1 },
-        c: { d: 2 },
-      });
+    it.each`
+      value
+      ${{ a: 1, b: 2 }}
+      ${{ a: { b: 1 }, c: { d: 2 } }}
+    `('allows non-circular object $value', ({ value }) => {
+      expect(Schema.parse(value)).toEqual(value);
     });
 
     it('allows objects reuse', () => {
-      const Schema = NotCircular.pipe(z.any());
-
       const reused = { value: 42 };
       const obj = {
         foo: reused,
@@ -645,8 +774,6 @@ describe('util/schema-utils/index', () => {
     });
 
     it('rejects circular objects', () => {
-      const Schema = NotCircular.pipe(z.any());
-
       const obj: any = { a: 1 };
       obj.self = obj;
 
@@ -665,8 +792,6 @@ describe('util/schema-utils/index', () => {
     });
 
     it('rejects circular arrays', () => {
-      const Schema = NotCircular.pipe(z.any());
-
       const arr: any[] = [1, 2, 3];
       arr.push(arr);
 
@@ -685,8 +810,6 @@ describe('util/schema-utils/index', () => {
     });
 
     it('rejects deeply nested circular references', () => {
-      const Schema = NotCircular.pipe(z.any());
-
       const obj: any = {
         a: {
           b: {

--- a/lib/util/schema-utils/index.ts
+++ b/lib/util/schema-utils/index.ts
@@ -201,6 +201,77 @@ export function Nullish<Schema extends z.ZodTypeAny>(
     .optional();
 }
 
+function deepNullishRewrite(node: z.ZodTypeAny): z.ZodTypeAny {
+  if (node instanceof z.ZodOptional) {
+    return Nullish(deepNullishRewrite(node.unwrap() as z.ZodTypeAny));
+  }
+  if (node instanceof z.ZodObject) {
+    const shape: Record<string, z.ZodTypeAny> = {};
+    for (const [key, value] of Object.entries(node.shape)) {
+      shape[key] = deepNullishRewrite(value as z.ZodTypeAny);
+    }
+    return z.object(shape);
+  }
+  if (node instanceof z.ZodArray) {
+    return z.array(deepNullishRewrite(node.element as z.ZodTypeAny));
+  }
+  if (node instanceof z.ZodRecord) {
+    return z.record(
+      node.keyType,
+      deepNullishRewrite(node.valueType as z.ZodTypeAny),
+    );
+  }
+  if (node instanceof z.ZodUnion) {
+    const options = node.options as z.ZodTypeAny[];
+    return z.union(
+      options.map(deepNullishRewrite) as [
+        z.ZodTypeAny,
+        z.ZodTypeAny,
+        ...z.ZodTypeAny[],
+      ],
+    );
+  }
+  if (node instanceof z.ZodDefault) {
+    return deepNullishRewrite(node.unwrap() as z.ZodTypeAny).default(
+      node.def.defaultValue,
+    );
+  }
+  if (node instanceof z.ZodNullable) {
+    return z.nullable(deepNullishRewrite(node.unwrap() as z.ZodTypeAny));
+  }
+  if (node instanceof z.ZodPipe) {
+    return z.pipe(
+      node.def.in as z.ZodTypeAny,
+      deepNullishRewrite(node.def.out as z.ZodTypeAny),
+    );
+  }
+  return node;
+}
+
+/**
+ * Walks `schema` at build time and replaces every `.optional()` position with
+ * `Nullish` semantics — accepting `null`/`undefined`/absent and normalizing all
+ * to `undefined`. Recurses through `object`, `array`, `record`, `union`,
+ * `default`, `nullable`, and the **output side** of `pipe`/transform nodes
+ * (e.g. `Json.pipe(…)`).
+ *
+ * Intentional `.nullable()` fields are preserved (null kept), distinguishing
+ * this from a blunt null-stripping preprocessor.
+ *
+ * The pipe **input** side (the decoder, e.g. `Json`) is left untouched.
+ * **`LooseArray`/`LooseRecord` remain opaque** because their element schema is
+ * captured in a closure — wrap the inner schema directly for those
+ * (e.g. `LooseArray(DeepNullish(Inner))`).
+ *
+ * Object modifiers (`.strict()`/`.catchall()`/`.passthrough()`/object-level
+ * `.refine()`) are dropped by the `z.object(shape)` rebuild.
+ */
+export function DeepNullish<Schema extends z.ZodTypeAny>(
+  schema: Schema,
+): z.ZodType<z.output<Schema>> {
+  return deepNullishRewrite(schema) as z.ZodType<z.output<Schema>>;
+}
+
 export const Json = z.string().transform((str, ctx): unknown => {
   try {
     return JSON.parse(str);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This introduces a new `DeepNullish` schema util, which applies replaces usages of `.optional()` with `Nullish()`, during module initialisation. 

This way whole object responses can be wrapped without the need to add it to every single field. 

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/43834

Using for now only on the Conda and Pypi datasources explicitly, but theoretically could be added centrally to `getJson` 

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
