### PR TITLE
fix(platform/azure): avoid corrupting HTML entities and URL anchors in massageMarkdown

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1636,6 +1636,19 @@ describe('modules/platform/azure/index', () => {
         'You can manually request rebase by renaming the PR to start with "rebase!".\n\nplus also [a link](https://github.com/foo/bar/issues/5)',
       );
     });
+
+    it('converts standalone PR references to Azure format', () => {
+      expect(azure.massageMarkdown('see #123 and (#456)')).toBe(
+        'see !123 and (!456)',
+      );
+    });
+
+    it('does not corrupt HTML entities or URL anchors', () => {
+      const input =
+        '[#&#8203;32124](https://github.com/org/repo/issues/32124) ' +
+        '[`v4.78.0`](https://github.com/org/repo/blob/HEAD/CHANGELOG.md#4780-june-18-2026)';
+      expect(azure.massageMarkdown(input)).toBe(input);
+    });
   });
 
   describe('setBranchStatus', () => {

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -893,8 +893,10 @@ export function massageMarkdown(input: string): string {
       .replace(regEx(/<!--renovate-(?:debug|config-hash):.*?-->/g), '')
       // Replace GitHub-style PR links with Azure DevOps format
       .replace(regEx(/\]\(\.\.\/pull\//g), '](!')
-      // Replace GitHub-style PR references (#123) with Azure DevOps format, needed for text linking config migration PR
-      .replace(regEx(/#(\d+)/g), '!$1')
+      // Replace GitHub-style PR references (#123) with Azure DevOps format, needed for text linking config migration PR.
+      // Only match a standalone reference (preceded by start, whitespace or `(`) so we don't corrupt
+      // HTML entities like `&#8203;` or URL anchors like `CHANGELOG.md#4780`.
+      .replace(regEx(/(^|[\s(])#(\d+)/g), '$1!$2')
   );
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

`massageMarkdown` in the Azure DevOps platform converts GitHub-style PR
references (`#123`) to Azure's `!123` format. The regex `/#(\d+)/g` (added in
#42758) matches **any** `#` followed by digits, so it also corrupts content that
legitimately contains `#<digits>`:

- HTML numeric entities — `&#8203;` (the zero-width space inserted by
  `util/markdown.ts` to stop issue auto-linking) becomes `&!8203;`, rendering as
  literal junk before every issue number in release notes.
- Changelog URL anchors — `…/CHANGELOG.md#4780-june-18-2026` becomes
  `…/CHANGELOG.md!4780-…`, breaking the deep-link.

Fix: only convert a **standalone** reference — preceded by start-of-string,
whitespace, or `(` — reusing the same boundary `util/markdown.ts` already uses:

```diff
- .replace(regEx(/#(\d+)/g), '!$1')
+ .replace(regEx(/(^|[\s(])#(\d+)/g), '$1!$2')
```

Genuine references (#123, (#456), line-leading #789) still convert, while
&#8203; entities and URL anchors are left intact. Added regression tests.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
