### PR TITLE
fix(manager/mise): disable digest pinning

### DIFF
--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -32,6 +32,7 @@ export const defaultConfig = {
     '**/.config/mise/conf.d/*.toml',
     '**/.rtx{,.*}.toml',
   ],
+  pinDigests: false,
 };
 
 const backendDatasources = {


### PR DESCRIPTION
## Changes

Set `pinDigests: false` in the mise manager's `defaultConfig`.

mise tool versions are plain version strings (e.g. `"aqua:pnpm/pnpm" = "11.6.0"`) with no syntax to attach a commit digest, so a digest can never be written to a mise config file. Several mise backends resolve to datasources that expose `getDigest` (e.g. `aqua` and `core` → `github-tags`), so a user with a global `pinDigests: true` causes Renovate to emit `pinDigest` updates for mise tools.

Those updates can't be applied: `doAutoReplace` finds no digest token to update and has nowhere to insert one, so the file content is unchanged. Post-update verification (`confirmIfDepUpdated`) then sees `isPinDigest === true` with a `newDigest` that isn't present in the re-extracted deps, logs `Digest is not updated`, and the branch fails every run with `Error updating branch: update failure`.

This mirrors `terraform`, `gomod`, `kustomize`, and the other managers whose dependencies have no place to store a digest — they all set `pinDigests: false` in their `defaultConfig` for the same reason.

Note: the sibling `asdf` manager has the same limitation (plain version strings in `.tool-versions`) and is likely affected in the same way; I've kept this PR scoped to mise and am happy to follow up on `asdf` separately if maintainers agree.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): The root cause was diagnosed from production Renovate debug logs and the one-line config change plus this PR description were authored with Claude Code (model: Claude Opus 4.8). The change itself is a single config default.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

<!-- Manager default config is auto-generated into the docs from `defaultConfig`. -->

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The existing mise manager test suite passes. The failure this fixes was captured in real Renovate production debug logs (a private repository, so no public URL). No new unit tests were added, matching the existing managers that set `pinDigests: false` (none of which have a dedicated test for the default). Happy to add a regression test if preferred.
