### PR TITLE
build: ensure package version is updated in prepare

### DIFF
--- a/tools/prepare-release.ts
+++ b/tools/prepare-release.ts
@@ -34,6 +34,7 @@ void (async () => {
   await program.parseAsync();
   const opts = program.opts();
   logger.info(`Preparing v${opts.version?.toString()} ...`);
+  await preparePackageVersion(opts.version?.toString());
   await build();
   await generateDocs(undefined, undefined, opts.version?.toString());
   await buildMkdocs(opts.version?.toString());
@@ -108,5 +109,35 @@ async function buildMkdocs(version: string | undefined): Promise<void> {
     process.exit(tarRes.exitCode);
   } else {
     logger.info('Mkdocs site packaged successfully to tmp/mkdocs-site.tgz');
+  }
+}
+async function preparePackageVersion(
+  version: string | undefined,
+): Promise<void> {
+  if (!version) {
+    return;
+  }
+  const res = await exec(
+    'pnpm',
+    [
+      'version',
+      version,
+      '--no-git-tag-version',
+      '--allow-same-version',
+      '--ignore-scripts',
+    ],
+    { reject: false },
+  );
+
+  if (res.signal) {
+    logger.error(`Signal received: ${res.signal}`);
+    process.exit(-1);
+  } else if (res.exitCode) {
+    logger.error(
+      `Error occurred updating package version:\n${res.stderr || res.stdout}`,
+    );
+    process.exit(res.exitCode);
+  } else {
+    logger.info('Package version updated');
   }
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes
Currently release is slow because docker images are build twice, the first time the package.json has `version=0.0.0-semantic-release` in prepare step, because npm plugin upüdates it after images are build.
Then on release `package.json` is updated with correct version and docker images are build again.
So now we ensure in our `release:prepare` script that the package json is updated.
I've tested locally by calling that script.
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
