### PR TITLE
fix(datasource/npm): handle array of `repository` for legacy packages

### DIFF
--- a/lib/modules/datasource/npm/schema.spec.ts
+++ b/lib/modules/datasource/npm/schema.spec.ts
@@ -165,5 +165,53 @@ describe('modules/datasource/npm/schema', () => {
         directory: 'test',
       });
     });
+
+    describe('parses a response with an array of objects for the `repository`, and returns the first element', () => {
+      // https://registry.npmjs.org/tmp
+      it('as a package response', () => {
+        const input = {
+          name: 'tmp',
+          versions: {
+            '0.0.4': {
+              repository: [
+                {
+                  url: 'git://github.com/raszi/tmp.git',
+                  type: 'git',
+                },
+              ],
+            },
+          },
+          repository: {
+            url: 'git://github.com/raszi/tmp.git',
+            type: 'git',
+          },
+        };
+        const result = NpmResponse.parse(input);
+        expect(result.repository).toEqual({
+          url: 'git://github.com/raszi/tmp.git',
+        });
+        expect(result.versions?.['0.0.4'].repository).toEqual({
+          url: 'git://github.com/raszi/tmp.git',
+        });
+      });
+
+      // https://registry.npmjs.org/tmp/0.0.4
+      it('as a version response', () => {
+        const input = {
+          name: 'tmp',
+          version: '0.0.4',
+          repository: [
+            {
+              url: 'git://github.com/raszi/tmp.git',
+              type: 'git',
+            },
+          ],
+        };
+        const result = NpmResponse.parse(input);
+        expect(result.repository).toEqual({
+          url: 'git://github.com/raszi/tmp.git',
+        });
+      });
+    });
   });
 });

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -9,6 +9,11 @@ const Repository = z.union([
   }),
 ]);
 
+const RepositoryNpmResponse = z
+  .unknown()
+  .transform((val) => (Array.isArray(val) ? val[0] : val))
+  .pipe(Repository);
+
 const Attestations = z.object({
   url: z.string().optional(),
 });
@@ -18,7 +23,7 @@ const Distribution = z.object({
 });
 
 export const NpmResponseVersion = z.object({
-  repository: Repository.optional(),
+  repository: RepositoryNpmResponse.optional(),
   homepage: z.string().optional().catch(undefined),
   deprecated: z.union([z.string(), z.boolean()]).optional(),
   gitHead: z.string().optional(),
@@ -54,7 +59,7 @@ export const NpmResponse = z.object({
   _id: z.string().optional(),
   name: z.string().optional(),
   versions: z.record(z.string(), NpmResponseVersionLoose).optional(),
-  repository: Repository.optional(),
+  repository: RepositoryNpmResponse.optional(),
   homepage: z.string().optional(),
   time: LooseRecord(z.string()).optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When attempting to perform dependency updates on the `tmp` package,
parsing a previous version's Zod schema results in a lookup failure, as
it had an incorrect form of `repository` as of tmp@0.0.4.

We can handle this by treating it more loosely to convert an array of
repositories into a single element, and handle this on both a
per-version and per-package lookup.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
