### PR TITLE
feat(platform/azure): make work item type and states configurable

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -339,6 +339,32 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.
 
+## `azureWorkItem`
+
+Configures the Azure Boards work item that Renovate uses to represent issues, such as the Dependency Dashboard.
+
+| Subkey        | Default  | Description                                                        |
+| ------------- | -------- | ----------------------------------------------------------------- |
+| `type`        | `Issue`  | The work item type, e.g. `Issue`, `Task` or `User Story`.         |
+| `openState`   | `New`    | The state Renovate sets when it creates or reopens the work item. |
+| `closedState` | `Closed` | The state Renovate sets when it closes the work item.             |
+
+Set this if your Azure DevOps process does not use the default `Issue` type or `New`/`Closed` states.
+For example, a Basic process uses `Issue` work items with `To Do`/`Done` states:
+
+```json
+{
+  "azureWorkItem": {
+    "type": "Issue",
+    "openState": "To Do",
+    "closedState": "Done"
+  }
+}
+```
+
+This option is `mergeable`, so you can override just one subkey while keeping the defaults for the others.
+The user that Renovate runs as must have permission to create and edit work items of the configured type.
+
 ## `azureWorkItemId`
 
 When creating a PR in Azure DevOps, some branches can be protected with branch policies to [check for linked work items](https://learn.microsoft.com/azure/devops/repos/git/branch-policies#check-for-linked-work-items).

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -342,14 +342,7 @@ If you're not already using `bors-ng` or similar, don't worry about this option.
 ## `azureWorkItem`
 
 Configures the Azure Boards work item that Renovate uses to represent issues, such as the Dependency Dashboard.
-
-| Subkey        | Default  | Description                                                       |
-| ------------- | -------- | ----------------------------------------------------------------- |
-| `type`        | `Issue`  | The work item type, e.g. `Issue`, `Task` or `User Story`.         |
-| `openState`   | `New`    | The state Renovate sets when it creates or reopens the work item. |
-| `closedState` | `Closed` | The state Renovate sets when it closes the work item.             |
-
-Set this if your Azure DevOps process does not use the default `Issue` type or `New`/`Closed` states.
+Set this if your Azure DevOps process does not use the default `Issue` work item type or the `New`/`Closed` states.
 For example, a Basic process uses `Issue` work items with `To Do`/`Done` states:
 
 ```json
@@ -364,6 +357,18 @@ For example, a Basic process uses `Issue` work items with `To Do`/`Done` states:
 
 This option is `mergeable`, so you can override just one subkey while keeping the defaults for the others.
 The user that Renovate runs as must have permission to create and edit work items of the configured type.
+
+### `azureWorkItem.closedState`
+
+The work item state Renovate sets when it closes an issue, for example `Closed` or `Done`.
+
+### `azureWorkItem.openState`
+
+The work item state Renovate sets when it opens or reopens an issue, for example `New` or `To Do`.
+
+### `azureWorkItem.type`
+
+The work item type Renovate creates for issues, for example `Issue`, `Task` or `User Story`.
 
 ## `azureWorkItemId`
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -343,7 +343,7 @@ If you're not already using `bors-ng` or similar, don't worry about this option.
 
 Configures the Azure Boards work item that Renovate uses to represent issues, such as the Dependency Dashboard.
 
-| Subkey        | Default  | Description                                                        |
+| Subkey        | Default  | Description                                                       |
 | ------------- | -------- | ----------------------------------------------------------------- |
 | `type`        | `Issue`  | The work item type, e.g. `Issue`, `Task` or `User Story`.         |
 | `openState`   | `New`    | The state Renovate sets when it creates or reopens the work item. |

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1459,8 +1459,7 @@ const options: Readonly<RenovateOptions>[] = [
   },
   {
     name: 'closedState',
-    description:
-      'The work item state Renovate sets when it closes an issue.',
+    description: 'The work item state Renovate sets when it closes an issue.',
     type: 'string',
     parents: ['azureWorkItem'],
     supportedPlatforms: ['azure'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1424,6 +1424,22 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
   },
   {
+    name: 'azureWorkItem',
+    description:
+      'Configures the Azure Boards work item Renovate uses to represent issues, such as the Dependency Dashboard: its `type` and the `openState`/`closedState` used when opening and closing it.',
+    type: 'object',
+    mergeable: true,
+    default: {
+      type: 'Issue',
+      openState: 'New',
+      closedState: 'Closed',
+    },
+    additionalProperties: {
+      type: 'string',
+    },
+    supportedPlatforms: ['azure'],
+  },
+  {
     name: 'azureWorkItemId',
     description:
       'The id of an existing work item on Azure Boards to link to each PR.',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1428,16 +1428,44 @@ const options: Readonly<RenovateOptions>[] = [
     description:
       'Configures the Azure Boards work item Renovate uses to represent issues, such as the Dependency Dashboard: its `type` and the `openState`/`closedState` used when opening and closing it.',
     type: 'object',
+    stage: 'repository',
     mergeable: true,
     default: {
       type: 'Issue',
       openState: 'New',
       closedState: 'Closed',
     },
-    additionalProperties: {
-      type: 'string',
-    },
     supportedPlatforms: ['azure'],
+  },
+  {
+    name: 'type',
+    description:
+      'The Azure Boards work item type Renovate creates for issues, such as the Dependency Dashboard.',
+    type: 'string',
+    parents: ['azureWorkItem'],
+    supportedPlatforms: ['azure'],
+    cli: false,
+    env: false,
+  },
+  {
+    name: 'openState',
+    description:
+      'The work item state Renovate sets when it opens or reopens an issue.',
+    type: 'string',
+    parents: ['azureWorkItem'],
+    supportedPlatforms: ['azure'],
+    cli: false,
+    env: false,
+  },
+  {
+    name: 'closedState',
+    description:
+      'The work item state Renovate sets when it closes an issue.',
+    type: 'string',
+    parents: ['azureWorkItem'],
+    supportedPlatforms: ['azure'],
+    cli: false,
+    env: false,
   },
   {
     name: 'azureWorkItemId',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -32,6 +32,20 @@ export type RenovateConfigStage =
   | 'branch'
   | 'pr';
 
+/**
+ * Describes the Azure DevOps work item Renovate uses to represent issues
+ * (such as the Dependency Dashboard): its work item type and the state names
+ * used when Renovate opens/reopens and closes it.
+ */
+export interface AzureWorkItem {
+  /** Work item type, e.g. `Issue`, `Task` or `User Story`. */
+  type: string;
+  /** State applied when opening or reopening a work item, e.g. `New`. */
+  openState: string;
+  /** State applied when closing a work item, e.g. `Closed`. */
+  closedState: string;
+}
+
 export type RenovateSplit =
   | 'init'
   | 'onboarding'
@@ -78,6 +92,7 @@ export interface RenovateSharedConfig {
   automergeStrategy?: MergeStrategy;
   automergeType?: AutoMergeType;
   azureWorkItemId?: number;
+  azureWorkItem?: AzureWorkItem;
   branchName?: string;
   branchNameStrict?: boolean;
   branchPrefix?: string;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -637,6 +637,7 @@ export interface ValidationMessage {
 
 export type AllowedParents =
   | '.'
+  | 'azureWorkItem'
   | 'bumpVersions'
   | 'customDatasources'
   | 'customManagers'

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -2199,6 +2199,47 @@ describe('modules/platform/azure/index', () => {
       'Issue',
     );
   });
+
+  it('ensureIssue creates a new issue with a configured work item', async () => {
+    await initRepo({
+      repository: 'some/repo',
+      azureWorkItem: { type: 'Task', openState: 'To Do', closedState: 'Done' },
+    });
+
+    const createWorkItemMock = vi.fn().mockResolvedValue({
+      id: 123,
+    });
+
+    azureApi.workItemTrackingApi.mockResolvedValueOnce(
+      partial<IWorkItemTrackingApi>({
+        queryByWiql: vi.fn().mockResolvedValue({ workItems: [] }),
+        createWorkItem: createWorkItemMock,
+      }),
+    );
+    const result = await azure.ensureIssue({
+      title: 'Test Issue',
+      body: 'Test body',
+    });
+    expect(result).toBe('created');
+    expect(createWorkItemMock).toHaveBeenCalledWith(
+      undefined, // no headers
+      expect.arrayContaining([
+        expect.objectContaining({
+          op: 'add',
+          path: '/fields/System.WorkItemType',
+          value: 'Task',
+        }),
+        expect.objectContaining({
+          op: 'add',
+          path: '/fields/System.State',
+          value: 'To Do',
+        }),
+      ]),
+      'some',
+      'Task',
+    );
+  });
+
   it('ensureIssue updates an existing issue', async () => {
     await initRepo({ repository: 'some/repo' });
 

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -199,6 +199,7 @@ export async function initRepo({
   repository,
   cloneSubmodules,
   cloneSubmodulesFilter,
+  azureWorkItem,
 }: RepoParams): Promise<RepoResult> {
   logger.debug(`initRepo("${repository}")`);
   config = { repository } as Config;
@@ -223,6 +224,11 @@ export async function initRepo({
   config.repoId = repo.id!;
 
   config.project = repo.project!.name!;
+  config.workItem = {
+    type: azureWorkItem?.type ?? 'Issue',
+    openState: azureWorkItem?.openState ?? 'New',
+    closedState: azureWorkItem?.closedState ?? 'Closed',
+  };
   issueService = new IssueService(config);
   config.owner = '?owner?';
   logger.debug(`${repository} owner = ${config.owner}`);

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -28,6 +28,7 @@ describe('modules/platform/azure/issue', () => {
       repository: 'test/repo',
       project: 'testProject',
       repoId: '123',
+      workItem: { type: 'Issue', openState: 'New', closedState: 'Closed' },
     } as Config;
 
     issueService = new IssueService(config);
@@ -121,6 +122,37 @@ describe('modules/platform/azure/issue', () => {
 
       expect(queryByWiqlMock.mock.calls[0][0].query).toContain(
         "AND [System.Title] = 'Test''s Filter'",
+      );
+    });
+
+    it('should query for the default work item type', async () => {
+      const queryByWiqlMock = vi.fn().mockResolvedValue({ workItems: [] });
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          queryByWiql: queryByWiqlMock,
+        }),
+      );
+
+      await issueService.getIssueList();
+
+      expect(queryByWiqlMock.mock.calls[0][0].query).toContain(
+        "[System.WorkItemType] = 'Issue'",
+      );
+    });
+
+    it('should query for the configured work item type', async () => {
+      config.workItem.type = 'Task';
+      const queryByWiqlMock = vi.fn().mockResolvedValue({ workItems: [] });
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          queryByWiql: queryByWiqlMock,
+        }),
+      );
+
+      await issueService.getIssueList();
+
+      expect(queryByWiqlMock.mock.calls[0][0].query).toContain(
+        "[System.WorkItemType] = 'Task'",
       );
     });
 
@@ -317,8 +349,71 @@ describe('modules/platform/azure/issue', () => {
         body: 'Test body content',
       });
 
-      expect(createWorkItemMock).toHaveBeenCalled();
+      expect(createWorkItemMock).toHaveBeenCalledWith(
+        undefined,
+        expect.arrayContaining([
+          { op: 'add', path: '/fields/System.WorkItemType', value: 'Issue' },
+        ]),
+        'testProject',
+        'Issue',
+      );
       expect(result).toEqual('created');
+    });
+
+    it('should create new issue with the configured work item type', async () => {
+      config.workItem = { type: 'Task', openState: 'To Do', closedState: 'Done' };
+      vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
+
+      const createWorkItemMock = vi.fn().mockResolvedValue({ id: 123 });
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          createWorkItem: createWorkItemMock,
+        }),
+      );
+
+      const result = await issueService.ensureIssue({
+        title: 'Test Issue',
+        body: 'Test body content',
+      });
+
+      expect(createWorkItemMock).toHaveBeenCalledWith(
+        undefined,
+        expect.arrayContaining([
+          { op: 'add', path: '/fields/System.WorkItemType', value: 'Task' },
+          { op: 'add', path: '/fields/System.State', value: 'To Do' },
+        ]),
+        'testProject',
+        'Task',
+      );
+      expect(result).toEqual('created');
+    });
+
+    it('should close an issue using the configured closed state', async () => {
+      config.workItem = { type: 'Task', openState: 'To Do', closedState: 'Done' };
+      const mockIssue = {
+        number: 1,
+        title: '[Renovate] Test Issue',
+        state: 'open',
+        body: 'Test description',
+      };
+
+      vi.spyOn(issueService, 'findIssue').mockResolvedValue(mockIssue);
+
+      const updateWorkItemMock = vi.fn();
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          updateWorkItem: updateWorkItemMock,
+        }),
+      );
+
+      await issueService.ensureIssueClosing('Test Issue');
+
+      expect(updateWorkItemMock).toHaveBeenCalledWith(
+        undefined,
+        [{ op: 'replace', path: '/fields/System.State', value: 'Done' }],
+        1,
+        'testProject',
+      );
     });
 
     it('should reopen closed issue when shouldReOpen is true', async () => {

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -361,7 +361,11 @@ describe('modules/platform/azure/issue', () => {
     });
 
     it('should create new issue with the configured work item type', async () => {
-      config.workItem = { type: 'Task', openState: 'To Do', closedState: 'Done' };
+      config.workItem = {
+        type: 'Task',
+        openState: 'To Do',
+        closedState: 'Done',
+      };
       vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
 
       const createWorkItemMock = vi.fn().mockResolvedValue({ id: 123 });
@@ -389,7 +393,11 @@ describe('modules/platform/azure/issue', () => {
     });
 
     it('should close an issue using the configured closed state', async () => {
-      config.workItem = { type: 'Task', openState: 'To Do', closedState: 'Done' };
+      config.workItem = {
+        type: 'Task',
+        openState: 'To Do',
+        closedState: 'Done',
+      };
       const mockIssue = {
         number: 1,
         title: '[Renovate] Test Issue',

--- a/lib/modules/platform/azure/issue.ts
+++ b/lib/modules/platform/azure/issue.ts
@@ -30,10 +30,11 @@ export class IssueService {
     try {
       const azureApiWit = await azureApi.workItemTrackingApi();
 
+      const escapedWorkItemType = this.config.workItem.type.replace(/'/g, "''");
       let wiql = `
         SELECT [System.Id]
         FROM WorkItems
-        WHERE [System.WorkItemType] = 'Issue'
+        WHERE [System.WorkItemType] = '${escapedWorkItemType}'
           AND [System.TeamProject] = '${this.config.project}'
       `;
 
@@ -62,7 +63,10 @@ export class IssueService {
       return workItems.map((wi: WorkItem) => ({
         number: wi.id!,
         title: wi.fields!['System.Title'],
-        state: wi.fields!['System.State'] === 'Closed' ? 'closed' : 'open',
+        state:
+          wi.fields!['System.State'] === this.config.workItem.closedState
+            ? 'closed'
+            : 'open',
         body: wi.fields!['System.Description'],
         createdAt: wi.fields!['System.CreatedDate'],
         lastModified: wi.fields!['System.ChangedDate'],
@@ -81,7 +85,13 @@ export class IssueService {
         const azureApiWit = await azureApi.workItemTrackingApi();
         await azureApiWit.updateWorkItem(
           undefined,
-          [{ op: 'replace', path: '/fields/System.State', value: 'Closed' }],
+          [
+            {
+              op: 'replace',
+              path: '/fields/System.State',
+              value: this.config.workItem.closedState,
+            },
+          ],
           issue.number,
           this.config.project,
         );
@@ -117,7 +127,7 @@ export class IssueService {
                 {
                   op: 'replace',
                   path: '/fields/System.State',
-                  value: 'Closed',
+                  value: this.config.workItem.closedState,
                 },
               ],
               issueNumber,
@@ -144,7 +154,11 @@ export class IssueService {
           await azureApiWit.updateWorkItem(
             undefined,
             [
-              { op: 'replace', path: '/fields/System.State', value: 'New' },
+              {
+                op: 'replace',
+                path: '/fields/System.State',
+                value: this.config.workItem.openState,
+              },
               {
                 op: 'replace',
                 path: '/fields/System.Title',
@@ -210,7 +224,11 @@ export class IssueService {
       const newWorkItem = await azureApiWit.createWorkItem(
         undefined,
         [
-          { op: 'add', path: '/fields/System.WorkItemType', value: 'Issue' },
+          {
+            op: 'add',
+            path: '/fields/System.WorkItemType',
+            value: this.config.workItem.type,
+          },
           { op: 'add', path: '/fields/System.Title', value: finalTitle },
           {
             op: 'add',
@@ -222,10 +240,14 @@ export class IssueService {
             path: '/multilineFieldsFormat/System.Description',
             value: 'Markdown',
           },
-          { op: 'add', path: '/fields/System.State', value: 'New' },
+          {
+            op: 'add',
+            path: '/fields/System.State',
+            value: this.config.workItem.openState,
+          },
         ],
         this.config.project,
-        'Issue',
+        this.config.workItem.type,
       );
 
       logger.debug(`Created new issue #${newWorkItem.id}`);

--- a/lib/modules/platform/azure/readme.md
+++ b/lib/modules/platform/azure/readme.md
@@ -196,6 +196,24 @@ Make sure the user has the following permissions on the work item's _area path_:
 
 If the user does not have these permissions, Renovate still creates a PR but it won't have a link to the work item.
 
+### Configuring the work item used for issues
+
+When Renovate creates issues on Azure Boards (for example the Dependency Dashboard) it creates a work item of type `Issue` with the states `New` (open) and `Closed` (closed) by default.
+If your Azure DevOps process does not use those, configure the `azureWorkItem` option:
+
+```json
+{
+  "azureWorkItem": {
+    "type": "Task",
+    "openState": "To Do",
+    "closedState": "Done"
+  }
+}
+```
+
+The option is mergeable, so you can override just `type`, `openState` or `closedState` and keep the defaults for the rest.
+The user that Renovate runs as must have permission to create and edit work items of the configured type.
+
 ### Adding tags to Pull Requests
 
 Tags can be added to Pull Requests using the `labels` or `addLabels` configurations.

--- a/lib/modules/platform/azure/types.ts
+++ b/lib/modules/platform/azure/types.ts
@@ -1,4 +1,5 @@
 import type { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
+import type { AzureWorkItem } from '../../../config/types.ts';
 import type { Pr } from '../types.ts';
 
 export interface AzurePr extends Pr {
@@ -23,4 +24,5 @@ export interface Config {
   fileList: null;
   repository: string;
   defaultBranch: string;
+  workItem: AzureWorkItem;
 }

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -1,5 +1,5 @@
 import type { DateTime } from 'luxon';
-import type { MergeStrategy } from '../../config/types.ts';
+import type { AzureWorkItem, MergeStrategy } from '../../config/types.ts';
 import type { BranchStatus, HostRule } from '../../types/index.ts';
 import type { CommitFilesConfig } from '../../util/git/types.ts';
 import type { LongCommitSha } from '../../util/schema-utils/git.ts';
@@ -44,6 +44,7 @@ export interface RepoParams {
   renovateUsername?: string;
   cloneSubmodules?: boolean;
   cloneSubmodulesFilter?: string[];
+  azureWorkItem?: AzureWorkItem;
 }
 
 export interface PrDebugData {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Add the `azureWorkItem` config option so Renovate's Azure Boards issues (such as the Dependency Dashboard) can use a work item type and open/closed state names other than the hard-coded Issue/New/Closed.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
