### PR TITLE
feat(monorepo): add google-cloud-rust

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -405,6 +405,7 @@
       "https://github.com/uber/mock"
     ],
     "google-api-dotnet-client": "https://github.com/googleapis/google-api-dotnet-client",
+    "google-cloud-rust": "https://github.com/googleapis/google-cloud-rust",
     "grafana": "https://github.com/grafana/grafana",
     "graphiql": "https://github.com/graphql/graphiql",
     "graphql-hive-gateway": "https://github.com/graphql-hive/gateway",


### PR DESCRIPTION
## Changes

Adds [googleapis/google-cloud-rust](https://github.com/googleapis/google-cloud-rust) to the monorepo presets as `monorepo:google-cloud-rust`.

This repository publishes the official Google Cloud client libraries for Rust to crates.io — `google-cloud-gax`, `google-cloud-auth`, `google-cloud-storage`, and the generated per-service crates (`google-cloud-aiplatform-v1`, `google-cloud-secretmanager-v1`, …). They are released together from this single repository, so grouping their updates into one PR is appropriate.

The `repository` field these crates publish on crates.io is `https://github.com/googleapis/google-cloud-rust/tree/main`; Renovate's source-URL massaging (`lib/modules/datasource/metadata.ts`) strips the `/tree/main` suffix, so the plain repository URL used here matches as expected.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Tool: Claude Code (Anthropic), using the Claude Fable 5 and Claude Opus 4.8 models. AI was used to identify the source repository, verify each crate's `repository` URL on crates.io, and draft this PR description. The change itself is a one-line data addition, reviewed by a human before submission.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A — data-only preset addition; the existing `lib/data/index.spec.ts` suite (which validates JSON structure and alphabetical key order) passes locally.
