### PR TITLE
feat(presets/workaround): add Grafana Docker image versioning workaround

### DIFF
--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -21,6 +21,7 @@ export const presets: Record<string, Preset> = {
       'workarounds:containerbase',
       'workarounds:bitnamiDockerImageVersioning',
       'workarounds:clamavDockerImageVersioning',
+      'workarounds:grafanaDockerImageVersioning',
       'workarounds:k3sKubernetesVersioning',
       'workarounds:rke2KubernetesVersioning',
       'workarounds:libericaJdkDockerVersioning',
@@ -116,6 +117,17 @@ export const presets: Record<string, Preset> = {
         matchCurrentVersion: '!/^\\d{8}$/',
         matchDatasources: ['docker'],
         matchPackageNames: ['alpine'],
+      },
+    ],
+  },
+  grafanaDockerImageVersioning: {
+    description: 'Use custom regex versioning for Grafana images',
+    packageRules: [
+      {
+        matchDatasources: ['docker'],
+        matchPackageNames: ['grafana/grafana', 'docker.io/grafana/grafana'],
+        versioning:
+          'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?:-security-(?<build>\\d+))?(?:-(?<compatibility>.*))?$',
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -121,7 +121,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
   grafanaDockerImageVersioning: {
-    description: 'Use custom regex versioning for Grafana images',
+    description: 'Support security releases on Grafana (product) images',
     packageRules: [
       {
         matchDatasources: ['docker'],

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -67,6 +67,56 @@ describe('config/presets/internal/workarounds', () => {
     });
   });
 
+  describe('grafanaDockerImageVersioning', () => {
+    const preset = presets.grafanaDockerImageVersioning;
+    const packageRule = preset.packageRules![0];
+    const versioning = versionings.get(packageRule.versioning);
+    const matchPackageNames = packageRule.matchPackageNames!;
+
+    it.each`
+      input                          | expected
+      ${'latest'}                    | ${false}
+      ${'main'}                      | ${false}
+      ${'13'}                        | ${false}
+      ${'13.0'}                      | ${false}
+      ${'13.0.1'}                    | ${true}
+      ${'13.0.1-security-01'}        | ${true}
+      ${'13.0.1-security-01-fips'}   | ${true}
+      ${'13.0.1-security-01-ubi'}    | ${true}
+      ${'13.0.1-security-01-ubuntu'} | ${true}
+      ${'13.0.2'}                    | ${true}
+      ${'13.0.2-ubuntu'}             | ${true}
+    `('versioning("$input") == "$expected"', ({ input, expected }) => {
+      expect(versioning.isValid(input)).toEqual(expected);
+    });
+
+    it.each`
+      input                          | expected
+      ${'grafana/grafana'}           | ${true}
+      ${'docker.io/grafana/grafana'} | ${true}
+      ${'grafana/loki'}              | ${false}
+      ${'ghcr.io/grafana/grafana'}   | ${false}
+    `('matchPackageNames("$input") == "$expected"', ({ input, expected }) => {
+      expect(
+        matchPackageNames.some((pattern) => matchRegexOrGlob(input, pattern)),
+      ).toEqual(expected);
+    });
+
+    it.each`
+      version                        | current                        | expected
+      ${'13.0.1-security-01'}        | ${'13.0.1'}                    | ${true}
+      ${'13.0.2'}                    | ${'13.0.1-security-01'}        | ${true}
+      ${'13.0.1-security-01-ubuntu'} | ${'13.0.1-ubuntu'}             | ${true}
+      ${'13.0.2-ubuntu'}             | ${'13.0.1-security-01-ubuntu'} | ${true}
+      ${'13.0.1-security-01-ubuntu'} | ${'13.0.1-security-01'}        | ${false}
+    `(
+      'isGreaterThan("$version", "$current") == "$expected"',
+      ({ version, current, expected }) => {
+        expect(versioning.isGreaterThan(version, current)).toEqual(expected);
+      },
+    );
+  });
+
   describe('libericaJdkDockerVersioning', () => {
     const preset = presets.libericaJdkDockerVersioning;
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR add an custom versioning for grafana images. The discussion:

https://github.com/renovatebot/renovate/discussions/43980#discussioncomment-17307921

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/grafana-community/helm-charts

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
