### PR TITLE
fix(workers/repository): use GlobalConfig for productLinks

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -140,7 +140,6 @@ export interface RenovateSharedConfig {
   prPriority?: number;
   prTitle?: string;
   prTitleStrict?: boolean;
-  productLinks?: Record<string, string>;
   pruneBranchAfterAutomerge?: boolean;
   rangeStrategy?: RangeStrategy;
   rebaseLabel?: string;

--- a/lib/workers/repository/config-migration/pr/index.ts
+++ b/lib/workers/repository/config-migration/pr/index.ts
@@ -7,7 +7,6 @@ import { platform } from '../../../../modules/platform/index.ts';
 import { hashBody } from '../../../../modules/platform/pr-body.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
 import { emojify } from '../../../../util/emoji.ts';
-import { coerceString } from '../../../../util/string.ts';
 import * as template from '../../../../util/template/index.ts';
 import { joinUrlParts } from '../../../../util/url.ts';
 import { getPlatformPrOptions } from '../../update/pr/index.ts';
@@ -23,7 +22,7 @@ export async function ensureConfigMigrationPr(
 ): Promise<Pr | null> {
   logger.debug('ensureConfigMigrationPr()');
   const docsLink = joinUrlParts(
-    coerceString(config.productLinks?.documentation),
+    GlobalConfig.get('productLinks').documentation,
     'configuration-options/#configmigration',
   );
   const branchName = getMigrationBranchName(config);
@@ -52,7 +51,7 @@ ${
 :no_bell: **Ignore**: Close this PR and you won't be reminded about config migration again, but one day your current config may no longer be valid.
 
 :question: Got questions? Does something look wrong to you? Please don't hesitate to [request help here](${
-      config.productLinks?.help
+      GlobalConfig.get('productLinks').help
     }).\n\n`,
   );
 

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -700,7 +700,7 @@ export function getAbandonedPackagesMd(
   abandonedMd += `<summary>View abandoned dependencies (${abandonedCount})</summary>\n\n`;
 
   abandonedMd += emojify('> :information_source: **Note**\n> \n');
-  abandonedMd += `Packages are marked as abandoned when they exceed the [\`abandonmentThreshold\`](${config.productLinks?.documentation}configuration-options/#abandonmentthreshold) since their last release. `;
+  abandonedMd += `Packages are marked as abandoned when they exceed the [\`abandonmentThreshold\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#abandonmentthreshold) since their last release. `;
   abandonedMd +=
     'Unlike deprecated packages with official notices, abandonment is detected by release inactivity.\n> \n';
 
@@ -771,7 +771,7 @@ export async function getDashboardMarkdownVulnerabilities(
   if (isTruthy(config.osvVulnerabilityAlerts)) {
     result += ' CVEs have Renovate fixes.\n\n';
   } else {
-    result += ` CVEs have possible Renovate fixes.\n> See [\`osvVulnerabilityAlerts\`](${config.productLinks?.documentation}configuration-options/#osvvulnerabilityalerts) to allow Renovate to supply fixes.\n\n`;
+    result += ` CVEs have possible Renovate fixes.\n> See [\`osvVulnerabilityAlerts\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#osvvulnerabilityalerts) to allow Renovate to supply fixes.\n\n`;
   }
 
   let renderedVulnerabilities: Vulnerability[];

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -138,7 +138,7 @@ export async function ensureOnboardingPr(
   const rebaseCheckBox = getRebaseCheckbox(config.onboardingRebaseCheckbox);
   logger.debug('Filling in onboarding PR template');
   let prTemplate = `Welcome to [Renovate](${
-    config.productLinks!.homepage
+    GlobalConfig.get('productLinks').homepage
   })! This is an onboarding PR to help you understand and configure settings before regular Pull Requests begin.\n\n`;
   prTemplate +=
     getInheritedOrGlobal('requireConfig') === 'required'
@@ -150,7 +150,7 @@ export async function ensureOnboardingPr(
         );
 
   prTemplate += emojify(
-    `:books: See our [Reading List](${config.productLinks!.documentation}reading-list/) for relevant documentation you may be interested in reading.\n\n`,
+    `:books: See our [Reading List](${GlobalConfig.get('productLinks').documentation}reading-list/) for relevant documentation you may be interested in reading.\n\n`,
   );
 
   const configFile = getDefaultConfigFileName();
@@ -178,10 +178,10 @@ export async function ensureOnboardingPr(
 ---
 
 :question: Got questions? Check out Renovate's [Docs](${
-      config.productLinks!.documentation
+      GlobalConfig.get('productLinks').documentation
     }), particularly the Getting Started section.
 If you need any further assistance then you can also [request help here](${
-      config.productLinks!.help
+      GlobalConfig.get('productLinks').help
     }).
 `,
   );

--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -10,7 +10,6 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
     beforeEach(() => {
       config = partial<RenovateConfig>({
         prHourlyLimit: 2, // default
-        productLinks: { documentation: 'https://docs.renovatebot.com/' },
       });
     });
 

--- a/lib/workers/repository/onboarding/pr/pr-list.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.ts
@@ -1,3 +1,4 @@
+import { GlobalConfig } from '../../../../config/global.ts';
 import type { RenovateConfig } from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import { emojify } from '../../../../util/emoji.ts';
@@ -79,7 +80,7 @@ export function getExpectedPrList(
     prHourlyLimit < branches.length
   ) {
     prDesc += emojify(
-      `\n\n:children_crossing: PR creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](${config.productLinks?.documentation}configuration-options/#prhourlylimit) for details.\n\n`,
+      `\n\n:children_crossing: PR creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#prhourlylimit) for details.\n\n`,
     );
   }
   return prDesc;

--- a/lib/workers/repository/reconfigure/comment.spec.ts
+++ b/lib/workers/repository/reconfigure/comment.spec.ts
@@ -19,11 +19,6 @@ describe('workers/repository/reconfigure/comment', () => {
         errors: [],
         warnings: [],
         description: [],
-        productLinks: {
-          documentation: 'https://docs.renovatebot.com/',
-          help: 'https://github.com/renovatebot/renovate/discussions',
-          homepage: 'https://github.com/renovatebot/renovate',
-        },
       };
       packageFiles = { npm: [{ packageFile: 'package.json', deps: [] }] };
       branches = [];

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1234,7 +1234,6 @@ describe('workers/repository/update/branch/get-updated', () => {
         branchName: 'renovate/pin',
         upgrades: [],
         minimumReleaseAgeBehaviour: 'timestamp-required',
-        productLinks: { documentation: 'https://docs.renovatebot.com/' },
       } satisfies BranchConfig;
       git.getFile.mockResolvedValueOnce('existing content');
     });

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -1,4 +1,5 @@
 import { isNonEmptyArray } from '@sindresorhus/is';
+import { GlobalConfig } from '../../../../config/global.ts';
 import { WORKER_FILE_UPDATE_FAILED } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
 import { extractPackageFile, get } from '../../../../modules/manager/index.ts';
@@ -656,7 +657,7 @@ async function checkForPendingVersions(
       );
       let stderr = `Artifact update for ${depName} resolved to version ${resolvedVersion}, which is a pending version that has not yet passed the Minimum Release Age threshold.`;
       stderr += `\nRenovate was attempting to update to ${expectedVersion}`;
-      stderr += `\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with \`rangeStrategy=pin\` for apps, or \`rangeStrategy=widen\` for libraries)\nSee also: ${config.productLinks?.documentation}dependency-pinning/`;
+      stderr += `\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with \`rangeStrategy=pin\` for apps, or \`rangeStrategy=widen\` for libraries)\nSee also: ${GlobalConfig.get('productLinks').documentation}dependency-pinning/`;
 
       artifactErrors.push({
         fileName: packageFileName,

--- a/lib/workers/repository/update/branch/status-checks.spec.ts
+++ b/lib/workers/repository/update/branch/status-checks.spec.ts
@@ -42,6 +42,29 @@ describe('workers/repository/update/branch/status-checks', () => {
       expect(platform.setBranchStatus).toHaveBeenCalledTimes(1);
     });
 
+    it('uses the productLinks documentation from GlobalConfig for the status url', async () => {
+      config.stabilityStatus = 'green';
+      await setStability(config);
+      expect(platform.setBranchStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://docs.renovatebot.com/key-concepts/minimum-release-age/',
+        }),
+      );
+    });
+
+    it('honours a custom productLinks documentation url', async () => {
+      config.stabilityStatus = 'green';
+      GlobalConfig.set({
+        productLinks: { documentation: 'https://example.com/docs/' },
+      });
+      await setStability(config);
+      expect(platform.setBranchStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://example.com/docs/key-concepts/minimum-release-age/',
+        }),
+      );
+    });
+
     it('skips status if already set', async () => {
       config.stabilityStatus = 'green';
       platform.getBranchStatusCheck.mockResolvedValueOnce('green');
@@ -184,6 +207,17 @@ describe('workers/repository/update/branch/status-checks', () => {
       await setConfidence(config);
       expect(platform.getBranchStatusCheck).toHaveBeenCalledTimes(1);
       expect(platform.setBranchStatus).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the productLinks documentation from GlobalConfig for the status url', async () => {
+      config.minimumConfidence = 'high';
+      config.confidenceStatus = 'green';
+      await setConfidence(config);
+      expect(platform.setBranchStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://docs.renovatebot.com/merge-confidence',
+        }),
+      );
     });
 
     it('skips status if already set', async () => {

--- a/lib/workers/repository/update/branch/status-checks.ts
+++ b/lib/workers/repository/update/branch/status-checks.ts
@@ -6,7 +6,6 @@ import type { BranchStatusConfig } from '../../../../modules/platform/types.ts';
 import type { BranchStatus } from '../../../../types/index.ts';
 import { isActiveConfidenceLevel } from '../../../../util/merge-confidence/index.ts';
 import type { MergeConfidence } from '../../../../util/merge-confidence/types.ts';
-import { coerceString } from '../../../../util/string.ts';
 import { joinUrlParts } from '../../../../util/url.ts';
 
 export async function resolveBranchStatus(
@@ -102,7 +101,7 @@ export async function setStability(config: StabilityConfig): Promise<void> {
       : 'Updates have not met minimum release age requirement';
 
   const docsLink = joinUrlParts(
-    coerceString(config.productLinks?.documentation),
+    GlobalConfig.get('productLinks').documentation,
     'key-concepts/minimum-release-age/',
   );
 
@@ -159,7 +158,7 @@ export async function setConfidence(config: ConfidenceConfig): Promise<void> {
       : 'Updates have not met Merge Confidence requirement';
 
   const docsLink = joinUrlParts(
-    coerceString(config.productLinks?.documentation),
+    GlobalConfig.get('productLinks').documentation,
     'merge-confidence',
   );
 

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -1,5 +1,6 @@
 import { CronPattern } from 'croner';
 import cronstrue from 'cronstrue';
+import { GlobalConfig } from '../../../../../config/global.ts';
 import { emojify } from '../../../../../util/emoji.ts';
 import { capitalize } from '../../../../../util/string.ts';
 import type { BranchConfig } from '../../../../types.ts';
@@ -40,7 +41,7 @@ export function getPrConfigDescription(config: BranchConfig): string {
   prBody += `, or you tick the rebase/retry checkbox.\n\n`;
   if (config.recreateClosed) {
     prBody += emojify(
-      `:ghost: **Immortal**: This PR will be recreated if closed unmerged. Get [config help](${config.productLinks?.help}) if that's undesired.\n\n`,
+      `:ghost: **Immortal**: This PR will be recreated if closed unmerged. Get [config help](${GlobalConfig.get('productLinks').help}) if that's undesired.\n\n`,
     );
   } else {
     prBody += emojify(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

#44098 moved productLinks into `GlobalConfig` and deletes it from the per-repo config, so `config.productLinks` is now `undefined` for unmigrated readers.

Most visibly, `setStability`/`setConfidence` produced a scheme-relative status `target_url` (`key-concepts/minimum-release-age/`) -> GitLab returns HTTP `400` -> throws in `setBranchStatus` -> branch aborts -> no MR. Migrates the remaining 9 readers to `GlobalConfig.get('productLinks')`, completing #44098; drops redundant `coerceString`/`!`.

Background: discussion #44110.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
