### PR TITLE
fix(datasource/cpanfile): strip v-prefix from CPAN versions

### DIFF
--- a/lib/modules/datasource/cpan/__fixtures__/Foo-Bar.json
+++ b/lib/modules/datasource/cpan/__fixtures__/Foo-Bar.json
@@ -1,0 +1,59 @@
+{
+   "took" : 2,
+   "_shards" : {
+      "total" : 3,
+      "successful" : 3,
+      "failed" : 0
+   },
+   "hits" : {
+      "total" : 2,
+      "hits" : [
+         {
+            "_type" : "file",
+            "_index" : "cpan_v1_01",
+            "_id" : "aaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "_score" : null,
+            "sort" : [
+               1685577600000
+            ],
+            "_source" : {
+               "deprecated" : false,
+               "module" : [
+                  {
+                     "name" : "Foo::Bar",
+                     "version" : "v1.1.1"
+                  }
+               ],
+               "status" : "latest",
+               "date" : "2023-06-01T00:00:00",
+               "maturity" : "released",
+               "distribution" : "Foo-Bar"
+            }
+         },
+         {
+            "_type" : "file",
+            "_index" : "cpan_v1_01",
+            "_id" : "bbbbbbbbbbbbbbbbbbbbbbbbbbb",
+            "_score" : null,
+            "sort" : [
+               1640995200000
+            ],
+            "_source" : {
+               "deprecated" : false,
+               "module" : [
+                  {
+                     "name" : "Foo::Bar",
+                     "version" : "v1.1.0"
+                  }
+               ],
+               "status" : "cpan",
+               "date" : "2022-01-01T00:00:00",
+               "maturity" : "released",
+               "distribution" : "Foo-Bar"
+            }
+         }
+      ],
+      "max_score" : null
+   },
+   "timed_out" : false
+}

--- a/lib/modules/datasource/cpan/index.spec.ts
+++ b/lib/modules/datasource/cpan/index.spec.ts
@@ -86,5 +86,22 @@ describe('modules/datasource/cpan/index', () => {
       });
       expect(res?.tags?.latest).toBe('1.0048');
     });
+
+    it('strips a leading v from v-prefixed versions', async () => {
+      httpMock
+        .scope(baseUrl)
+        .post(
+          '/v1/file/_search',
+          (body) =>
+            body.query.bool.filter[0].term['module.name'] === 'Foo::Bar',
+        )
+        .reply(200, Fixtures.get('Foo-Bar.json'));
+      const res = await getPkgReleases({
+        datasource: CpanDatasource.id,
+        packageName: 'Foo::Bar',
+      });
+      expect(res?.releases.map((r) => r.version)).toEqual(['1.1.0', '1.1.1']);
+      expect(res?.tags?.latest).toBe('1.1.1');
+    });
   });
 });

--- a/lib/modules/datasource/cpan/schema.spec.ts
+++ b/lib/modules/datasource/cpan/schema.spec.ts
@@ -71,5 +71,34 @@ describe('modules/datasource/cpan/schema', () => {
         isLatest: true,
       });
     });
+
+    it.each`
+      version     | expected
+      ${'v1.1.1'} | ${'1.1.1'}
+      ${'1.1.1'}  | ${'1.1.1'}
+    `(
+      'normalizes version $version to $expected',
+      ({ version, expected }: { version: string; expected: string }) => {
+        const response = {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  module: [{ name: 'Test::Module', version }],
+                  distribution: 'Test-Package',
+                  date: '2023-01-01T00:00:00',
+                  deprecated: false,
+                  maturity: 'released',
+                  status: 'latest',
+                },
+              },
+            ],
+          },
+        };
+        const result = MetaCpanApiFileSearchResponse.parse(response);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({ version: expected });
+      },
+    );
   });
 });

--- a/lib/modules/datasource/cpan/schema.ts
+++ b/lib/modules/datasource/cpan/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { regEx } from '../../../util/regex.ts';
 import { LooseArray } from '../../../util/schema-utils/index.ts';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
 import type { CpanRelease } from './types.ts';
@@ -37,7 +38,10 @@ const MetaCpanApiFile = z
         return undefined;
       }
       return {
-        version: module[0].version,
+        // Modules with dotted-decimal versions are published with a leading
+        // 'v' (e.g. `v1.1.1`); strip it so versions match the cpanfile, where
+        // the manager already reads them without the prefix.
+        version: module[0].version.replace(regEx(/^v/), ''),
         distribution,
         isDeprecated: deprecated,
         isStable: maturity === 'released',


### PR DESCRIPTION
**Problem**: 
CPAN modules that use dotted-decimal versions are published to MetaCPAN with a
leading `v` (e.g. `v1.1.1`), and the `cpan` datasource returns those versions
verbatim.

When the `cpanfile` manager parses a requirement it already strips a leading `v`
(and any comparison operator) from the value it reads out of the file — see
`lib/modules/manager/cpanfile/parser.ts`, where the string handler does
`value.replace(/^(?:\s*(?:==|>=|>))?\s*v?/, '')`. So `currentValue` is stored
without the `v`.

That asymmetry breaks updates. During `autoReplace`, Renovate re-extracts the
file after substituting the new version and checks that the new dependency's
`currentValue` matches the version it intended to write. The datasource supplies
`v1.1.1`, but re-extraction yields `1.1.1`; the two never match, so the update is
considered unverifiable and is silently dropped. The result is that affected
Perl modules are simply never updated.

---
**Solution**:
The `cpanfile` manager now sets `extractVersion: '^v?(?<version>.+)$'` on every
dependency that uses the `cpan` datasource, so a leading `v` is stripped from
versions returned by the datasource before they are compared against the value
written in the file.
