### PR TITLE
feat(datasource/gitlab-tags): replace getJsonUnchecked with validated getJson

### DIFF
--- a/lib/modules/datasource/gitlab-tags/index.spec.ts
+++ b/lib/modules/datasource/gitlab-tags/index.spec.ts
@@ -11,15 +11,23 @@ describe('modules/datasource/gitlab-tags/index', () => {
         {
           name: 'v1.0.0',
           commit: {
+            id: 'abc100',
             created_at: '2020-03-04T12:01:37.000-06:00',
           },
         },
         {
           name: 'v1.1.0',
-          commit: {},
+          commit: {
+            id: 'abc110',
+            created_at: '',
+          },
         },
         {
           name: 'v1.1.1',
+          commit: {
+            id: 'abc111',
+            created_at: '',
+          },
         },
       ];
       httpMock
@@ -40,15 +48,23 @@ describe('modules/datasource/gitlab-tags/index', () => {
         {
           name: 'v1.0.0',
           commit: {
+            id: 'abc100',
             created_at: '2020-03-04T12:01:37.000-06:00',
           },
         },
         {
           name: 'v1.1.0',
-          commit: {},
+          commit: {
+            id: 'abc110',
+            created_at: '',
+          },
         },
         {
           name: 'v1.1.1',
+          commit: {
+            id: 'abc111',
+            created_at: '',
+          },
         },
       ];
       httpMock
@@ -65,7 +81,10 @@ describe('modules/datasource/gitlab-tags/index', () => {
     });
 
     it('returns tags with default registry', async () => {
-      const body = [{ name: 'v1.0.0' }, { name: 'v1.1.0' }];
+      const body = [
+        { name: 'v1.0.0', commit: { id: 'abc100', created_at: '' } },
+        { name: 'v1.1.0', commit: { id: 'abc110', created_at: '' } },
+      ];
       httpMock
         .scope('https://gitlab.com')
         .get('/api/v4/projects/some%2Fdep2/repository/tags?per_page=100')
@@ -85,6 +104,7 @@ describe('modules/datasource/gitlab-tags/index', () => {
       const body = [
         {
           id: digest,
+          created_at: '2020-03-04T12:01:37.000-06:00',
         },
       ];
       httpMock
@@ -103,6 +123,7 @@ describe('modules/datasource/gitlab-tags/index', () => {
       const digest = 'abcd00001234';
       const body = {
         id: digest,
+        created_at: '2020-03-04T12:01:37.000-06:00',
       };
       httpMock
         .scope('https://gitlab.company.com')

--- a/lib/modules/datasource/gitlab-tags/index.ts
+++ b/lib/modules/datasource/gitlab-tags/index.ts
@@ -9,7 +9,7 @@ import type {
   GetReleasesConfig,
   ReleaseResult,
 } from '../types.ts';
-import type { GitlabCommit, GitlabTag } from './types.ts';
+import { GitlabCommit, GitlabCommits, GitlabTags } from './schema.ts';
 import { defaultRegistryUrl, getDepHost, getSourceUrl } from './util.ts';
 
 export class GitlabTagsDatasource extends Datasource {
@@ -48,9 +48,7 @@ export class GitlabTagsDatasource extends Datasource {
     );
 
     const gitlabTags = (
-      await this.http.getJsonUnchecked<GitlabTag[]>(url, {
-        paginate: true,
-      })
+      await this.http.getJson(url, { paginate: true }, GitlabTags)
     ).body;
 
     const dependency: ReleaseResult = {
@@ -60,7 +58,7 @@ export class GitlabTagsDatasource extends Datasource {
     dependency.releases = gitlabTags.map(({ name, commit }) => ({
       version: name,
       gitRef: name,
-      releaseTimestamp: asTimestamp(commit?.created_at),
+      releaseTimestamp: asTimestamp(commit.created_at),
     }));
 
     return dependency;
@@ -100,9 +98,8 @@ export class GitlabTagsDatasource extends Datasource {
           `repository/commits/`,
           newValue,
         );
-        const gitlabCommits =
-          await this.http.getJsonUnchecked<GitlabCommit>(url);
-        digest = gitlabCommits.body.id;
+        const gitlabCommit = await this.http.getJson(url, GitlabCommit);
+        digest = gitlabCommit.body.id;
       } else {
         const url = joinUrlParts(
           depHost,
@@ -110,8 +107,7 @@ export class GitlabTagsDatasource extends Datasource {
           urlEncodedRepo,
           `repository/commits?per_page=1`,
         );
-        const gitlabCommits =
-          await this.http.getJsonUnchecked<GitlabCommit[]>(url);
+        const gitlabCommits = await this.http.getJson(url, GitlabCommits);
         digest = gitlabCommits.body[0].id;
       }
     } catch (err) {

--- a/lib/modules/datasource/gitlab-tags/schema.ts
+++ b/lib/modules/datasource/gitlab-tags/schema.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod/v4';
+
+export const GitlabCommit = z.object({
+  id: z.string(),
+  created_at: z.string(),
+});
+export type GitlabCommit = z.infer<typeof GitlabCommit>;
+
+export const GitlabCommits = z.array(GitlabCommit);
+export type GitlabCommits = z.infer<typeof GitlabCommits>;
+
+export const GitlabTag = z.object({
+  name: z.string(),
+  commit: GitlabCommit,
+});
+export type GitlabTag = z.infer<typeof GitlabTag>;
+
+export const GitlabTags = z.array(GitlabTag);

--- a/lib/modules/datasource/go/releases-direct.spec.ts
+++ b/lib/modules/datasource/go/releases-direct.spec.ts
@@ -136,7 +136,10 @@ describe('modules/datasource/go/releases-direct', () => {
       httpMock
         .scope('https://gitlab.com/')
         .get('/api/v4/projects/golang%2Ftext/repository/tags?per_page=100')
-        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }]);
+        .reply(200, [
+          { name: 'v1.0.0', commit: { id: 'aaa100', created_at: '' } },
+          { name: 'v2.0.0', commit: { id: 'aaa200', created_at: '' } },
+        ]);
       const res = await datasource.getReleases({
         packageName: 'golang.org/x/text',
       });
@@ -235,7 +238,10 @@ describe('modules/datasource/go/releases-direct', () => {
       httpMock
         .scope('https://my.custom.domain/')
         .get('/api/v4/projects/golang%2Fmyrepo/repository/tags?per_page=100')
-        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }]);
+        .reply(200, [
+          { name: 'v1.0.0', commit: { id: 'aaa100', created_at: '' } },
+          { name: 'v2.0.0', commit: { id: 'aaa200', created_at: '' } },
+        ]);
       const res = await datasource.getReleases({
         packageName: 'my.custom.domain/golang/myrepo',
       });
@@ -335,7 +341,10 @@ describe('modules/datasource/go/releases-direct', () => {
         .get(
           '/api/v4/projects/group%2Fsubgroup%2Frepo/repository/tags?per_page=100',
         )
-        .reply(200, [{ name: 'v1.0.0' }, { name: 'v2.0.0' }]);
+        .reply(200, [
+          { name: 'v1.0.0', commit: { id: 'aaa100', created_at: '' } },
+          { name: 'v2.0.0', commit: { id: 'aaa200', created_at: '' } },
+        ]);
       const res = await datasource.getReleases({
         packageName: 'gitlab.com/group/subgroup/repo',
       });

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
@@ -110,12 +110,12 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         .scope(matchHost)
         .get('/api/v4/projects/meno%2Fdropzone/repository/tags?per_page=100')
         .reply(200, [
-          { name: 'v5.2.0' },
-          { name: 'v5.4.0' },
-          { name: 'v5.5.0' },
-          { name: 'v5.6.0' },
-          { name: 'v5.6.1' },
-          { name: 'v5.7.0' },
+          { name: 'v5.2.0', commit: { id: 'aaa520', created_at: '' } },
+          { name: 'v5.4.0', commit: { id: 'aaa540', created_at: '' } },
+          { name: 'v5.5.0', commit: { id: 'aaa550', created_at: '' } },
+          { name: 'v5.6.0', commit: { id: 'aaa560', created_at: '' } },
+          { name: 'v5.6.1', commit: { id: 'aaa561', created_at: '' } },
+          { name: 'v5.7.0', commit: { id: 'aaa570', created_at: '' } },
         ])
         .persist()
         .get('/api/v4/projects/meno%2Fdropzone/repository/tree?per_page=100')
@@ -339,9 +339,9 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         .scope('https://git.test.com/')
         .get('/api/v4/projects/some%2Frepo/repository/tags?per_page=100')
         .reply(200, [
-          { name: 'v5.2.0' },
-          { name: 'v5.4.0' },
-          { name: 'v5.5.0' },
+          { name: 'v5.2.0', commit: { id: 'aaa520', created_at: '' } },
+          { name: 'v5.4.0', commit: { id: 'aaa540', created_at: '' } },
+          { name: 'v5.5.0', commit: { id: 'aaa550', created_at: '' } },
         ]);
       expect(
         await changelogSource.getAllTags('https://git.test.com/', 'some/repo'),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Validate API requests using schemas for `gitlab-tags` 

The go datasource embeds GitlabTagsDatasource, so its test mocks are updated to satisfy the stricter GitlabTag schema (commit.id/created_at).

<!-- Describe what behavior is changed by this PR. -->

## Context

This is split of from https://github.com/renovatebot/renovate/pull/44142

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
