### PR TITLE
feat(datasource/packagist): prefer published-time over time for release timestamp

### DIFF
--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -159,6 +159,21 @@ describe('modules/datasource/packagist/schema', () => {
 
       expect(
         ComposerRelease.parse({
+          version: '1.2.3',
+          time: '2025-01-16T12:00:00.000Z',
+          'published-time': '2025-02-20T08:30:00.000Z',
+        }),
+      ).toEqual({
+        version: '1.2.3',
+        time: '2025-01-16T12:00:00.000Z',
+        'published-time': '2025-02-20T08:30:00.000Z',
+        homepage: null,
+        source: null,
+        require: null,
+      });
+
+      expect(
+        ComposerRelease.parse({
           version: 123,
         }),
       ).toEqual({
@@ -461,6 +476,41 @@ describe('modules/datasource/packagist/schema', () => {
           'This package is abandoned and no longer maintained. The author suggests using the `scheb/2fa-bundle` package instead.',
         releases: [
           { version: '4.18.4', gitRef: 'v4.18.4', isDeprecated: true },
+        ],
+      } satisfies ReleaseResult);
+    });
+
+    it('prefers published-time over time, falling back to time', () => {
+      expect(
+        parsePackagesResponses('foo/bar', [
+          {
+            packages: {
+              'foo/bar': {
+                '1.1.1': {
+                  version: 'v1.1.1',
+                  time: '2025-01-16T12:00:00+00:00',
+                  'published-time': '2025-02-20T08:30:00+00:00',
+                },
+                '2.2.2': {
+                  version: 'v2.2.2',
+                  time: '2025-03-10T09:00:00+00:00',
+                },
+              },
+            },
+          },
+        ]),
+      ).toEqual({
+        releases: [
+          {
+            version: '1.1.1',
+            gitRef: 'v1.1.1',
+            releaseTimestamp: '2025-02-20T08:30:00.000Z' as Timestamp,
+          },
+          {
+            version: '2.2.2',
+            gitRef: 'v2.2.2',
+            releaseTimestamp: '2025-03-10T09:00:00.000Z' as Timestamp,
+          },
         ],
       } satisfies ReleaseResult);
     });

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -111,7 +111,7 @@ export function extractReleaseResult(
       const dep: Release = { version, gitRef };
 
       // Packagist's `published-time` reflects when the version was actually published to the registry;
-      // prefer it over `time` (the git tag's `releasedAt`, which can be backdated), falling back when absent.
+      // prefer it over `time` (the git tag's `releasedAt`, which could be when the commit that the tag points at was pushed, not the time the release itself was made public to the world), falling back when absent.
       const releaseTimestamp =
         composerRelease['published-time'] ?? composerRelease.time;
       if (releaseTimestamp) {

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -1,7 +1,11 @@
 import { isUndefined } from '@sindresorhus/is';
 import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
-import { LooseArray, LooseRecord } from '../../../util/schema-utils/index.ts';
+import {
+  LooseArray,
+  LooseRecord,
+  Nullish,
+} from '../../../util/schema-utils/index.ts';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
 import type { Release, ReleaseResult } from '../types.ts';
 
@@ -48,7 +52,7 @@ export const ComposerRelease = z.object({
   homepage: z.string().nullable().catch(null),
   source: z.object({ url: z.string() }).nullable().catch(null),
   time: MaybeTimestamp,
-  ['published-time']: MaybeTimestamp.optional(),
+  ['published-time']: Nullish(MaybeTimestamp),
   require: z.object({ php: z.string() }).nullable().catch(null),
   abandoned: z.union([z.string(), z.boolean()]).optional().catch(undefined),
 });

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -48,6 +48,7 @@ export const ComposerRelease = z.object({
   homepage: z.string().nullable().catch(null),
   source: z.object({ url: z.string() }).nullable().catch(null),
   time: MaybeTimestamp,
+  ['published-time']: MaybeTimestamp.optional(),
   require: z.object({ php: z.string() }).nullable().catch(null),
   abandoned: z.union([z.string(), z.boolean()]).optional().catch(undefined),
 });
@@ -105,8 +106,12 @@ export function extractReleaseResult(
 
       const dep: Release = { version, gitRef };
 
-      if (composerRelease.time) {
-        dep.releaseTimestamp = composerRelease.time;
+      // Packagist's `published-time` reflects when the version was actually published to the registry;
+      // prefer it over `time` (the git tag's `releasedAt`, which can be backdated), falling back when absent.
+      const releaseTimestamp =
+        composerRelease['published-time'] ?? composerRelease.time;
+      if (releaseTimestamp) {
+        dep.releaseTimestamp = releaseTimestamp;
       }
 
       if (composerRelease.require?.php) {


### PR DESCRIPTION
## Changes

Prefer Packagist's `published-time` over `time` when setting a release's `releaseTimestamp`, falling back to `time` when `published-time` is absent.

Packagist [composer/packagist#1765](https://github.com/composer/packagist/pull/1765) adds a `published-time` field that reflects when a version was actually published to the registry (`createdAt` for stable, `updatedAt` for dev), whereas the existing `time` field is the git tag's `releasedAt`, which can be backdated. `published-time` is the more accurate signal for age-based logic such as `minimumReleaseAge`. The fallback keeps older/self-hosted registries (which only emit `time`) working unchanged.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Claude Code (Opus 4.8) wrote the schema/extraction change and the accompanying unit tests, reviewed by the author.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests
