### PR TITLE
docs: don't include announcement bar in release notes' attachment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -901,18 +901,17 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LOG_LEVEL: debug
 
-      - name: Build mkdocs site for deployment (when no release)
+      - name: Build mkdocs site for deployment
         if: github.ref_name == 'main'
         run: |
-          # If there wasn't a release, we won't have executed `tools/prepare-release.ts`, and the mkdocs site won't be built, but we do want it built regardless, so we can update the docs site
-          if [[ ! -f tmp/mkdocs-site.tgz ]]; then
-            latest_tag=$(gh release view --json tagName -q .tagName)
-            pnpm mkdocs build --version "$latest_tag"
-            mkdir -p tmp
-            tar -czf tmp/mkdocs-site.tgz -C tools/mkdocs/site .
-          fi
+          # Always rebuild the docs site with the announcement bar for deployment to GitHub Pages, including the announcement bar (which isn't included when preparing a release's docs)
+          latest_tag=$(gh release view --json tagName -q .tagName)
+          pnpm mkdocs build --version "$latest_tag"
+          mkdir -p tmp
+          tar -czf tmp/mkdocs-site.tgz -C tools/mkdocs/site .
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MKDOCS_INCLUDE_ANNOUNCEMENT: 'true'
 
       - name: Upload docs artifact for deployment
         if: github.ref_name == 'main'

--- a/tools/mkdocs.ts
+++ b/tools/mkdocs.ts
@@ -22,9 +22,14 @@ program
   .option('--version <version>', 'the current version of the Renovate CLI')
   .option('--no-build', 'do not build docs from source')
   .option('--no-strict', 'do not build in strict mode')
+  .option('--no-announcement', 'do not include the announcement bar')
   .action(async (opts) => {
     await prepareDocs(opts);
-    logger.info('* running mkdocs build');
+    if (opts.announcement) {
+      logger.info('* running mkdocs build');
+    } else {
+      logger.info('* running mkdocs build (without announcement bar)');
+    }
     const args = ['run', 'mkdocs', 'build'];
     if (opts.strict) {
       args.push('--strict');
@@ -35,6 +40,7 @@ program
       env: {
         ...process.env,
         RENOVATE_VERSION: opts.version ?? '',
+        MKDOCS_INCLUDE_ANNOUNCEMENT: opts.announcement ? 'true' : '',
       },
       reject: false,
     });

--- a/tools/mkdocs/mkdocs.yml
+++ b/tools/mkdocs/mkdocs.yml
@@ -30,6 +30,7 @@ hooks:
 # Metadata
 extra:
   version: !ENV RENOVATE_VERSION
+  include_announcement: !ENV MKDOCS_INCLUDE_ANNOUNCEMENT
 
 # Set the main title for the project.
 # Required setting.

--- a/tools/mkdocs/overrides/main.html
+++ b/tools/mkdocs/overrides/main.html
@@ -12,9 +12,13 @@
 <!-- 1. Open the tools/mkdocs/mkdocs.yml file. -->
 <!-- 2. Make sure the `theme.custom_dir` entry is plain code. -->
 
+<!-- When building a release, MKDOCS_INCLUDE_ANNOUNCEMENT=false, so the release notes don't include the announcement bar -->
+<!-- When building locally, you can set MKDOCS_INCLUDE_ANNOUNCEMENT=true to see the announcement bar -->
 
 {% block announce %}
+{% if config.extra.include_announcement %}
 The Renovate maintainers would like to hear your feedback about <a href="https://github.com/renovatebot/renovate/discussions/41414"> monorepos, getting started + "week 1" problems, where you see complexity in Renovate, and to hear what's on your wishlist</a>.
+{% endif %}
 {% endblock %}
 
 <!-- add to block above when done -->

--- a/tools/prepare-release.ts
+++ b/tools/prepare-release.ts
@@ -68,7 +68,7 @@ async function build(): Promise<void> {
 async function buildMkdocs(version: string | undefined): Promise<void> {
   logger.info('Building Mkdocs site ...');
 
-  const mkdocsArgs = ['mkdocs', 'build'];
+  const mkdocsArgs = ['mkdocs', 'build', '--no-announcement'];
   if (version) {
     mkdocsArgs.push('--version', version);
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When building the docs site in CI on `main` (or a release branch), we
currently package up the docs site into the GitHub Release.

However, this includes the "announcement bar", which can include stale
info.

In the case where a user is looking to add a mirror for their Renovate
CLI docs[0], this means they now see an announcement bar which includes
unhelpful - and possibly outdated - information.

As noted in #44030, we can improve this to:

- not include the announcement bar when preparing the attachment for the
  release
- include the announcement bar only when we're updating the docs site

To do this, we need to:

- add a new `--no-announcement` flag (which ensures the default is "do
  add the announcement")
- log when we're not using announcements
- detect the environment variable when building the mkdocs site locally

This means we'll always be rebuilding the docs site (to inject the
announcement bar) which is ~16s as of a recent run.

[0]: https://www.jvt.me/posts/2024/11/19/renovate-private-docs/

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #44030
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
