### PR TITLE
feat: independent CI-status-based timing for assignees and reviewers

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -174,6 +174,17 @@ Read the docs for your platform for details on syntax and allowed file locations
 - [GitLab, Code Owners](https://docs.gitlab.com/ee/user/project/codeowners/)
 - [Bitbucket, Set up and use code owners](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/)
 
+## assigneesOnChecks
+
+Controls when Renovate adds assignees to a PR, relative to CI status.
+
+If unset, Renovate preserves its prior default behavior: assignees are added immediately, unless `automerge` is enabled without `assignAutomerge`, in which case assignees are only added once status checks turn red.
+
+- `never`: never add assignees via this mechanism
+- `red`: only add assignees when status checks are red
+- `green`: only add assignees when status checks are green
+- `always`: always add assignees immediately, regardless of automerge settings
+
 ## `assigneesSampleSize`
 
 If configured, Renovate will take a random sample of given size from assignees and assign them only, instead of assigning the entire list of `assignees` you have configured.
@@ -4705,6 +4716,12 @@ Read the docs for your platform for details on syntax and allowed file locations
 - [Bitbucket, Set up and use code owners](https://support.atlassian.com/bitbucket-cloud/docs/set-up-and-use-code-owners/)
 
 Please note that Reviewers are only added during creation of a PR, but are not modified afterwards.
+
+## reviewersOnChecks
+
+Controls when Renovate adds reviewers to a PR, relative to CI status.
+
+Same semantics and default behavior as `assigneesOnChecks`, applied to reviewers instead.
 
 ## `reviewersSampleSize`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -64,6 +64,30 @@ const options: Readonly<RenovateOptions>[] = [
     mergeable: true,
   },
   {
+    name: 'assigneesOnChecks',
+    description:
+      'Controls when Renovate adds assignees to a PR, relative to CI status. ' +
+      'Unset (default): preserves prior behavior — assignees are added immediately, ' +
+      'unless `automerge` is enabled without `assignAutomerge`, in which case assignees ' +
+      'are only added once status checks turn red. ' +
+      '`never`: never add assignees via this mechanism. ' +
+      '`red`: only add assignees when status checks are red. ' +
+      '`green`: only add assignees when status checks are green. ' +
+      '`always`: always add assignees immediately, regardless of automerge settings.',
+    type: 'string',
+    allowedValues: ['never', 'red', 'green', 'always'],
+    default: null,
+  },
+  {
+    name: 'reviewersOnChecks',
+    description:
+      'Controls when Renovate adds reviewers to a PR, relative to CI status. ' +
+      'Same semantics and default behavior as `assigneesOnChecks`, applied to reviewers instead.',
+    type: 'string',
+    allowedValues: ['never', 'red', 'green', 'always'],
+    default: null,
+  },
+  {
     name: 'detectGlobalManagerConfig',
     description:
       'If `true`, Renovate tries to detect global manager configuration from the file system.',

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -914,7 +914,7 @@ describe('workers/repository/update/pr/index', () => {
         expect(participants.addReviewers).toHaveBeenCalled();
       });
 
-      it('applies the same independent gating for an existing PR', async () => {
+      it('does nothing for an existing PR without automerge', async () => {
         const changedPr: Pr = { ...pr, hasAssignees: false };
         platform.getBranchPr.mockResolvedValueOnce(changedPr);
         checks.resolveBranchStatus.mockResolvedValueOnce('red');
@@ -923,6 +923,25 @@ describe('workers/repository/update/pr/index', () => {
           ...config,
           assigneesOnChecks: 'red',
           reviewersOnChecks: 'green',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr: changedPr });
+        expect(participants.addAssignees).not.toHaveBeenCalled();
+        expect(participants.addReviewers).not.toHaveBeenCalled();
+      });
+
+      it('assigns participants accordingly to an existing PR with automerge', async () => {
+        const changedPr: Pr = { ...pr, hasAssignees: false };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        checks.resolveBranchStatus.mockResolvedValueOnce('red');
+
+        const res = await ensurePr({
+          ...config,
+          assigneesOnChecks: 'red',
+          reviewersOnChecks: 'green',
+          automerge: true,
+          automergeType: 'pr',
+          assignAutomerge: false,
         });
 
         expect(res).toEqual({ type: 'with-pr', pr: changedPr });

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -914,20 +914,20 @@ describe('workers/repository/update/pr/index', () => {
         expect(participants.addReviewers).toHaveBeenCalled();
       });
 
-      it('does nothing for an existing PR without automerge', async () => {
+      it('assigns participants accordingly to an existing PR without automerge with assigneesOnChecks', async () => {
         const changedPr: Pr = { ...pr, hasAssignees: false };
         platform.getBranchPr.mockResolvedValueOnce(changedPr);
         checks.resolveBranchStatus.mockResolvedValueOnce('red');
 
         const res = await ensurePr({
           ...config,
-          assigneesOnChecks: 'red',
-          reviewersOnChecks: 'green',
+          assigneesOnChecks: 'green',
+          reviewersOnChecks: 'red',
         });
 
         expect(res).toEqual({ type: 'with-pr', pr: changedPr });
         expect(participants.addAssignees).not.toHaveBeenCalled();
-        expect(participants.addReviewers).not.toHaveBeenCalled();
+        expect(participants.addReviewers).toHaveBeenCalled();
       });
 
       it('assigns participants accordingly to an existing PR with automerge', async () => {

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -914,7 +914,7 @@ describe('workers/repository/update/pr/index', () => {
         expect(participants.addReviewers).toHaveBeenCalled();
       });
 
-      it('assigns participants accordingly to an existing PR without automerge with assigneesOnChecks', async () => {
+      it('independently gates assignees and reviewers for an existing PR without automerge', async () => {
         const changedPr: Pr = { ...pr, hasAssignees: false };
         platform.getBranchPr.mockResolvedValueOnce(changedPr);
         checks.resolveBranchStatus.mockResolvedValueOnce('red');

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -609,7 +609,8 @@ describe('workers/repository/update/pr/index', () => {
         });
 
         expect(res).toEqual({ type: 'with-pr', pr: changedPr });
-        expect(participants.addParticipants).toHaveBeenCalled();
+        expect(participants.addAssignees).toHaveBeenCalled();
+        expect(participants.addReviewers).toHaveBeenCalled();
         expect(prCache.setPrCache).toHaveBeenCalled();
       });
 
@@ -631,7 +632,8 @@ describe('workers/repository/update/pr/index', () => {
         });
 
         expect(res).toEqual({ type: 'with-pr', pr: changedPr });
-        expect(participants.addParticipants).toHaveBeenCalled();
+        expect(participants.addAssignees).toHaveBeenCalled();
+        expect(participants.addReviewers).toHaveBeenCalled();
       });
 
       it('skips branch automerge and forces PR creation due to artifact errors', async () => {
@@ -646,7 +648,8 @@ describe('workers/repository/update/pr/index', () => {
 
         expect(res).toEqual({ type: 'with-pr', pr });
         expect(platform.createPr).toHaveBeenCalled();
-        expect(participants.addParticipants).not.toHaveBeenCalled();
+        expect(participants.addAssignees).not.toHaveBeenCalled();
+        expect(participants.addReviewers).not.toHaveBeenCalled();
         expect(prCache.setPrCache).toHaveBeenCalled();
       });
 
@@ -743,8 +746,7 @@ describe('workers/repository/update/pr/index', () => {
         checks.resolveBranchStatus.mockResolvedValueOnce('red');
 
         const err = new Error('unknown');
-        participants.addParticipants.mockRejectedValueOnce(err);
-
+        participants.addAssignees.mockRejectedValueOnce(err);
         await ensurePr({
           ...config,
           automerge: true,
@@ -767,7 +769,7 @@ describe('workers/repository/update/pr/index', () => {
         checks.resolveBranchStatus.mockResolvedValueOnce('red');
 
         const err = new ExternalHostError(new Error('unknown'));
-        participants.addParticipants.mockRejectedValueOnce(err);
+        participants.addAssignees.mockRejectedValueOnce(err);
 
         await expect(
           ensurePr({
@@ -795,7 +797,7 @@ describe('workers/repository/update/pr/index', () => {
           checks.resolveBranchStatus.mockResolvedValueOnce('red');
 
           const err = new Error(message);
-          participants.addParticipants.mockRejectedValueOnce(err);
+          participants.addAssignees.mockRejectedValueOnce(err);
 
           await expect(
             ensurePr({
@@ -807,6 +809,126 @@ describe('workers/repository/update/pr/index', () => {
           ).rejects.toThrow(err);
         },
       );
+    });
+
+    describe('assigneesOnChecks / reviewersOnChecks', () => {
+      it('preserves default behavior: assigns both immediately with no automerge', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('yellow');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({ ...config });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).toHaveBeenCalled();
+        expect(participants.addReviewers).toHaveBeenCalled();
+      });
+
+      it('preserves default automerge-red behavior for both roles when neither flag is set', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('yellow');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          automerge: true,
+          automergeType: 'pr',
+          assignAutomerge: false,
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).not.toHaveBeenCalled();
+        expect(participants.addReviewers).not.toHaveBeenCalled();
+      });
+
+      it('assigns assignees on red even when reviewers are gated to green', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('red');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          assigneesOnChecks: 'red',
+          reviewersOnChecks: 'green',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).toHaveBeenCalled();
+        expect(participants.addReviewers).not.toHaveBeenCalled();
+      });
+
+      it('assigns reviewers on green even when assignees are gated to red', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('green');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          assigneesOnChecks: 'red',
+          reviewersOnChecks: 'green',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).not.toHaveBeenCalled();
+        expect(participants.addReviewers).toHaveBeenCalled();
+      });
+
+      it('skips both when status is yellow and both roles are gated to red/green', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('yellow');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          assigneesOnChecks: 'red',
+          reviewersOnChecks: 'green',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).not.toHaveBeenCalled();
+        expect(participants.addReviewers).not.toHaveBeenCalled();
+      });
+
+      it('explicit "always" overrides automerge-red default', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('green');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          automerge: true,
+          automergeType: 'pr',
+          assignAutomerge: false,
+          assigneesOnChecks: 'always',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).toHaveBeenCalled();
+      });
+
+      it('explicit "never" suppresses assignees even without automerge', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('green');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          assigneesOnChecks: 'never',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(participants.addAssignees).not.toHaveBeenCalled();
+        expect(participants.addReviewers).toHaveBeenCalled();
+      });
+
+      it('applies the same independent gating for an existing PR', async () => {
+        const changedPr: Pr = { ...pr, hasAssignees: false };
+        platform.getBranchPr.mockResolvedValueOnce(changedPr);
+        checks.resolveBranchStatus.mockResolvedValueOnce('red');
+
+        const res = await ensurePr({
+          ...config,
+          assigneesOnChecks: 'red',
+          reviewersOnChecks: 'green',
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr: changedPr });
+        expect(participants.addAssignees).toHaveBeenCalled();
+        expect(participants.addReviewers).not.toHaveBeenCalled();
+      });
     });
 
     describe('Changelog', () => {

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -442,11 +442,17 @@ export async function ensurePr(
 
       if (
         !existingPr.hasAssignees &&
-        !hasNotIgnoredReviewers(existingPr, config) &&
-        config.automerge &&
-        !config.assignAutomerge
+        ((config.automerge && !config.assignAutomerge) ||
+          config.assigneesOnChecks !== undefined)
       ) {
         await maybeAddAssignees(config, existingPr, await getBranchStatus());
+      }
+
+      if (
+        !hasNotIgnoredReviewers(existingPr, config) &&
+        ((config.automerge && !config.assignAutomerge) ||
+          config.reviewersOnChecks !== undefined)
+      ) {
         await maybeAddReviewers(config, existingPr, await getBranchStatus());
       }
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../../modules/platform/pr-body.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
+import type { BranchStatus } from '../../../../types/index.ts';
 import { getElapsedHours } from '../../../../util/date.ts';
 import { stripEmojis } from '../../../../util/emoji.ts';
 import { fingerprint } from '../../../../util/fingerprint.ts';
@@ -31,6 +32,7 @@ import { incCountValue, isLimitReached } from '../../../global/limits.ts';
 import type {
   BranchConfig,
   BranchUpgradeConfig,
+  ChecksAssignTiming,
   PrBlockedBy,
 } from '../../../types.ts';
 import { embedChangelogs } from '../../changelog/index.ts';
@@ -41,7 +43,7 @@ import {
   prepareLabels,
   shouldUpdateLabels,
 } from './labels.ts';
-import { addParticipants } from './participants.ts';
+import { addAssignees, addReviewers } from './participants.ts';
 import { getPrCache, setPrCache } from './pr-cache.ts';
 import {
   generatePrBodyFingerprintConfig,
@@ -120,6 +122,57 @@ function hasNotIgnoredReviewers(pr: Pr, config: BranchConfig): boolean {
     );
   }
   return isNonEmptyArray(pr.reviewers);
+}
+
+function matchesTiming(
+  timing: ChecksAssignTiming,
+  status: BranchStatus,
+): boolean {
+  switch (timing) {
+    case 'never':
+      return false;
+    case 'red':
+      return status === 'red';
+    case 'green':
+      return status === 'green';
+    case 'always':
+      return true;
+  }
+}
+
+function defaultAssigneeTiming(config: BranchConfig): ChecksAssignTiming {
+  if (config.automerge && !config.assignAutomerge) {
+    return 'red';
+  }
+  return 'always';
+}
+
+async function maybeAddAssignees(
+  config: BranchConfig,
+  pr: Pr,
+  status: BranchStatus,
+): Promise<void> {
+  const timing = config.assigneesOnChecks ?? defaultAssigneeTiming(config);
+  if (matchesTiming(timing, status)) {
+    logger.debug(`Setting assignees (timing=${timing}, status=${status})`);
+    await addAssignees(config, pr);
+  } else {
+    logger.debug(`Skipping assignees (timing=${timing}, status=${status})`);
+  }
+}
+
+async function maybeAddReviewers(
+  config: BranchConfig,
+  pr: Pr,
+  status: BranchStatus,
+): Promise<void> {
+  const timing = config.reviewersOnChecks ?? defaultAssigneeTiming(config);
+  if (matchesTiming(timing, status)) {
+    logger.debug(`Setting reviewers (timing=${timing}, status=${status})`);
+    await addReviewers(config, pr);
+  } else {
+    logger.debug(`Skipping reviewers (timing=${timing}, status=${status})`);
+  }
 }
 
 function addPullRequestNoteIfAttestationHasBeenLost(
@@ -389,14 +442,12 @@ export async function ensurePr(
 
       if (
         !existingPr.hasAssignees &&
-        !hasNotIgnoredReviewers(existingPr, config) &&
-        config.automerge &&
-        !config.assignAutomerge &&
-        (await getBranchStatus()) === 'red'
+        !hasNotIgnoredReviewers(existingPr, config)
       ) {
-        logger.debug(`Setting assignees and reviewers as status checks failed`);
-        await addParticipants(config, existingPr);
+        await maybeAddAssignees(config, existingPr, await getBranchStatus());
+        await maybeAddReviewers(config, existingPr, await getBranchStatus());
       }
+
       // Check if existing PR needs updating
       const existingPrTitle = stripEmojis(existingPr.title);
       const existingPrBodyHash = existingPr.bodyStruct?.hash;
@@ -597,17 +648,9 @@ export async function ensurePr(
     }
     // Skip assign and review if automerging PR
     if (pr) {
-      if (
-        config.automerge &&
-        !config.assignAutomerge &&
-        (await getBranchStatus()) !== 'red'
-      ) {
-        logger.debug(
-          `Skipping assignees and reviewers as automerge=${config.automerge}`,
-        );
-      } else {
-        await addParticipants(config, pr);
-      }
+      const status = await getBranchStatus();
+      await maybeAddAssignees(config, pr, status);
+      await maybeAddReviewers(config, pr, status);
       setPrCache(branchName, prBodyFingerprint, true);
       logger.debug(`Created Pull Request #${pr.number}`);
       return { type: 'with-pr', pr };

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -442,7 +442,9 @@ export async function ensurePr(
 
       if (
         !existingPr.hasAssignees &&
-        !hasNotIgnoredReviewers(existingPr, config)
+        !hasNotIgnoredReviewers(existingPr, config) &&
+        config.automerge &&
+        !config.assignAutomerge
       ) {
         await maybeAddAssignees(config, existingPr, await getBranchStatus());
         await maybeAddReviewers(config, existingPr, await getBranchStatus());

--- a/lib/workers/repository/update/pr/participants.ts
+++ b/lib/workers/repository/update/pr/participants.ts
@@ -42,12 +42,12 @@ function prepareParticipants(
   return filterUnavailableUsers(config, normalizedUsernames);
 }
 
-export async function addParticipants(
+export async function addAssignees(
   config: RenovateConfig,
   pr: Pr,
 ): Promise<void> {
   let assignees = config.assignees ?? [];
-  logger.debug(`addParticipants(pr=${pr?.number})`);
+  logger.debug(`addAssignees(pr=${pr?.number})`);
   if (config.assigneesFromCodeOwners) {
     assignees = await addCodeOwners(config, assignees, pr);
   }
@@ -72,7 +72,12 @@ export async function addParticipants(
       );
     }
   }
+}
 
+export async function addReviewers(
+  config: RenovateConfig,
+  pr: Pr,
+): Promise<void> {
   let reviewers = config.reviewers ?? [];
   if (config.reviewersFromCodeOwners) {
     reviewers = await addCodeOwners(config, reviewers, pr);
@@ -113,4 +118,12 @@ export async function addParticipants(
       );
     }
   }
+}
+
+export async function addParticipants(
+  config: RenovateConfig,
+  pr: Pr,
+): Promise<void> {
+  await addAssignees(config, pr);
+  await addReviewers(config, pr);
 }

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -157,6 +157,8 @@ export type CacheFingerprintMatchResult =
   | 'no-match'
   | 'no-fingerprint';
 
+export type ChecksAssignTiming = 'never' | 'red' | 'green' | 'always';
+
 export interface BranchConfig
   extends BranchUpgradeConfig, LegacyAdminConfig, PlatformPrOptions {
   automergeComment?: string;
@@ -196,6 +198,8 @@ export interface BranchConfig
   commitFingerprint?: string;
   cacheFingerprintMatch?: CacheFingerprintMatchResult;
   prNotPendingHours?: number;
+  assigneesOnChecks?: ChecksAssignTiming;
+  reviewersOnChecks?: ChecksAssignTiming;
 }
 
 export interface BranchMetadata {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds two new config options, `assigneesOnChecks` and `reviewersOnChecks`, which let users independently control *when* Renovate adds assignees and reviewers to a PR, relative to branch CI status (`never` / `red` / `green` / `always`).

### Background

Previously, assignee/reviewer timing was a single combined behavior:
- On creation, both roles were always added together immediately, unless `automerge` was enabled (without `assignAutomerge`) and status wasn't red, in which case both were skipped until a later run found the branch red.
- On an existing PR, both roles were only re-evaluated together, and only if `automerge` was enabled (without `assignAutomerge`) and status was red. Otherwise the existing-PR path never touched assignees/reviewers at all, since they'd already been added during creation time.

### What this PR does

- Splits `addParticipants` in `participants.ts` into `addAssignees` and `addReviewers`, callable independently. `addParticipants` remains as a thin wrapper calling both, for any other existing callers.
- Adds `assigneesOnChecks` / `reviewersOnChecks` as optional per-role timing controls (`never` / `red` / `green` / `always`).
- Each role's add/skip decision is evaluated independently, both at PR creation and on subsequent runs against an existing PR e.g. assignees can be added on red (something needs fixing) while reviewers are only added once status turns green (something needs approving).
- **Reachability is also evaluated per-role on existing PRs**, not as a single combined gate. Because Renovate can only observe branch status once it actually runs, a role gated to (say) `'green'` may correctly be skipped at creation time (status yellow during creation) and can only be added later, once a subsequent run observes the status has changed. If the two roles shared one combined presence/reachability check, the role that *was* already added at creation (e.g. an unconfigured assignee, added immediately by default) would permanently block the other role's delayed catch-up from ever running. This defeats the purpose of the feature for the most common use case. Each role's reachability and presence is therefore checked independently.
- **When neither option is set, behavior is unchanged from before this PR.** The original reachability gate (`automerge` enabled, `assignAutomerge` disabled) is preserved verbatim as a fallback for both roles; the new options only widen reachability for existing PRs when explicitly set (checked via `!== undefined`, so an explicit `'never'` is correctly distinguished from "unset").

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Used for writing tests and drafitng this PR

- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository:

I tested against three real GitHub repositories, each running the actual built code against a live outdated dependency (`lodash@4.17.20`), with CI configured to deterministically report red or green status. Debug logs are above the captions. 

<img width="1004" height="184" alt="image" src="https://github.com/user-attachments/assets/4a907a4a-fa59-4318-b8c1-28b7449e07b2" />


1. **[renovate-test-red](https://github.com/Respirayson/renovate-test-red/pull/4)** : `assigneesOnChecks: 'red'`, `reviewersOnChecks: 'green'`, CI forced red.
   Result: assignee added (`timing=red, status=red`), reviewer correctly skipped (`timing=green, status=red`). Confirms each role's timing gate fires independently based on its own configured condition.

<img width="1038" height="206" alt="image" src="https://github.com/user-attachments/assets/109bfb4a-538e-4b0f-a4bf-1b5230684476" />


2. **[renovate-test-green](https://github.com/Respirayson/renovate-test-green/pull/2)** : same config as above, CI forced green.
   Result: assignee correctly skipped (`timing=red, status=green`), reviewer added (`timing=green, status=green`). Same config, opposite branch status, opposite (and correct) outcome for each role. Confirms the two options don't interfere with each other.

<img width="1056" height="250" alt="image" src="https://github.com/user-attachments/assets/3ee76ef2-49c7-429d-93e8-2eaa5b9af9bd" />

3. **[renovate-test-default](https://github.com/Respirayson/renovate-test-default/pull/3)** — no `assigneesOnChecks`/`reviewersOnChecks` set, CI status yellow (pending).
   Result: both assignee and reviewer added immediately (`timing=always, status=yellow`), matching the original/default behavior. Confirms the new options don't change anything for users who don't opt in.






<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
