### PR TITLE
build: fix docker build cross-compilation after pnpm v11

### DIFF
--- a/patches/install-artifact-from-github@1.6.0.patch
+++ b/patches/install-artifact-from-github@1.6.0.patch
@@ -1,0 +1,24 @@
+diff --git a/bin/install-from-cache.js b/bin/install-from-cache.js
+index 29c682ff236ff59d678bd26f6a9d93ad710cfad8..7cda10259cfb429a47eb0626a0cb9871ac599ccb 100755
+--- a/bin/install-from-cache.js
++++ b/bin/install-from-cache.js
+@@ -27,7 +27,8 @@ const getPlatform = () => {
+ };
+ 
+ const platform = getPlatform(),
+-  platformArch = process.env.npm_config_platform_arch || process.arch,
++  // TODO: remove this patch once https://github.com/pnpm/pnpm/pull/12400 lands
++  platformArch = process.env.npm_config_platform_arch || process.env.pnpm_config_platform_arch || process.arch,
+   platformABI = process.env.npm_config_platform_abi || process.versions.modules;
+ 
+ const isParamPresent = name => process.argv.indexOf('--' + name) > 0;
+@@ -117,7 +118,8 @@ const run = (cmd, suppressOutput) =>
+   });
+ 
+ const isVerified = async () => {
+-  if (process.env.npm_config_platform || process.env.npm_config_platform_arch || process.env.npm_config_platform_abi) {
++  // TODO: remove this patch once https://github.com/pnpm/pnpm/pull/12400 lands
++  if (process.env.npm_config_platform || process.env.npm_config_platform_arch || process.env.pnpm_config_platform_arch || process.env.npm_config_platform_abi) {
+     console.log(`Fetched for the custom platform "${platform}-${platformArch}-${platformABI}" -- skipping the verification.`);
+     return true;
+   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ overrides:
   protobufjs@8.0.1: 8.6.1
   vite: 8.0.16
 
+patchedDependencies:
+  install-artifact-from-github@1.6.0: 0ceb8fd926db68d46ee8734f3c5924f9c67d8749303a18a09c8bb8d6fe2ddeb8
+
 importers:
 
   .:
@@ -8764,7 +8767,7 @@ snapshots:
 
   ini@6.0.0: {}
 
-  install-artifact-from-github@1.6.0:
+  install-artifact-from-github@1.6.0(patch_hash=0ceb8fd926db68d46ee8734f3c5924f9c67d8749303a18a09c8bb8d6fe2ddeb8):
     optional: true
 
   is-alphabetical@2.0.1: {}
@@ -10090,7 +10093,7 @@ snapshots:
 
   re2@1.24.1:
     dependencies:
-      install-artifact-from-github: 1.6.0
+      install-artifact-from-github: 1.6.0(patch_hash=0ceb8fd926db68d46ee8734f3c5924f9c67d8749303a18a09c8bb8d6fe2ddeb8)
       nan: 2.27.0
       node-gyp: 12.3.0
     optional: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,3 +47,6 @@ minimumReleaseAgeExclude:
   - '@containerbase/semantic-release-pnpm'
 
 provenance: true
+
+patchedDependencies:
+  install-artifact-from-github@1.6.0: patches/install-artifact-from-github@1.6.0.patch

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -61,6 +61,9 @@ ENV ARCH=${TARGETARCH/amd64/x64}
 # set `npm_config_platform_arch` for `install-artifact-from-github`
 ENV npm_config_arch=${ARCH} npm_config_platform_arch=${ARCH}
 
+# TODO: remove this once https://github.com/pnpm/pnpm/pull/12400 lands
+ENV pnpm_config_platform_arch=${ARCH}
+
 COPY --link patches ./patches
 COPY --link pnpm-lock.yaml ./
 COPY --link pnpm-workspace.yaml ./


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Since we cannot afford having the release workflow broken, this is a workaround and should be reverted once https://github.com/pnpm/pnpm/pull/12400 lands.

Refs https://github.com/renovatebot/renovate/pull/43885#issuecomment-4698169948

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
