### PR TITLE
fix(workers/global): parse `.jsonc` files

### DIFF
--- a/lib/workers/global/config/parse/util.spec.ts
+++ b/lib/workers/global/config/parse/util.spec.ts
@@ -1,7 +1,41 @@
+import { getConfigFileNames } from '../../../../config/app-strings.ts';
 import { logger } from '../../../../logger/index.ts';
-import { migrateAndValidateConfig } from './util.ts';
+import { readSystemFile } from '../../../../util/fs/index.ts';
+import { getParsedContent, migrateAndValidateConfig } from './util.ts';
+
+vi.mock('../../../../util/fs/index.ts');
 
 describe('workers/global/config/parse/util', () => {
+  describe('getParsedContent()', () => {
+    it.each(getConfigFileNames())('parses %s', async (file) => {
+      vi.mocked(readSystemFile).mockResolvedValueOnce('{"token":"abc"}');
+
+      const result = await getParsedContent(file);
+
+      expect(result).toMatchObject({ token: 'abc' });
+    });
+
+    it.each`
+      file              | content
+      ${'config.jsonc'} | ${'{"token":"abc"} // comment'}
+      ${'config.json5'} | ${'{"token":"abc",}'}
+      ${'config.yaml'}  | ${'token: abc'}
+      ${'config.yml'}   | ${'token: abc'}
+    `('parses $file', async ({ file, content }) => {
+      vi.mocked(readSystemFile).mockResolvedValueOnce(content);
+
+      const result = await getParsedContent(file);
+
+      expect(result).toMatchObject({ token: 'abc' });
+    });
+
+    it('throws for unsupported file type', async () => {
+      await expect(getParsedContent('config.txt')).rejects.toThrow(
+        'Unsupported file type',
+      );
+    });
+  });
+
   it('massages config', async () => {
     const config = {
       packageRules: [

--- a/lib/workers/global/config/parse/util.ts
+++ b/lib/workers/global/config/parse/util.ts
@@ -54,6 +54,7 @@ export async function getParsedContent(file: string): Promise<RenovateConfig> {
       return parseSingleYaml(await readSystemFile(file, 'utf8'));
     case '.json5':
     case '.json':
+    case '.jsonc':
       return parseJson(
         await readSystemFile(file, 'utf8'),
         file,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #44033, this leads to cases where
`renovate-config-validator` can't parse a repo's `renovate.jsonc`.

This doesn't currently affect when Renovate itself runs fully.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
