### PR TITLE
feat(platform/gitea,forgejo): use login instead of username for user handles

### DIFF
--- a/lib/modules/platform/forgejo/forgejo-helper.spec.ts
+++ b/lib/modules/platform/forgejo/forgejo-helper.spec.ts
@@ -58,14 +58,14 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
 
   const mockUser: User = {
     id: 1,
-    username: 'admin',
+    login: 'admin',
     full_name: 'The Administrator',
     email: 'admin@example.com',
   };
 
   const otherMockUser: User & Required<Pick<User, 'full_name'>> = {
     ...mockUser,
-    username: 'renovate',
+    login: 'renovate',
     full_name: 'Renovate Bot',
     email: 'renovate@example.com',
   };
@@ -167,7 +167,7 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
     author: {
       name: otherMockUser.full_name,
       email: otherMockUser.email,
-      username: otherMockUser.username,
+      login: otherMockUser.login,
     },
   };
 
@@ -220,15 +220,15 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
     it('should call /api/v1/orgs/[org] endpoint', async () => {
       httpMock
         .scope(baseUrl)
-        .get(`/orgs/${mockRepo.owner.username}`)
+        .get(`/orgs/${mockRepo.owner.login}`)
         .reply(200, {})
         .get(`/orgs/user`)
         .reply(404)
         .get(`/orgs/error`)
         .reply(503);
-      expect(await isOrg(mockRepo.owner.username)).toEqual(true);
+      expect(await isOrg(mockRepo.owner.login)).toEqual(true);
       // uses cached result
-      expect(await isOrg(mockRepo.owner.username)).toEqual(true);
+      expect(await isOrg(mockRepo.owner.login)).toEqual(true);
       expect(await isOrg('user')).toEqual(false);
       await expect(isOrg('error')).rejects.toThrow();
     });
@@ -371,7 +371,7 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
         body: mockPR.body,
         base: mockPR.base?.ref,
         head: mockPR.head?.label,
-        assignees: [mockUser.username],
+        assignees: [mockUser.login],
         labels: [mockLabel.id],
       });
       expect(res).toEqual(mockPR);
@@ -396,7 +396,7 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
         state: 'closed',
         title: 'new-title',
         body: 'new-body',
-        assignees: [otherMockUser.username],
+        assignees: [otherMockUser.login],
         labels: [otherMockLabel.id],
       });
       expect(res).toEqual(updatedMockPR);
@@ -524,7 +524,7 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
         state: mockIssue.state,
         title: mockIssue.title,
         body: mockIssue.body,
-        assignees: [mockUser.username],
+        assignees: [mockUser.login],
       });
       expect(res).toEqual(mockIssue);
     });
@@ -549,7 +549,7 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
         state: 'closed',
         title: 'new-title',
         body: 'new-body',
-        assignees: [otherMockUser.username],
+        assignees: [otherMockUser.login],
       });
       expect(res).toEqual(updatedMockIssue);
     });
@@ -642,10 +642,10 @@ describe('modules/platform/forgejo/forgejo-helper', () => {
     it('should call /api/v1/orgs/[org]/labels endpoint', async () => {
       httpMock
         .scope(baseUrl)
-        .get(`/orgs/${mockRepo.owner.username}/labels`)
+        .get(`/orgs/${mockRepo.owner.login}/labels`)
         .reply(200, [mockLabel, otherMockLabel]);
 
-      const res = await getOrgLabels(mockRepo.owner.username);
+      const res = await getOrgLabels(mockRepo.owner.login);
       expect(res).toEqual([mockLabel, otherMockLabel]);
     });
   });

--- a/lib/modules/platform/forgejo/index.spec.ts
+++ b/lib/modules/platform/forgejo/index.spec.ts
@@ -50,7 +50,7 @@ describe('modules/platform/forgejo/index', () => {
 
   const mockUser: User = {
     id: 1,
-    username: 'renovate',
+    login: 'renovate',
     full_name: 'Renovate Bot',
     email: 'renovate@example.com',
   };
@@ -63,7 +63,7 @@ describe('modules/platform/forgejo/index', () => {
     default_branch: 'master',
     full_name: 'some/repo',
     owner: partial<User>({
-      username: 'some',
+      login: 'some',
     }),
   });
 
@@ -269,7 +269,7 @@ describe('modules/platform/forgejo/index', () => {
     scope
       .get(`/repos/${repository}`)
       .reply(200, repoResult)
-      .get(`/orgs/${repoResult.owner.username}`)
+      .get(`/orgs/${repoResult.owner.login}`)
       .reply(orgCode, {});
     GlobalConfig.set({ ignorePrAuthor: true, ...config });
     await forgejo.initRepo({ repository });
@@ -1219,7 +1219,7 @@ describe('modules/platform/forgejo/index', () => {
           sha: 'other-head-sha' as LongCommitSha,
           repo: partial<Repo>({ full_name: mockRepo.full_name }),
         },
-        user: { username: 'not-renovate' },
+        user: { login: 'not-renovate' },
       });
 
       const scope = httpMock
@@ -1230,7 +1230,7 @@ describe('modules/platform/forgejo/index', () => {
           thirdPartyPr,
           ...mockPRs.map((pr) => ({
             ...pr,
-            user: { username: 'renovate' },
+            user: { login: 'renovate' },
           })),
         ]);
       await initFakePlatform(scope);
@@ -1254,7 +1254,7 @@ describe('modules/platform/forgejo/index', () => {
           state: 'all',
           sort: 'recentupdate',
           limit: 100,
-          poster: mockUser.username,
+          poster: mockUser.login,
         })
         .reply(200, mockPRs.slice(0, 2), {
           // test correct pagination handling, domain should be ignored

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -228,9 +228,9 @@ const platform: Platform = {
     try {
       const user = await helper.getCurrentUser({ token });
       // oxlint-disable-next-line typescript/prefer-nullish-coalescing -- `full_name` can be emtpy string
-      gitAuthor = `${user.full_name || user.username} <${user.email}>`;
+      gitAuthor = `${user.full_name || user.login} <${user.email}>`;
       botUserID = user.id;
-      botUserName = user.username;
+      botUserName = user.login;
       const env = getEnv();
       /* v8 ignore if: experimental feature */
       if (semver.valid(env.RENOVATE_X_PLATFORM_VERSION)) {
@@ -345,7 +345,7 @@ const platform: Platform = {
     }
 
     try {
-      config.isOrgRepo = await helper.isOrg(repo.owner.username);
+      config.isOrgRepo = await helper.isOrg(repo.owner.login);
     } catch (err) {
       logger.debug({ err }, 'Forgejo initRepo() error');
       throw err;
@@ -367,7 +367,7 @@ const platform: Platform = {
     config.issueList = null;
     config.labelList = null;
     config.hasIssuesEnabled = !repo.external_tracker && repo.has_issues;
-    config.orgName = repo.owner.username;
+    config.orgName = repo.owner.login;
 
     return {
       defaultBranch: config.defaultBranch,

--- a/lib/modules/platform/forgejo/pr-cache.spec.ts
+++ b/lib/modules/platform/forgejo/pr-cache.spec.ts
@@ -33,7 +33,7 @@ const pr1: PR = {
     sha: 'other-head-sha' as LongCommitSha,
     repo: partial<Repo>({ full_name: 'SOME/repo' }),
   },
-  user: { username: 'some-author' },
+  user: { login: 'some-author' },
 };
 
 const pr2: PR = {
@@ -52,7 +52,7 @@ const pr2: PR = {
     sha: 'other-head-sha' as LongCommitSha,
     repo: partial<Repo>({ full_name: 'SOME/repo' }),
   },
-  user: { username: 'some-author' },
+  user: { login: 'some-author' },
 };
 
 describe('modules/platform/forgejo/pr-cache', () => {

--- a/lib/modules/platform/forgejo/types.ts
+++ b/lib/modules/platform/forgejo/types.ts
@@ -50,7 +50,7 @@ export interface PR {
     login?: string;
   };
   assignees?: any[];
-  user?: { username?: string };
+  user?: { login?: string };
 
   // labels returned from the Forgejo API are represented as an array of objects
   // ref: https://docs.forgejo.com/api/1.20/#tag/repository/operation/repoGetPullRequest
@@ -70,7 +70,7 @@ export interface User {
   id: number;
   email: EmailAddress;
   full_name?: string;
-  username: string;
+  login: string;
 }
 
 export interface Repo {
@@ -138,7 +138,7 @@ export interface Commit {
 export interface CommitUser {
   name: string;
   email: EmailAddress;
-  username: string;
+  login: string;
 }
 
 export interface CommitStatus {

--- a/lib/modules/platform/forgejo/utils.ts
+++ b/lib/modules/platform/forgejo/utils.ts
@@ -108,7 +108,7 @@ export function toRenovatePR(data: PR, author: string | null): Pr | null {
     return null;
   }
 
-  const createdBy = data.user?.username;
+  const createdBy = data.user?.login;
   if (
     createdBy &&
     author &&

--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -57,14 +57,14 @@ describe('modules/platform/gitea/gitea-helper', () => {
 
   const mockUser: User = {
     id: 1,
-    username: 'admin',
+    login: 'admin',
     full_name: 'The Administrator',
     email: 'admin@example.com',
   };
 
   const otherMockUser: User & Required<Pick<User, 'full_name'>> = {
     ...mockUser,
-    username: 'renovate',
+    login: 'renovate',
     full_name: 'Renovate Bot',
     email: 'renovate@example.com',
   };
@@ -166,7 +166,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
     author: {
       name: otherMockUser.full_name,
       email: otherMockUser.email,
-      username: otherMockUser.username,
+      login: otherMockUser.login,
     },
   };
 
@@ -352,7 +352,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         body: mockPR.body,
         base: mockPR.base?.ref,
         head: mockPR.head?.label,
-        assignees: [mockUser.username],
+        assignees: [mockUser.login],
         labels: [mockLabel.id],
       });
       expect(res).toEqual(mockPR);
@@ -377,7 +377,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         state: 'closed',
         title: 'new-title',
         body: 'new-body',
-        assignees: [otherMockUser.username],
+        assignees: [otherMockUser.login],
         labels: [otherMockLabel.id],
       });
       expect(res).toEqual(updatedMockPR);
@@ -505,7 +505,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         state: mockIssue.state,
         title: mockIssue.title,
         body: mockIssue.body,
-        assignees: [mockUser.username],
+        assignees: [mockUser.login],
       });
       expect(res).toEqual(mockIssue);
     });
@@ -530,7 +530,7 @@ describe('modules/platform/gitea/gitea-helper', () => {
         state: 'closed',
         title: 'new-title',
         body: 'new-body',
-        assignees: [otherMockUser.username],
+        assignees: [otherMockUser.login],
       });
       expect(res).toEqual(updatedMockIssue);
     });
@@ -623,10 +623,10 @@ describe('modules/platform/gitea/gitea-helper', () => {
     it('should call /api/v1/orgs/[org]/labels endpoint', async () => {
       httpMock
         .scope(baseUrl)
-        .get(`/orgs/${mockRepo.owner.username}/labels`)
+        .get(`/orgs/${mockRepo.owner.login}/labels`)
         .reply(200, [mockLabel, otherMockLabel]);
 
-      const res = await getOrgLabels(mockRepo.owner.username);
+      const res = await getOrgLabels(mockRepo.owner.login);
       expect(res).toEqual([mockLabel, otherMockLabel]);
     });
   });

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -50,7 +50,7 @@ describe('modules/platform/gitea/index', () => {
 
   const mockUser: User = {
     id: 1,
-    username: 'renovate',
+    login: 'renovate',
     full_name: 'Renovate Bot',
     email: 'renovate@example.com',
   };
@@ -1177,7 +1177,7 @@ describe('modules/platform/gitea/index', () => {
           sha: 'other-head-sha' as LongCommitSha,
           repo: partial<Repo>({ full_name: mockRepo.full_name }),
         },
-        user: { username: 'not-renovate' },
+        user: { login: 'not-renovate' },
       });
 
       const scope = httpMock
@@ -1188,7 +1188,7 @@ describe('modules/platform/gitea/index', () => {
           thirdPartyPr,
           ...mockPRs.map((pr) => ({
             ...pr,
-            user: { username: 'renovate' },
+            user: { login: 'renovate' },
           })),
         ]);
       await initFakePlatform(scope);
@@ -1212,7 +1212,7 @@ describe('modules/platform/gitea/index', () => {
           state: 'all',
           sort: 'recentupdate',
           limit: 100,
-          poster: mockUser.username,
+          poster: mockUser.login,
         })
         .reply(200, mockPRs.slice(0, 2), {
           // test correct pagination handling, domain should be ignored

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -224,9 +224,9 @@ const platform: Platform = {
     try {
       const user = await helper.getCurrentUser({ token });
       // oxlint-disable-next-line typescript/prefer-nullish-coalescing -- `full_name` can be emtpy string
-      gitAuthor = `${user.full_name || user.username} <${user.email}>`;
+      gitAuthor = `${user.full_name || user.login} <${user.email}>`;
       botUserID = user.id;
-      botUserName = user.username;
+      botUserName = user.login;
       const env = getEnv();
       /* v8 ignore next: experimental feature */
       if (semver.valid(env.RENOVATE_X_PLATFORM_VERSION)) {

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -50,7 +50,7 @@ export interface PR {
     login?: string;
   };
   assignees?: any[];
-  user?: { username?: string };
+  user?: { login?: string };
 
   // labels returned from the Gitea API are represented as an array of objects
   // ref: https://docs.gitea.com/api/1.20/#tag/repository/operation/repoGetPullRequest
@@ -70,7 +70,7 @@ export interface User {
   id: number;
   email: EmailAddress;
   full_name?: string;
-  username: string;
+  login: string;
 }
 
 export interface Repo {
@@ -138,7 +138,7 @@ export interface Commit {
 export interface CommitUser {
   name: string;
   email: EmailAddress;
-  username: string;
+  login: string;
 }
 
 export interface CommitStatus {

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -108,7 +108,7 @@ export function toRenovatePR(data: PR, author: string | null): Pr | null {
     return null;
   }
 
-  const createdBy = data.user?.username;
+  const createdBy = data.user?.login;
   if (
     createdBy &&
     author &&


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Replace all usages of the deprecated `username` field with `login` on Gitea/Forgejo API response objects in `lib/modules/platform/gitea` and `lib/modules/platform/forgejo`. 

The `username` field was renamed to `login` in the Gitea go-sdk in [2016](https://github.com/go-gitea/go-sdk/pull/28#issuecomment-267481370) and is no longer part of the Forgejo or Gitea API docs. It remains in
responses for backwards compatibility, but `login` is the canonical field.

Affected files:
- `types.ts` - `User.username`, `CommitUser.username`, `PR.user.username` → `login`
- `utils.ts` - `data.user?.login` in `toRenovatePR`
- `index.ts` -  `user.login` for `gitAuthor`/`botUserName`; `repo.owner.login` for `orgName`/`isOrgRepo` (forgejo only)
- All corresponding spec files updated to match

Note: `url.username` / `repoUrl.username` in `utils.ts` are intentionally unchanged, those are the WHATWG `URL` standard property for embedding auth tokens in clone URLs, unrelated to the Gitea API.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #43889

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
Used Claude Code (claude-sonnet-4-6) to identify all affected usages across both platform modules and apply the rename consistently.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
