### PR TITLE
chore(util/exec): log the environment variable names when exerting a command

### DIFF
--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -1084,6 +1084,19 @@ describe('util/exec/index', () => {
     await expect(promise).rejects.toThrow('No tool releases found.');
   });
 
+  it('logs "Executing command" with the command', async () => {
+    process.env = processEnv;
+    cpExec.mockResolvedValue({ stdout: '', stderr: '' });
+    GlobalConfig.set({ ...globalConfig, localDir: cwd });
+
+    await exec(inCmd);
+
+    expect(logger.logger.debug).toHaveBeenCalledWith(
+      { command: inCmd },
+      'Executing command',
+    );
+  });
+
   it('logs ignored tool constraints for binarySource=global', async () => {
     process.env = processEnv;
     cpExec.mockResolvedValue({ stdout: '', stderr: '' });

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -1084,7 +1084,7 @@ describe('util/exec/index', () => {
     await expect(promise).rejects.toThrow('No tool releases found.');
   });
 
-  it('logs "Executing command" with the command', async () => {
+  it('logs "Executing command" with the command and environment variable names', async () => {
     process.env = processEnv;
     cpExec.mockResolvedValue({ stdout: '', stderr: '' });
     GlobalConfig.set({ ...globalConfig, localDir: cwd });
@@ -1092,7 +1092,18 @@ describe('util/exec/index', () => {
     await exec(inCmd);
 
     expect(logger.logger.debug).toHaveBeenCalledWith(
-      { command: inCmd },
+      {
+        command: inCmd,
+        env: [
+          'HTTP_PROXY',
+          'HTTPS_PROXY',
+          'NO_PROXY',
+          'HOME',
+          'PATH',
+          'LC_ALL',
+          'LANG',
+        ],
+      },
       'Executing command',
     );
   });

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -177,7 +177,10 @@ export async function exec(
     if (useDocker) {
       await removeDockerContainer(sideCarImage, dockerChildPrefix);
     }
-    logger.debug({ command: rawCmd }, 'Executing command');
+    logger.debug(
+      { command: rawCmd, env: Object.keys(rawOptions.env ?? {}) },
+      'Executing command',
+    );
     logger.trace({ commandOptions: rawOptions }, 'Command options');
     try {
       res = await rawExec(rawCmd, rawOptions);

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -5,6 +5,7 @@ import type { ToolSettingsOptions } from '../../config/types.ts';
 import { TEMPORARY_ERROR } from '../../constants/error-messages.ts';
 import { logger } from '../../logger/index.ts';
 import { getCustomEnv, getUserEnv } from '../env.ts';
+import { coerceObject } from '../object.ts';
 import { rawExec } from './common.ts';
 import { generateInstallCommands, isDynamicInstall } from './containerbase.ts';
 import {
@@ -178,7 +179,7 @@ export async function exec(
       await removeDockerContainer(sideCarImage, dockerChildPrefix);
     }
     logger.debug(
-      { command: rawCmd, env: Object.keys(rawOptions.env ?? {}) },
+      { command: rawCmd, env: Object.keys(coerceObject(rawOptions.env)) },
       'Executing command',
     );
     logger.trace({ commandOptions: rawOptions }, 'Command options');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->


When debugging, it's often unclear as to whether an environment variable
was passed to a command, unless we see the command fail (which includes
the environment variable names).

We can make sure we log the environment variable names themselves, when
executing the command, to make it more clear.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
