### PR TITLE
refactor(cache): prepare package cache for binary payloads

### DIFF
--- a/lib/util/cache/package/codec.spec.ts
+++ b/lib/util/cache/package/codec.spec.ts
@@ -1,0 +1,75 @@
+import { DateTime } from 'luxon';
+import { decodeEntry, encodeEntry, isEnvelope } from './codec.ts';
+
+const cachedAt = DateTime.fromISO('2024-01-02T03:04:05.678Z', {
+  zone: 'utc',
+});
+
+describe('util/cache/package/codec', () => {
+  it('round-trips an envelope entry', async () => {
+    const value = { foo: 'bar', nested: [1, true, null] };
+
+    const encoded = await encodeEntry(value, cachedAt);
+    const decoded = await decodeEntry(encoded);
+
+    expect(decoded.value).toEqual(value);
+    expect(decoded.cachedAt.toMillis()).toBe(
+      Math.floor(cachedAt.toSeconds()) * 1000,
+    );
+  });
+
+  it('writes the expected header bytes', async () => {
+    const encoded = await encodeEntry('value', cachedAt);
+
+    expect(encoded.subarray(0, 4)).toEqual(
+      Buffer.from([0x11, 0x91, 0x01, 0x00]),
+    );
+    expect(encoded.readUInt32BE(4)).toBe(Math.floor(cachedAt.toSeconds()));
+  });
+
+  it.each`
+    data                                                 | expected
+    ${Buffer.from([0x11, 0x91, 0x01, 0x00, 0, 0, 0, 0])} | ${true}
+    ${Buffer.from([0x11])}                               | ${false}
+    ${Buffer.from([0x11, 0x90, 0x01, 0x00, 0, 0, 0, 0])} | ${false}
+    ${Buffer.from('{"value":"legacy"}')}                 | ${false}
+  `('returns $expected for isEnvelope($data)', ({ data, expected }) => {
+    expect(isEnvelope(data)).toBe(expected);
+  });
+
+  it('throws for truncated entries', async () => {
+    await expect(decodeEntry(Buffer.from([0x11, 0x91]))).rejects.toThrow(
+      'Truncated package cache entry',
+    );
+  });
+
+  it('throws for wrong magic bytes', async () => {
+    await expect(decodeEntry(Buffer.alloc(8))).rejects.toThrow(
+      'Unsupported package cache format',
+    );
+  });
+
+  it('throws for wrong version bytes', async () => {
+    const encoded = await encodeEntry('value', cachedAt);
+    encoded[2] = 0x02;
+
+    await expect(decodeEntry(encoded)).rejects.toThrow(
+      'Unsupported package cache format',
+    );
+  });
+
+  it('throws for invalid brotli data', async () => {
+    const encoded = Buffer.from([0x11, 0x91, 0x01, 0x00, 0, 0, 0, 0, 1]);
+
+    await expect(decodeEntry(encoded)).rejects.toThrow();
+  });
+
+  it.each`
+    timestamp                            | message
+    ${DateTime.invalid('invalid')}       | ${'Invalid package cache timestamp'}
+    ${DateTime.fromSeconds(-1)}          | ${'Package cache timestamp is out of range'}
+    ${DateTime.fromSeconds(0x100000000)} | ${'Package cache timestamp is out of range'}
+  `('throws for $timestamp', async ({ timestamp, message }) => {
+    await expect(encodeEntry('value', timestamp)).rejects.toThrow(message);
+  });
+});

--- a/lib/util/cache/package/codec.ts
+++ b/lib/util/cache/package/codec.ts
@@ -1,0 +1,84 @@
+import { DateTime } from 'luxon';
+import { compressToBuffer, decompressFromBuffer } from '../../compress.ts';
+
+const headerLength = 8;
+const prefixWord = 0x11910100;
+
+/**
+ * Format detection must not collide with anything older Renovate versions
+ * stored. Legacy entries are either JSON wrappers, which always start with `{`
+ * (`0x7b`), or raw brotli blobs from the SQLite backend.
+ *
+ * Brotli streams start with the WBITS field (RFC 7932, section 9.1). Standard
+ * brotli reserves `0010001` as an invalid bit pattern. The only byte values
+ * whose low seven bits match that pattern are `0x11` and `0x91`, so no valid
+ * legacy brotli stream can start with either byte.
+ *
+ * This does not account for `BROTLI_PARAM_LARGE_WINDOW`, which Renovate has
+ * never enabled. Both bytes also fall outside the base64 alphabet and printable
+ * JSON, giving the prefix extra margin against other legacy-looking payloads.
+ */
+const magic0 = 0x11;
+const magic1 = 0x91;
+
+const formatVersion = 0x01;
+const reserved = 0x00;
+
+export interface EnvelopeEntry {
+  value: unknown;
+  cachedAt: DateTime;
+}
+
+export function isEnvelope(data: Buffer): boolean {
+  return data[0] === magic0 && data[1] === magic1;
+}
+
+export async function encodeEntry(
+  value: unknown,
+  cachedAt: DateTime,
+): Promise<Buffer> {
+  const cachedAtSeconds = cachedAtToSeconds(cachedAt);
+  const compressed = await compressToBuffer(JSON.stringify(value));
+  const data = Buffer.alloc(headerLength + compressed.length);
+
+  data[0] = magic0;
+  data[1] = magic1;
+  data[2] = formatVersion;
+  data[3] = reserved;
+  data.writeUInt32BE(cachedAtSeconds, 4);
+  compressed.copy(data, headerLength);
+
+  return data;
+}
+
+export async function decodeEntry(data: Buffer): Promise<EnvelopeEntry> {
+  if (data.length < headerLength) {
+    throw new Error('Truncated package cache entry');
+  }
+
+  if (data.readUInt32BE(0) !== prefixWord) {
+    throw new Error('Unsupported package cache format');
+  }
+
+  const cachedAtSeconds = data.readUInt32BE(4);
+  const json = await decompressFromBuffer(data.subarray(headerLength));
+
+  return {
+    value: JSON.parse(json),
+    cachedAt: DateTime.fromSeconds(cachedAtSeconds),
+  };
+}
+
+function cachedAtToSeconds(cachedAt: DateTime): number {
+  if (!cachedAt.isValid) {
+    throw new Error('Invalid package cache timestamp');
+  }
+
+  const cachedAtSeconds = Math.floor(cachedAt.toSeconds());
+  // UInt32 seconds are enough for cache timestamps until 2106.
+  if (cachedAtSeconds < 0 || cachedAtSeconds > 0xffffffff) {
+    throw new Error('Package cache timestamp is out of range');
+  }
+
+  return cachedAtSeconds;
+}

--- a/lib/util/cache/package/impl/base.ts
+++ b/lib/util/cache/package/impl/base.ts
@@ -1,10 +1,50 @@
+import { DateTime } from 'luxon';
+import { logger } from '../../../../logger/index.ts';
+import type { MaybePromise } from '../../../../types/index.ts';
+import { decodeEntry, isEnvelope } from '../codec.ts';
+import type { LegacyEntry } from '../legacy.ts';
+import { decodeLegacyEntry } from '../legacy.ts';
 import type { PackageCacheNamespace } from '../types.ts';
 
 export abstract class PackageCacheBase {
-  abstract get<T = unknown>(
+  async get<T = unknown>(
     namespace: PackageCacheNamespace,
     key: string,
-  ): Promise<T | undefined>;
+  ): Promise<T | undefined> {
+    let raw: Buffer | undefined;
+    try {
+      raw = await this.readRaw(namespace, key);
+    } catch (err) {
+      logger.once.debug({ err }, 'Error while reading package cache value');
+      return undefined;
+    }
+
+    if (!raw) {
+      logger.trace({ namespace, key }, 'Cache miss');
+      return undefined;
+    }
+
+    try {
+      if (isEnvelope(raw)) {
+        const entry = await decodeEntry(raw);
+        logger.trace({ namespace, key }, 'Returning cached value');
+        return entry.value as T;
+      }
+
+      const entry = await decodeLegacyEntry(raw);
+      if (isExpiredLegacyEntry(entry)) {
+        await this.removeInvalidEntry(namespace, key);
+        return undefined;
+      }
+
+      logger.trace({ namespace, key }, 'Returning cached value');
+      return entry.value as T;
+    } catch (err) {
+      logger.once.debug({ err }, 'Error while reading package cache value');
+      await this.removeInvalidEntry(namespace, key);
+      return undefined;
+    }
+  }
 
   abstract set(
     namespace: PackageCacheNamespace,
@@ -14,4 +54,32 @@ export abstract class PackageCacheBase {
   ): Promise<void>;
 
   abstract destroy(): Promise<void>;
+
+  protected abstract readRaw(
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): MaybePromise<Buffer | undefined>;
+
+  protected abstract rm(
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): MaybePromise<void>;
+
+  private async removeInvalidEntry(
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): Promise<void> {
+    try {
+      await this.rm(namespace, key);
+    } catch (err) {
+      logger.once.debug({ err }, 'Error while removing package cache value');
+    }
+  }
+}
+
+function isExpiredLegacyEntry(entry: LegacyEntry): boolean {
+  const { expiry } = entry;
+  return (
+    expiry !== undefined && (!expiry.isValid || DateTime.local() >= expiry)
+  );
 }

--- a/lib/util/cache/package/impl/file.spec.ts
+++ b/lib/util/cache/package/impl/file.spec.ts
@@ -2,8 +2,12 @@ import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import { type DirectoryResult, dir } from 'tmp-promise';
 import upath from 'upath';
+import { logger as _logger } from '~test/util.ts';
 import { compressToBase64 } from '../../../compress.ts';
+import { encodeEntry } from '../codec.ts';
 import { PackageCacheFile } from './file.ts';
+
+const { logger } = _logger;
 
 describe('util/cache/package/impl/file', () => {
   let tmpDir: DirectoryResult;
@@ -78,6 +82,21 @@ describe('util/cache/package/impl/file', () => {
       expect(res).toBeUndefined();
     });
 
+    it('removes invalid entries', async () => {
+      await cacache.put(cacheFileName, '_test-namespace-key', 'invalid-json');
+
+      const res = await cache.get('_test-namespace', 'key');
+
+      expect(res).toBeUndefined();
+      expect(logger.once.debug).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Error while reading package cache value',
+      );
+      await expect(
+        cacache.get(cacheFileName, '_test-namespace-key'),
+      ).rejects.toThrow('No cache entry');
+    });
+
     it('returns undefined for corrupted cache payload', async () => {
       const payload = JSON.stringify({
         value: 'not-base64-encoded-gzip',
@@ -116,6 +135,18 @@ describe('util/cache/package/impl/file', () => {
       const expiry = DateTime.local().plus({ minutes: 5 });
       const payload = JSON.stringify({ value, expiry });
       await cacache.put(cacheFileName, '_test-namespace-key', payload);
+
+      const res = await cache.get('_test-namespace', 'key');
+
+      expect(res).toBe(1234);
+    });
+
+    it('retrieves value from envelope payload', async () => {
+      await cacache.put(
+        cacheFileName,
+        '_test-namespace-key',
+        await encodeEntry(1234, DateTime.local()),
+      );
 
       const res = await cache.get('_test-namespace', 'key');
 

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -3,7 +3,7 @@ import { LRUCache } from 'lru-cache';
 import { DateTime } from 'luxon';
 import upath from 'upath';
 import { logger } from '../../../../logger/index.ts';
-import { compressToBase64, decompressFromBase64 } from '../../../compress.ts';
+import { compressToBase64 } from '../../../compress.ts';
 import type { PackageCacheNamespace } from '../types.ts';
 import { PackageCacheBase } from './base.ts';
 
@@ -29,39 +29,6 @@ export class PackageCacheFile extends PackageCacheBase {
 
   private getKey(namespace: PackageCacheNamespace, key: string): string {
     return `${namespace}-${key}`;
-  }
-
-  override async get<T = unknown>(
-    namespace: PackageCacheNamespace,
-    key: string,
-  ): Promise<T | undefined> {
-    try {
-      const entry = await cacache.get(
-        this.cacheFileName,
-        this.getKey(namespace, key),
-      );
-      const raw = entry.data.toString();
-      const cached = JSON.parse(raw);
-
-      if (!cached) {
-        return undefined;
-      }
-
-      const expiry = DateTime.fromISO(cached.expiry);
-      if (!expiry.isValid || DateTime.local() >= expiry) {
-        await this.rm(namespace, key);
-        return undefined;
-      }
-
-      logger.trace({ namespace, key }, 'Returning cached value');
-      this.expiryMap.set(this.getKey(namespace, key), expiry);
-
-      const json = await decompressFromBase64(cached.value);
-      return JSON.parse(json);
-    } catch {
-      logger.trace({ namespace, key }, 'Cache miss');
-    }
-    return undefined;
   }
 
   override async set(
@@ -139,11 +106,26 @@ export class PackageCacheFile extends PackageCacheBase {
     );
   }
 
-  private async rm(
+  protected override async readRaw(
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): Promise<Buffer | undefined> {
+    const cacheKey = this.getKey(namespace, key);
+    try {
+      const entry = await cacache.get(this.cacheFileName, cacheKey);
+      return entry.data;
+    } catch {
+      return undefined;
+    }
+  }
+
+  protected override async rm(
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<void> {
     logger.trace({ namespace, key }, 'Removing cache entry');
-    await cacache.rm.entry(this.cacheFileName, this.getKey(namespace, key));
+    const cacheKey = this.getKey(namespace, key);
+    await cacache.rm.entry(this.cacheFileName, cacheKey);
+    this.expiryMap.delete(cacheKey);
   }
 }

--- a/lib/util/cache/package/impl/redis.spec.ts
+++ b/lib/util/cache/package/impl/redis.spec.ts
@@ -1,7 +1,11 @@
 import { createClient, createCluster } from '@redis/client';
 import { DateTime } from 'luxon';
+import { logger as _logger } from '~test/util.ts';
 import { compressToBase64 } from '../../../compress.ts';
+import { encodeEntry } from '../codec.ts';
 import { PackageCacheRedis, normalizeRedisUrl } from './redis.ts';
+
+const { logger } = _logger;
 
 vi.mock('@redis/client');
 
@@ -25,9 +29,11 @@ describe('util/cache/package/impl/redis', () => {
       set: vi.fn(),
       del: vi.fn(),
       destroy: vi.fn(),
+      withTypeMapping: vi.fn(),
     };
 
     beforeEach(() => {
+      clientMock.withTypeMapping.mockReturnValue(clientMock);
       vi.mocked(createClient).mockReturnValue(
         clientMock as unknown as ReturnType<typeof createClient>,
       );
@@ -46,6 +52,7 @@ describe('util/cache/package/impl/redis', () => {
           url: 'redis://host',
         });
         expect(clientMock.connect).toHaveBeenCalled();
+        expect(clientMock.withTypeMapping).toHaveBeenCalled();
 
         const reconnectStrategy = vi.mocked(createClient).mock.calls[0][0]!
           .socket!.reconnectStrategy as (retries: number) => number;
@@ -125,18 +132,32 @@ describe('util/cache/package/impl/redis', () => {
           value: payloadValue,
           expiry: DateTime.local().plus({ minutes: 5 }),
         });
-        clientMock.get.mockResolvedValueOnce(payload);
+        clientMock.get.mockResolvedValueOnce(Buffer.from(payload));
+
+        expect(await cache.get('_test-namespace', 'key')).toEqual(value);
+      });
+
+      it('returns value from envelope payload', async () => {
+        const cache = await PackageCacheRedis.create('redis://host', 'p:');
+        const value = { foo: 'bar' };
+
+        clientMock.get.mockResolvedValueOnce(
+          await encodeEntry(value, DateTime.local()),
+        );
 
         expect(await cache.get('_test-namespace', 'key')).toEqual(value);
       });
 
       it('removes expired cached entry', async () => {
         const cache = await PackageCacheRedis.create('redis://host', 'p:');
+        const value = { foo: 'bar' };
+        const payloadValue = await compressToBase64(JSON.stringify(value));
 
         const payload = JSON.stringify({
+          value: payloadValue,
           expiry: DateTime.local().minus({ minutes: 1 }),
         });
-        clientMock.get.mockResolvedValueOnce(payload);
+        clientMock.get.mockResolvedValueOnce(Buffer.from(payload));
 
         expect(await cache.get('_test-namespace', 'key')).toBeUndefined();
         expect(clientMock.del).toHaveBeenCalledWith('p:_test-namespace-key');
@@ -144,9 +165,11 @@ describe('util/cache/package/impl/redis', () => {
 
       it('returns undefined for missing expiry', async () => {
         const cache = await PackageCacheRedis.create('redis://host', 'p:');
+        const value = { foo: 'bar' };
+        const payloadValue = await compressToBase64(JSON.stringify(value));
 
-        const payload = JSON.stringify({ value: 1234 });
-        clientMock.get.mockResolvedValueOnce(payload);
+        const payload = JSON.stringify({ value: payloadValue });
+        clientMock.get.mockResolvedValueOnce(Buffer.from(payload));
 
         expect(await cache.get('_test-namespace', 'key')).toBeUndefined();
         expect(clientMock.del).toHaveBeenCalledWith('p:_test-namespace-key');
@@ -159,10 +182,36 @@ describe('util/cache/package/impl/redis', () => {
           value: 1234,
           expiry: 'not-a-date',
         });
-        clientMock.get.mockResolvedValueOnce(payload);
+        clientMock.get.mockResolvedValueOnce(Buffer.from(payload));
 
         expect(await cache.get('_test-namespace', 'key')).toBeUndefined();
         expect(clientMock.del).toHaveBeenCalledWith('p:_test-namespace-key');
+      });
+
+      it('removes invalid entries', async () => {
+        const cache = await PackageCacheRedis.create('redis://host', 'p:');
+
+        clientMock.get.mockResolvedValueOnce(Buffer.from('garbage'));
+
+        expect(await cache.get('_test-namespace', 'key')).toBeUndefined();
+        expect(logger.once.debug).toHaveBeenCalledWith(
+          { err: expect.any(Error) },
+          'Error while reading package cache value',
+        );
+        expect(clientMock.del).toHaveBeenCalledWith('p:_test-namespace-key');
+      });
+
+      it('returns undefined when invalid entry removal fails', async () => {
+        const cache = await PackageCacheRedis.create('redis://host', 'p:');
+
+        clientMock.get.mockResolvedValueOnce(Buffer.from('garbage'));
+        clientMock.del.mockRejectedValueOnce(new Error('delete failed'));
+
+        expect(await cache.get('_test-namespace', 'key')).toBeUndefined();
+        expect(logger.once.debug).toHaveBeenCalledWith(
+          { err: expect.any(Error) },
+          'Error while removing package cache value',
+        );
       });
 
       it('returns undefined on cache miss', async () => {

--- a/lib/util/cache/package/impl/redis.ts
+++ b/lib/util/cache/package/impl/redis.ts
@@ -1,8 +1,8 @@
 import type { RedisClusterOptions } from '@redis/client';
-import { createClient, createCluster } from '@redis/client';
+import { RESP_TYPES, createClient, createCluster } from '@redis/client';
 import { DateTime } from 'luxon';
 import { logger } from '../../../../logger/index.ts';
-import { compressToBase64, decompressFromBase64 } from '../../../compress.ts';
+import { compressToBase64 } from '../../../compress.ts';
 import { regEx } from '../../../regex.ts';
 import { parseUrl } from '../../../url.ts';
 import type { PackageCacheNamespace } from '../types.ts';
@@ -15,6 +15,10 @@ export function normalizeRedisUrl(url: string): string {
 type RedisClient =
   | ReturnType<typeof createClient>
   | ReturnType<typeof createCluster>;
+
+interface RedisBinaryClient {
+  get(key: string): Promise<Buffer | null>;
+}
 
 export class PackageCacheRedis extends PackageCacheBase {
   static async create(
@@ -59,52 +63,29 @@ export class PackageCacheRedis extends PackageCacheBase {
 
     await client.connect();
     logger.debug('Redis cache connected');
-    return new PackageCacheRedis(client, rprefix);
+    const binaryClient = client.withTypeMapping({
+      [RESP_TYPES.BLOB_STRING]: Buffer,
+    }) as RedisBinaryClient;
+    return new PackageCacheRedis(client, binaryClient, rprefix);
   }
 
   private readonly client: RedisClient;
+  private readonly binaryClient: RedisBinaryClient;
   private readonly rprefix: string;
 
-  private constructor(client: RedisClient, rprefix: string) {
+  private constructor(
+    client: RedisClient,
+    binaryClient: RedisBinaryClient,
+    rprefix: string,
+  ) {
     super();
     this.client = client;
+    this.binaryClient = binaryClient;
     this.rprefix = rprefix;
   }
 
   private getKey(namespace: PackageCacheNamespace, key: string): string {
     return `${this.rprefix}${namespace}-${key}`;
-  }
-
-  override async get<T = unknown>(
-    namespace: PackageCacheNamespace,
-    key: string,
-  ): Promise<T | undefined> {
-    logger.trace(`cache.get(${namespace}, ${key})`);
-    try {
-      const raw = await this.client.get(this.getKey(namespace, key));
-      if (!raw) {
-        return undefined;
-      }
-
-      const cached = JSON.parse(raw);
-
-      const expiry = DateTime.fromISO(cached.expiry);
-      if (!expiry.isValid || DateTime.local() >= expiry) {
-        await this.rm(namespace, key);
-        return undefined;
-      }
-
-      logger.trace(
-        { rprefix: this.rprefix, namespace, key },
-        'Returning cached value',
-      );
-
-      const json = await decompressFromBase64(cached.value);
-      return JSON.parse(json);
-    } catch {
-      logger.trace({ rprefix: this.rprefix, namespace, key }, 'Cache miss');
-    }
-    return undefined;
   }
 
   override async set(
@@ -151,7 +132,16 @@ export class PackageCacheRedis extends PackageCacheBase {
     return Promise.resolve();
   }
 
-  private async rm(
+  protected override async readRaw(
+    namespace: PackageCacheNamespace,
+    key: string,
+  ): Promise<Buffer | undefined> {
+    const raw = await this.binaryClient.get(this.getKey(namespace, key));
+
+    return raw ?? undefined;
+  }
+
+  protected override async rm(
     namespace: PackageCacheNamespace,
     key: string,
   ): Promise<void> {

--- a/lib/util/cache/package/impl/sqlite.spec.ts
+++ b/lib/util/cache/package/impl/sqlite.spec.ts
@@ -1,8 +1,10 @@
 import { promisify } from 'node:util';
 import zlib from 'node:zlib';
+import { DateTime } from 'luxon';
 import { withDir } from 'tmp-promise';
 import { logger as _logger } from '~test/util.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
+import { encodeEntry } from '../codec.ts';
 import { PackageCacheSqlite } from './sqlite.ts';
 
 const { logger } = _logger;
@@ -59,17 +61,25 @@ describe('util/cache/package/impl/sqlite', () => {
       expect(logger.warn).not.toHaveBeenCalled();
     });
 
-    it('returns undefined for invalid compressed payload', async () => {
+    it('removes invalid compressed payloads', async () => {
       const res = await withSqlite(async (sqlite) => {
         insertRawCacheEntry(sqlite, 'bar', Buffer.from('not-brotli'));
 
-        return sqlite.get('_test-namespace', 'bar');
+        const value = await sqlite.get('_test-namespace', 'bar');
+        const row = sqlite.client
+          .prepare(
+            'SELECT data FROM package_cache WHERE namespace = ? AND key = ?',
+          )
+          .get('_test-namespace', 'bar');
+
+        return { value, row };
       });
 
-      expect(res).toBeUndefined();
-      expect(logger.once.warn).toHaveBeenCalledWith(
+      expect(res.value).toBeUndefined();
+      expect(res.row).toBeUndefined();
+      expect(logger.once.debug).toHaveBeenCalledWith(
         { err: expect.any(Error) },
-        'Error while reading SQLite cache value',
+        'Error while reading package cache value',
       );
       expect(logger.warn).not.toHaveBeenCalled();
     });
@@ -83,9 +93,9 @@ describe('util/cache/package/impl/sqlite', () => {
       });
 
       expect(res).toBeUndefined();
-      expect(logger.once.warn).toHaveBeenCalledWith(
+      expect(logger.once.debug).toHaveBeenCalledWith(
         { err: expect.any(Error) },
-        'Error while reading SQLite cache value',
+        'Error while reading package cache value',
       );
       expect(logger.warn).not.toHaveBeenCalled();
     });
@@ -100,9 +110,9 @@ describe('util/cache/package/impl/sqlite', () => {
           const res = await sqlite.get('_test-namespace', 'bar');
 
           expect(res).toBeUndefined();
-          expect(logger.once.warn).toHaveBeenCalledWith(
+          expect(logger.once.debug).toHaveBeenCalledWith(
             { err: expect.any(Error) },
-            'Error while reading SQLite cache value',
+            'Error while reading package cache value',
           );
           expect(logger.trace).not.toHaveBeenCalledWith(
             { namespace: '_test-namespace', key: 'bar' },
@@ -167,6 +177,20 @@ describe('util/cache/package/impl/sqlite', () => {
       });
 
       expect(res).toEqual({ baz: 'baz' });
+    });
+
+    it('returns value from envelope payload', async () => {
+      const res = await withSqlite(async (sqlite) => {
+        insertRawCacheEntry(
+          sqlite,
+          'bar',
+          await encodeEntry({ foo: 'bar' }, DateTime.local()),
+        );
+
+        return sqlite.get('_test-namespace', 'bar');
+      });
+
+      expect(res).toEqual({ foo: 'bar' });
     });
   });
 

--- a/lib/util/cache/package/impl/sqlite.ts
+++ b/lib/util/cache/package/impl/sqlite.ts
@@ -12,7 +12,6 @@ import { PackageCacheBase } from './base.ts';
 
 const { exists } = fs;
 const brotliCompress = promisify(zlib.brotliCompress);
-const brotliDecompress = promisify(zlib.brotliDecompress);
 
 function compress(input: unknown): Promise<Buffer> {
   const jsonStr = JSON.stringify(input);
@@ -22,12 +21,6 @@ function compress(input: unknown): Promise<Buffer> {
       [constants.BROTLI_PARAM_QUALITY]: 3,
     },
   });
-}
-
-async function decompress<T>(input: Buffer): Promise<T> {
-  const buf = await brotliDecompress(input);
-  const jsonStr = buf.toString('utf8');
-  return JSON.parse(jsonStr) as T;
 }
 
 export class PackageCacheSqlite extends PackageCacheBase {
@@ -52,6 +45,7 @@ export class PackageCacheSqlite extends PackageCacheBase {
 
   private readonly upsertStatement: StatementSync;
   private readonly getStatement: StatementSync;
+  private readonly deleteStatement: StatementSync;
   private readonly deleteExpiredRows: StatementSync;
   private readonly countStatement: StatementSync;
 
@@ -92,6 +86,11 @@ export class PackageCacheSqlite extends PackageCacheBase {
         `,
     );
 
+    this.deleteStatement = client.prepare(`
+      DELETE FROM package_cache
+      WHERE namespace = @namespace AND key = @key
+    `);
+
     this.deleteExpiredRows = client.prepare(`
       DELETE FROM package_cache
       WHERE expiry <= unixepoch()
@@ -122,25 +121,30 @@ export class PackageCacheSqlite extends PackageCacheBase {
     }
   }
 
-  override async get<T = unknown>(
+  protected override readRaw(
     namespace: PackageCacheNamespace,
     key: string,
-  ): Promise<T | undefined> {
-    try {
-      const data = this.getStatement.get({ namespace, key })?.data as
-        | Buffer
-        | undefined;
+  ): Buffer | undefined {
+    const row = this.getStatement.get({ namespace, key }) as
+      | { data: Uint8Array }
+      | undefined;
 
-      if (!data) {
-        logger.trace({ namespace, key }, 'Cache miss');
-        return undefined;
-      }
-
-      return await decompress<T>(data);
-    } catch (err) {
-      logger.once.warn({ err }, 'Error while reading SQLite cache value');
+    if (!row) {
       return undefined;
     }
+
+    // `Buffer.from(row.data)` copies the whole payload.
+    // This call does zero copy.
+    return Buffer.from(
+      row.data.buffer,
+      row.data.byteOffset,
+      row.data.byteLength,
+    );
+  }
+
+  protected override rm(namespace: PackageCacheNamespace, key: string): void {
+    logger.trace({ namespace, key }, 'Removing cache entry');
+    this.deleteStatement.run({ namespace, key });
   }
 
   override destroy(): Promise<void> {

--- a/lib/util/cache/package/legacy.spec.ts
+++ b/lib/util/cache/package/legacy.spec.ts
@@ -1,0 +1,62 @@
+import { DateTime } from 'luxon';
+import { compressToBase64, compressToBuffer } from '../../compress.ts';
+import { isEnvelope } from './codec.ts';
+import { decodeLegacyEntry } from './legacy.ts';
+
+async function legacyJsonWrapper(
+  value: unknown,
+  expiry: DateTime,
+): Promise<Buffer> {
+  const payload = JSON.stringify({
+    value: await compressToBase64(JSON.stringify(value)),
+    expiry,
+  });
+
+  return Buffer.from(payload);
+}
+
+describe('util/cache/package/legacy', () => {
+  it('decodes legacy JSON-wrapper entries', async () => {
+    const expiry = DateTime.local().plus({ minutes: 5 });
+    const value = { foo: 'bar' };
+
+    const entry = await decodeLegacyEntry(
+      await legacyJsonWrapper(value, expiry),
+    );
+
+    expect(entry.value).toEqual(value);
+    expect(entry.expiry?.toISO()).toBe(expiry.toISO());
+  });
+
+  it('decodes legacy SQLite raw-brotli entries', async () => {
+    const value = { foo: 'bar' };
+    const data = await compressToBuffer(JSON.stringify(value), 3);
+
+    const entry = await decodeLegacyEntry(data);
+
+    expect(entry.value).toEqual(value);
+    expect(entry.expiry).toBeUndefined();
+  });
+
+  it('throws for garbage entries', async () => {
+    await expect(decodeLegacyEntry(Buffer.from('garbage'))).rejects.toThrow();
+  });
+
+  it('does not classify legacy brotli payloads as envelopes', async () => {
+    const inputs = [
+      '',
+      'foobar',
+      JSON.stringify({ foo: 'bar' }),
+      'x'.repeat(1024),
+      'αβγ'.repeat(128),
+    ];
+
+    for (const quality of [3, 8]) {
+      for (const input of inputs) {
+        const compressed = await compressToBuffer(input, quality);
+
+        expect(isEnvelope(compressed)).toBeFalse();
+      }
+    }
+  });
+});

--- a/lib/util/cache/package/legacy.ts
+++ b/lib/util/cache/package/legacy.ts
@@ -1,0 +1,46 @@
+import { DateTime } from 'luxon';
+import { decompressFromBase64, decompressFromBuffer } from '../../compress.ts';
+
+// Decode-only support for pre-binary cache formats. Delete this file (and its single call site in impl/base.ts) once entries written before <release> have expired.
+
+export interface LegacyEntry {
+  value: unknown;
+  expiry: DateTime | undefined;
+}
+
+interface LegacyJsonEntry {
+  value: unknown;
+  expiry: unknown;
+}
+
+export async function decodeLegacyEntry(data: Buffer): Promise<LegacyEntry> {
+  if (data[0] === 0x7b) {
+    return await decodeLegacyJsonEntry(data);
+  }
+
+  return await decodeLegacySqliteEntry(data);
+}
+
+async function decodeLegacyJsonEntry(data: Buffer): Promise<LegacyEntry> {
+  const cached = JSON.parse(data.toString('utf8')) as LegacyJsonEntry;
+
+  if (typeof cached.value !== 'string' || typeof cached.expiry !== 'string') {
+    throw new Error('Invalid legacy JSON package cache entry');
+  }
+
+  const json = await decompressFromBase64(cached.value);
+
+  return {
+    value: JSON.parse(json),
+    expiry: DateTime.fromISO(cached.expiry),
+  };
+}
+
+async function decodeLegacySqliteEntry(data: Buffer): Promise<LegacyEntry> {
+  const json = await decompressFromBuffer(data);
+
+  return {
+    value: JSON.parse(json),
+    expiry: undefined,
+  };
+}

--- a/lib/util/cache/package/types.ts
+++ b/lib/util/cache/package/types.ts
@@ -1,18 +1,5 @@
 export type { CombinedKey, PackageCacheNamespace } from './namespaces.ts';
 
-export interface PackageCache {
-  get<T = any>(namespace: string, key: string): Promise<T | undefined>;
-
-  set<T = any>(
-    namespace: string,
-    key: string,
-    value: T,
-    hardTtlMinutes?: number,
-  ): Promise<void>;
-
-  cleanup?(): Promise<void>;
-}
-
 export interface CachedRecord {
   value: unknown;
   cachedAt: string;

--- a/lib/util/compress.spec.ts
+++ b/lib/util/compress.spec.ts
@@ -1,4 +1,9 @@
-import { compressToBase64, decompressFromBase64 } from './compress.ts';
+import {
+  compressToBase64,
+  compressToBuffer,
+  decompressFromBase64,
+  decompressFromBuffer,
+} from './compress.ts';
 
 describe('util/compress', () => {
   it('compresses strings', async () => {
@@ -8,6 +13,16 @@ describe('util/compress', () => {
     expect(compressed).toBe('iwKAZm9vYmFyAw==');
 
     const decompressed = await decompressFromBase64(compressed);
+    expect(decompressed).toBe(input);
+  });
+
+  it('compresses strings to buffers', async () => {
+    const input = 'foobar';
+
+    const compressed = await compressToBuffer(input);
+    expect(compressed.toString('base64')).toBe('iwKAZm9vYmFyAw==');
+
+    const decompressed = await decompressFromBuffer(compressed);
     expect(decompressed).toBe(input);
   });
 });

--- a/lib/util/compress.ts
+++ b/lib/util/compress.ts
@@ -4,18 +4,28 @@ import zlib, { constants } from 'node:zlib';
 const brotliCompress = promisify(zlib.brotliCompress);
 const brotliDecompress = promisify(zlib.brotliDecompress);
 
-export async function compressToBase64(input: string): Promise<string> {
-  const buf = await brotliCompress(input, {
+export async function compressToBuffer(
+  input: string,
+  quality = 8,
+): Promise<Buffer> {
+  return await brotliCompress(input, {
     params: {
       [constants.BROTLI_PARAM_MODE]: constants.BROTLI_MODE_TEXT,
-      [constants.BROTLI_PARAM_QUALITY]: 8,
+      [constants.BROTLI_PARAM_QUALITY]: quality,
     },
   });
+}
+
+export async function decompressFromBuffer(input: Buffer): Promise<string> {
+  const str = await brotliDecompress(input);
+  return str.toString('utf8');
+}
+
+export async function compressToBase64(input: string): Promise<string> {
+  const buf = await compressToBuffer(input);
   return buf.toString('base64');
 }
 
 export async function decompressFromBase64(input: string): Promise<string> {
-  const buf = Buffer.from(input, 'base64');
-  const str = await brotliDecompress(buf);
-  return str.toString('utf8');
+  return await decompressFromBuffer(Buffer.from(input, 'base64'));
 }


### PR DESCRIPTION
## Changes

Prepare the package cache for binary payloads.

- `compress.ts` adds `compressToBuffer` and `decompressFromBuffer` for buffer-based brotli. The existing base64 functions are reimplemented on top.
- `codec.ts` introduces a binary envelope format:
   - 8-byte header:
     - magic bytes (`0x11 0x91`) — collision-proof against legacy data
       - Redis and `cacache`: JSON starts with `{`
       - SQLite: valid brotli but never starts with `0x1191` per [RFC 7932 §9.1](https://datatracker.ietf.org/doc/html/draft-alakuijala-brotli-09#section-9.1)
     - version byte (`0x01`)
     - reserved byte
     - `cachedAt` as uint32 Unix seconds (not used in new model, but worth keeping)
   - body: raw brotli content
- `legacy.ts` adds decode-only support for the two old formats (JSON wrapper for file/Redis, raw brotli for SQLite). To be deleted couple months later.
- `PackageCacheBase` now owns `get()`. Backends expose `readRaw()` and `rm()` instead of duplicating read logic. The base handles format detection, legacy fallback, expiry, and corrupt-entry cleanup.

Read-path behavior changes:
- Corrupt or undecodable entries are now removed and logged once at debug level, instead of silently persisting.
- The new format degrades to a clean miss on every backend, so the follow-up PR can be safely rolled back.
- All backends still write their existing formats. No stored bytes change yet.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
