### PR TITLE
fix: delay participant addition to avoid race condition

### DIFF
--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -1,3 +1,4 @@
+import { setTimeout } from 'node:timers/promises';
 import { isNumber, isString } from '@sindresorhus/is';
 import { GlobalConfig } from '../../../../config/global.ts';
 import type { RenovateConfig } from '../../../../config/types.ts';
@@ -276,6 +277,8 @@ If you need any further assistance then you can also [request help here](${
         { pr: `Pull Request #${pr!.number}` },
         'Onboarding PR created',
       );
+      // prevent a possibly race condition by giving the platform a moment to create the PR
+      await setTimeout(1000);
       await addParticipants(config, pr!);
     }
   } catch (err) {


### PR DESCRIPTION
## Changes

Adds a delay before setting participants to avoid a possible race condition, where the PR does not exist yet, thus assignment of participants fails.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] Yes — minimal assistance (locating relevant code sections)

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/thasmo/renovate/