### PR TITLE
fix(manager/deno): tolerate compilerOptions without jsx fields

### DIFF
--- a/lib/modules/manager/deno/schema.spec.ts
+++ b/lib/modules/manager/deno/schema.spec.ts
@@ -572,6 +572,25 @@ describe('modules/manager/deno/schema', () => {
       expect(result.content.dependencies).toEqual([]);
     });
 
+    it('parses deno.json with compilerOptions lacking dependency fields', () => {
+      const result = DenoExtract.parse({
+        content: JSON.stringify({
+          compilerOptions: {
+            lib: ['deno.ns', 'deno.window'],
+            strict: true,
+          },
+          imports: {
+            dep1: 'npm:package@1.0.0',
+          },
+        }),
+        fileName: 'deno.json',
+      });
+
+      expect(result.content.dependencies).toEqual([
+        expect.objectContaining({ depName: 'package', depType: 'imports' }),
+      ]);
+    });
+
     it('parses deno.json with workspace', () => {
       const result = DenoExtract.parse({
         content: JSON.stringify({

--- a/lib/modules/manager/deno/schema.ts
+++ b/lib/modules/manager/deno/schema.ts
@@ -254,8 +254,11 @@ const DenoPackageFile = z
       .optional(
         z.object({
           types: CompilerOptionsTypes,
-          jsxImportSource: CompilerOptionsJsxImportSource,
-          jsxImportSourceTypes: CompilerOptionsJsxImportSourceTypes,
+          jsxImportSource: CompilerOptionsJsxImportSource.optional().default(
+            [],
+          ),
+          jsxImportSourceTypes:
+            CompilerOptionsJsxImportSourceTypes.optional().default([]),
         }),
       )
       .default({ types: [], jsxImportSource: [], jsxImportSourceTypes: [] }),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

The zod v3→v4 migration (#43691) regressed Deno extraction: 

A `union([string, undefined]).pipe(...)` object key is treated as **nonoptional** in zod v4 when the key is missing (it was effectively optional in v3). So any `deno.json` whose `compilerOptions` omits `jsxImportSource`/`jsxImportSourceTypes` (e.g. `{ "compilerOptions": { "lib": ["deno.ns"] } }`) failed schema validation and aborted dependency extraction.

This marks those two fields `.optional().default([])` so absent keys are tolerated, and adds a regression test. 

## Context

Reported in discussion https://github.com/renovatebot/renovate/discussions/43925.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Opus 4.8) diagnosed the regression and wrote the fix and test.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
