### PR TITLE
fix: initialise logger before proxy

### DIFF
--- a/lib/renovate.ts
+++ b/lib/renovate.ts
@@ -8,12 +8,6 @@ void (async (): Promise<void> => {
   // This has to be imported before logger and other libraries which are instrumented.
   const otel = await import('./instrumentation/index.ts');
   otel.init();
-  (await import('./proxy.ts')).bootstrap();
-
-  // prints and exits the process if --version or --help is passed
-  const { parseEarlyFlags } =
-    await import('./workers/global/config/parse/cli.ts');
-  parseEarlyFlags();
 
   const logger = await import('./logger/index.ts');
   /* v8 ignore next -- not easily testable */
@@ -21,6 +15,14 @@ void (async (): Promise<void> => {
     logger.logger.error({ err }, 'unhandledRejection');
   });
   await logger.init();
+
+  (await import('./proxy.ts')).bootstrap();
+
+  // prints and exits the process if --version or --help is passed
+  const { parseEarlyFlags } =
+    await import('./workers/global/config/parse/cli.ts');
+
+  parseEarlyFlags();
 
   const { start } = await import('./workers/global/index.ts');
   process.exitCode = await otel.instrument('run', start);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As noted in #44128 and
https://github.com/mend/renovate-ce-ee/issues/879, without this change,
we see a `Renovate's logger has not yet been initialized` warning, which
isn't necessary as we can reorder these.

Before:

```
% env LOG_LEVEL=debug HTTP_PROXY=foo node lib/renovate.ts
⚠️ NOTE ⚠️: Renovate's logger has not yet been initialized. If you see no other output, this is a bug
DEBUG: Detected HTTP_PROXY value in env
 INFO: Renovate started
       "renovateVersion": "0.0.0-semantic-release"
 WARN: RE2 not usable, falling back to RegExp
...
```

After:

```
jamietanna@caerbannog renovate (git)-[fix/logger] % env LOG_LEVEL=debug HTTP_PROXY=foo node lib/renovate.ts
DEBUG: Detected HTTP_PROXY value in env
 INFO: Renovate started
       "renovateVersion": "0.0.0-semantic-release"
 WARN: RE2 not usable, falling back to RegExp
       "err": {
...
```
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
