### PR TITLE
feat(releases): concurrent hydration of in-range releases via postprocessRelease

### DIFF
--- a/lib/workers/repository/update/pr/changelog/releases.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/releases.spec.ts
@@ -1,5 +1,6 @@
 import { partial } from '~test/util.ts';
 import * as datasource from '../../../../../modules/datasource/index.ts';
+import * as releasePostprocess from '../../../../../modules/datasource/postprocess-release.ts';
 import * as dockerVersioning from '../../../../../modules/versioning/docker/index.ts';
 import * as npmVersioning from '../../../../../modules/versioning/npm/index.ts';
 import type { BranchUpgradeConfig } from '../../../../types.ts';
@@ -133,6 +134,151 @@ describe('workers/repository/update/pr/changelog/releases', () => {
       });
       const res = await releases.getInRangeReleases(config);
       expect(res).toEqual([{ version: '1.0.1' }, { version: '1.1.0' }]);
+    });
+
+    it('postprocesses releases before returning them', async () => {
+      vi.spyOn(releasePostprocess, 'postprocessRelease').mockImplementation(
+        (_config, release) => {
+          if (release.version === '1.0.1') {
+            return Promise.resolve(null);
+          }
+          if (release.version === '1.1.0') {
+            return Promise.resolve({ ...release, gitRef: 'release/1.1.0' });
+          }
+          return Promise.resolve(release);
+        },
+      );
+
+      const config = partial<BranchUpgradeConfig>({
+        datasource: 'some-datasource',
+        packageName: 'some-depname',
+        versioning: npmVersioning.id,
+        currentVersion: '1.0.0',
+        newVersion: '1.1.0',
+      });
+
+      const res = await releases.getInRangeReleases(config);
+
+      expect(res).toEqual([
+        { version: '1.0.0' },
+        { version: '1.0.1' },
+        { version: '1.1.0', gitRef: 'release/1.1.0' },
+      ]);
+    });
+
+    it('keeps the original release when postprocessing rejects it', async () => {
+      vi.mocked(datasource.getPkgReleases).mockReset();
+      vi.mocked(datasource.getPkgReleases).mockResolvedValueOnce({
+        releases: [{ version: '1.0.0' }, { version: '1.1.0' }],
+      });
+
+      vi.spyOn(releasePostprocess, 'postprocessRelease').mockImplementation(
+        (_config, release) =>
+          Promise.resolve(release.version === '1.0.0' ? null : release),
+      );
+
+      const config = partial<BranchUpgradeConfig>({
+        datasource: 'some-datasource',
+        packageName: 'some-depname',
+        versioning: npmVersioning.id,
+        currentVersion: '1.0.0',
+        newVersion: '1.1.0',
+      });
+
+      const res = await releases.getInRangeReleases(config);
+
+      expect(res).toEqual([{ version: '1.0.0' }, { version: '1.1.0' }]);
+    });
+
+    it('hydrates releases concurrently while preserving order', async () => {
+      vi.mocked(datasource.getPkgReleases).mockReset();
+      vi.mocked(datasource.getPkgReleases).mockResolvedValueOnce({
+        releases: [
+          { version: '1.0.0' },
+          { version: '1.0.1' },
+          { version: '1.1.0' },
+        ],
+      });
+
+      let inFlight = 0;
+      let maxConcurrent = 0;
+      vi.spyOn(releasePostprocess, 'postprocessRelease').mockImplementation(
+        async (_config, release) => {
+          inFlight += 1;
+          maxConcurrent = Math.max(maxConcurrent, inFlight);
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+          });
+          inFlight -= 1;
+          return { ...release, gitRef: `release/${release.version}` };
+        },
+      );
+
+      const config = partial<BranchUpgradeConfig>({
+        datasource: 'some-datasource',
+        packageName: 'some-depname',
+        versioning: npmVersioning.id,
+        currentVersion: '1.0.0',
+        newVersion: '1.1.0',
+      });
+
+      const res = await releases.getInRangeReleases(config);
+
+      expect(maxConcurrent).toBeGreaterThan(1);
+      expect(res).toEqual([
+        { version: '1.0.0', gitRef: 'release/1.0.0' },
+        { version: '1.0.1', gitRef: 'release/1.0.1' },
+        { version: '1.1.0', gitRef: 'release/1.1.0' },
+      ]);
+    });
+
+    it('uses the release registryUrl when hydrating merged-registry releases', async () => {
+      vi.mocked(datasource.getPkgReleases).mockReset();
+      vi.mocked(datasource.getPkgReleases).mockResolvedValueOnce({
+        releases: [
+          { version: '1.0.0', registryUrl: 'https://registry-a.example' },
+          { version: '1.1.0', registryUrl: 'https://registry-b.example' },
+        ],
+      });
+
+      const postprocessSpy = vi
+        .spyOn(releasePostprocess, 'postprocessRelease')
+        .mockImplementation((_config, release) => Promise.resolve(release));
+
+      const config = partial<BranchUpgradeConfig>({
+        datasource: 'some-datasource',
+        packageName: 'some-depname',
+        versioning: npmVersioning.id,
+        currentVersion: '1.0.0',
+        newVersion: '1.1.0',
+        registryUrls: [
+          'https://registry-a.example',
+          'https://registry-b.example',
+        ],
+      });
+
+      await releases.getInRangeReleases(config);
+
+      expect(postprocessSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          registryUrl: 'https://registry-a.example',
+        }),
+        expect.objectContaining({
+          version: '1.0.0',
+          registryUrl: 'https://registry-a.example',
+        }),
+      );
+      expect(postprocessSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          registryUrl: 'https://registry-b.example',
+        }),
+        expect.objectContaining({
+          version: '1.1.0',
+          registryUrl: 'https://registry-b.example',
+        }),
+      );
     });
   });
 });

--- a/lib/workers/repository/update/pr/changelog/releases.ts
+++ b/lib/workers/repository/update/pr/changelog/releases.ts
@@ -5,9 +5,11 @@ import {
   getPkgReleases,
   isGetPkgReleasesConfig,
 } from '../../../../../modules/datasource/index.ts';
+import { postprocessRelease } from '../../../../../modules/datasource/postprocess-release.ts';
 import type { VersioningApi } from '../../../../../modules/versioning/index.ts';
 import { get } from '../../../../../modules/versioning/index.ts';
 import { coerceArray } from '../../../../../util/array.ts';
+import * as p from '../../../../../util/promises.ts';
 import type { BranchUpgradeConfig } from '../../../../types.ts';
 
 function matchesMMP(
@@ -87,12 +89,25 @@ export async function getInRangeReleases(
       }
     }
 
+    const hydratedReleases = await p.map(releases, async (release) => {
+      const hydratedRelease = await postprocessRelease(
+        {
+          datasource,
+          packageName: config.packageName,
+          registryUrl: release.registryUrl ?? config.registryUrl,
+          registryUrls: config.registryUrls,
+        },
+        release,
+      );
+      return hydratedRelease ?? release;
+    });
+
     if (version.valueToVersion) {
-      for (const release of coerceArray(releases)) {
+      for (const release of coerceArray(hydratedReleases)) {
         release.version = version.valueToVersion(release.version);
       }
     }
-    return releases;
+    return hydratedReleases;
   } catch (err) /* istanbul ignore next */ {
     logger.debug({ err }, 'getInRangeReleases err');
     logger.debug(`Error getting releases for ${depName} from ${datasource}`);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Hydrate in-range releases by invoking postprocessRelease concurrently while preserving order, using release-specific registryUrl and retaining the original release when postprocessing rejects it.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
