### PR TITLE
docs: restructure postUpdateOptions table into headers

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4063,11 +4063,16 @@ Run `dotnet workload restore` before `dotnet restore` commands.
 
 ### `goGenerate`
 
-Run `go generate ./...` after vendoring (if vendoring was required).
+Run `go generate ./...`.
 This will then commit any files which were added or modified by running `go generate`.
+
 Note this will not install any other tools as part of the process.
 See [Go Tool](https://tip.golang.org/doc/go1.24#tools) usage for how to incorporate these as part of your build process.
-In order for this option to function, the global configuration option `allowedUnsafeExecutions` must include `goGenerate`.
+
+This runs after vendoring, if vendoring was required.
+
+!!! note
+  In order for this option to function, the global configuration option [`allowedUnsafeExecutions`](./self-hosted-configuration.md#allowedunsafeexecutions) must include `goGenerate`.
 
 ### `gomodMassage`
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4044,29 +4044,87 @@ This way Renovate can use GitHub's [Commit signing support for bots and other Gi
 
 ## `postUpdateOptions`
 
-Table with options:
+### `bundlerConservative`
 
-| Name                         | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `bundlerConservative`        | Enable conservative mode for `bundler` (Ruby dependencies). This will only update the immediate dependency in the lockfile instead of all subdependencies.                                                                                                                                                                                                                                                                                                                         |
-| `composerNoMinimalChanges`   | Run `composer update` with no `--minimal-changes` flag (does not affect lock file maintenance, which will never use `--minimal-changes`).                                                                                                                                                                                                                                                                                                                                          |
-| `composerWithAll`            | Run `composer update` with `--with-all-dependencies` flag instead of the default `--with-dependencies`.                                                                                                                                                                                                                                                                                                                                                                            |
-| `dotnetWorkloadRestore`      | Run `dotnet workload restore` before `dotnet restore` commands.                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `gomodMassage`               | Enable massaging `replace` directives before calling `go` commands.                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `gomodTidy`                  | Run `go mod tidy` after Go module updates. This is implicitly enabled for major module updates when `gomodUpdateImportPaths` is enabled.                                                                                                                                                                                                                                                                                                                                           |
-| `gomodTidy1.17`              | Run `go mod tidy -compat=1.17` after Go module updates.                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| `gomodTidyE`                 | Run `go mod tidy -e` after Go module updates.                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `gomodUpdateImportPaths`     | Update source import paths on major module updates, using [mod](https://github.com/marwan-at-work/mod).                                                                                                                                                                                                                                                                                                                                                                            |
-| `gomodSkipVendor`            | Never run `go mod vendor` after Go module updates.                                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `gomodVendor`                | Always run `go mod vendor` after Go module updates even if vendor files aren't detected.                                                                                                                                                                                                                                                                                                                                                                                           |
-| `goGenerate`                 | Run `go generate ./...` after vendoring (if vendoring was required). This will then commit any files which were added or modified by running `go generate`. Note this will not install any other tools as part of the process. See [Go Tool](https://tip.golang.org/doc/go1.24#tools) usage for how to incorporate these as part of your build process. In order for this option to function, the global configuration option `allowedUnsafeExecutions` must include `goGenerate`. |
-| `helmUpdateSubChartArchives` | Update subchart archives in the `/charts` folder.                                                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `kustomizeInflateHelmCharts` | Inflate updated helm charts referenced in the kustomization.                                                                                                                                                                                                                                                                                                                                                                                                                       |
-| `npmDedupe`                  | Run `npm install` with `--prefer-dedupe` for npm >= 7 or `npm dedupe` after `package-lock.json` update for npm <= 6.                                                                                                                                                                                                                                                                                                                                                               |
-| `npmInstallTwice`            | Run `npm install` commands _twice_ to work around bugs where `npm` generates invalid lock files if run only once                                                                                                                                                                                                                                                                                                                                                                   |
-| `pnpmDedupe`                 | Run `pnpm dedupe --ignore-scripts` after `pnpm-lock.yaml` updates.                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `yarnDedupeFewer`            | Run `yarn-deduplicate --strategy fewer` after `yarn.lock` updates.                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `yarnDedupeHighest`          | Run `yarn-deduplicate --strategy highest` (`yarn dedupe --strategy highest` for Yarn >=2.2.0) after `yarn.lock` updates.                                                                                                                                                                                                                                                                                                                                                           |
+Enable conservative mode for `bundler` (Ruby dependencies).
+This will only update the immediate dependency in the lockfile instead of all subdependencies.
+
+### `composerNoMinimalChanges`
+
+Run `composer update` with no `--minimal-changes` flag (does not affect lock file maintenance, which will never use `--minimal-changes`).
+
+### `composerWithAll`
+
+Run `composer update` with `--with-all-dependencies` flag instead of the default `--with-dependencies`.
+
+### `dotnetWorkloadRestore`
+
+Run `dotnet workload restore` before `dotnet restore` commands.
+
+### `goGenerate`
+
+Run `go generate ./...` after vendoring (if vendoring was required).
+This will then commit any files which were added or modified by running `go generate`.
+Note this will not install any other tools as part of the process.
+See [Go Tool](https://tip.golang.org/doc/go1.24#tools) usage for how to incorporate these as part of your build process.
+In order for this option to function, the global configuration option `allowedUnsafeExecutions` must include `goGenerate`.
+
+### `gomodMassage`
+
+Enable massaging `replace` directives before calling `go` commands.
+
+### `gomodSkipVendor`
+
+Never run `go mod vendor` after Go module updates.
+
+### `gomodTidy`
+
+Run `go mod tidy` after Go module updates.
+This is implicitly enabled for major module updates when `gomodUpdateImportPaths` is enabled.
+
+### `gomodTidy1.17`
+
+Run `go mod tidy -compat=1.17` after Go module updates.
+
+### `gomodTidyE`
+
+Run `go mod tidy -e` after Go module updates.
+
+### `gomodUpdateImportPaths`
+
+Update source import paths on major module updates, using [mod](https://github.com/marwan-at-work/mod).
+
+### `gomodVendor`
+
+Always run `go mod vendor` after Go module updates even if vendor files aren't detected.
+
+### `helmUpdateSubChartArchives`
+
+Update subchart archives in the `/charts` folder.
+
+### `kustomizeInflateHelmCharts`
+
+Inflate updated helm charts referenced in the kustomization.
+
+### `npmDedupe`
+
+Run `npm install` with `--prefer-dedupe` for npm >= 7 or `npm dedupe` after `package-lock.json` update for npm <= 6.
+
+### `npmInstallTwice`
+
+Run `npm install` commands _twice_ to work around bugs where `npm` generates invalid lock files if run only once.
+
+### `pnpmDedupe`
+
+Run `pnpm dedupe --ignore-scripts` after `pnpm-lock.yaml` updates.
+
+### `yarnDedupeFewer`
+
+Run `yarn-deduplicate --strategy fewer` after `yarn.lock` updates.
+
+### `yarnDedupeHighest`
+
+Run `yarn-deduplicate --strategy highest` (`yarn dedupe --strategy highest` for Yarn >=2.2.0) after `yarn.lock` updates.
 
 ## `postUpgradeTasks`
 

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -26,10 +26,10 @@ describe('docs/documentation', () => {
     ): Promise<string[]> {
       const subHeadings = [];
       const content = await fs.readFile(`docs/usage/${file}`, 'utf8');
-      const reg = regEx(`##\\s${configOption}[\\s\\S]+?\n##\\s`);
+      const reg = regEx(`##\\s\`?${configOption}\`?[\\s\\S]+?\n##\\s`);
       const match = reg.exec(content);
       const subHeadersMatch = match?.[0]?.matchAll(
-        /\n###\s(?<child>[\w.]+)\n/g,
+        /\n###\s`?(?<child>[\w.]+)`?\n/g,
       );
       if (subHeadersMatch) {
         for (const subHeaderStr of subHeadersMatch) {
@@ -85,13 +85,20 @@ describe('docs/documentation', () => {
         );
       });
 
+      function getPostUpdateOptionsValues(): Set<string> {
+        const option = options.find((o) => o.name === 'postUpdateOptions');
+        return new Set(option?.allowedValues ?? []);
+      }
+
       async function getConfigSubHeaders(file: string): Promise<string[]> {
+        const postUpdateValues = getPostUpdateOptionsValues();
         const content = await fs.readFile(`docs/usage/${file}`, 'utf8');
         const matches = content.match(/\n### (.*?)\n/g) ?? [];
         return matches
           .map((match) =>
             match.substring(5, match.length - 1).replace(/^`|`$/g, ''),
           )
+          .filter((header) => !postUpdateValues.has(header))
           .sort();
       }
 
@@ -158,6 +165,20 @@ describe('docs/documentation', () => {
           );
         },
       );
+
+      it('has a sorted header for every postUpdateOptions value', async () => {
+        const postUpdateHeaders = await getConfigOptionSubHeaders(
+          'configuration-options.md',
+          'postUpdateOptions',
+        );
+        const postUpdateOption = options.find(
+          (o) => o.name === 'postUpdateOptions',
+        );
+        const allowedValues = [
+          ...(postUpdateOption?.allowedValues ?? []),
+        ].sort();
+        expect(postUpdateHeaders).toEqual(allowedValues);
+      });
     });
 
     describe('docs/usage/self-hosted-configuration.md', () => {


### PR DESCRIPTION
## Changes

Replace the wide markdown table under `postUpdateOptions` with individual `###` headers per option, sorted alphabetically. Each option is now directly linkable and easier to read, matching the style used by other config sections like `postUpgradeTasks`.

Also improve `getConfigOptionSubHeaders` in the docs test to handle backtick-wrapped section and sub-header names, and add a dedicated test ensuring every `postUpdateOptions` allowed value has a corresponding sorted header.

## Context

- [x] This closes an existing Issue, Closes: #44028

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). Claude Opus 4.6 via Claude Code.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
