### PR TITLE
ci(mend-slack): correctly escape discussion inputs

### DIFF
--- a/.github/workflows/mend-slack.yml
+++ b/.github/workflows/mend-slack.yml
@@ -37,6 +37,6 @@ jobs:
           method: chat.postMessage
           payload: |
             channel: 'C05NLTMGCJC'
-            text: '<${{ github.event.discussion.html_url }}|${{ github.event.discussion.title }}> (${{ github.event.discussion.created_at }}, ${{ steps.timeago.outputs.ago }})'
+            text: ${{ toJSON(format('<{0}|{1}> ({2}, {3})', github.event.discussion.html_url, github.event.discussion.title, github.event.discussion.created_at, steps.timeago.outputs.ago)) }}
           errors: true
           token: ${{ secrets.SLACK_BOT_TOKEN }}


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

The existing text concatenation doesn't correctly handle more complex
escaping i.e. of `'` characters inside the `title`.

We can instead wrap it all in a JSON string to prevent this breaking.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
