### PR TITLE
docs(versioning): replace bare links with descriptive markdown links in urls

### DIFF
--- a/lib/modules/versioning/apk/index.ts
+++ b/lib/modules/versioning/apk/index.ts
@@ -6,8 +6,8 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'apk';
 export const displayName = 'Alpine Package Keeper (APK)';
 export const urls = [
-  'https://wiki.alpinelinux.org/wiki/Package_policies',
-  'https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper#Package_pinning',
+  '[Alpine Linux package policies](https://wiki.alpinelinux.org/wiki/Package_policies)',
+  '[Alpine Package Keeper - Package pinning](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper#Package_pinning)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/azure-rest-api/index.ts
+++ b/lib/modules/versioning/azure-rest-api/index.ts
@@ -7,7 +7,7 @@ export const id = 'azure-rest-api';
 export const displayName = 'azure-rest-api';
 
 export const urls = [
-  'https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#api-versioning',
+  '[Microsoft Azure API versioning guidelines](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#api-versioning)',
 ];
 
 export const supportsRanges = false;

--- a/lib/modules/versioning/bazel-module/index.ts
+++ b/lib/modules/versioning/bazel-module/index.ts
@@ -3,7 +3,7 @@ import { BzlmodVersion } from './bzlmod-version.ts';
 
 export const id = 'bazel-module';
 export const displayName = 'Bazel Module';
-export const urls = ['https://bazel.build/external/module'];
+export const urls = ['[Bazel modules](https://bazel.build/external/module)'];
 export const supportsRanges = false;
 
 function getBzlmodVersion(version: string): BzlmodVersion {

--- a/lib/modules/versioning/cargo/index.ts
+++ b/lib/modules/versioning/cargo/index.ts
@@ -9,7 +9,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 export const id = 'cargo';
 export const displayName = 'Cargo';
 export const urls = [
-  'https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html',
+  '[Cargo - Specifying Dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = ['bump', 'replace'];

--- a/lib/modules/versioning/common.ts
+++ b/lib/modules/versioning/common.ts
@@ -1,6 +1,8 @@
 import { regEx } from '../../util/regex.ts';
 import type { VersioningApi, VersioningApiConstructor } from './types.ts';
 
+export const markdownLinkRegex = regEx(/\[[^\]]+\]\([^)]+\)/);
+
 export function isVersioningApiConstructor(
   obj: VersioningApi | VersioningApiConstructor,
 ): obj is VersioningApiConstructor {

--- a/lib/modules/versioning/composer/index.ts
+++ b/lib/modules/versioning/composer/index.ts
@@ -10,10 +10,10 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 export const id = 'composer';
 export const displayName = 'Composer';
 export const urls = [
-  'https://getcomposer.org/doc/articles/versions.md',
-  'https://packagist.org/packages/composer/semver',
-  'https://madewithlove.be/tilde-and-caret-constraints/',
-  'https://semver.mwl.be',
+  '[Composer versions](https://getcomposer.org/doc/articles/versions.md)',
+  '[composer/semver package](https://packagist.org/packages/composer/semver)',
+  '[Tilde and caret constraints](https://madewithlove.be/tilde-and-caret-constraints/)',
+  '[Composer semver checker](https://semver.mwl.be)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/conan/index.ts
+++ b/lib/modules/versioning/conan/index.ts
@@ -21,10 +21,10 @@ import {
 export const id = 'conan';
 export const displayName = 'conan';
 export const urls = [
-  'https://semver.org/',
-  'https://github.com/podhmo/python-node-semver',
-  'https://github.com/podhmo/python-node-semver/tree/master/examples',
-  'https://docs.conan.io/en/latest/versioning/version_ranges.html#version-ranges',
+  '[Semantic Versioning](https://semver.org/)',
+  '[python-node-semver](https://github.com/podhmo/python-node-semver)',
+  '[python-node-semver examples](https://github.com/podhmo/python-node-semver/tree/master/examples)',
+  '[Conan version ranges](https://docs.conan.io/en/latest/versioning/version_ranges.html#version-ranges)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/conda/index.ts
+++ b/lib/modules/versioning/conda/index.ts
@@ -16,7 +16,7 @@ function parse(v: string): Version | null {
 export const id = 'conda';
 export const displayName = 'conda';
 export const urls = [
-  'https://docs.conda.io/projects/conda-build/en/stable/resources/package-spec.html#package-match-specifications',
+  '[Conda package match specifications](https://docs.conda.io/projects/conda-build/en/stable/resources/package-spec.html#package-match-specifications)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/deb/index.ts
+++ b/lib/modules/versioning/deb/index.ts
@@ -6,8 +6,8 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'deb';
 export const displayName = 'Deb version';
 export const urls = [
-  'https://www.debian.org/doc/debian-policy/ch-controlfields.html#version',
-  'https://manpages.debian.org/unstable/dpkg-dev/deb-version.7.en.html',
+  '[Debian policy - Version](https://www.debian.org/doc/debian-policy/ch-controlfields.html#version)',
+  '[deb-version man page](https://manpages.debian.org/unstable/dpkg-dev/deb-version.7.en.html)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/debian/index.ts
+++ b/lib/modules/versioning/debian/index.ts
@@ -14,7 +14,7 @@ import {
 export const id = 'debian';
 export const displayName = 'Debian';
 export const urls = [
-  'https://debian.pages.debian.net/distro-info-data/debian.csv',
+  '[Debian distro info data](https://debian.pages.debian.net/distro-info-data/debian.csv)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = ['replace'];

--- a/lib/modules/versioning/deno/index.ts
+++ b/lib/modules/versioning/deno/index.ts
@@ -5,7 +5,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 export const id = 'deno';
 export const displayName = 'deno';
 export const urls = [
-  'https://docs.deno.com/runtime/fundamentals/modules/#package-versions',
+  '[Deno - Package versions](https://docs.deno.com/runtime/fundamentals/modules/#package-versions)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/docker/index.ts
+++ b/lib/modules/versioning/docker/index.ts
@@ -7,7 +7,7 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'docker';
 export const displayName = 'Docker';
 export const urls = [
-  'https://docs.docker.com/engine/reference/commandline/tag/',
+  '[Docker tag command](https://docs.docker.com/engine/reference/commandline/tag/)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/elm/index.ts
+++ b/lib/modules/versioning/elm/index.ts
@@ -6,7 +6,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 
 export const id = 'elm';
 export const displayName = 'Elm';
-export const urls = ['https://elm-lang.org'];
+export const urls = ['[Elm](https://elm-lang.org)'];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',

--- a/lib/modules/versioning/git/index.ts
+++ b/lib/modules/versioning/git/index.ts
@@ -5,7 +5,7 @@ import type { VersioningApi } from '../types.ts';
 
 export const id = 'git';
 export const displayName = 'git';
-export const urls = ['https://git-scm.com/'];
+export const urls = ['[Git](https://git-scm.com/)'];
 export const supportsRanges = false;
 
 const regex = regEx('^[0-9a-f]{7,40}$', 'i');

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -8,7 +8,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 export const id = 'github-actions';
 export const displayName = 'GitHub Actions';
 export const urls = [
-  'https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#using-release-management-for-your-custom-actions',
+  '[GitHub Actions - Using release management for custom actions](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#using-release-management-for-your-custom-actions)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies = ['pin', 'replace'];

--- a/lib/modules/versioning/go-mod-directive/index.ts
+++ b/lib/modules/versioning/go-mod-directive/index.ts
@@ -5,7 +5,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 
 export const id = 'go-mod-directive';
 export const displayName = 'Go Modules Directive';
-export const urls = ['https://go.dev/ref/mod'];
+export const urls = ['[Go Modules Reference](https://go.dev/ref/mod)'];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = ['bump', 'replace'];
 

--- a/lib/modules/versioning/gradle/index.ts
+++ b/lib/modules/versioning/gradle/index.ts
@@ -16,7 +16,7 @@ import {
 export const id = 'gradle';
 export const displayName = 'Gradle';
 export const urls = [
-  'https://docs.gradle.org/current/userguide/single_versions.html#version_ordering',
+  '[Gradle version ordering](https://docs.gradle.org/current/userguide/single_versions.html#version_ordering)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = ['bump'];

--- a/lib/modules/versioning/hashicorp/index.ts
+++ b/lib/modules/versioning/hashicorp/index.ts
@@ -8,7 +8,7 @@ import { hashicorp2npm, npm2hashicorp } from './convertor.ts';
 export const id = 'hashicorp';
 export const displayName = 'Hashicorp';
 export const urls = [
-  'https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version',
+  '[Terraform - Specifying a required version](https://www.terraform.io/docs/configuration/terraform.html#specifying-a-required-terraform-version)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/helm/index.ts
+++ b/lib/modules/versioning/helm/index.ts
@@ -5,9 +5,9 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'helm';
 export const displayName = 'helm';
 export const urls = [
-  'https://semver.org/',
-  'https://helm.sh/docs/chart_best_practices/dependencies/#versions',
-  'https://github.com/Masterminds/semver#basic-comparisons',
+  '[Semantic Versioning](https://semver.org/)',
+  '[Helm chart dependencies - Versions](https://helm.sh/docs/chart_best_practices/dependencies/#versions)',
+  '[Masterminds semver - Basic comparisons](https://github.com/Masterminds/semver#basic-comparisons)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/hermit/index.ts
+++ b/lib/modules/versioning/hermit/index.ts
@@ -6,7 +6,7 @@ import type { VersioningApiConstructor } from '../types.ts';
 export const id = 'hermit';
 export const displayName = 'Hermit';
 export const urls = [
-  'https://cashapp.github.io/hermit/packaging/reference/#versions',
+  '[Hermit packaging reference - Versions](https://cashapp.github.io/hermit/packaging/reference/#versions)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/hex/index.ts
+++ b/lib/modules/versioning/hex/index.ts
@@ -5,7 +5,9 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 
 export const id = 'hex';
 export const displayName = 'Hex';
-export const urls = ['https://hexdocs.pm/elixir/Version.html'];
+export const urls = [
+  '[Elixir Version module](https://hexdocs.pm/elixir/Version.html)',
+];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',

--- a/lib/modules/versioning/ivy/index.ts
+++ b/lib/modules/versioning/ivy/index.ts
@@ -16,7 +16,7 @@ import {
 
 export const id = 'ivy';
 export const displayName = 'Ivy';
-export const urls = ['https://ant.apache.org/ivy/'];
+export const urls = ['[Apache Ivy](https://ant.apache.org/ivy/)'];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',

--- a/lib/modules/versioning/kubernetes-api/index.ts
+++ b/lib/modules/versioning/kubernetes-api/index.ts
@@ -4,7 +4,7 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'kubernetes-api';
 export const displayName = 'Kubernetes API';
 export const urls = [
-  'https://kubernetes.io/docs/reference/using-api/#api-versioning',
+  '[Kubernetes API versioning](https://kubernetes.io/docs/reference/using-api/#api-versioning)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/maven/index.ts
+++ b/lib/modules/versioning/maven/index.ts
@@ -19,9 +19,9 @@ import {
 export const id = 'maven';
 export const displayName = 'Maven';
 export const urls = [
-  'https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification',
-  'https://octopus.com/blog/maven-versioning-explained',
-  'https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html',
+  '[Maven POM - Dependency version requirements](https://maven.apache.org/pom.html#Dependency_Version_Requirement_Specification)',
+  '[Maven versioning explained](https://octopus.com/blog/maven-versioning-explained)',
+  '[Maven Enforcer - Version ranges](https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/nixpkgs/index.ts
+++ b/lib/modules/versioning/nixpkgs/index.ts
@@ -9,7 +9,7 @@ import type { VersioningApiConstructor } from '../types.ts';
 
 export const id = 'nixpkgs';
 export const displayName = 'Nixpkgs';
-export const urls = ['https://github.com/NixOS/nixpkgs'];
+export const urls = ['[Nixpkgs repository](https://github.com/NixOS/nixpkgs)'];
 export const supportsRanges = false;
 
 export class NixPkgsVersioning extends RegExpVersioningApi {

--- a/lib/modules/versioning/npm/index.ts
+++ b/lib/modules/versioning/npm/index.ts
@@ -8,10 +8,10 @@ import { getNewValue } from './range.ts';
 export const id = 'npm';
 export const displayName = 'npm';
 export const urls = [
-  'https://semver.org/',
-  'https://www.npmjs.com/package/semver',
-  'https://docs.npmjs.com/about-semantic-versioning',
-  'https://semver.npmjs.com/',
+  '[Semantic Versioning](https://semver.org/)',
+  '[semver npm package](https://www.npmjs.com/package/semver)',
+  '[npm - About semantic versioning](https://docs.npmjs.com/about-semantic-versioning)',
+  '[npm semver calculator](https://semver.npmjs.com/)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/nuget/index.ts
+++ b/lib/modules/versioning/nuget/index.ts
@@ -17,8 +17,8 @@ import { compare, versionToString } from './version.ts';
 export const id = 'nuget';
 export const displayName = 'NuGet';
 export const urls = [
-  'https://learn.microsoft.com/nuget/concepts/package-versioning',
-  'https://nugettools.azurewebsites.net/',
+  '[NuGet package versioning](https://learn.microsoft.com/nuget/concepts/package-versioning)',
+  '[NuGet version range tool](https://nugettools.azurewebsites.net/)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies = ['bump'];

--- a/lib/modules/versioning/pep440/index.ts
+++ b/lib/modules/versioning/pep440/index.ts
@@ -5,7 +5,9 @@ import { getNewValue, getPinnedValue, isLessThanRange } from './range.ts';
 
 export const id = 'pep440';
 export const displayName = 'PEP440';
-export const urls = ['https://www.python.org/dev/peps/pep-0440/'];
+export const urls = [
+  '[PEP 440 - Version Identification](https://www.python.org/dev/peps/pep-0440/)',
+];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',

--- a/lib/modules/versioning/perl/index.ts
+++ b/lib/modules/versioning/perl/index.ts
@@ -5,7 +5,7 @@ import type { VersioningApi } from '../types.ts';
 
 export const id = 'perl';
 export const displayName = 'Perl';
-export const urls = ['https://metacpan.org/pod/version'];
+export const urls = ['[Perl version module](https://metacpan.org/pod/version)'];
 export const supportsRanges = false;
 
 // https://metacpan.org/pod/version#Decimal-Versions

--- a/lib/modules/versioning/poetry/index.ts
+++ b/lib/modules/versioning/poetry/index.ts
@@ -16,9 +16,9 @@ import {
 export const id = 'poetry';
 export const displayName = 'Poetry';
 export const urls = [
-  'https://python-poetry.org/docs/dependency-specification/',
-  'https://python-poetry.org/docs/faq#why-does-poetry-not-adhere-to-semantic-versioning',
-  'https://python-poetry.org/docs/faq#why-does-poetry-enforce-pep-440-versions',
+  '[Poetry dependency specification](https://python-poetry.org/docs/dependency-specification/)',
+  '[Poetry FAQ - Why does Poetry not adhere to semantic versioning?](https://python-poetry.org/docs/faq#why-does-poetry-not-adhere-to-semantic-versioning)',
+  '[Poetry FAQ - Why does Poetry enforce PEP 440 versions?](https://python-poetry.org/docs/faq#why-does-poetry-enforce-pep-440-versions)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/pvp/index.ts
+++ b/lib/modules/versioning/pvp/index.ts
@@ -7,7 +7,9 @@ import { compareIntArray, extractAllParts, getParts, plusOne } from './util.ts';
 
 export const id = 'pvp';
 export const displayName = 'Package Versioning Policy (Haskell)';
-export const urls = ['https://pvp.haskell.org'];
+export const urls = [
+  '[Haskell Package Versioning Policy](https://pvp.haskell.org)',
+];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = ['widen'];
 

--- a/lib/modules/versioning/rez/index.ts
+++ b/lib/modules/versioning/rez/index.ts
@@ -24,7 +24,7 @@ import {
 
 export const id = 'rez';
 export const displayName = 'rez';
-export const urls = ['https://github.com/nerdvegas/rez'];
+export const urls = ['[Rez package manager](https://github.com/nerdvegas/rez)'];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',

--- a/lib/modules/versioning/rpm/index.ts
+++ b/lib/modules/versioning/rpm/index.ts
@@ -7,9 +7,9 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'rpm';
 export const displayName = 'RPM version';
 export const urls = [
-  'https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/',
-  'https://fedoraproject.org/wiki/Package_Versioning_Examples',
-  'https://fedoraproject.org/wiki/User:Tibbs/TildeCaretVersioning',
+  '[Fedora packaging guidelines - Versioning](https://docs.fedoraproject.org/en-US/packaging-guidelines/Versioning/)',
+  '[Fedora package versioning examples](https://fedoraproject.org/wiki/Package_Versioning_Examples)',
+  '[Fedora tilde and caret versioning](https://fedoraproject.org/wiki/User:Tibbs/TildeCaretVersioning)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/ruby/index.ts
+++ b/lib/modules/versioning/ruby/index.ts
@@ -18,9 +18,9 @@ import { parse as parseVersion } from './version.ts';
 export const id = 'ruby';
 export const displayName = 'Ruby';
 export const urls = [
-  'https://guides.rubygems.org/patterns/',
-  'https://bundler.io/guides/gemfile.html',
-  'https://www.devalot.com/articles/2012/04/gem-versions.html',
+  '[RubyGems patterns](https://guides.rubygems.org/patterns/)',
+  '[Bundler Gemfile guide](https://bundler.io/guides/gemfile.html)',
+  '[Understanding Gem versions](https://www.devalot.com/articles/2012/04/gem-versions.html)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [

--- a/lib/modules/versioning/rust-release-channel/index.ts
+++ b/lib/modules/versioning/rust-release-channel/index.ts
@@ -6,7 +6,7 @@ import { sortParsed } from './util.ts';
 export const id = 'rust-release-channel';
 export const displayName = 'Rust Release Channel';
 export const urls = [
-  'https://rust-lang.github.io/rustup/concepts/toolchains.html',
+  '[Rustup - Toolchains](https://rust-lang.github.io/rustup/concepts/toolchains.html)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies = ['pin', 'replace'];

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -8,7 +8,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 
 export const id = 'semver-coerced';
 export const displayName = 'Coerced Semantic Versioning';
-export const urls = ['https://semver.org/'];
+export const urls = ['[Semantic Versioning](https://semver.org/)'];
 export const supportsRanges = false;
 
 function isStable(version: string): boolean {

--- a/lib/modules/versioning/semver-partial/index.ts
+++ b/lib/modules/versioning/semver-partial/index.ts
@@ -7,7 +7,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 export const id = 'semver-partial';
 export const displayName = 'Partial Semantic Versioning';
 export const urls = [
-  'https://docs.gitlab.com/ci/components/#partial-semantic-versions',
+  '[GitLab CI components - Partial semantic versions](https://docs.gitlab.com/ci/components/#partial-semantic-versions)',
 ];
 export const supportsRanges = true;
 export const supportedRangeStrategies = ['pin', 'replace'];

--- a/lib/modules/versioning/semver/index.ts
+++ b/lib/modules/versioning/semver/index.ts
@@ -4,7 +4,7 @@ import type { NewValueConfig, VersioningApi } from '../types.ts';
 
 export const id = 'semver';
 export const displayName = 'Semantic';
-export const urls = ['https://semver.org/'];
+export const urls = ['[Semantic Versioning](https://semver.org/)'];
 export const supportsRanges = false;
 
 const { is: isStable } = stable;

--- a/lib/modules/versioning/swift/index.ts
+++ b/lib/modules/versioning/swift/index.ts
@@ -7,7 +7,9 @@ import { getNewValue, toSemverRange } from './range.ts';
 
 export const id = 'swift';
 export const displayName = 'Swift';
-export const urls = ['https://swift.org/package-manager/'];
+export const urls = [
+  '[Swift Package Manager](https://swift.org/package-manager/)',
+];
 export const supportsRanges = true;
 export const supportedRangeStrategies: RangeStrategy[] = [
   'bump',

--- a/lib/modules/versioning/ubuntu/index.ts
+++ b/lib/modules/versioning/ubuntu/index.ts
@@ -12,8 +12,8 @@ import {
 export const id = 'ubuntu';
 export const displayName = 'Ubuntu';
 export const urls = [
-  'https://changelogs.ubuntu.com/meta-release',
-  'https://debian.pages.debian.net/distro-info-data/ubuntu.csv',
+  '[Ubuntu meta-release](https://changelogs.ubuntu.com/meta-release)',
+  '[Ubuntu distro info data](https://debian.pages.debian.net/distro-info-data/ubuntu.csv)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/unity3d-packages/index.ts
+++ b/lib/modules/versioning/unity3d-packages/index.ts
@@ -6,8 +6,8 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'unity3d-packages';
 export const displayName = 'Unity3D Packages';
 export const urls = [
-  'https://docs.unity3d.com/Manual/upm-semver.html',
-  'https://docs.unity3d.com/Manual/upm-lifecycle.html',
+  '[Unity Package Manager - Versioning](https://docs.unity3d.com/Manual/upm-semver.html)',
+  '[Unity Package Manager - Lifecycle](https://docs.unity3d.com/Manual/upm-lifecycle.html)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/unity3d/index.ts
+++ b/lib/modules/versioning/unity3d/index.ts
@@ -6,7 +6,7 @@ import type { VersioningApi } from '../types.ts';
 export const id = 'unity3d';
 export const displayName = 'Unity3D';
 export const urls = [
-  'https://docs.unity3d.com/Manual/assembly-definition-includes.html#version-define-expressions',
+  '[Unity version define expressions](https://docs.unity3d.com/Manual/assembly-definition-includes.html#version-define-expressions)',
 ];
 export const supportsRanges = false;
 

--- a/lib/modules/versioning/versioning-metadata.spec.ts
+++ b/lib/modules/versioning/versioning-metadata.spec.ts
@@ -1,6 +1,7 @@
 import { readdirSync } from 'node:fs';
 import { readFile } from 'fs-extra';
 import { z } from 'zod/v4';
+import { markdownLinkRegex } from './common.ts';
 
 describe('modules/versioning/versioning-metadata', () => {
   const allVersioning = readdirSync('lib/modules/versioning', {
@@ -38,12 +39,11 @@ describe('modules/versioning/versioning-metadata', () => {
     });
 
     it('contains mandatory fields', async () => {
-      const goodUrlRegex = /\[[^\]]+\]\([^)]+\)/;
       const Base = z.object({
         id: z.string(),
         displayName: z.string(),
         urls: z.array(
-          z.string().regex(goodUrlRegex, 'url must be a markdown link'),
+          z.string().regex(markdownLinkRegex, 'url must be a markdown link'),
         ),
       });
       const VersioningMetadata = z.discriminatedUnion('supportsRanges', [

--- a/lib/modules/versioning/versioning-metadata.spec.ts
+++ b/lib/modules/versioning/versioning-metadata.spec.ts
@@ -38,10 +38,13 @@ describe('modules/versioning/versioning-metadata', () => {
     });
 
     it('contains mandatory fields', async () => {
+      const goodUrlRegex = /\[[^\]]+\]\([^)]+\)/;
       const Base = z.object({
         id: z.string(),
         displayName: z.string(),
-        urls: z.array(z.unknown()),
+        urls: z.array(
+          z.string().regex(goodUrlRegex, 'url must be a markdown link'),
+        ),
       });
       const VersioningMetadata = z.discriminatedUnion('supportsRanges', [
         Base.extend({


### PR DESCRIPTION
## Changes

Replace all 65 bare URLs in versioning module `urls` arrays with descriptive markdown links, improving accessibility and readability in generated docs.

Also tighten the `urls` validation in `versioning-metadata.spec.ts` from `z.array(z.unknown())` to `z.array(z.string().regex(...))`, enforcing the `[text](url)` format going forward.

## Context

Closes #30312

## AI assistance disclosure

- [x] Yes — substantive assistance (AI generated non-trivial portions of code, tests, or documentation).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests