### PR TITLE
feat(datasource/packagist): mark abandoned packages as deprecated

### DIFF
--- a/lib/modules/datasource/packagist/index.spec.ts
+++ b/lib/modules/datasource/packagist/index.spec.ts
@@ -543,6 +543,45 @@ describe('modules/datasource/packagist/index', () => {
       });
     });
 
+    it('marks abandoned packages as deprecated', async () => {
+      httpMock
+        .scope('https://example.com')
+        .get('/packages.json')
+        .reply(200, {
+          'metadata-url': 'https://example.com/p2/%package%.json',
+        })
+        .get('/p2/drewm/mailchimp-api.json')
+        .reply(200, {
+          minified: 'composer/2.0',
+          packages: {
+            'drewm/mailchimp-api': [
+              {
+                name: 'drewm/mailchimp-api',
+                version: 'v2.5.4',
+                abandoned: 'foo/replacement',
+              },
+            ],
+          },
+        })
+        .get('/p2/drewm/mailchimp-api~dev.json')
+        .reply(404);
+      config.registryUrls = ['https://example.com'];
+
+      const res = await getPkgReleases({
+        ...config,
+        datasource,
+        versioning,
+        packageName: 'drewm/mailchimp-api',
+      });
+
+      expect(res).toEqual({
+        registryUrl: 'https://example.com',
+        deprecationMessage:
+          'This package is abandoned and no longer maintained. The author suggests using the `foo/replacement` package instead.',
+        releases: [{ gitRef: 'v2.5.4', version: '2.5.4', isDeprecated: true }],
+      });
+    });
+
     it('respects "available-packages" list', async () => {
       httpMock
         .scope('https://example.com')

--- a/lib/modules/datasource/packagist/index.spec.ts
+++ b/lib/modules/datasource/packagist/index.spec.ts
@@ -543,27 +543,27 @@ describe('modules/datasource/packagist/index', () => {
       });
     });
 
-    it('marks abandoned packages as deprecated', async () => {
+    it('marks abandoned packages as deprecated with a replacement', async () => {
       httpMock
         .scope('https://example.com')
         .get('/packages.json')
         .reply(200, {
           'metadata-url': 'https://example.com/p2/%package%.json',
         })
-        .get('/p2/drewm/mailchimp-api.json')
+        .get('/p2/scheb/two-factor-bundle.json')
         .reply(200, {
           minified: 'composer/2.0',
           packages: {
-            'drewm/mailchimp-api': [
+            'scheb/two-factor-bundle': [
               {
-                name: 'drewm/mailchimp-api',
-                version: 'v2.5.4',
-                abandoned: 'foo/replacement',
+                name: 'scheb/two-factor-bundle',
+                version: 'v4.18.4',
+                abandoned: 'scheb/2fa-bundle',
               },
             ],
           },
         })
-        .get('/p2/drewm/mailchimp-api~dev.json')
+        .get('/p2/scheb/two-factor-bundle~dev.json')
         .reply(404);
       config.registryUrls = ['https://example.com'];
 
@@ -571,14 +571,55 @@ describe('modules/datasource/packagist/index', () => {
         ...config,
         datasource,
         versioning,
-        packageName: 'drewm/mailchimp-api',
+        packageName: 'scheb/two-factor-bundle',
       });
 
       expect(res).toEqual({
         registryUrl: 'https://example.com',
         deprecationMessage:
-          'This package is abandoned and no longer maintained. The author suggests using the `foo/replacement` package instead.',
-        releases: [{ gitRef: 'v2.5.4', version: '2.5.4', isDeprecated: true }],
+          'This package is abandoned and no longer maintained. The author suggests using the `scheb/2fa-bundle` package instead.',
+        releases: [
+          { gitRef: 'v4.18.4', version: '4.18.4', isDeprecated: true },
+        ],
+      });
+    });
+
+    it('marks abandoned packages as deprecated without a replacement', async () => {
+      httpMock
+        .scope('https://example.com')
+        .get('/packages.json')
+        .reply(200, {
+          'metadata-url': 'https://example.com/p2/%package%.json',
+        })
+        .get('/p2/sonata-project/core-bundle.json')
+        .reply(200, {
+          minified: 'composer/2.0',
+          packages: {
+            'sonata-project/core-bundle': [
+              {
+                name: 'sonata-project/core-bundle',
+                version: '3.20.0',
+                abandoned: true,
+              },
+            ],
+          },
+        })
+        .get('/p2/sonata-project/core-bundle~dev.json')
+        .reply(404);
+      config.registryUrls = ['https://example.com'];
+
+      const res = await getPkgReleases({
+        ...config,
+        datasource,
+        versioning,
+        packageName: 'sonata-project/core-bundle',
+      });
+
+      expect(res).toEqual({
+        registryUrl: 'https://example.com',
+        deprecationMessage:
+          'This package is abandoned and no longer maintained.',
+        releases: [{ gitRef: '3.20.0', version: '3.20.0', isDeprecated: true }],
       });
     });
 

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -434,7 +434,7 @@ describe('modules/datasource/packagist/schema', () => {
               ],
             },
           },
-        ] satisfies { packages: Record<string, ComposerRelease[]> }[]),
+        ]),
       ).toEqual({
         deprecationMessage:
           'This package is abandoned and no longer maintained.',
@@ -453,7 +453,7 @@ describe('modules/datasource/packagist/schema', () => {
               'foo/bar': [{ version: 'v1.1.1', abandoned: 'foo/replacement' }],
             },
           },
-        ] satisfies { packages: Record<string, ComposerRelease[]> }[]),
+        ]),
       ).toEqual({
         deprecationMessage:
           'This package is abandoned and no longer maintained. The author suggests using the `foo/replacement` package instead.',

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -183,11 +183,11 @@ describe('modules/datasource/packagist/schema', () => {
       expect(
         ComposerRelease.parse({
           version: '1.2.3',
-          abandoned: 'foo/replacement',
+          abandoned: 'scheb/2fa-bundle',
         }),
       ).toEqual({
         version: '1.2.3',
-        abandoned: 'foo/replacement',
+        abandoned: 'scheb/2fa-bundle',
         homepage: null,
         source: null,
         time: null,
@@ -425,12 +425,12 @@ describe('modules/datasource/packagist/schema', () => {
 
     it('marks abandoned packages as deprecated', () => {
       expect(
-        parsePackagesResponses('foo/bar', [
+        parsePackagesResponses('sonata-project/core-bundle', [
           {
             packages: {
-              'foo/bar': [
-                { version: 'v2.2.2', abandoned: true },
-                { version: 'v1.1.1', abandoned: true },
+              'sonata-project/core-bundle': [
+                { version: '3.20.0', abandoned: true },
+                { version: '3.19.0', abandoned: true },
               ],
             },
           },
@@ -439,25 +439,29 @@ describe('modules/datasource/packagist/schema', () => {
         deprecationMessage:
           'This package is abandoned and no longer maintained.',
         releases: [
-          { version: '2.2.2', gitRef: 'v2.2.2', isDeprecated: true },
-          { version: '1.1.1', gitRef: 'v1.1.1', isDeprecated: true },
+          { version: '3.20.0', gitRef: '3.20.0', isDeprecated: true },
+          { version: '3.19.0', gitRef: '3.19.0', isDeprecated: true },
         ],
       } satisfies ReleaseResult);
     });
 
     it('suggests a replacement for abandoned packages', () => {
       expect(
-        parsePackagesResponses('foo/bar', [
+        parsePackagesResponses('scheb/two-factor-bundle', [
           {
             packages: {
-              'foo/bar': [{ version: 'v1.1.1', abandoned: 'foo/replacement' }],
+              'scheb/two-factor-bundle': [
+                { version: 'v4.18.4', abandoned: 'scheb/2fa-bundle' },
+              ],
             },
           },
         ]),
       ).toEqual({
         deprecationMessage:
-          'This package is abandoned and no longer maintained. The author suggests using the `foo/replacement` package instead.',
-        releases: [{ version: '1.1.1', gitRef: 'v1.1.1', isDeprecated: true }],
+          'This package is abandoned and no longer maintained. The author suggests using the `scheb/2fa-bundle` package instead.',
+        releases: [
+          { version: '4.18.4', gitRef: 'v4.18.4', isDeprecated: true },
+        ],
       } satisfies ReleaseResult);
     });
   });

--- a/lib/modules/datasource/packagist/schema.spec.ts
+++ b/lib/modules/datasource/packagist/schema.spec.ts
@@ -168,6 +168,41 @@ describe('modules/datasource/packagist/schema', () => {
         source: null,
         require: null,
       });
+
+      expect(
+        ComposerRelease.parse({ version: '1.2.3', abandoned: true }),
+      ).toEqual({
+        version: '1.2.3',
+        abandoned: true,
+        homepage: null,
+        source: null,
+        time: null,
+        require: null,
+      });
+
+      expect(
+        ComposerRelease.parse({
+          version: '1.2.3',
+          abandoned: 'foo/replacement',
+        }),
+      ).toEqual({
+        version: '1.2.3',
+        abandoned: 'foo/replacement',
+        homepage: null,
+        source: null,
+        time: null,
+        require: null,
+      });
+
+      expect(
+        ComposerRelease.parse({ version: '1.2.3', abandoned: 42 }),
+      ).toEqual({
+        version: '1.2.3',
+        homepage: null,
+        source: null,
+        time: null,
+        require: null,
+      });
     });
   });
 
@@ -385,6 +420,44 @@ describe('modules/datasource/packagist/schema', () => {
             constraints: { php: ['^7.0'] },
           },
         ],
+      } satisfies ReleaseResult);
+    });
+
+    it('marks abandoned packages as deprecated', () => {
+      expect(
+        parsePackagesResponses('foo/bar', [
+          {
+            packages: {
+              'foo/bar': [
+                { version: 'v2.2.2', abandoned: true },
+                { version: 'v1.1.1', abandoned: true },
+              ],
+            },
+          },
+        ] satisfies { packages: Record<string, ComposerRelease[]> }[]),
+      ).toEqual({
+        deprecationMessage:
+          'This package is abandoned and no longer maintained.',
+        releases: [
+          { version: '2.2.2', gitRef: 'v2.2.2', isDeprecated: true },
+          { version: '1.1.1', gitRef: 'v1.1.1', isDeprecated: true },
+        ],
+      } satisfies ReleaseResult);
+    });
+
+    it('suggests a replacement for abandoned packages', () => {
+      expect(
+        parsePackagesResponses('foo/bar', [
+          {
+            packages: {
+              'foo/bar': [{ version: 'v1.1.1', abandoned: 'foo/replacement' }],
+            },
+          },
+        ] satisfies { packages: Record<string, ComposerRelease[]> }[]),
+      ).toEqual({
+        deprecationMessage:
+          'This package is abandoned and no longer maintained. The author suggests using the `foo/replacement` package instead.',
+        releases: [{ version: '1.1.1', gitRef: 'v1.1.1', isDeprecated: true }],
       } satisfies ReleaseResult);
     });
   });

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -49,6 +49,7 @@ export const ComposerRelease = z.object({
   source: z.object({ url: z.string() }).nullable().catch(null),
   time: MaybeTimestamp,
   require: z.object({ php: z.string() }).nullable().catch(null),
+  abandoned: z.union([z.string(), z.boolean()]).optional().catch(undefined),
 });
 export type ComposerRelease = z.infer<typeof ComposerRelease>;
 
@@ -95,6 +96,7 @@ export function extractReleaseResult(
   const releases: Release[] = [];
   let homepage: string | null | undefined;
   let sourceUrl: string | null | undefined;
+  let deprecationMessage: string | undefined;
 
   for (const composerReleasesArray of composerReleasesArrays) {
     for (const composerRelease of composerReleasesArray) {
@@ -109,6 +111,11 @@ export function extractReleaseResult(
 
       if (composerRelease.require?.php) {
         dep.constraints = { php: [composerRelease.require.php] };
+      }
+
+      if (composerRelease.abandoned) {
+        dep.isDeprecated = true;
+        deprecationMessage ??= getAbandonedMessage(composerRelease.abandoned);
       }
 
       releases.push(dep);
@@ -137,7 +144,19 @@ export function extractReleaseResult(
     result.sourceUrl = sourceUrl;
   }
 
+  if (deprecationMessage) {
+    result.deprecationMessage = deprecationMessage;
+  }
+
   return result;
+}
+
+function getAbandonedMessage(abandoned: string | boolean): string {
+  const message = 'This package is abandoned and no longer maintained.';
+  if (typeof abandoned === 'string') {
+    return `${message} The author suggests using the \`${abandoned}\` package instead.`;
+  }
+  return message;
 }
 
 export function extractDepReleases(

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -116,7 +116,7 @@ export function extractReleaseResult(
       if (composerRelease.abandoned) {
         dep.isDeprecated = true;
         deprecationMessage ??= getAbandonedMessage(composerRelease.abandoned);
-        // TODO: when `abandoned` is a package name, emit replacementName/replacementVersion to open a replacement PR (follow-up)
+        // TODO #44060 when `abandoned` is a package name, emit replacementName/replacementVersion to open a replacement PR
       }
 
       releases.push(dep);

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -116,6 +116,7 @@ export function extractReleaseResult(
       if (composerRelease.abandoned) {
         dep.isDeprecated = true;
         deprecationMessage ??= getAbandonedMessage(composerRelease.abandoned);
+        // TODO: when `abandoned` is a package name, emit replacementName/replacementVersion to open a replacement PR (follow-up)
       }
 
       releases.push(dep);


### PR DESCRIPTION
## Changes

Parse Packagist's `abandoned` field and surface it via `isDeprecated` /
`deprecationMessage`, matching how the npm datasource handles npm's `deprecated`
field. Each release of an abandoned package gets `isDeprecated: true`, the result
gets a package-level `deprecationMessage`, and when `abandoned` is a string the
message names the suggested replacement.

**For reviewers:** despite the field name, this is unrelated to Renovate's
abandonment-detection heuristic (`abandonmentThreshold`). Per #34127, "abandoned"
in Renovate means *derived from stale timestamps*, whereas "deprecated" means
*officially flagged by the registry*. Composer's `abandoned` is an official
maintainer signal, so it maps to deprecation — exactly like npm's `deprecated`.

Verified against a live `p2` response (`swiftmailer/swiftmailer`): in the
minified `composer/2.0` format the `abandoned` field is only present on the
newest version entry, but `MinifiedArray` propagates it to all older entries, so
every release is correctly flagged.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

AI (Claude Code, Opus 4.8) implemented the schema change and tests test-first; all output reviewed by me.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests
