### PR TITLE
refactor(platform/gitlab): use detailed merge status

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2439,7 +2439,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: { status: 'running' },
         })
         .post(
@@ -2491,7 +2491,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: { status: 'running' },
         })
         .put('/api/v4/projects/some%2Frepo/merge_requests/12345/merge')
@@ -2544,7 +2544,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: { status: 'running' },
         })
         .post('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/12345')
@@ -2638,6 +2638,65 @@ describe('modules/platform/gitlab/index', () => {
       await initPlatform('15.6.0-ee');
       const reply_body = {
         detailed_merge_status: 'pending',
+      };
+      httpMock
+        .scope(gitlabApiHost)
+        .get(
+          '/api/v4/projects/undefined/merge_requests?per_page=100&order_by=updated_at&sort=desc&scope=created_by_me',
+        )
+        .reply(200, [])
+        .post('/api/v4/projects/undefined/merge_requests')
+        .reply(200, {
+          id: 1,
+          iid: 12345,
+          title: 'some title',
+          source_branch: 'some-branch',
+          target_branch: 'master',
+          description: 'the-body',
+        })
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, reply_body)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, reply_body)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, reply_body)
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge')
+        .reply(200, {});
+      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
+      const pr = await gitlab.createPr({
+        sourceBranch: 'some-branch',
+        targetBranch: 'master',
+        prTitle: 'some-title',
+        prBody: 'the-body',
+        platformPrOptions: {
+          usePlatformAutomerge: true,
+        },
+      });
+      expect(pr).toMatchObject({
+        number: 12345,
+        sourceBranch: 'some-branch',
+        title: 'some title',
+      });
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'PR not yet in mergeable state. Retrying 1',
+      );
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'PR not yet in mergeable state. Retrying 2',
+      );
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'PR not yet in mergeable state. Retrying 3',
+      );
+      expect(timers.setTimeout.mock.calls).toMatchObject([[100], [400], [900]]);
+    });
+
+    it('should not parse deprecated merge_status attribute on >= 15.6', async () => {
+      await initPlatform('15.6.0-ee');
+      const reply_body = {
+        merge_status: 'can_be_merged',
+        pipeline: { status: 'running' },
       };
       httpMock
         .scope(gitlabApiHost)

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -585,6 +585,10 @@ async function tryPrAutomerge(
         'ci_still_running',
         'not_approved',
       ];
+      const supportsDetailedMergeStatus = !semver.lt(
+        defaults.version,
+        '15.6.0',
+      );
       const desiredPipelineStatus = [
         'failed', // don't lose time if pipeline failed
         'running', // pipeline is running, no need to wait for it
@@ -605,7 +609,7 @@ async function tryPrAutomerge(
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         const { body } = await gitlabApi.getJsonUnchecked<{
-          merge_status: string;
+          merge_status?: string;
           detailed_merge_status?: string;
           merge_when_pipeline_succeeds?: boolean;
           pipeline: {
@@ -622,14 +626,13 @@ async function tryPrAutomerge(
           );
           return;
         }
-        // detailed_merge_status is available with Gitlab >=15.6.0
-        const use_detailed_merge_status = !!body.detailed_merge_status;
+        const detailedMergeStatus = body.detailed_merge_status;
         const detailed_merge_status_check =
-          use_detailed_merge_status &&
-          desiredDetailedMergeStatus.includes(body.detailed_merge_status!);
-        // merge_status is deprecated with Gitlab >= 15.6
+          supportsDetailedMergeStatus &&
+          detailedMergeStatus !== undefined &&
+          desiredDetailedMergeStatus.includes(detailedMergeStatus);
         const deprecated_merge_status_check =
-          !use_detailed_merge_status && body.merge_status === desiredStatus;
+          !supportsDetailedMergeStatus && body.merge_status === desiredStatus;
 
         // Only continue if the merge request can be merged and has a pipeline.
         if (

--- a/lib/modules/platform/gitlab/schema.ts
+++ b/lib/modules/platform/gitlab/schema.ts
@@ -26,6 +26,7 @@ export const GitLabMergeRequest = z.object({
   updated_at: z.string(),
   diverged_commits_count: z.number().optional(),
   merge_status: z.string().optional(),
+  detailed_merge_status: z.string().optional(),
   assignee: GitlabUser.nullish(),
   assignees: LooseArray(GitlabUser).catch([]),
   reviewers: LooseArray(GitlabUser).catch([]),


### PR DESCRIPTION
## Changes

- Use `detailed_merge_status` as the mergeability signal for GitLab 15.6+ before enabling platform automerge.
- Keep the deprecated `merge_status` fallback only for GitLab versions before 15.6.
- Add `detailed_merge_status` to the GitLab merge request schema and update automerge fixtures/tests.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44114
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was prepared with substantive assistance from OpenAI Codex. Codex inspected the GitLab platform code, wrote the test/code changes, and ran local verification.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Verification:

- `pnpm vitest run lib/modules/platform/gitlab/index.spec.ts -t "should not parse deprecated merge_status attribute on >= 15.6" --coverage false` (RED before implementation, GREEN after)
- `pnpm vitest run lib/modules/platform/gitlab/index.spec.ts lib/modules/platform/gitlab/pr-cache.spec.ts --coverage false`
- `pnpm check --all lib/modules/platform/gitlab/index.ts lib/modules/platform/gitlab/index.spec.ts lib/modules/platform/gitlab/schema.ts`
- `pnpm type-check`
- `git diff --check`