### PR TITLE
feat(datasource/gitlab-releases): replace getJsonUnchecked with validated getJson

### DIFF
--- a/lib/modules/datasource/gitlab-releases/index.ts
+++ b/lib/modules/datasource/gitlab-releases/index.ts
@@ -3,7 +3,7 @@ import { GitlabHttp } from '../../../util/http/gitlab.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
-import type { GitlabRelease } from './types.ts';
+import { GitlabReleases } from './schema.ts';
 
 export class GitlabReleasesDatasource extends Datasource {
   static readonly id = 'gitlab-releases';
@@ -38,7 +38,7 @@ export class GitlabReleasesDatasource extends Datasource {
 
     try {
       const gitlabReleasesResponse = (
-        await this.http.getJsonUnchecked<GitlabRelease[]>(apiUrl)
+        await this.http.getJson(apiUrl, GitlabReleases)
       ).body;
 
       return {

--- a/lib/modules/datasource/gitlab-releases/schema.ts
+++ b/lib/modules/datasource/gitlab-releases/schema.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod/v4';
+import { DeepNullish } from '../../../util/schema-utils/index.ts';
+
+export const GitlabRelease = DeepNullish(
+  z.object({
+    description: z.string().optional().default(''),
+    name: z.string().optional().default(''),
+    tag_name: z.string(),
+    released_at: z.string(),
+  }),
+);
+export type GitlabRelease = z.infer<typeof GitlabRelease>;
+
+export const GitlabReleases = z.array(GitlabRelease);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Use Zod schemas for validating API requests in the `gitlab-releases` datasource 

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
