### PR TITLE
docs(manager/sveltos): remove duplicated depTypes table from readme

### DIFF
--- a/lib/modules/manager/sveltos/dep-types.ts
+++ b/lib/modules/manager/sveltos/dep-types.ts
@@ -3,18 +3,22 @@ import type { DepTypeMetadata } from '../types.ts';
 export const knownDepTypes = [
   {
     depType: 'ClusterProfile',
-    description: 'A Sveltos `ClusterProfile` resource',
+    description:
+      'A Sveltos [`ClusterProfile`](https://projectsveltos.github.io/sveltos/addons/clusterprofile/) resource',
   },
   {
     depType: 'Profile',
-    description: 'A Sveltos `Profile` resource',
+    description:
+      'A Sveltos [`Profile`](https://projectsveltos.github.io/sveltos/addons/profile/) resource',
   },
   {
     depType: 'EventTrigger',
-    description: 'A Sveltos `EventTrigger` resource',
+    description:
+      'A Sveltos [`EventTrigger`](https://projectsveltos.github.io/sveltos/events/addon_event_deployment/#eventtrigger) resource',
   },
   {
     depType: 'ClusterPromotion',
-    description: 'A Sveltos `ClusterPromotion` resource',
+    description:
+      'A Sveltos [`ClusterPromotion`](https://projectsveltos.github.io/sveltos/addons/clusterpromotion/) resource',
   },
 ] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/sveltos/readme.md
+++ b/lib/modules/manager/sveltos/readme.md
@@ -36,11 +36,16 @@ You must set your own `managerFilePatterns` rules, so Renovate knows which `*.ya
 
 ### Disabling parts of the sveltos manager
 
-You can use these `depTypes` for fine-grained control, for example to disable parts of the Sveltos manager.
+You can use `depTypes` for fine-grained control, for example to disable parts of the Sveltos manager.
 
-| Resource                                                                                             | `depType`          |
-| :--------------------------------------------------------------------------------------------------- | :----------------- |
-| [Cluster Profiles](https://projectsveltos.github.io/sveltos/addons/clusterprofile/)                  | `ClusterProfile`   |
-| [Profiles](https://projectsveltos.github.io/sveltos/addons/profile/)                                 | `Profile`          |
-| [EventTrigger](https://projectsveltos.github.io/sveltos/events/addon_event_deployment/#eventtrigger) | `EventTrigger`     |
-| [ClusterPromotion](https://projectsveltos.github.io/sveltos/addons/clusterpromotion/)                | `ClusterPromotion` |
+```json title="Disable ClusterPromotion resources"
+{
+  "packageRules": [
+    {
+      "matchManagers": ["sveltos"],
+      "matchDepTypes": ["ClusterPromotion"],
+      "enabled": false
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Changes

Remove the duplicated `depTypes` table from the sveltos manager `readme.md`. The table was hand-written but the same information is auto-generated from `dep-types.ts` into the docs site's Dependency types section.

- **`dep-types.ts`**: Added Sveltos documentation links to each `description` field, so they appear in the auto-generated Dependency types table
- **`readme.md`**: Replaced the duplicate hand-written table with a config example showing how to use `depTypes` to disable specific resource types

Per the discussion in https://github.com/renovatebot/renovate/pull/43612#discussion_r3310432910.

## Context

- [x] This closes an existing Issue, Closes: #43627
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Code (Claude Opus 4.6) for code edits and PR creation.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository