### PR TITLE
feat(git): validate commit shas

### DIFF
--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -297,6 +297,7 @@ if (end) {
 - Avoid exporting functions purely for the purpose of testing unless you really need to
 - Avoid cast or prefer `x as T` instead of `<T>x` cast
   - Use `partial<T>()` from `test/util` if only a partial object is required
+  - Use `fakeSha(seed)` from `test/util` to generate deterministic, valid `LongCommitSha` values in tests
 
 ## Fixtures
 

--- a/lib/modules/platform/bitbucket-server/index.spec.ts
+++ b/lib/modules/platform/bitbucket-server/index.spec.ts
@@ -9,7 +9,7 @@ import {
   REPOSITORY_NOT_FOUND,
 } from '../../../constants/error-messages.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { ensureTrailingSlash, parseUrl } from '../../../util/url.ts';
 import type { ReattemptPlatformAutomergeConfig } from '../types.ts';
 import * as bitbucket from './index.ts';

--- a/lib/modules/platform/default-scm.spec.ts
+++ b/lib/modules/platform/default-scm.spec.ts
@@ -1,6 +1,7 @@
 import { git, partial } from '~test/util.ts';
 import { RENOVATE_FORK_UPSTREAM } from '../../util/git/index.ts';
-import type { CommitFilesConfig, LongCommitSha } from '../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../util/git/types.ts';
+import type { LongCommitSha } from '../../util/schema-utils/git.ts';
 import { DefaultGitScm } from './default-scm.ts';
 
 describe('modules/platform/default-scm', () => {

--- a/lib/modules/platform/default-scm.ts
+++ b/lib/modules/platform/default-scm.ts
@@ -1,6 +1,7 @@
 import type { DateTime } from 'luxon';
 import * as git from '../../util/git/index.ts';
-import type { CommitFilesConfig, LongCommitSha } from '../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../util/git/types.ts';
+import type { LongCommitSha } from '../../util/schema-utils/git.ts';
 import type { PlatformScm } from './types.ts';
 
 export class DefaultGitScm implements PlatformScm {

--- a/lib/modules/platform/forgejo/forgejo-helper.spec.ts
+++ b/lib/modules/platform/forgejo/forgejo-helper.spec.ts
@@ -1,7 +1,7 @@
 import * as httpMock from '~test/http-mock.ts';
 import { logger, partial } from '~test/util.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import { setBaseUrl } from '../../../util/http/forgejo.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { toBase64 } from '../../../util/string.ts';
 import {
   closeIssue,

--- a/lib/modules/platform/forgejo/index.spec.ts
+++ b/lib/modules/platform/forgejo/index.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import * as memCache from '../../../util/cache/memory/index.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { parseUrl } from '../../../util/url.ts';
 import type { EnsureIssueConfig, RepoParams } from '../index.ts';
 import * as helper from './forgejo-helper.ts';

--- a/lib/modules/platform/forgejo/pr-cache.spec.ts
+++ b/lib/modules/platform/forgejo/pr-cache.spec.ts
@@ -5,8 +5,8 @@ import {
   getCache,
   resetCache as repoCacheReset,
 } from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import { ForgejoHttp, setBaseUrl } from '../../../util/http/forgejo.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { ForgejoPrCache } from './pr-cache.ts';
 import type { PR, Repo } from './types.ts';
 import { toRenovatePR } from './utils.ts';

--- a/lib/modules/platform/forgejo/types.ts
+++ b/lib/modules/platform/forgejo/types.ts
@@ -1,4 +1,4 @@
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import type { EmailAddress } from '../../../util/schema-utils/index.ts';
 import type { Pr, RepoSortMethod, SortMethod } from '../types.ts';
 

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -214,11 +214,12 @@ describe('modules/platform/gerrit/index', () => {
     it('findPr() - found', async () => {
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: 'some-revision',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: source',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: source',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -356,11 +357,12 @@ describe('modules/platform/gerrit/index', () => {
       git.pushCommit.mockResolvedValueOnce(true);
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: 'some-revision',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: source',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: source',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -389,11 +391,12 @@ describe('modules/platform/gerrit/index', () => {
       git.pushCommit.mockResolvedValueOnce(true);
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: 'some-revision',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: source',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: source',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -425,11 +428,12 @@ describe('modules/platform/gerrit/index', () => {
       git.pushCommit.mockResolvedValueOnce(true);
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: 'some-revision',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: source',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: source',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -509,11 +513,12 @@ describe('modules/platform/gerrit/index', () => {
     it('getBranchPr() - found', async () => {
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: 'some-revision',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -535,11 +540,12 @@ describe('modules/platform/gerrit/index', () => {
     it('getBranchPr() - found even without targetBranch', async () => {
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: 'some-revision',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          'some-revision': partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -574,11 +580,12 @@ describe('modules/platform/gerrit/index', () => {
 
     it('getPrList() - multiple results', async () => {
       const change = partial<GerritChange>({
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -634,11 +641,12 @@ describe('modules/platform/gerrit/index', () => {
       const change = partial<GerritChange>({
         submittable: true,
         problems: [{ message: 'error1' }, { message: 'error2' }],
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
         },
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
@@ -651,11 +659,12 @@ describe('modules/platform/gerrit/index', () => {
       const change = partial<GerritChange>({
         submittable: false,
         problems: [{ message: 'error1' }, { message: 'error2' }],
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
         },
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
@@ -671,11 +680,12 @@ describe('modules/platform/gerrit/index', () => {
         labels: {
           Verified: { blocking: true },
         },
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
         },
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
@@ -824,11 +834,13 @@ describe('modules/platform/gerrit/index', () => {
         async ({ ctx, branchState, expectedVote, expectedLabel }) => {
           const change = partial<GerritChange>({
             _number: 123456,
-            current_revision: 'abc',
+            current_revision: '0123456789abcdef0123456789abcdef01234567',
             revisions: {
-              abc: partial<GerritRevisionInfo>({
-                commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-              }),
+              '0123456789abcdef0123456789abcdef01234567':
+                partial<GerritRevisionInfo>({
+                  commit_with_footers:
+                    'Renovate-Branch: renovate/dependency-1.x',
+                }),
             },
             labels: {
               [ctx]: partial<GerritLabelInfo>({
@@ -868,11 +880,12 @@ describe('modules/platform/gerrit/index', () => {
       it('does not call setLabel() if label does not exist in change', async () => {
         const change = partial<GerritChange>({
           _number: 123456,
-          current_revision: 'abc',
+          current_revision: '0123456789abcdef0123456789abcdef01234567',
           revisions: {
-            abc: partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+            '0123456789abcdef0123456789abcdef01234567':
+              partial<GerritRevisionInfo>({
+                commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+              }),
           },
         });
         clientMock.findChanges.mockResolvedValueOnce([change]);

--- a/lib/modules/platform/gerrit/index.spec.ts
+++ b/lib/modules/platform/gerrit/index.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { git, hostRules, partial } from '~test/util.ts';
+import { fakeSha, git, hostRules, partial } from '~test/util.ts';
 import { REPOSITORY_ARCHIVED } from '../../../constants/error-messages.ts';
 import type { BranchStatus } from '../../../types/index.ts';
 import { repoFingerprint } from '../util.ts';
@@ -38,6 +38,8 @@ vi.mock('./client.ts');
 const clientMock = vi.mocked(_client);
 
 describe('modules/platform/gerrit/index', () => {
+  const currentRevision = fakeSha('gerrit');
+
   beforeEach(async () => {
     hostRules.find.mockReturnValue({
       username: 'user',
@@ -214,12 +216,11 @@ describe('modules/platform/gerrit/index', () => {
     it('findPr() - found', async () => {
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: source',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: source',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -357,12 +358,11 @@ describe('modules/platform/gerrit/index', () => {
       git.pushCommit.mockResolvedValueOnce(true);
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: source',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: source',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -391,12 +391,11 @@ describe('modules/platform/gerrit/index', () => {
       git.pushCommit.mockResolvedValueOnce(true);
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: source',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: source',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -428,12 +427,11 @@ describe('modules/platform/gerrit/index', () => {
       git.pushCommit.mockResolvedValueOnce(true);
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: source',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: source',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -513,12 +511,11 @@ describe('modules/platform/gerrit/index', () => {
     it('getBranchPr() - found', async () => {
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -540,12 +537,11 @@ describe('modules/platform/gerrit/index', () => {
     it('getBranchPr() - found even without targetBranch', async () => {
       const change = partial<GerritChange>({
         _number: 123456,
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -580,12 +576,11 @@ describe('modules/platform/gerrit/index', () => {
 
     it('getPrList() - multiple results', async () => {
       const change = partial<GerritChange>({
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+          }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -641,12 +636,11 @@ describe('modules/platform/gerrit/index', () => {
       const change = partial<GerritChange>({
         submittable: true,
         problems: [{ message: 'error1' }, { message: 'error2' }],
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+          }),
         },
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
@@ -659,12 +653,11 @@ describe('modules/platform/gerrit/index', () => {
       const change = partial<GerritChange>({
         submittable: false,
         problems: [{ message: 'error1' }, { message: 'error2' }],
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+          }),
         },
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
@@ -680,12 +673,11 @@ describe('modules/platform/gerrit/index', () => {
         labels: {
           Verified: { blocking: true },
         },
-        current_revision: '0123456789abcdef0123456789abcdef01234567',
+        current_revision: currentRevision,
         revisions: {
-          '0123456789abcdef0123456789abcdef01234567':
-            partial<GerritRevisionInfo>({
-              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-            }),
+          [currentRevision]: partial<GerritRevisionInfo>({
+            commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+          }),
         },
       });
       clientMock.findChanges.mockResolvedValueOnce([change]);
@@ -834,13 +826,11 @@ describe('modules/platform/gerrit/index', () => {
         async ({ ctx, branchState, expectedVote, expectedLabel }) => {
           const change = partial<GerritChange>({
             _number: 123456,
-            current_revision: '0123456789abcdef0123456789abcdef01234567',
+            current_revision: currentRevision,
             revisions: {
-              '0123456789abcdef0123456789abcdef01234567':
-                partial<GerritRevisionInfo>({
-                  commit_with_footers:
-                    'Renovate-Branch: renovate/dependency-1.x',
-                }),
+              [currentRevision]: partial<GerritRevisionInfo>({
+                commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+              }),
             },
             labels: {
               [ctx]: partial<GerritLabelInfo>({
@@ -880,12 +870,11 @@ describe('modules/platform/gerrit/index', () => {
       it('does not call setLabel() if label does not exist in change', async () => {
         const change = partial<GerritChange>({
           _number: 123456,
-          current_revision: '0123456789abcdef0123456789abcdef01234567',
+          current_revision: currentRevision,
           revisions: {
-            '0123456789abcdef0123456789abcdef01234567':
-              partial<GerritRevisionInfo>({
-                commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
-              }),
+            [currentRevision]: partial<GerritRevisionInfo>({
+              commit_with_footers: 'Renovate-Branch: renovate/dependency-1.x',
+            }),
           },
         });
         clientMock.findChanges.mockResolvedValueOnce([change]);

--- a/lib/modules/platform/gerrit/scm.spec.ts
+++ b/lib/modules/platform/gerrit/scm.spec.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { git, partial } from '~test/util.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { client as _client } from './client.ts';
 import type {
   GerritAccountInfo,
@@ -222,10 +222,11 @@ describe('modules/platform/gerrit/scm', () => {
     });
 
     it('open change found for branchname -> return true', async () => {
-      const change = partial<GerritChange>({ current_revision: 'curSha' });
+      const sha40 = '0123456789abcdef0123456789abcdef01234567';
+      const change = partial<GerritChange>({ current_revision: sha40 });
       clientMock.findChanges.mockResolvedValueOnce([change]);
       await expect(gerritScm.getBranchCommit('myBranchName')).resolves.toBe(
-        'curSha',
+        sha40,
       );
     });
   });

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -3,12 +3,10 @@ import { isNonEmptyArray } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { logger } from '../../../logger/index.ts';
 import * as git from '../../../util/git/index.ts';
-import type {
-  CommitFilesConfig,
-  FileChange,
-  LongCommitSha,
-} from '../../../util/git/types.ts';
+import type { CommitFilesConfig, FileChange } from '../../../util/git/types.ts';
 import { hash } from '../../../util/hash.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
+import { isLongCommitSha } from '../../../util/schema-utils/git.ts';
 import { DefaultGitScm } from '../default-scm.ts';
 import { client } from './client.ts';
 import type { GerritFindPRConfig } from './types.ts';
@@ -77,8 +75,8 @@ export class GerritScm extends DefaultGitScm {
       requestDetails: ['CURRENT_REVISION'],
     };
     const change = (await client.findChanges(repository, searchConfig)).pop();
-    if (change) {
-      return change.current_revision as LongCommitSha;
+    if (isLongCommitSha(change?.current_revision)) {
+      return change.current_revision;
     }
     return git.getBranchCommit(branchName);
   }

--- a/lib/modules/platform/gerrit/utils.spec.ts
+++ b/lib/modules/platform/gerrit/utils.spec.ts
@@ -147,12 +147,13 @@ describe('modules/platform/gerrit/utils', () => {
         reviewers: {
           REVIEWER: [partial<GerritAccountInfo>({ username: 'username' })],
         },
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers:
-              'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers:
+                'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
+            }),
         },
         messages: [
           partial<GerritChangeMessageInfo>({
@@ -184,7 +185,7 @@ describe('modules/platform/gerrit/utils', () => {
         bodyStruct: {
           hash: hashBody('Last PR-Body'),
         },
-        sha: 'abc',
+        sha: '0123456789abcdef0123456789abcdef01234567',
       });
     });
 
@@ -195,12 +196,13 @@ describe('modules/platform/gerrit/utils', () => {
         branch: 'main',
         subject: 'Fix for',
         reviewers: {},
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers:
-              'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers:
+                'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -211,7 +213,7 @@ describe('modules/platform/gerrit/utils', () => {
         sourceBranch: 'renovate/dependency-1.x',
         targetBranch: 'main',
         reviewers: [],
-        sha: 'abc',
+        sha: '0123456789abcdef0123456789abcdef01234567',
         bodyStruct: {
           hash: hashBody(''),
         },
@@ -225,12 +227,13 @@ describe('modules/platform/gerrit/utils', () => {
         status: 'NEW',
         branch: 'main',
         subject: 'Fix for',
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers:
-              'Some change\n\nRenovate-Broke: renovate/dependency-1.x\nChange-Id: ...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers:
+                'Some change\n\nRenovate-Broke: renovate/dependency-1.x\nChange-Id: ...',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -243,12 +246,13 @@ describe('modules/platform/gerrit/utils', () => {
         status: 'NEW',
         branch: 'main',
         subject: 'Fix for',
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers:
-              'Some change\n\nRenovate-Broke: renovate/dependency-1.x\nChange-Id: ...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers:
+                'Some change\n\nRenovate-Broke: renovate/dependency-1.x\nChange-Id: ...',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -263,7 +267,7 @@ describe('modules/platform/gerrit/utils', () => {
         sourceBranch: 'renovate/dependency-1.x',
         targetBranch: 'main',
         reviewers: [],
-        sha: 'abc',
+        sha: '0123456789abcdef0123456789abcdef01234567',
         bodyStruct: {
           hash: hashBody(''),
         },
@@ -277,12 +281,13 @@ describe('modules/platform/gerrit/utils', () => {
         status: 'NEW',
         branch: 'main',
         subject: 'Fix for',
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers:
-              'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers:
+                'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
+            }),
         },
         created: '2025-04-14 16:33:37.000000000',
       });
@@ -297,7 +302,7 @@ describe('modules/platform/gerrit/utils', () => {
         sourceBranch: 'renovate/dependency-1.x',
         targetBranch: 'main',
         reviewers: [],
-        sha: 'abc',
+        sha: '0123456789abcdef0123456789abcdef01234567',
         bodyStruct: {
           hash: hashBody('PR Body'),
         },
@@ -314,11 +319,12 @@ describe('modules/platform/gerrit/utils', () => {
 
     it('commit message with no footer', () => {
       const change = partial<GerritChange>({
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers: 'some message...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers: 'some message...',
+            }),
         },
       });
       expect(utils.extractSourceBranch(change)).toBeUndefined();
@@ -326,12 +332,13 @@ describe('modules/platform/gerrit/utils', () => {
 
     it('commit message with footer', () => {
       const change = partial<GerritChange>({
-        current_revision: 'abc',
+        current_revision: '0123456789abcdef0123456789abcdef01234567',
         revisions: {
-          abc: partial<GerritRevisionInfo>({
-            commit_with_footers:
-              'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
-          }),
+          '0123456789abcdef0123456789abcdef01234567':
+            partial<GerritRevisionInfo>({
+              commit_with_footers:
+                'Some change\n\nRenovate-Branch: renovate/dependency-1.x\nChange-Id: ...',
+            }),
         },
       });
       expect(utils.extractSourceBranch(change)).toBe('renovate/dependency-1.x');

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -1,9 +1,9 @@
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { BranchStatus, PrState } from '../../../types/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
+import { toLongCommitSha } from '../../../util/schema-utils/git.ts';
 import { joinUrlParts, parseUrl } from '../../../util/url.ts';
 import { hashBody } from '../pr-body.ts';
 import type { GitUrlOption, Pr } from '../types.ts';
@@ -117,7 +117,7 @@ export function mapGerritChangeToPr(
     bodyStruct: {
       hash: hashBody(knownProperties?.prBody ?? findPullRequestBody(change)),
     },
-    sha: change.current_revision as LongCommitSha,
+    sha: toLongCommitSha(change.current_revision),
   };
 }
 

--- a/lib/modules/platform/gitea/gitea-helper.spec.ts
+++ b/lib/modules/platform/gitea/gitea-helper.spec.ts
@@ -1,7 +1,7 @@
 import * as httpMock from '~test/http-mock.ts';
 import { logger, partial } from '~test/util.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import { setBaseUrl } from '../../../util/http/gitea.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { toBase64 } from '../../../util/string.ts';
 import {
   closeIssue,

--- a/lib/modules/platform/gitea/index.spec.ts
+++ b/lib/modules/platform/gitea/index.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import * as memCache from '../../../util/cache/memory/index.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { parseUrl } from '../../../util/url.ts';
 import type { EnsureIssueConfig, RepoParams } from '../index.ts';
 import * as helper from './gitea-helper.ts';

--- a/lib/modules/platform/gitea/pr-cache.spec.ts
+++ b/lib/modules/platform/gitea/pr-cache.spec.ts
@@ -5,8 +5,8 @@ import {
   getCache,
   resetCache as repoCacheReset,
 } from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import { GiteaHttp, setBaseUrl } from '../../../util/http/gitea.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { GiteaPrCache } from './pr-cache.ts';
 import type { PR, Repo } from './types.ts';
 import { toRenovatePR } from './utils.ts';

--- a/lib/modules/platform/gitea/types.ts
+++ b/lib/modules/platform/gitea/types.ts
@@ -1,4 +1,4 @@
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import type { EmailAddress } from '../../../util/schema-utils/index.ts';
 import type { Pr, RepoSortMethod, SortMethod } from '../types.ts';
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -17,9 +17,9 @@ import {
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import * as repository from '../../../util/cache/repository/index.ts';
 import * as _git from '../../../util/git/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import * as _hostRules from '../../../util/host-rules.ts';
 import { setBaseUrl } from '../../../util/http/github.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { toBase64 } from '../../../util/string.ts';
 import { hashBody } from '../pr-body.ts';
 import type {
@@ -5604,8 +5604,10 @@ describe('modules/platform/github/index', () => {
         .post('/repos/some/repo/git/trees')
         .reply(200, { sha: '111' })
         .post('/repos/some/repo/git/commits')
-        .reply(200, { sha: '222' })
-        .head('/repos/some/repo/git/commits/222')
+        .reply(200, { sha: '0123456789abcdef0123456789abcdef01234567' })
+        .head(
+          '/repos/some/repo/git/commits/0123456789abcdef0123456789abcdef01234567',
+        )
         .reply(200)
         .post('/repos/some/repo/git/refs')
         .reply(200);
@@ -5630,8 +5632,10 @@ describe('modules/platform/github/index', () => {
         .post('/repos/some/repo/git/trees')
         .reply(200, { sha: '111' })
         .post('/repos/some/repo/git/commits')
-        .reply(200, { sha: '222' })
-        .head('/repos/some/repo/git/commits/222')
+        .reply(200, { sha: '0123456789abcdef0123456789abcdef01234567' })
+        .head(
+          '/repos/some/repo/git/commits/0123456789abcdef0123456789abcdef01234567',
+        )
         .reply(200)
         .patch('/repos/some/repo/git/refs/heads/foo/bar')
         .reply(200);
@@ -5656,8 +5660,10 @@ describe('modules/platform/github/index', () => {
         .post('/repos/some/repo/git/trees')
         .reply(200, { sha: '111' })
         .post('/repos/some/repo/git/commits')
-        .reply(200, { sha: '222' })
-        .head('/repos/some/repo/git/commits/222')
+        .reply(200, { sha: '0123456789abcdef0123456789abcdef01234567' })
+        .head(
+          '/repos/some/repo/git/commits/0123456789abcdef0123456789abcdef01234567',
+        )
         .reply(200)
         .patch('/repos/some/repo/git/refs/heads/foo/bar')
         .reply(422)
@@ -5684,8 +5690,10 @@ describe('modules/platform/github/index', () => {
         .post('/repos/some/repo/git/trees')
         .reply(200, { sha: '111' })
         .post('/repos/some/repo/git/commits')
-        .reply(200, { sha: '222' })
-        .head('/repos/some/repo/git/commits/222')
+        .reply(200, { sha: '0123456789abcdef0123456789abcdef01234567' })
+        .head(
+          '/repos/some/repo/git/commits/0123456789abcdef0123456789abcdef01234567',
+        )
         .reply(200)
         .patch('/repos/some/repo/git/refs/heads/foo/bar')
         .reply(404);
@@ -5710,8 +5718,10 @@ describe('modules/platform/github/index', () => {
         .post('/repos/some/repo/git/trees')
         .reply(200, { sha: '111' })
         .post('/repos/some/repo/git/commits')
-        .reply(200, { sha: '222' })
-        .head('/repos/some/repo/git/commits/222')
+        .reply(200, { sha: '0123456789abcdef0123456789abcdef01234567' })
+        .head(
+          '/repos/some/repo/git/commits/0123456789abcdef0123456789abcdef01234567',
+        )
         .reply(404);
 
       const res = await github.commitFiles({

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -36,7 +36,6 @@ import {
 import type {
   CommitFilesConfig,
   CommitResult,
-  LongCommitSha,
 } from '../../../util/git/types.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
@@ -47,6 +46,8 @@ import type { HttpResponse } from '../../../util/http/types.ts';
 import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
+import { toLongCommitSha } from '../../../util/schema-utils/git.ts';
 import { fromBase64, looseEquals } from '../../../util/string.ts';
 import { ensureTrailingSlash, isHttpUrl, parseUrl } from '../../../util/url.ts';
 import { incLimitedValue } from '../../../workers/global/limits.ts';
@@ -2275,7 +2276,7 @@ async function pushFiles(
       { body: { message, tree: treeSha, parents: [parentCommitSha] } },
     );
     incLimitedValue('Commits');
-    const remoteCommitSha = commitRes.body.sha as LongCommitSha;
+    const remoteCommitSha = toLongCommitSha(commitRes.body.sha);
     await ensureBranchSha(branchName, remoteCommitSha);
     return remoteCommitSha;
   } catch (err) {

--- a/lib/modules/platform/github/scm.spec.ts
+++ b/lib/modules/platform/github/scm.spec.ts
@@ -1,8 +1,6 @@
 import { git } from '~test/util.ts';
-import type {
-  CommitFilesConfig,
-  LongCommitSha,
-} from '../../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import * as _github from './index.ts';
 import { GithubScm } from './scm.ts';
 

--- a/lib/modules/platform/github/scm.ts
+++ b/lib/modules/platform/github/scm.ts
@@ -1,8 +1,6 @@
 import * as git from '../../../util/git/index.ts';
-import type {
-  CommitFilesConfig,
-  LongCommitSha,
-} from '../../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { DefaultGitScm } from '../default-scm.ts';
 import { commitFiles, isGHApp } from './index.ts';
 

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -1,4 +1,4 @@
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import type { EmailAddress } from '../../../util/schema-utils/index.ts';
 import type { Pr, PrBodyStruct } from '../types.ts';
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -15,7 +15,7 @@ import {
 import type { BranchStatus } from '../../../types/index.ts';
 import * as memCache from '../../../util/cache/memory/index.ts';
 import * as repoCache from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { toBase64 } from '../../../util/string.ts';
 import type { RepoParams } from '../index.ts';
 import * as prBodyModule from '../utils/pr-body.ts';

--- a/lib/modules/platform/gitlab/pr-cache.spec.ts
+++ b/lib/modules/platform/gitlab/pr-cache.spec.ts
@@ -4,8 +4,8 @@ import {
   getCache,
   resetCache as repoCacheReset,
 } from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
 import { GitlabHttp, setBaseUrl } from '../../../util/http/gitlab.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { GitlabPrCache } from './pr-cache.ts';
 import type { GitLabMergeRequest } from './schema.ts';
 import type { GitlabPrCacheData } from './types.ts';
@@ -26,7 +26,7 @@ const pr1: GitLabMergeRequest = {
   labels: [],
   merge_status: 'cannot_be_merged',
   description: 'a merge request',
-  sha: 'defg' as LongCommitSha,
+  sha: '0123456789abcdef0123456789abcdef01234567' as LongCommitSha,
   assignee: null,
   assignees: [],
 };
@@ -43,7 +43,7 @@ const pr2: GitLabMergeRequest = {
   labels: [],
   merge_status: 'cannot_be_merged',
   description: 'a merge request',
-  sha: 'defg' as LongCommitSha,
+  sha: '0123456789abcdef0123456789abcdef01234567' as LongCommitSha,
   assignee: null,
   assignees: [],
   reviewers: [],
@@ -61,7 +61,7 @@ const pr3: GitLabMergeRequest = {
   labels: [],
   merge_status: 'cannot_be_merged',
   description: 'a merge request',
-  sha: 'defg' as LongCommitSha,
+  sha: '0123456789abcdef0123456789abcdef01234567' as LongCommitSha,
   assignee: null,
   assignees: [],
   reviewers: [],

--- a/lib/modules/platform/gitlab/schema.ts
+++ b/lib/modules/platform/gitlab/schema.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod/v4';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { LooseArray } from '../../../util/schema-utils/index.ts';
 
 export const LastPipelineId = z
@@ -14,8 +14,6 @@ const GitlabUser = z.object({
   id: z.number(),
   username: z.string(),
 });
-
-const LongCommitSha = z.string().transform((val) => val as LongCommitSha);
 
 export const GitLabMergeRequest = z.object({
   iid: z.number(),

--- a/lib/modules/platform/local/scm.spec.ts
+++ b/lib/modules/platform/local/scm.spec.ts
@@ -50,7 +50,7 @@ describe('modules/platform/local/scm', () => {
     });
 
     it('checkoutBranch', async () => {
-      expect(await localFs.checkoutBranch('')).toBe('');
+      expect(await localFs.checkoutBranch('')).toBeNull();
     });
   });
 

--- a/lib/modules/platform/local/scm.ts
+++ b/lib/modules/platform/local/scm.ts
@@ -2,10 +2,8 @@ import { glob } from 'glob';
 import type { DateTime } from 'luxon';
 import { logger } from '../../../logger/index.ts';
 import { rawExec } from '../../../util/exec/common.ts';
-import type {
-  CommitFilesConfig,
-  LongCommitSha,
-} from '../../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import type { PlatformScm } from '../types.ts';
 
 let fileList: string[] | undefined;
@@ -58,9 +56,8 @@ export class LocalFs implements PlatformScm {
     return fileList;
   }
 
-  checkoutBranch(_branchName: string): Promise<LongCommitSha> {
-    // We don't care about the commit sha in local mode
-    return Promise.resolve('' as LongCommitSha);
+  checkoutBranch(_branchName: string): Promise<LongCommitSha | null> {
+    return Promise.resolve(null);
   }
 
   mergeAndPush(_branchName: string): Promise<void> {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -1,7 +1,8 @@
 import type { DateTime } from 'luxon';
 import type { MergeStrategy } from '../../config/types.ts';
 import type { BranchStatus, HostRule } from '../../types/index.ts';
-import type { CommitFilesConfig, LongCommitSha } from '../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../util/git/types.ts';
+import type { LongCommitSha } from '../../util/schema-utils/git.ts';
 import type { GithubVulnerabilityAlert } from './github/schema.ts';
 export type VulnerabilityAlert = GithubVulnerabilityAlert;
 
@@ -330,7 +331,7 @@ export interface PlatformScm {
   deleteBranch(branchName: string): Promise<void>;
   commitAndPush(commitConfig: CommitFilesConfig): Promise<LongCommitSha | null>;
   getFileList(): Promise<string[]>;
-  checkoutBranch(branchName: string): Promise<LongCommitSha>;
+  checkoutBranch(branchName: string): Promise<LongCommitSha | null>;
   mergeToLocal(branchName: string): Promise<void>;
   mergeAndPush(branchName: string): Promise<void>;
   syncForkWithUpstream?(baseBranch: string): Promise<void>;

--- a/lib/util/git/behind-base-branch-cache.spec.ts
+++ b/lib/util/git/behind-base-branch-cache.spec.ts
@@ -1,11 +1,11 @@
 import { logger, partial } from '~test/util.ts';
 import * as _repositoryCache from '../cache/repository/index.ts';
 import type { BranchCache, RepoCacheData } from '../cache/repository/types.ts';
+import type { LongCommitSha } from '../schema-utils/git.ts';
 import {
   getCachedBehindBaseResult,
   setCachedBehindBaseResult,
 } from './behind-base-branch-cache.ts';
-import type { LongCommitSha } from './types.ts';
 
 vi.mock('../cache/repository/index.ts');
 const repositoryCache = vi.mocked(_repositoryCache);

--- a/lib/util/git/behind-base-branch-cache.ts
+++ b/lib/util/git/behind-base-branch-cache.ts
@@ -1,7 +1,7 @@
 import { isNonEmptyObject } from '@sindresorhus/is';
 import { logger } from '../../logger/index.ts';
 import { getCache } from '../cache/repository/index.ts';
-import type { LongCommitSha } from './types.ts';
+import type { LongCommitSha } from '../schema-utils/git.ts';
 
 export function getCachedBehindBaseResult(
   branchName: string,

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -13,13 +13,14 @@ import {
 } from '../../constants/error-messages.ts';
 import { setCustomEnv } from '../env.ts';
 import { newlineRegex, regEx } from '../regex.ts';
+import { toLongCommitSha } from '../schema-utils/git.ts';
 import * as _auth from './auth.ts';
 import * as _behindBaseCache from './behind-base-branch-cache.ts';
 import * as _conflictsCache from './conflicts-cache.ts';
 import * as git from './index.ts';
 import { setNoVerify } from './index.ts';
 import * as _modifiedCache from './modified-cache.ts';
-import type { FileChange, LongCommitSha } from './types.ts';
+import type { FileChange } from './types.ts';
 import * as _updateDateCache from './update-date-cache.ts';
 
 vi.mock('./conflicts-cache.ts');
@@ -1459,7 +1460,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       await repo.raw(['mv', 'master_file', 'renamed_master_file']);
       await repo.commit('rename master file');
 
-      const commit = (await repo.revparse(['HEAD'])).trim() as LongCommitSha;
+      const commit = toLongCommitSha((await repo.revparse(['HEAD'])).trim());
       const diff = await git.diffCommitTree(parentCommit, commit);
 
       expect(diff).toHaveLength(2);

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -36,6 +36,8 @@ import { getEnv } from '../env.ts';
 import type { ExtraEnv } from '../exec/types.ts';
 import { getChildEnv } from '../exec/utils.ts';
 import { newlineRegex, regEx } from '../regex.ts';
+import type { LongCommitSha } from '../schema-utils/git.ts';
+import { toLongCommitSha } from '../schema-utils/git.ts';
 import { matchRegexOrGlobList } from '../string-match.ts';
 import { logWarningIfUnicodeHiddenCharactersInPackageFile } from '../unicode.ts';
 import { getGitEnvironmentVariables } from './auth.ts';
@@ -67,7 +69,6 @@ import type {
   DiffTreeItem,
   GitObjectType,
   LocalConfig,
-  LongCommitSha,
   PushFilesConfig,
   StatusResult,
   StorageConfig,
@@ -268,7 +269,7 @@ async function fetchBranchCommits(preferUpstream = true): Promise<void> {
       .map((line) => line.trim().split(regEx(/\s+/)))
       .forEach(([sha, ref]) => {
         config.branchCommits[ref.replace('refs/heads/', '')] =
-          sha as LongCommitSha;
+          toLongCommitSha(sha);
       });
     logger.trace({ branchCommits: config.branchCommits }, 'branch commits');
   } catch (err) /* v8 ignore next -- TODO: add test #40625 */ {
@@ -525,9 +526,9 @@ export const syncGit = withInstrumenting(
       });
     }
     try {
-      config.currentBranchSha = (
-        await git.raw(['rev-parse', 'HEAD'])
-      ).trim() as LongCommitSha;
+      config.currentBranchSha = toLongCommitSha(
+        (await git.raw(['rev-parse', 'HEAD'])).trim(),
+      );
     } catch (err) /* v8 ignore next -- TODO: add test #40625 */ {
       if (err.message?.includes('fatal: not a git repository')) {
         throw new Error(REPOSITORY_CHANGED);
@@ -578,9 +579,9 @@ export const syncGit = withInstrumenting(
       });
     }
 
-    config.currentBranchSha = (
-      await git.revparse('HEAD')
-    ).trim() as LongCommitSha;
+    config.currentBranchSha = toLongCommitSha(
+      (await git.revparse('HEAD')).trim(),
+    );
     logger.debug(`Current branch SHA: ${config.currentBranchSha}`);
   },
 );
@@ -669,9 +670,9 @@ export async function checkoutBranch(
       ),
     );
     config.currentBranch = branchName;
-    config.currentBranchSha = (
-      await git.raw(['rev-parse', 'HEAD'])
-    ).trim() as LongCommitSha;
+    config.currentBranchSha = toLongCommitSha(
+      (await git.raw(['rev-parse', 'HEAD'])).trim(),
+    );
     const latestCommitDate = await getCommitDate(config.currentBranchSha);
     // v8 ignore else -- TODO: add test #40625
     if (latestCommitDate) {
@@ -706,9 +707,9 @@ export async function checkoutBranchFromRemote(
       git.checkoutBranch(branchName, `${remoteName}/${branchName}`),
     );
     config.currentBranch = branchName;
-    config.currentBranchSha = (
-      await git.revparse('HEAD')
-    ).trim() as LongCommitSha;
+    config.currentBranchSha = toLongCommitSha(
+      (await git.revparse('HEAD')).trim(),
+    );
     logger.debug(`Checked out branch ${branchName} from remote ${remoteName}`);
     config.branchCommits[branchName] = config.currentBranchSha;
     return config.currentBranchSha;
@@ -1338,9 +1339,9 @@ export async function prepareCommit({
       return null;
     }
 
-    const commitSha = (
-      await git.revparse([branchName])
-    ).trim() as LongCommitSha;
+    const commitSha = toLongCommitSha(
+      (await git.revparse([branchName])).trim(),
+    );
     const result: CommitResult = {
       parentCommitSha,
       commitSha,
@@ -1401,7 +1402,7 @@ export async function fetchBranch(
   try {
     const ref = `refs/heads/${branchName}:refs/remotes/origin/${branchName}`;
     await gitRetry(() => git.pull(['origin', ref, '--force']));
-    const commit = (await git.revparse([branchName])).trim() as LongCommitSha;
+    const commit = toLongCommitSha((await git.revparse([branchName])).trim());
     config.branchCommits[branchName] = commit;
     config.branchIsModified[branchName] = false;
     return commit;
@@ -1576,7 +1577,7 @@ export async function getCommitTreeSha(
       `Could not extract tree SHA from commit ${commitSha}: ${snippet}`,
     );
   }
-  return treeSha as LongCommitSha;
+  return toLongCommitSha(treeSha);
 }
 
 function treeTypeFromMode(mode: string): GitObjectType {
@@ -1636,7 +1637,7 @@ export async function diffCommitTree(
             path: targetPath,
             mode: newMode,
             type: treeTypeFromMode(newMode),
-            sha: newSha as LongCommitSha,
+            sha: toLongCommitSha(newSha),
           });
           break;
         default:
@@ -1645,7 +1646,7 @@ export async function diffCommitTree(
             path: targetPath ?? sourcePath,
             mode: newMode,
             type: treeTypeFromMode(newMode),
-            sha: newSha as LongCommitSha,
+            sha: toLongCommitSha(newSha),
           });
           break;
       }

--- a/lib/util/git/set-branch-commit.spec.ts
+++ b/lib/util/git/set-branch-commit.spec.ts
@@ -2,8 +2,8 @@ import { DateTime } from 'luxon';
 import { git, logger, partial } from '~test/util.ts';
 import * as _repositoryCache from '../cache/repository/index.ts';
 import type { BranchCache, RepoCacheData } from '../cache/repository/types.ts';
+import type { LongCommitSha } from '../schema-utils/git.ts';
 import { setBranchNewCommit } from './set-branch-commit.ts';
-import type { LongCommitSha } from './types.ts';
 
 vi.mock('../cache/repository/index.ts');
 vi.mock('./index.ts');

--- a/lib/util/git/types.ts
+++ b/lib/util/git/types.ts
@@ -1,5 +1,6 @@
 import type { PlatformCommitOptions } from '../../config/types.ts';
 import type { GitOptions } from '../../types/git.ts';
+import type { LongCommitSha } from '../schema-utils/git.ts';
 import type { EmailAddress } from '../schema-utils/index.ts';
 
 export type { DiffResult, StatusResult } from 'simple-git';
@@ -10,11 +11,6 @@ export interface GitAuthor {
 }
 
 export type GitNoVerifyOption = 'commit' | 'push';
-
-/**
- * We want to make sure this is a long sha of 40 characters and not just any string
- */
-export type LongCommitSha = string & { __longCommitSha: never };
 
 export interface StorageConfig {
   currentBranch?: string;

--- a/lib/util/schema-utils/git.spec.ts
+++ b/lib/util/schema-utils/git.spec.ts
@@ -2,34 +2,49 @@ import { LongCommitSha, isLongCommitSha, toLongCommitSha } from './git.ts';
 
 describe('util/schema-utils/git', () => {
   const sha40 = '0123456789abcdef0123456789abcdef01234567';
+  const sha64 =
+    '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
 
-  it('parses a valid 40-char sha', () => {
-    expect(LongCommitSha.parse(sha40)).toBe(sha40);
+  describe('LongCommitSha', () => {
+    it.each([
+      ['40-char sha', sha40],
+      ['64-char sha', sha64],
+    ])('parses a valid %s', (_label, sha) => {
+      expect(LongCommitSha.parse(sha)).toBe(sha);
+    });
+
+    it.each([
+      ['short sha', 'abc'],
+      ['non-hex 40-char string', 'g'.repeat(40)],
+    ])('rejects a %s', (_label, value) => {
+      expect(() => LongCommitSha.parse(value)).toThrow();
+    });
   });
 
-  it('rejects a short sha', () => {
-    expect(() => LongCommitSha.parse('abc')).toThrow();
+  describe('isLongCommitSha', () => {
+    it.each([
+      ['40-char sha', sha40, true],
+      ['64-char sha', sha64, true],
+      ['short sha', 'abc', false],
+      ['non-hex 40-char string', 'g'.repeat(40), false],
+      ['non-string', 42, false],
+    ])('%s → %s', (_label, value, expected) => {
+      expect(isLongCommitSha(value)).toBe(expected);
+    });
   });
 
-  it('isLongCommitSha returns true for valid sha', () => {
-    expect(isLongCommitSha(sha40)).toBe(true);
-  });
+  describe('toLongCommitSha', () => {
+    it.each([
+      ['40-char sha', sha40],
+      ['64-char sha', sha64],
+    ])('returns branded value for %s', (_label, sha) => {
+      expect(toLongCommitSha(sha)).toBe(sha);
+    });
 
-  it('isLongCommitSha returns false for short sha', () => {
-    expect(isLongCommitSha('abc')).toBe(false);
-  });
-
-  it('isLongCommitSha returns false for non-string', () => {
-    expect(isLongCommitSha(42)).toBe(false);
-  });
-
-  it('toLongCommitSha returns branded value for valid sha', () => {
-    expect(toLongCommitSha(sha40)).toBe(sha40);
-  });
-
-  it('toLongCommitSha throws for invalid value', () => {
-    expect(() => toLongCommitSha('short')).toThrow(
-      'Invalid long commit SHA: short',
-    );
+    it('throws for invalid value', () => {
+      expect(() => toLongCommitSha('short')).toThrow(
+        'Invalid long commit SHA: short',
+      );
+    });
   });
 });

--- a/lib/util/schema-utils/git.spec.ts
+++ b/lib/util/schema-utils/git.spec.ts
@@ -1,0 +1,35 @@
+import { LongCommitSha, isLongCommitSha, toLongCommitSha } from './git.ts';
+
+describe('util/schema-utils/git', () => {
+  const sha40 = '0123456789abcdef0123456789abcdef01234567';
+
+  it('parses a valid 40-char sha', () => {
+    expect(LongCommitSha.parse(sha40)).toBe(sha40);
+  });
+
+  it('rejects a short sha', () => {
+    expect(() => LongCommitSha.parse('abc')).toThrow();
+  });
+
+  it('isLongCommitSha returns true for valid sha', () => {
+    expect(isLongCommitSha(sha40)).toBe(true);
+  });
+
+  it('isLongCommitSha returns false for short sha', () => {
+    expect(isLongCommitSha('abc')).toBe(false);
+  });
+
+  it('isLongCommitSha returns false for non-string', () => {
+    expect(isLongCommitSha(42)).toBe(false);
+  });
+
+  it('toLongCommitSha returns branded value for valid sha', () => {
+    expect(toLongCommitSha(sha40)).toBe(sha40);
+  });
+
+  it('toLongCommitSha throws for invalid value', () => {
+    expect(() => toLongCommitSha('short')).toThrow(
+      'Invalid long commit SHA: short',
+    );
+  });
+});

--- a/lib/util/schema-utils/git.ts
+++ b/lib/util/schema-utils/git.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod/v4';
+
+export const LongCommitSha = z.string().length(40).brand('LongCommitSha');
+export type LongCommitSha = z.infer<typeof LongCommitSha>;
+
+export function isLongCommitSha(value: unknown): value is LongCommitSha {
+  return LongCommitSha.safeParse(value).success;
+}
+
+export function toLongCommitSha(value: unknown): LongCommitSha {
+  if (!isLongCommitSha(value)) {
+    throw new Error(`Invalid long commit SHA: ${String(value)}`);
+  }
+  return value;
+}

--- a/lib/util/schema-utils/git.ts
+++ b/lib/util/schema-utils/git.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod/v4';
+import { regEx } from '../regex.ts';
 
-export const LongCommitSha = z.string().length(40).brand('LongCommitSha');
+export const LongCommitSha = z
+  .string()
+  .regex(regEx(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/))
+  .brand('LongCommitSha');
 export type LongCommitSha = z.infer<typeof LongCommitSha>;
 
 export function isLongCommitSha(value: unknown): value is LongCommitSha {

--- a/lib/util/schema-utils/index.spec.ts
+++ b/lib/util/schema-utils/index.spec.ts
@@ -15,8 +15,10 @@ import {
   Toml,
   UtcDate,
   Yaml,
+  isEmailAdress,
   multidocYaml,
   withDebugMessage,
+  withDepType,
   withTraceMessage,
 } from './index.ts';
 
@@ -616,6 +618,51 @@ describe('util/schema-utils/index', () => {
           foo: 222
         `),
       ).toEqual([{ foo: 111 }, { foo: 222 }]);
+    });
+
+    it('rejects invalid yaml', () => {
+      expect(multidocYaml().safeParse(': invalid: yaml: {')).toMatchObject({
+        success: false,
+        error: { issues: [{ code: 'custom', message: 'Invalid YAML' }] },
+      });
+    });
+  });
+
+  describe('withDepType()', () => {
+    const Base = z.array(
+      z.object({ depName: z.string(), depType: z.string().optional() }),
+    );
+
+    it('sets depType on all deps when force=true (default)', () => {
+      const result = withDepType(Base, 'devDependencies').parse([
+        { depName: 'foo' },
+        { depName: 'bar', depType: 'existing' },
+      ]);
+      expect(result).toEqual([
+        { depName: 'foo', depType: 'devDependencies' },
+        { depName: 'bar', depType: 'devDependencies' },
+      ]);
+    });
+
+    it('preserves existing depType when force=false', () => {
+      const result = withDepType(Base, 'devDependencies', false).parse([
+        { depName: 'foo' },
+        { depName: 'bar', depType: 'existing' },
+      ]);
+      expect(result).toEqual([
+        { depName: 'foo', depType: 'devDependencies' },
+        { depName: 'bar', depType: 'existing' },
+      ]);
+    });
+  });
+
+  describe('isEmailAdress()', () => {
+    it('returns true for valid email', () => {
+      expect(isEmailAdress('user@example.com')).toBe(true);
+    });
+
+    it('returns false for invalid email', () => {
+      expect(isEmailAdress('not-an-email')).toBe(false);
     });
   });
 

--- a/lib/workers/repository/onboarding/branch/check.spec.ts
+++ b/lib/workers/repository/onboarding/branch/check.spec.ts
@@ -7,7 +7,7 @@ import { REPOSITORY_CLOSED_ONBOARDING } from '../../../../constants/error-messag
 import { logger } from '../../../../logger/index.ts';
 import type { Pr } from '../../../../modules/platform/types.ts';
 import * as _cache from '../../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import { isOnboarded } from './check.ts';
 
 vi.mock('../../../../util/cache/repository/index.ts');

--- a/lib/workers/repository/onboarding/branch/index.spec.ts
+++ b/lib/workers/repository/onboarding/branch/index.spec.ts
@@ -14,10 +14,8 @@ import type { Pr } from '../../../../modules/platform/index.ts';
 import * as memCache from '../../../../util/cache/memory/index.ts';
 import * as _cache from '../../../../util/cache/repository/index.ts';
 import type { RepoCacheData } from '../../../../util/cache/repository/types.ts';
-import type {
-  FileAddition,
-  LongCommitSha,
-} from '../../../../util/git/types.ts';
+import type { FileAddition } from '../../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import { OnboardingState } from '../common.ts';
 import * as _config from './config.ts';
 import { checkOnboardingBranch } from './index.ts';

--- a/lib/workers/repository/onboarding/branch/onboarding-branch-cache.spec.ts
+++ b/lib/workers/repository/onboarding/branch/onboarding-branch-cache.spec.ts
@@ -4,7 +4,7 @@ import type {
   OnboardingBranchCache,
   RepoCacheData,
 } from '../../../../util/cache/repository/types.ts';
-import type { LongCommitSha } from '../../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import {
   deleteOnboardingCache,
   getOnboardingConfigFromCache,

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -3,7 +3,7 @@ import type { PackageFile } from '../../../modules/manager/types.ts';
 import * as _repositoryCache from '../../../util/cache/repository/index.ts';
 import type { BaseBranchCache } from '../../../util/cache/repository/types.ts';
 import { fingerprint } from '../../../util/fingerprint.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { generateFingerprintConfig } from '../extract/extract-fingerprint-config.ts';
 import * as _branchify from '../updates/branchify.ts';
 import {

--- a/lib/workers/repository/process/write.spec.ts
+++ b/lib/workers/repository/process/write.spec.ts
@@ -12,7 +12,7 @@ import type {
   RepoCacheData,
 } from '../../../util/cache/repository/types.ts';
 import { fingerprint } from '../../../util/fingerprint.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { counts } from '../../global/limits.ts';
 import type { BranchConfig, BranchUpgradeConfig } from '../../types.ts';
 import * as _branchWorker from '../update/branch/index.ts';

--- a/lib/workers/repository/reconfigure/index.spec.ts
+++ b/lib/workers/repository/reconfigure/index.spec.ts
@@ -4,7 +4,7 @@ import { GlobalConfig } from '../../../config/global.ts';
 import { type AllConfig } from '../../../config/types.ts';
 import type { Pr } from '../../../modules/platform/index.ts';
 import * as _cache from '../../../util/cache/repository/index.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import type { BranchConfig } from '../../types.ts';
 import * as _inherited from '../init/inherited.ts';
 import * as _merge from '../init/merge.ts';

--- a/lib/workers/repository/reconfigure/validate.spec.ts
+++ b/lib/workers/repository/reconfigure/validate.spec.ts
@@ -4,7 +4,7 @@ import { git, partial, platform } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import type { Pr } from '../../../modules/platform/types.ts';
-import type { LongCommitSha } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { validateReconfigureBranch } from './validate.ts';
 
 vi.mock('../../../util/git/index.ts');

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -1,6 +1,6 @@
 import { logger, scm } from '~test/util.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
-import type { LongCommitSha } from '../../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import type { BranchConfig } from '../../../types.ts';
 import { commitFilesToBranch } from './commit.ts';
 

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -4,12 +4,10 @@ import { GlobalConfig } from '../../../../config/global.ts';
 import { CONFIG_SECRETS_EXPOSED } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
-import type {
-  CommitFilesConfig,
-  LongCommitSha,
-} from '../../../../util/git/types.ts';
+import type { CommitFilesConfig } from '../../../../util/git/types.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
 import { sanitize } from '../../../../util/sanitize.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import type { BranchConfig } from '../../../types.ts';
 
 export function commitFilesToBranch(

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -22,13 +22,10 @@ import type {
 import { hashBody } from '../../../../modules/platform/pr-body.ts';
 import * as _repoCache from '../../../../util/cache/repository/index.ts';
 import * as _exec from '../../../../util/exec/index.ts';
-import type {
-  FileChange,
-  LongCommitSha,
-  StatusResult,
-} from '../../../../util/git/types.ts';
+import type { FileChange, StatusResult } from '../../../../util/git/types.ts';
 import * as _mergeConfidence from '../../../../util/merge-confidence/index.ts';
 import * as _sanitize from '../../../../util/sanitize.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
 import * as _limits from '../../../global/limits.ts';
 import type {

--- a/lib/workers/repository/update/pr/code-owners.spec.ts
+++ b/lib/workers/repository/update/pr/code-owners.spec.ts
@@ -4,7 +4,7 @@ import { fs, git, platform } from '~test/util.ts';
 import * as bitbucketserver from '../../../../modules/platform/bitbucket-server/index.ts';
 import * as gitlab from '../../../../modules/platform/gitlab/index.ts';
 import type { Pr } from '../../../../modules/platform/index.ts';
-import type { LongCommitSha } from '../../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../../util/schema-utils/git.ts';
 import { codeOwnersForPr } from './code-owners.ts';
 
 vi.mock('../../../../util/fs/index.ts');

--- a/test/util.ts
+++ b/test/util.ts
@@ -8,7 +8,12 @@ import { scm as _scm } from '../lib/modules/platform/scm.ts';
 import * as _env from '../lib/util/exec/env.ts';
 import * as _fs from '../lib/util/fs/index.ts';
 import * as _git from '../lib/util/git/index.ts';
+import { hash } from '../lib/util/hash.ts';
 import * as _hostRules from '../lib/util/host-rules.ts';
+import {
+  type LongCommitSha,
+  toLongCommitSha,
+} from '../lib/util/schema-utils/git.ts';
 
 /**
  * Simple wrapper for getting mocked version of a module
@@ -77,4 +82,16 @@ function getCallerFileName(): string | null {
 export function getFixturePath(fixtureFile: string, fixtureRoot = '.'): string {
   const callerDir = upath.dirname(getCallerFileName()!);
   return upath.join(callerDir, fixtureRoot, '__fixtures__', fixtureFile);
+}
+
+/**
+ * Deterministically derive a valid {@link LongCommitSha} from a seed, for tests.
+ * Same seed always yields the same SHA, keeping snapshots stable.
+ * Defaults to a 40-char (sha1) hash; pass 'sha256' for a 64-char hash.
+ */
+export function fakeSha(
+  seed: string,
+  algorithm: 'sha1' | 'sha256' = 'sha1',
+): LongCommitSha {
+  return toLongCommitSha(hash(seed, algorithm));
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

- Add a new Schema helper for Commit hashes and replace the current type with an inferred one. 
- Added two helper functions `isLongCommitSha` and `toLongCommitSha` to replace `as LongCommitSha` calls 
- Also replaces the already existing schema specific for Gitlab with this new one

There is a small behaviour change outside of only validating the commit hashes now. 
`checkoutBranch` now returns `null` or a valid commit hash as before the `local` platform would simply return an empty string. 

https://github.com/renovatebot/renovate/pull/43988/changes#diff-bcc41603946777dedac5cb64fa89ebedc6a35e5242ec5c0e90e8a46af93b52ccR59

<!-- Describe what behavior is changed by this PR. -->

## Context

https://github.com/renovatebot/renovate/pull/43900/changes#r3405047484

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
