### PR TITLE
ci: use mnt for docker for older gh runners

### DIFF
--- a/.github/actions/setup-docker/action.yml
+++ b/.github/actions/setup-docker/action.yml
@@ -11,7 +11,7 @@ runs:
         if [ ! -f /etc/docker/daemon.json ]; then
             echo "{}" | sudo tee /etc/docker/daemon.json
         fi
-        cat /etc/docker/daemon.json | jq '. | .+{"features": {"containerd-snapshotter": true}}' | sudo tee /etc/docker/daemon.json
+        cat /etc/docker/daemon.json | jq '. | .+{"features": {"containerd-snapshotter": true},"data-root": "/mnt/docker"}' | sudo tee /etc/docker/daemon.json
         sudo systemctl restart docker
 
     - name: Check docker service


### PR DESCRIPTION
some older runners have a smaller root partition but a second bigger one at `/mnt`