### PR TITLE
test(config-validation): add a test harness for `renovate-config-validator`

### DIFF
--- a/lib/config-validator.spec.ts
+++ b/lib/config-validator.spec.ts
@@ -1,0 +1,310 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { codeBlock } from 'common-tags';
+import { execa } from 'execa';
+import { dir } from 'tmp-promise';
+import { getConfigFileNames } from './config/app-strings.ts';
+import type { AllConfig, RenovateConfig } from './config/types.ts';
+
+const CLI = path.resolve('lib/config-validator.ts');
+
+async function runValidator(args: string[], opts: { cwd?: string } = {}) {
+  return execa('node', [CLI, ...args], {
+    cwd: opts.cwd,
+    reject: false,
+    all: true,
+    env: {
+      ...process.env,
+      LOG_LEVEL: 'info',
+      LOG_FORMAT: 'json',
+    },
+  });
+}
+
+async function withTmpDir<T>(fn: (dirPath: string) => Promise<T>): Promise<T> {
+  const tmpDir = await dir({ unsafeCleanup: true });
+  try {
+    return await fn(tmpDir.path);
+  } finally {
+    await tmpDir.cleanup();
+  }
+}
+
+async function writeRepoConfig(
+  dirPath: string,
+  name: string,
+  content: RenovateConfig,
+): Promise<string> {
+  const filePath = path.join(dirPath, name);
+  await fs.writeFile(filePath, JSON.stringify(content, null, 2));
+  return filePath;
+}
+
+async function writeGlobalConfig(
+  dirPath: string,
+  name: string,
+  content: AllConfig,
+): Promise<string> {
+  const filePath = path.join(dirPath, name);
+  await fs.writeFile(filePath, JSON.stringify(content, null, 2));
+  return filePath;
+}
+
+describe.concurrent('config-validator', () => {
+  describe('--version', () => {
+    it('exits 0 and prints version', async () => {
+      const { exitCode, stdout } = await runValidator(['-v']);
+
+      expect(exitCode).toBe(0);
+      expect(stdout).toMatch(/\d+\.\d+/);
+    });
+  });
+
+  describe('explicit file arguments', () => {
+    it('exits 0 for a valid repo config', async () => {
+      await withTmpDir(async (dirPath) => {
+        const file = await writeRepoConfig(dirPath, 'renovate.json', {
+          extends: ['config:recommended'],
+        });
+
+        const { exitCode, all } = await runValidator(['--no-global', file]);
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain(
+          'Config validated successfully against 1 file(s)',
+        );
+      });
+    });
+
+    it('exits 1 for a config with an unknown option', async () => {
+      await withTmpDir(async (dirPath) => {
+        const file = await writeRepoConfig(dirPath, 'renovate.json', {
+          notARealOption: true,
+        } as RenovateConfig);
+
+        const { exitCode, all } = await runValidator(['--no-global', file]);
+
+        expect(exitCode).toBe(1);
+        expect(all).toContain('Found errors in configuration');
+      });
+    });
+
+    it('exits 1 when the file does not exist', async () => {
+      const { exitCode, all } = await runValidator([
+        '--no-global',
+        '/tmp/does-not-exist-renovate.json',
+      ]);
+
+      expect(exitCode).toBe(1);
+      expect(all).toContain('File does not exist');
+    });
+
+    it('exits 0 without --strict when migration is needed', async () => {
+      await withTmpDir(async (dirPath) => {
+        const file = await writeRepoConfig(dirPath, 'renovate.json', {
+          packageRules: [
+            {
+              // @ts-expect-error -- intentionally using an unmigrated config fields
+              packagePatterns: ['foo'],
+              updateTypes: ['major'],
+              automerge: true,
+            },
+          ],
+        });
+
+        const { exitCode, all } = await runValidator(['--no-global', file]);
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain('Config migration necessary');
+      });
+    });
+
+    it('exits 1 with --strict when migration is needed', async () => {
+      await withTmpDir(async (dirPath) => {
+        const file = await writeRepoConfig(dirPath, 'renovate.json', {
+          packageRules: [
+            {
+              // @ts-expect-error -- intentionally using unmigrated config fields
+              packagePatterns: ['foo'],
+              updateTypes: ['major'],
+              automerge: true,
+            },
+          ],
+        });
+
+        const { exitCode, all } = await runValidator([
+          '--no-global',
+          '--strict',
+          file,
+        ]);
+
+        expect(exitCode).toBe(1);
+        expect(all).toContain('Config migration necessary');
+      });
+    });
+
+    it('treats file as global config by default', async () => {
+      await withTmpDir(async (dirPath) => {
+        const file = await writeGlobalConfig(dirPath, 'config.json', {
+          platform: 'github',
+          repositories: ['foo/bar'],
+        });
+
+        const { exitCode } = await runValidator([file]);
+
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    it('treats file as repo config with --no-global', async () => {
+      await withTmpDir(async (dirPath) => {
+        const file = await writeRepoConfig(dirPath, 'renovate.json', {
+          extends: ['config:recommended'],
+        });
+
+        const { exitCode, all } = await runValidator(['--no-global', file]);
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain('Validating');
+        expect(all).toContain('as repo config');
+      });
+    });
+  });
+
+  describe('auto-discovery (no file arguments)', () => {
+    it('exits 0 with no warning when no config files are present', async () => {
+      await withTmpDir(async (dirPath) => {
+        const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain(
+          'No files to perform configuration validation against',
+        );
+      });
+    });
+
+    const autoDiscoveredFiles = getConfigFileNames().filter(
+      (name) => name !== 'package.json',
+    );
+
+    it.each(autoDiscoveredFiles)(
+      'exits 0 for a valid config in %s',
+      async (configFile) => {
+        await withTmpDir(async (dirPath) => {
+          const fullPath = path.join(dirPath, configFile);
+          await fs.mkdir(path.dirname(fullPath), { recursive: true });
+          await fs.writeFile(
+            fullPath,
+            JSON.stringify({ extends: ['config:recommended'] }),
+          );
+
+          const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+          expect(exitCode).toBe(0);
+          expect(all).toContain(
+            'Config validated successfully against 1 file(s)',
+          );
+        });
+      },
+    );
+
+    it.each(autoDiscoveredFiles)(
+      'exits 1 for an invalid config in %s',
+      async (configFile) => {
+        await withTmpDir(async (dirPath) => {
+          const fullPath = path.join(dirPath, configFile);
+          await fs.mkdir(path.dirname(fullPath), { recursive: true });
+          await fs.writeFile(
+            fullPath,
+            JSON.stringify({ notARealOption: true }),
+          );
+
+          const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+          expect(exitCode).toBe(1);
+          expect(all).toContain('Found errors in configuration');
+        });
+      },
+    );
+
+    it('validates JSONC comment syntax in .jsonc files', async () => {
+      await withTmpDir(async (dirPath) => {
+        const fullPath = path.join(dirPath, 'renovate.jsonc');
+        await fs.writeFile(
+          fullPath,
+          codeBlock`
+            {
+              // Use the recommended preset
+              "extends": ["config:recommended"]
+            }
+          `,
+        );
+
+        const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain(
+          'Config validated successfully against 1 file(s)',
+        );
+      });
+    });
+
+    it('validates JSON5 syntax in .json5 files', async () => {
+      await withTmpDir(async (dirPath) => {
+        const fullPath = path.join(dirPath, 'renovate.json5');
+        await fs.writeFile(
+          fullPath,
+          codeBlock`
+            {
+              // trailing commas and unquoted keys are valid JSON5
+              extends: ["config:recommended"],
+            }
+          `,
+        );
+
+        const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain(
+          'Config validated successfully against 1 file(s)',
+        );
+      });
+    });
+
+    it('validates package.json renovate-config presets', async () => {
+      await withTmpDir(async (dirPath) => {
+        await fs.writeFile(
+          path.join(dirPath, 'package.json'),
+          JSON.stringify({
+            name: 'test',
+            'renovate-config': {
+              default: { extends: ['config:recommended'] },
+            },
+          }),
+        );
+
+        const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain('Validating package.json > renovate-config');
+      });
+    });
+
+    it('validates package.json renovate field', async () => {
+      await withTmpDir(async (dirPath) => {
+        await fs.writeFile(
+          path.join(dirPath, 'package.json'),
+          JSON.stringify({
+            name: 'test',
+            renovate: { extends: ['config:recommended'] },
+          }),
+        );
+
+        const { exitCode, all } = await runValidator([], { cwd: dirPath });
+
+        expect(exitCode).toBe(0);
+        expect(all).toContain('Validating package.json > renovate');
+      });
+    });
+  });
+});


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Per #40738 and #44034, we're seeing recent changes to
`renovate-config-validator` that have led to either a gap in
functionality or a breaking change that makes
`renovate-config-validator` unusable.

To make sure that we ensure that we're always making reasonable changes
to `renovate-config-validator`, we can introduce an integration test
harness to validate the call end-to-end.

We can make sure to handle:

- `--version`
- using global/repo config files
- any of the known config filenames (#44034)
- explicitly test a JSONC and JSON5 file with their respective example
  content

Due to the full end-to-end run of `renovate-config-validator`, which
creates a full Node process, we can run the tests concurrently to ensure
that we speed up the test runs, as they're fairly slow in comparison to
regular tests.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [x] This closes an existing Issue: Closes #40738
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
