### PR TITLE
feat(datasource/github-runners): add ubuntu 26

### DIFF
--- a/lib/modules/datasource/github-runners/index.spec.ts
+++ b/lib/modules/datasource/github-runners/index.spec.ts
@@ -18,6 +18,8 @@ describe('modules/datasource/github-runners/index', () => {
           { version: '22.04' },
           { version: '24.04-arm' },
           { version: '24.04' },
+          { version: '26.04-arm', isStable: false },
+          { version: '26.04', isStable: false },
         ],
         sourceUrl: 'https://github.com/actions/runner-images',
       });

--- a/lib/modules/datasource/github-runners/index.ts
+++ b/lib/modules/datasource/github-runners/index.ts
@@ -18,6 +18,8 @@ export class GithubRunnersDatasource extends Datasource {
    */
   private static readonly releases: Record<string, Release[] | undefined> = {
     ubuntu: [
+      { version: '26.04', isStable: false },
+      { version: '26.04-arm', isStable: false },
       { version: '24.04' },
       { version: '24.04-arm' },
       { version: '22.04' },


### PR DESCRIPTION
## Changes

Add support for GitHub Actions `ubuntu-26.04` and `ubuntu-26.04-arm` runners in preview.

[New runner images in public preview](https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/)

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

