### PR TITLE
feat(github): re-request review from users with dismissed approvals

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4506,6 +4506,12 @@ The `in-range-only` strategy behaves like `update-lockfile`, but discards any up
 We recommend you avoid using the `in-range-only` strategy unless you strictly need it.
 Using the `in-range-only` strategy may result in you being multiple releases behind without knowing it.
 
+## `reRequestApprovedReviews`
+
+When enabled, Renovate will re-request review from users whose approvals were dismissed on existing PRs.
+This is useful when branch protection rules dismiss stale approvals after new commits are pushed, leaving PRs without active reviewers.
+This option is only supported on the GitHub platform.
+
 ## `rebaseLabel`
 
 On supported platforms it is possible to add a label to a PR to manually request Renovate to recreate/rebase it.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2731,6 +2731,14 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
   },
   {
+    name: 'reRequestApprovedReviews',
+    description:
+      'Re-request review from users whose approvals were dismissed on existing PRs.',
+    type: 'boolean',
+    default: false,
+    supportedPlatforms: ['github'],
+  },
+  {
     name: 'managerFilePatterns',
     description: 'RegEx (`re2`) and glob patterns for matching manager files.',
     type: 'array',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -530,6 +530,7 @@ export interface AssigneesAndReviewersConfig {
   reviewersSampleSize?: number;
   additionalReviewers?: string[];
   filterUnavailableUsers?: boolean;
+  reRequestApprovedReviews?: boolean;
 }
 
 export type UpdateType =

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -3449,6 +3449,68 @@ describe('modules/platform/github/index', () => {
     });
   });
 
+  describe('getPrDismissedReviewers(prNo)', () => {
+    it('should return logins whose latest review state is DISMISSED', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/pulls/42/reviews').reply(200, [
+        { user: { login: 'user1' }, state: 'APPROVED' },
+        { user: { login: 'user1' }, state: 'DISMISSED' },
+        { user: { login: 'user2' }, state: 'CHANGES_REQUESTED' },
+        { user: { login: 'user3' }, state: 'DISMISSED' },
+      ]);
+      await github.initRepo({ repository: 'some/repo' });
+      const result = await github.getPrDismissedReviewers(42);
+      expect(result).toEqual(['user1', 'user3']);
+    });
+
+    it('should not return users who re-approved after dismissal', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/pulls/42/reviews').reply(200, [
+        { user: { login: 'user1' }, state: 'APPROVED' },
+        { user: { login: 'user1' }, state: 'DISMISSED' },
+        { user: { login: 'user1' }, state: 'APPROVED' },
+      ]);
+      await github.initRepo({ repository: 'some/repo' });
+      const result = await github.getPrDismissedReviewers(42);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array when no dismissed reviews exist', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/pulls/42/reviews').reply(200, [
+        { user: { login: 'user1' }, state: 'APPROVED' },
+        { user: { login: 'user2' }, state: 'CHANGES_REQUESTED' },
+      ]);
+      await github.initRepo({ repository: 'some/repo' });
+      const result = await github.getPrDismissedReviewers(42);
+      expect(result).toEqual([]);
+    });
+
+    it('should return empty array on error', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/pulls/42/reviews').reply(404);
+      await github.initRepo({ repository: 'some/repo' });
+      const result = await github.getPrDismissedReviewers(42);
+      expect(result).toEqual([]);
+    });
+
+    it('should handle reviews with null user', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.get('/repos/some/repo/pulls/42/reviews').reply(200, [
+        { user: null, state: 'DISMISSED' },
+        { user: { login: 'user1' }, state: 'DISMISSED' },
+      ]);
+      await github.initRepo({ repository: 'some/repo' });
+      const result = await github.getPrDismissedReviewers(42);
+      expect(result).toEqual(['user1']);
+    });
+  });
+
   describe('ensureComment', () => {
     it('add comment if not found', async () => {
       const scope = httpMock.scope(githubApiHost);

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1640,7 +1640,7 @@ export async function addReviewers(
 export async function getPrDismissedReviewers(prNo: number): Promise<string[]> {
   logger.debug(`Getting reviewers with dismissed approvals for PR #${prNo}`);
   try {
-    const res = await githubApi.getJson<
+    const res = await githubApi.getJsonUnchecked<
       { user: { login: string } | null; state: string }[]
     >(`repos/${config.parentRepo ?? config.repository}/pulls/${prNo}/reviews`, {
       paginate: true,

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1637,6 +1637,33 @@ export async function addReviewers(
   }
 }
 
+export async function getPrDismissedReviewers(prNo: number): Promise<string[]> {
+  logger.debug(`Getting reviewers with dismissed approvals for PR #${prNo}`);
+  try {
+    const res = await githubApi.getJson<
+      { user: { login: string } | null; state: string }[]
+    >(`repos/${config.parentRepo ?? config.repository}/pulls/${prNo}/reviews`, {
+      paginate: true,
+    });
+    const latestReviewByUser = new Map<string, string>();
+    for (const review of res.body) {
+      if (review.user?.login) {
+        latestReviewByUser.set(review.user.login, review.state);
+      }
+    }
+    const dismissedLogins: string[] = [];
+    for (const [login, state] of latestReviewByUser) {
+      if (state === 'DISMISSED') {
+        dismissedLogins.push(login);
+      }
+    }
+    return dismissedLogins;
+  } catch (err) /* v8 ignore next */ {
+    logger.warn({ err }, 'Failed to get PR reviews');
+    return [];
+  }
+}
+
 export async function addLabels(
   issueNo: number,
   labels: string[] | null | undefined,

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -316,6 +316,7 @@ export interface Platform {
   commitFiles?(config: CommitFilesConfig): Promise<LongCommitSha | null>;
   expandGroupMembers?(reviewersOrAssignees: string[]): Promise<string[]>;
   extractRulesFromCodeOwnersLines?(cleanedLines: string[]): FileOwnerRule[];
+  getPrDismissedReviewers?(prNo: number): Promise<string[]>;
 
   maxBodyLength(): number;
   labelCharLimit?(): number;

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -502,6 +502,94 @@ describe('workers/repository/update/pr/index', () => {
           'Pull Request #123 does not need updating',
         );
       });
+
+      it('re-requests review from users with dismissed reviews on existing PR', async () => {
+        const changedPr: Pr = { ...pr, title: 'Another title' };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        platform.getPrDismissedReviewers = vi
+          .fn()
+          .mockResolvedValueOnce(['user1', 'user2']);
+
+        const res = await ensurePr({
+          ...config,
+          reRequestApprovedReviews: true,
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(platform.getPrDismissedReviewers).toHaveBeenCalledWith(
+          pr.number,
+        );
+        expect(platform.addReviewers).toHaveBeenCalledWith(pr.number, [
+          'user1',
+          'user2',
+        ]);
+      });
+
+      it('re-requests review even when PR does not need updating', async () => {
+        platform.getBranchPr.mockResolvedValueOnce(pr);
+        platform.getPrDismissedReviewers = vi
+          .fn()
+          .mockResolvedValueOnce(['user1']);
+
+        const res = await ensurePr({
+          ...config,
+          reRequestApprovedReviews: true,
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(platform.updatePr).not.toHaveBeenCalled();
+        expect(platform.getPrDismissedReviewers).toHaveBeenCalledWith(
+          pr.number,
+        );
+        expect(platform.addReviewers).toHaveBeenCalledWith(pr.number, [
+          'user1',
+        ]);
+      });
+
+      it('does not re-request review when reRequestApprovedReviews is disabled', async () => {
+        const changedPr: Pr = { ...pr, title: 'Another title' };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        platform.getPrDismissedReviewers = vi.fn();
+
+        await ensurePr({
+          ...config,
+          reRequestApprovedReviews: false,
+        });
+
+        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.getPrDismissedReviewers).not.toHaveBeenCalled();
+      });
+
+      it('does not re-request review when no dismissed reviews exist', async () => {
+        const changedPr: Pr = { ...pr, title: 'Another title' };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        platform.getPrDismissedReviewers = vi.fn().mockResolvedValueOnce([]);
+
+        await ensurePr({
+          ...config,
+          reRequestApprovedReviews: true,
+        });
+
+        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.getPrDismissedReviewers).toHaveBeenCalledWith(
+          pr.number,
+        );
+        expect(platform.addReviewers).not.toHaveBeenCalled();
+      });
+
+      it('does not re-request review when platform lacks getPrDismissedReviewers', async () => {
+        const changedPr: Pr = { ...pr, title: 'Another title' };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        platform.getPrDismissedReviewers = undefined;
+
+        await ensurePr({
+          ...config,
+          reRequestApprovedReviews: true,
+        });
+
+        expect(platform.updatePr).toHaveBeenCalled();
+        expect(platform.addReviewers).not.toHaveBeenCalled();
+      });
     });
 
     describe('dry-run', () => {
@@ -539,6 +627,29 @@ describe('workers/repository/update/pr/index', () => {
 
         expect(logger.logger.info).toHaveBeenCalledWith(
           `DRY-RUN: Would update PR #${pr.number}`,
+        );
+      });
+
+      it('dry-runs re-request review from users with dismissed reviews', async () => {
+        const changedPr: Pr = { ...pr, title: 'Another title' };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        platform.getPrDismissedReviewers = vi
+          .fn()
+          .mockResolvedValueOnce(['user1', 'user2']);
+
+        await ensurePr({
+          ...config,
+          reRequestApprovedReviews: true,
+        });
+
+        expect(platform.updatePr).not.toHaveBeenCalled();
+        expect(platform.getPrDismissedReviewers).toHaveBeenCalledWith(
+          pr.number,
+        );
+        expect(platform.addReviewers).not.toHaveBeenCalled();
+        expect(logger.logger.info).toHaveBeenCalledWith(
+          { dismissedReviewers: ['user1', 'user2'] },
+          `DRY-RUN: Would re-request review from reviewers with dismissed approvals for PR #${pr.number}`,
         );
       });
 

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -580,7 +580,7 @@ describe('workers/repository/update/pr/index', () => {
       it('does not re-request review when platform lacks getPrDismissedReviewers', async () => {
         const changedPr: Pr = { ...pr, title: 'Another title' };
         platform.getBranchPr.mockResolvedValueOnce(changedPr);
-        platform.getPrDismissedReviewers = undefined;
+        platform.getPrDismissedReviewers = undefined as never;
 
         await ensurePr({
           ...config,

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -397,6 +397,25 @@ export async function ensurePr(
         logger.debug(`Setting assignees and reviewers as status checks failed`);
         await addParticipants(config, existingPr);
       }
+      if (config.reRequestApprovedReviews && platform.getPrDismissedReviewers) {
+        const dismissedReviewers = await platform.getPrDismissedReviewers(
+          existingPr.number,
+        );
+        if (dismissedReviewers.length > 0) {
+          if (GlobalConfig.get('dryRun')) {
+            logger.info(
+              { dismissedReviewers },
+              `DRY-RUN: Would re-request review from reviewers with dismissed approvals for PR #${existingPr.number}`,
+            );
+          } else {
+            logger.debug(
+              { dismissedReviewers },
+              `Re-requesting review from reviewers with dismissed approvals for PR #${existingPr.number}`,
+            );
+            await platform.addReviewers(existingPr.number, dismissedReviewers);
+          }
+        }
+      }
       // Check if existing PR needs updating
       const existingPrTitle = stripEmojis(existingPr.title);
       const existingPrBodyHash = existingPr.bodyStruct?.hash;


### PR DESCRIPTION
## Changes

Adds a new config option `reRequestApprovedReviews` (GitHub-only, default `false`) that, when enabled, automatically re-requests review from users whose approvals were dismissed on existing PRs.

When Renovate processes an existing PR:
1. Fetches all reviews via the GitHub Reviews API
2. Determines each user's latest review state
3. If a user's latest state is `DISMISSED`, re-requests their review

This handles cases where stale approval dismissal (from rebases, force pushes, or admin actions) leaves PRs without active reviewers indefinitely.

**Implementation:**
- New optional `getPrDismissedReviewers` method on the `Platform` interface
- GitHub implementation that tracks latest review state per user and returns those with `DISMISSED` as their most recent state
- Integration in `ensurePr` that runs early in the existing-PR path (before the "needs updating" check), so it catches dismissed reviews regardless of whether the PR body/title changed
- Proper dry-run support that logs what would happen without making changes

## Context

- Discussion: https://github.com/renovatebot/renovate/discussions/43482
- Approved by maintainer: https://github.com/renovatebot/renovate/discussions/43482#discussioncomment-17135060
- Previous PR (closed): https://github.com/renovatebot/renovate/pull/43463

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Cursor (Claude) was used to implement the feature, write tests, and iterate on the design.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Both unit tests + ran on a real repository

The public repository: https://github.snooguts.net/reddit/data-api-firehose (GitHub Enterprise, verified via dry-run against PRs with dismissed approvals)