### PR TITLE
refactor: use `GlobalConfig` for `productLinks`

### DIFF
--- a/lib/config/decrypt.spec.ts
+++ b/lib/config/decrypt.spec.ts
@@ -53,9 +53,28 @@ describe('config/decrypt', () => {
 
       process.env.MEND_HOSTED = 'true';
       process.env.RENOVATE_X_ENCRYPTED_STRICT = 'true';
-      await expect(decryptConfig(config, repository)).rejects.toThrow(
-        'config-validation',
-      );
+
+      await expect(decryptConfig(config, repository)).rejects.toMatchObject({
+        message: 'config-validation',
+        validationMessage: expect.stringContaining(
+          'https://docs.renovatebot.com/mend-hosted/migrating-secrets/',
+        ),
+      });
+    });
+
+    it('uses productLinks.documentation in Mend Hosted error URL', async () => {
+      config.encrypted = { a: '1' };
+      GlobalConfig.set({
+        productLinks: { documentation: 'https://custom.example.com/' },
+      });
+      process.env.MEND_HOSTED = 'true';
+      process.env.RENOVATE_X_ENCRYPTED_STRICT = 'true';
+
+      await expect(decryptConfig(config, repository)).rejects.toMatchObject({
+        validationMessage: expect.stringContaining(
+          'https://custom.example.com/mend-hosted/migrating-secrets/',
+        ),
+      });
     });
   });
 

--- a/lib/config/decrypt.ts
+++ b/lib/config/decrypt.ts
@@ -180,11 +180,10 @@ export async function decryptConfig<T extends RenovateConfig = AllConfig>(
           error.validationError = 'Encrypted config unsupported';
           error.validationMessage = `This config contains an encrypted object at location \`$.${key}\` but no privateKey is configured. To support encrypted config, the Renovate administrator must configure a \`privateKey\` in Global Configuration.`;
           if (env.MEND_HOSTED === 'true') {
-            // oxlint-disable-next-line renovate/no-hardcoded-docs-url -- no config access during decryption
             error.validationMessage = `Mend-hosted Renovate Apps no longer support the use of encrypted secrets in Renovate file config (e.g. renovate.json).
 Please migrate all secrets to the Developer Portal using the web UI available at https://developer.mend.io/
 
-Refer to migration documents here: https://docs.renovatebot.com/mend-hosted/migrating-secrets/`;
+Refer to migration documents here: ${GlobalConfig.get('productLinks').documentation}mend-hosted/migrating-secrets/`;
           }
           throw error;
         } else {

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -51,6 +51,7 @@ export class GlobalConfig {
     'platform',
     'prCacheSyncMaxPages',
     'presetCachePersistence',
+    'productLinks',
     'repositoryCacheForceLocal',
     'requireConfig',
     's3Endpoint',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -275,6 +275,7 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   ignorePrAuthor?: boolean;
   allowedUnsafeExecutions?: AllowedUnsafeExecution[];
   onboardingAutoCloseAge?: number;
+  productLinks?: Record<string, string>;
   toolSettings?: ToolSettingsOptions;
 }
 

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -1,7 +1,7 @@
 import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { envMock, mockExecAll } from '~test/exec-util.ts';
-import { env, fs, hostRules } from '~test/util.ts';
+import { env, fs, hostRules, logger } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type { RepoGlobalConfig } from '../../../config/types.ts';
 import type { ConstraintName } from '../../../util/exec/types.ts';
@@ -139,6 +139,32 @@ describe('modules/manager/mix/artifacts', () => {
         config: { ...config, isLockFileMaintenance: true },
       }),
     ).toBeNull();
+    expect(logger.logger.debug).toHaveBeenCalledWith(
+      'Cannot use lockFileMaintenance in an umbrella project, see https://docs.renovatebot.com/modules/manager/mix/#lockFileMaintenance',
+    );
+  });
+
+  it('uses productLinks.documentation in lockFileMaintenance umbrella log URL', async () => {
+    GlobalConfig.set({
+      ...adminConfig,
+      productLinks: { documentation: 'https://custom.example.com/' },
+    });
+    fs.getSiblingFileName.mockReturnValueOnce('apps/foo/mix.lock');
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('mix.lock');
+    fs.readLocalFile.mockResolvedValueOnce(null);
+    fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
+    fs.readLocalFile.mockResolvedValueOnce('New mix.lock');
+    expect(
+      await updateArtifacts({
+        packageFileName: 'apps/foo/mix.exs',
+        updatedDeps: [],
+        newPackageFileContent: '{}',
+        config: { ...config, isLockFileMaintenance: true },
+      }),
+    ).toBeNull();
+    expect(logger.logger.debug).toHaveBeenCalledWith(
+      'Cannot use lockFileMaintenance in an umbrella project, see https://custom.example.com/modules/manager/mix/#lockFileMaintenance',
+    );
   });
 
   it('returns updated mix.lock', async () => {

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -1,5 +1,6 @@
 import { isEmptyArray, isString } from '@sindresorhus/is';
 import { quote } from 'shlex';
+import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { exec } from '../../../util/exec/index.ts';
@@ -67,8 +68,7 @@ export async function updateArtifacts({
 
   if (isLockFileMaintenance && isUmbrella) {
     logger.debug(
-      // oxlint-disable-next-line renovate/no-hardcoded-docs-url -- no config access in manager artifact code
-      'Cannot use lockFileMaintenance in an umbrella project, see https://docs.renovatebot.com/modules/manager/mix/#lockFileMaintenance',
+      `Cannot use lockFileMaintenance in an umbrella project, see ${GlobalConfig.get('productLinks').documentation}modules/manager/mix/#lockFileMaintenance`,
     );
     return null;
   }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -2191,8 +2191,7 @@ export async function getVulnerabilityAlerts(): Promise<GithubVulnerabilityAlert
     logger.debug({ err }, 'Error retrieving vulnerability alerts');
     logger.warn(
       {
-        // oxlint-disable-next-line renovate/no-hardcoded-docs-url -- no config access in platform code
-        url: 'https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts',
+        url: `${GlobalConfig.get('productLinks').documentation}configuration-options/#vulnerabilityalerts`,
       },
       'Cannot access vulnerability alerts. Please ensure permissions have been granted.',
     );

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -2,6 +2,7 @@ import { codeBlock } from 'common-tags';
 import { DateTime } from 'luxon';
 import * as httpMock from '~test/http-mock.ts';
 import { logger } from '~test/util.ts';
+import { GlobalConfig } from '../../config/global.ts';
 import {
   EXTERNAL_HOST_ERROR,
   PLATFORM_BAD_CREDENTIALS,
@@ -61,6 +62,7 @@ describe('util/http/github', () => {
 
   afterEach(() => {
     hostRules.clear();
+    GlobalConfig.reset();
   });
 
   describe('HTTP', () => {
@@ -404,6 +406,28 @@ describe('util/http/github', () => {
           {
             documentationUrl:
               'https://docs.renovatebot.com/getting-started/running/#githubcom-token-for-changelogs-and-tools',
+          },
+          'Rate limit exceeded for api.github.com, as no hostRules set for this host. Please set a GITHUB_COM_TOKEN',
+        );
+      });
+
+      it('uses productLinks.documentation in rate limit warn URL', async () => {
+        GlobalConfig.set({
+          productLinks: { documentation: 'https://custom.example.com/' },
+        });
+        hostRules.clear();
+
+        await expect(
+          fail(403, {
+            message:
+              "API rate limit exceeded for xxx.xxx.xxx.xxx. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
+          }),
+        ).rejects.toThrow(PLATFORM_RATE_LIMIT_EXCEEDED);
+
+        expect(logger.logger.once.warn).toHaveBeenCalledWith(
+          {
+            documentationUrl:
+              'https://custom.example.com/getting-started/running/#githubcom-token-for-changelogs-and-tools',
           },
           'Rate limit exceeded for api.github.com, as no hostRules set for this host. Please set a GITHUB_COM_TOKEN',
         );

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -5,6 +5,7 @@ import {
   isPlainObject,
 } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
+import { GlobalConfig } from '../../config/global.ts';
 import {
   PLATFORM_BAD_CREDENTIALS,
   PLATFORM_INTEGRATION_UNAUTHORIZED,
@@ -129,9 +130,7 @@ function handleGotError(
       if (parsed?.hostname === 'api.github.com') {
         logger.once.warn(
           {
-            documentationUrl:
-              // oxlint-disable-next-line renovate/no-hardcoded-docs-url -- no config access in HTTP utility
-              'https://docs.renovatebot.com/getting-started/running/#githubcom-token-for-changelogs-and-tools',
+            documentationUrl: `${GlobalConfig.get('productLinks').documentation}getting-started/running/#githubcom-token-for-changelogs-and-tools`,
           },
           `Rate limit exceeded for ${parsed.host}, as no hostRules set for this host. Please set a GITHUB_COM_TOKEN`,
         );

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -1,4 +1,5 @@
 import { hostRules } from '~test/util.ts';
+import { GlobalConfig } from '../../config/global.ts';
 import type { PackageRuleInputConfig, UpdateType } from '../../config/types.ts';
 import { MISSING_API_CREDENTIALS } from '../../constants/error-messages.ts';
 import { DockerDatasource } from '../../modules/datasource/docker/index.ts';
@@ -862,6 +863,10 @@ describe('util/package-rules/index', () => {
       hostRules.add(hostRule);
     });
 
+    afterEach(() => {
+      GlobalConfig.reset();
+    });
+
     it('matches matchConfidence', async () => {
       const config: TestConfig = {
         packageRules: [
@@ -944,6 +949,28 @@ describe('util/package-rules/index', () => {
       expect(error.validationMessage).toBe(
         'The `matchConfidence` matcher in `packageRules` requires authentication. Please refer to the [documentation](https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence) and add the required host rule.',
       );
+    });
+
+    it('uses productLinks.documentation in error message URL', async () => {
+      GlobalConfig.set({
+        productLinks: { documentation: 'https://custom.example.com/' },
+      });
+      hostRules.clear();
+      const config: TestConfig = {
+        packageRules: [
+          {
+            matchUpdateTypes: ['major'],
+            matchConfidence: ['high'],
+            // @ts-expect-error -- testing
+            x: 1,
+          },
+        ],
+      };
+
+      await expect(applyPackageRules(config)).rejects.toMatchObject({
+        validationMessage:
+          'The `matchConfidence` matcher in `packageRules` requires authentication. Please refer to the [documentation](https://custom.example.com/configuration-options/#packagerulesmatchconfidence) and add the required host rule.',
+      });
     });
   });
 

--- a/lib/util/package-rules/merge-confidence.ts
+++ b/lib/util/package-rules/merge-confidence.ts
@@ -4,6 +4,7 @@ import {
   isNullOrUndefined,
   isUndefined,
 } from '@sindresorhus/is';
+import { GlobalConfig } from '../../config/global.ts';
 import type {
   PackageRule,
   PackageRuleInputConfig,
@@ -28,9 +29,7 @@ export class MergeConfidenceMatcher extends Matcher {
       const error = new Error(MISSING_API_CREDENTIALS);
       error.validationSource = 'MatchConfidence Authenticator';
       error.validationError = 'Missing credentials';
-      error.validationMessage =
-        // oxlint-disable-next-line renovate/no-hardcoded-docs-url -- no config access in package rule utility
-        'The `matchConfidence` matcher in `packageRules` requires authentication. Please refer to the [documentation](https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence) and add the required host rule.';
+      error.validationMessage = `The \`matchConfidence\` matcher in \`packageRules\` requires authentication. Please refer to the [documentation](${GlobalConfig.get('productLinks').documentation}configuration-options/#packagerulesmatchconfidence) and add the required host rule.`;
       throw error;
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As a follow-up to #44066, we can make
sure that we remove references to hardcoded docs site URLs, by wiring in
the `GlobalConfig.get(...)` call.

To do this, we need to make sure that `productLinks` exists to be called
by `GlobalConfig.get`.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
