### PR TITLE
feat(manager/github-actions): support dtolnay/rust-toolchain `toolchain` input

### DIFF
--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -6,6 +6,7 @@ import { GithubReleasesDatasource } from '../../datasource/github-releases/index
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as condaVersioning from '../../versioning/conda/index.ts';
 import * as npmVersioning from '../../versioning/npm/index.ts';
 import type { PackageDependency } from '../types.ts';
@@ -139,6 +140,12 @@ export const communityActions: Record<string, CommunityActionConfig> = {
     depName: 'docker',
     packageName: 'moby/moby',
     extractVersion: '^docker-(?<version>.+)$',
+  },
+  // https://github.com/dtolnay/rust-toolchain
+  'dtolnay/rust-toolchain': {
+    datasource: RustVersionDatasource.id,
+    packageName: 'rust',
+    withSchema: valSchema('toolchain'),
   },
   'golangci/golangci-lint-action': {
     datasource: GithubReleasesDatasource.id,

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1685,6 +1685,67 @@ describe('modules/manager/github-actions/extract', () => {
         },
       ],
     },
+    {
+      step: {
+        uses: 'dtolnay/rust-toolchain@master',
+        with: { toolchain: '1.89.0' },
+      },
+      expected: [
+        {
+          currentValue: '1.89.0',
+          datasource: 'rust-version',
+          depName: 'rust',
+          depType: 'uses-with',
+          packageName: 'rust',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'dtolnay/rust-toolchain@master',
+        with: { toolchain: 'nightly-2025-01-01' },
+      },
+      expected: [
+        {
+          currentValue: 'nightly-2025-01-01',
+          datasource: 'rust-version',
+          depName: 'rust',
+          depType: 'uses-with',
+          packageName: 'rust',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'dtolnay/rust-toolchain@stable',
+        with: { toolchain: 'stable' },
+      },
+      expected: [
+        {
+          currentValue: 'stable',
+          datasource: 'rust-version',
+          depName: 'rust',
+          depType: 'uses-with',
+          packageName: 'rust',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'dtolnay/rust-toolchain@master',
+        with: {},
+      },
+      expected: [
+        {
+          datasource: 'rust-version',
+          depName: 'rust',
+          depType: 'uses-with',
+          packageName: 'rust',
+          skipStage: 'extract',
+          skipReason: 'unspecified-version',
+        },
+      ],
+    },
   ])('extract from $step.uses', ({ step, expected }) => {
     const yamlContent = yaml.dump({ jobs: { build: { steps: [step] } } });
 

--- a/lib/modules/manager/github-actions/index.ts
+++ b/lib/modules/manager/github-actions/index.ts
@@ -3,6 +3,7 @@ import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
 import { GithubDigestDatasource } from '../../datasource/github-digest/index.ts';
 import { GithubRunnersDatasource } from '../../datasource/github-runners/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 
 export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
@@ -23,4 +24,5 @@ export const supportedDatasources = [
   GithubDigestDatasource.id,
   GithubRunnersDatasource.id,
   GithubTagsDatasource.id,
+  RustVersionDatasource.id,
 ];


### PR DESCRIPTION
## Changes

Adds `dtolnay/rust-toolchain` to the github-actions manager's community action list, so the `toolchain:` input is extracted as a `rust` dependency and kept up to date.

```yaml
- uses: dtolnay/rust-toolchain@master
  with:
    toolchain: 1.89.0 # now updated by Renovate
```

It uses the `rust-version` datasource (versioning resolves to `rust-release-channel` from the datasource default), mirroring the existing `rust-toolchain` manager. Sliding-window expressions such as `stable 18 months ago` are extracted as-is and rejected by the versioning during lookup, so they produce no update.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used Claude Code to draft the code and tests, then reviewed and refined the result myself.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The community action table in the github-actions manager docs is autogenerated from `communityActions` at build time, so the new entry appears automatically.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
