### PR TITLE
fix(semver): Add legacy layer for x-ranges

### DIFF
--- a/lib/modules/versioning/npm/index.spec.ts
+++ b/lib/modules/versioning/npm/index.spec.ts
@@ -16,11 +16,16 @@ describe('modules/versioning/npm/index', () => {
     ${'1.2.x'}                                       | ${true}
     ${'1.2.X'}                                       | ${true}
     ${'1.2.*'}                                       | ${true}
+    ${'1.x.5'}                                       | ${true}
+    ${'1.x.5-alpha+build'}                           | ${true}
+    ${'1.x.5+bad+bad'}                               | ${true}
+    ${'1.x.05'}                                      | ${false}
     ${'~1.2.3'}                                      | ${true}
     ${'^1.2.3'}                                      | ${true}
     ${'>1.2.3'}                                      | ${true}
     ${'renovatebot/renovate'}                        | ${false}
     ${'renovatebot/renovate#main'}                   | ${false}
+    ${'1.x.5.6'}                                     | ${false}
     ${'https://github.com/renovatebot/renovate.git'} | ${false}
   `('isValid("$version") === $isValid', ({ version, isValid }) => {
     const res = semver.isValid(version);
@@ -28,18 +33,55 @@ describe('modules/versioning/npm/index', () => {
   });
 
   it.each`
-    versions                                          | range      | maxSatisfying
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'*'}     | ${'3.0.0'}
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'x'}     | ${'3.0.0'}
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'X'}     | ${'3.0.0'}
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2'}     | ${'2.5.1'}
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.*'}   | ${'2.5.1'}
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.3'}   | ${'2.3.4'}
-    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.3.*'} | ${'2.3.4'}
+    versions                                          | range             | maxSatisfying
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'*'}            | ${'3.0.0'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'x'}            | ${'3.0.0'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'X'}            | ${'3.0.0'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2'}            | ${'2.5.1'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.*'}          | ${'2.5.1'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.*.3'}        | ${'2.5.1'}
+    ${['4.2.1', '4.2.5', '4.3.0']}                    | ${'4.*.0 <4.2.5'} | ${'4.2.1'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.3'}          | ${'2.3.4'}
+    ${['2.3.3.', '2.3.4', '2.4.5', '2.5.1', '3.0.0']} | ${'2.3.*'}        | ${'2.3.4'}
   `(
     'getSatisfyingVersion("$versions","$range") === $maxSatisfying',
     ({ versions, range, maxSatisfying }) => {
       expect(semver.getSatisfyingVersion(versions, range)).toBe(maxSatisfying);
+    },
+  );
+
+  it.each`
+    version    | range                  | expected
+    ${'1.2.0'} | ${'1.x.5'}             | ${true}
+    ${'1.2.0'} | ${'1.x.5-alpha+build'} | ${true}
+    ${'1.2.0'} | ${'1.x.5+bad+bad'}     | ${true}
+    ${'1.2.0'} | ${'1.x.05'}            | ${false}
+    ${'2.0.0'} | ${'1.x.5'}             | ${false}
+  `(
+    'matches("$version", "$range") === $expected',
+    ({ version, range, expected }) => {
+      expect(semver.matches(version, range)).toBe(expected);
+    },
+  );
+
+  it.each`
+    versions                       | range      | minSatisfying
+    ${['1.0.0', '1.2.0', '2.0.0']} | ${'1.x.5'} | ${'1.0.0'}
+  `(
+    'minSatisfyingVersion("$versions", "$range") === $minSatisfying',
+    ({ versions, range, minSatisfying }) => {
+      expect(semver.minSatisfyingVersion(versions, range)).toBe(minSatisfying);
+    },
+  );
+
+  it.each`
+    version    | range      | expected
+    ${'0.9.0'} | ${'1.x.5'} | ${true}
+    ${'1.2.0'} | ${'1.x.5'} | ${false}
+  `(
+    'isLessThanRange("$version", "$range") === $expected',
+    ({ version, range, expected }) => {
+      expect(semver.isLessThanRange?.(version, range)).toBe(expected);
     },
   );
 
@@ -71,6 +113,7 @@ describe('modules/versioning/npm/index', () => {
     ${'^1.0.0'}           | ${'^0.9.0'}           | ${false}
     ${'^1.1.0 || ^2.0.0'} | ${'^1.0.0 || ^2.0.0'} | ${true}
     ${'^1.0.0 || ^2.0.0'} | ${'^1.1.0 || ^2.0.0'} | ${false}
+    ${'1.x.5'}            | ${'1.x'}              | ${true}
   `('subset("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(semver.subset!(a, b)).toBe(expected);
   });
@@ -91,6 +134,7 @@ describe('modules/versioning/npm/index', () => {
     ${'^1.0.0'}           | ${'^0.9.0'}           | ${false}
     ${'^1.1.0 || ^2.0.0'} | ${'^1.0.0 || ^2.0.0'} | ${true}
     ${'^1.0.0 || ^2.0.0'} | ${'^1.1.0 || ^2.0.0'} | ${true}
+    ${'1.x.5'}            | ${'1.2.x'}            | ${true}
   `('intersects("$a", "$b") === $expected', ({ a, b, expected }) => {
     expect(semver.intersects!(a, b)).toBe(expected);
   });
@@ -174,10 +218,13 @@ describe('modules/versioning/npm/index', () => {
     ${'^1.2.3'}             | ${'replace'}         | ${'1.2.3'}       | ${'1.2.2'}              | ${'^1.2.2'}
     ${'^0.9.21'}            | ${'replace'}         | ${'0.9.21'}      | ${'0.9.22'}             | ${'^0.9.21'}
     ${'1.x'}                | ${'update-lockfile'} | ${'1.0.0'}       | ${'1.0.1'}              | ${'1.x'}
+    ${'1.x.5'}              | ${'update-lockfile'} | ${'1.0.0'}       | ${'1.0.1'}              | ${'1.x.5'}
     ${'1.x'}                | ${'update-lockfile'} | ${'1.0.0'}       | ${'2.0.1'}              | ${'2.x'}
     ${'<2.0.0'}             | ${'widen'}           | ${'1.0.0'}       | ${'2.0.1'}              | ${'<3.0.0'}
+    ${'1.x.5'}              | ${'widen'}           | ${'1.0.0'}       | ${'1.0.1'}              | ${'1.x.5'}
     ${'1.0.0 - 2.0.0'}      | ${'widen'}           | ${'1.0.0'}       | ${'2.1.0'}              | ${'1.0.0 - 2.1'}
     ${'1.x >2.0.0'}         | ${'widen'}           | ${'1.0.0'}       | ${'2.1.0'}              | ${null}
+    ${'<1.x.5 >=0.1.0'}     | ${'bump'}            | ${'0.8.0'}       | ${'0.9.0'}              | ${'<1.x.5 >=0.9.0'}
     ${'^1.0.0'}             | ${'bump'}            | ${'1.0.0'}       | ${'2.0.0'}              | ${'^2.0.0'}
     ${'~1.0.0'}             | ${'bump'}            | ${'1.0.0'}       | ${'2.0.0'}              | ${'~2.0.0'}
     ${'~1.0.0'}             | ${'bump'}            | ${'v1.0.0'}      | ${'v2.0.0'}             | ${'~2.0.0'}
@@ -185,9 +232,11 @@ describe('modules/versioning/npm/index', () => {
     ${'^1.0.0-alpha'}       | ${'replace'}         | ${'1.0.0-alpha'} | ${'1.0.0-beta'}         | ${'^1.0.0-beta'}
     ${'~1.0.0'}             | ${'replace'}         | ${'1.0.0'}       | ${'1.1.0'}              | ${'~1.1.0'}
     ${'1.0.x'}              | ${'replace'}         | ${'1.0.0'}       | ${'1.1.0'}              | ${'1.1.x'}
+    ${'<2.0'}               | ${'replace'}         | ${'1.0.0'}       | ${'2.1.0'}              | ${'<2.2'}
     ${'<=1.0'}              | ${'replace'}         | ${'1.0.0'}       | ${'1.2.0'}              | ${'<=1.2'}
     ${'<=1'}                | ${'replace'}         | ${'1.0.0'}       | ${'2.0.0'}              | ${'<=2'}
     ${'<= 1'}               | ${'replace'}         | ${'1.0.0'}       | ${'2.0.0'}              | ${'<= 2'}
+    ${'5'}                  | ${'replace'}         | ${'5.0.0'}       | ${'6.1.7'}              | ${'6'}
     ${'>=18.17.0'}          | ${'bump'}            | ${'v18.17.0'}    | ${'v18.17.1'}           | ${'>=18.17.1'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',

--- a/lib/modules/versioning/npm/index.ts
+++ b/lib/modules/versioning/npm/index.ts
@@ -1,6 +1,7 @@
 import semver from 'semver';
 import stable from 'semver-stable';
 import type { RangeStrategy } from '../../../types/versioning.ts';
+import { normalizeLegacyXRanges } from '../semver/common.ts';
 import { isBreaking } from '../semver/index.ts';
 import type { VersioningApi } from '../types.ts';
 import { getNewValue } from './range.ts';
@@ -22,24 +23,62 @@ export const supportedRangeStrategies: RangeStrategy[] = [
 
 const {
   compare: sortVersions,
-  maxSatisfying: getSatisfyingVersion,
-  minSatisfying: minSatisfyingVersion,
+  maxSatisfying,
+  minSatisfying,
   major: getMajor,
   minor: getMinor,
   patch: getPatch,
-  satisfies: matches,
+  satisfies,
   valid,
   validRange,
-  ltr: isLessThanRange,
+  ltr,
   gt: isGreaterThan,
   eq: equals,
-  subset,
-  intersects,
+  subset: semverSubset,
+  intersects: semverIntersects,
 } = semver;
 
+function normalizeNpmRange(range: string): string {
+  return normalizeLegacyXRanges(range);
+}
+
 // If this is left as an alias, inputs like "17.04.0" throw errors
-export const isValid = (input: string): boolean => !!validRange(input);
+export const isValid = (input: string): boolean =>
+  !!validRange(normalizeNpmRange(input));
 export const isVersion = (input: string): boolean => !!valid(input);
+
+function matches(version: string, range: string): boolean {
+  return satisfies(version, normalizeNpmRange(range));
+}
+
+function getSatisfyingVersion(
+  versions: string[],
+  range: string,
+): string | null {
+  return maxSatisfying(versions, normalizeNpmRange(range));
+}
+
+function minSatisfyingVersion(
+  versions: string[],
+  range: string,
+): string | null {
+  return minSatisfying(versions, normalizeNpmRange(range));
+}
+
+function isLessThanRange(version: string, range: string): boolean {
+  return ltr(version, normalizeNpmRange(range));
+}
+
+function subset(subRange: string, superRange: string): boolean | undefined {
+  return semverSubset(
+    normalizeNpmRange(subRange),
+    normalizeNpmRange(superRange),
+  );
+}
+
+function intersects(range1: string, range2: string): boolean {
+  return semverIntersects(normalizeNpmRange(range1), normalizeNpmRange(range2));
+}
 
 function isSingleVersion(constraint: string): boolean {
   return (

--- a/lib/modules/versioning/npm/range.ts
+++ b/lib/modules/versioning/npm/range.ts
@@ -3,7 +3,7 @@ import semver from 'semver';
 import semverUtils from 'semver-utils';
 import { logger } from '../../../logger/index.ts';
 import { regEx } from '../../../util/regex.ts';
-import { isSemVerXRange } from '../semver/common.ts';
+import { isSemVerXRange, normalizeLegacyXRanges } from '../semver/common.ts';
 import type { NewValueConfig } from '../types.ts';
 
 const {
@@ -61,6 +61,10 @@ function stripV(value: string): string {
   return value.replace(/^v/, '');
 }
 
+function satisfiesRange(version: string, range: string): boolean {
+  return satisfies(version, normalizeLegacyXRanges(range));
+}
+
 // TODO: #22198
 export function getNewValue({
   currentValue,
@@ -75,7 +79,7 @@ export function getNewValue({
     return newVersion;
   }
   if (rangeStrategy === 'update-lockfile') {
-    if (satisfies(newVersion, currentValue)) {
+    if (satisfiesRange(newVersion, currentValue)) {
       return currentValue;
     }
     return getNewValue({
@@ -88,7 +92,7 @@ export function getNewValue({
   const parsedRange = semverUtils.parseRange(currentValue);
   const element = parsedRange[parsedRange.length - 1];
   if (rangeStrategy === 'widen') {
-    if (satisfies(newVersion, currentValue)) {
+    if (satisfiesRange(newVersion, currentValue)) {
       return currentValue;
     }
     const newValue = getNewValue({
@@ -160,7 +164,7 @@ export function getNewValue({
             currentVersion,
             newVersion,
           });
-          if (bumpedSubRange && satisfies(newVersion, bumpedSubRange)) {
+          if (bumpedSubRange && satisfiesRange(newVersion, bumpedSubRange)) {
             return bumpedSubRange;
           }
 

--- a/lib/modules/versioning/semver/common.spec.ts
+++ b/lib/modules/versioning/semver/common.spec.ts
@@ -1,4 +1,4 @@
-import { isSemVerXRange } from './common.ts';
+import { isSemVerXRange, normalizeLegacyXRanges } from './common.ts';
 
 describe('modules/versioning/semver/common', () => {
   it.each`
@@ -13,4 +13,45 @@ describe('modules/versioning/semver/common', () => {
   `('isSemVerXRange("range") === $expected', ({ range, expected }) => {
     expect(isSemVerXRange(range)).toBe(expected);
   });
+
+  it.each`
+    input                      | expected
+    ${'1.x.5'}                 | ${'1.x'}
+    ${'1.*.5'}                 | ${'1.*'}
+    ${'1.X.5'}                 | ${'1.X'}
+    ${'1.x.5-alpha'}           | ${'1.x'}
+    ${'1.x.5+build'}           | ${'1.x'}
+    ${'1.x.5-alpha+build'}     | ${'1.x'}
+    ${'1.x.5+bad+bad'}         | ${'1.x'}
+    ${'1.x.5-alpha+bad+bad'}   | ${'1.x'}
+    ${'1.x.5-alpha.1+build.5'} | ${'1.x'}
+    ${'1.x.5 || 2.*.5'}        | ${'1.x || 2.*'}
+    ${'< 1.x.5'}               | ${'< 1.x'}
+    ${'>=x.1'}                 | ${'>=x'}
+    ${'x.1'}                   | ${'x'}
+    ${'x.1.2'}                 | ${'x'}
+    ${'x.x.1'}                 | ${'x'}
+    ${'1.2.*'}                 | ${'1.2.*'}
+    ${'1.2.x'}                 | ${'1.2.x'}
+    ${'1.2.3'}                 | ${'1.2.3'}
+    ${'1.x.05'}                | ${'1.x.05'}
+    ${'1.*.05'}                | ${'1.*.05'}
+    ${'x.01'}                  | ${'x.01'}
+    ${'*.01'}                  | ${'*.01'}
+    ${'01.x.5'}                | ${'01.x.5'}
+    ${'1.x.5-alpha.'}          | ${'1.x.5-alpha.'}
+    ${'1.x.5-01'}              | ${'1.x.5-01'}
+    ${'1.x.5+build.'}          | ${'1.x.5+build.'}
+    ${'1.x.5+bad+'}            | ${'1.x.5+bad+'}
+    ${'1.x.5++bad'}            | ${'1.x.5++bad'}
+    ${'1.x.5.6'}               | ${'1.x.5.6'}
+    ${'1.*.x.2'}               | ${'1.*.x.2'}
+    ${'x.0.0.0'}               | ${'x.0.0.0'}
+    ${'renovatebot/x'}         | ${'renovatebot/x'}
+  `(
+    'normalizeLegacyXRanges("$input") === "$expected"',
+    ({ input, expected }) => {
+      expect(normalizeLegacyXRanges(input)).toBe(expected);
+    },
+  );
 });

--- a/lib/modules/versioning/semver/common.ts
+++ b/lib/modules/versioning/semver/common.ts
@@ -1,10 +1,58 @@
+import { regEx } from '../../../util/regex.ts';
+
 const SEMVER_X_RANGE = ['*', 'x', 'X', ''] as const;
 type SemVerXRangeArray = typeof SEMVER_X_RANGE;
 export type SemVerXRange = SemVerXRangeArray[number];
+
+const RANGE_SEPARATOR = regEx(/(\s+|,|\|\||[()])/);
+const NUMERIC_RELEASE_PART = '(?:0|[1-9]\\d*)';
+const X_RELEASE_PART = '[xX*]';
+const RELEASE_PART = `(?:${NUMERIC_RELEASE_PART}|${X_RELEASE_PART})`;
+const PRERELEASE_IDENTIFIER = `(?:${NUMERIC_RELEASE_PART}|\\d*[A-Za-z-][0-9A-Za-z-]*)`;
+const BUILD_IDENTIFIER = '[0-9A-Za-z-]+';
+const LEGACY_X_RANGE = regEx(
+  `^((?:\\^|~|>=|<=|>|<|=)?\\s*v?)(${RELEASE_PART}(?:\\.${RELEASE_PART})+)(?:-${PRERELEASE_IDENTIFIER}(?:\\.${PRERELEASE_IDENTIFIER})*)?(?:\\+${BUILD_IDENTIFIER}(?:[.+]${BUILD_IDENTIFIER})*)?$`,
+);
+const NUMERIC_RELEASE_PART_RE = regEx(`^${NUMERIC_RELEASE_PART}$`);
 
 /**
  * https://docs.npmjs.com/cli/v6/using-npm/semver#x-ranges-12x-1x-12-
  */
 export function isSemVerXRange(range: string): range is SemVerXRange {
   return SEMVER_X_RANGE.includes(range as SemVerXRange);
+}
+
+function isSemVerNumericPart(part: string): boolean {
+  return NUMERIC_RELEASE_PART_RE.test(part);
+}
+
+function normalizeLegacyXRangeToken(input: string): string {
+  const match = LEGACY_X_RANGE.exec(input);
+  if (!match) {
+    return input;
+  }
+
+  const [, operator, release] = match;
+  const parts = release.split('.');
+  if (parts.length > 3) {
+    return input;
+  }
+
+  const xRangeIndex = parts.findIndex(isSemVerXRange);
+  if (xRangeIndex === -1) {
+    return input;
+  }
+
+  const hasTrailingNumericPart = parts
+    .slice(xRangeIndex + 1)
+    .some(isSemVerNumericPart);
+  if (!hasTrailingNumericPart) {
+    return input;
+  }
+
+  return `${operator}${parts.slice(0, xRangeIndex + 1).join('.')}`;
+}
+
+export function normalizeLegacyXRanges(input: string): string {
+  return input.split(RANGE_SEPARATOR).map(normalizeLegacyXRangeToken).join('');
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
- #44053


## Context


- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
