### PR TITLE
feat(config): set `groupSingleUpdates=false` by default

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2032,7 +2032,6 @@ For example, to group all non-major devDependencies updates together into a sing
 
 ## `groupSingleUpdates`
 
-<!-- prettier-ignore -->
 !!! note
   This option was [recently made opt-in, instead of opt-out](https://github.com/renovatebot/renovate/pull/44168).
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2032,7 +2032,9 @@ For example, to group all non-major devDependencies updates together into a sing
 
 ## `groupSingleUpdates`
 
-For example, you can set it to `false` if you prefer individual dependency names in PR titles when only one update is in the group.
+<!-- prettier-ignore -->
+!!! note
+  This option was [recently made opt-in, instead of opt-out](https://github.com/renovatebot/renovate/pull/44168).
 
 ## `groupSlug`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2617,7 +2617,7 @@ const options: Readonly<RenovateOptions>[] = [
     description:
       'Apply group settings even when the group contains only one update.',
     type: 'boolean',
-    default: true,
+    default: false,
     cli: false,
     env: false,
   },

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -28,7 +28,7 @@ beforeEach(() => {
 
 describe('workers/repository/updates/generate', () => {
   describe('generateBranchConfig()', () => {
-    it('groups single upgrade by default', () => {
+    it('does not group single upgrade by default', () => {
       const { groupSingleUpdates } = getConfig();
       const branch = [
         {
@@ -47,10 +47,10 @@ describe('workers/repository/updates/generate', () => {
         },
       ] satisfies BranchUpgradeConfig[];
       const res = generateBranchConfig(branch);
-      expect(res.groupName).toBe('some-group');
-      expect(res.isGroup).toBeTrue();
-      expect(res.recreateClosed).toBeTrue();
-      expect(res.commitMessageExtra).toBeUndefined();
+      expect(res.groupName).toBeUndefined();
+      expect(res.isGroup).toBeUndefined();
+      expect(res.recreateClosed).toBeFalse();
+      expect(res.commitMessageExtra).toEqual('to 1.2.3');
     });
 
     it('groups single upgrade across multiple files', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Although it didn't seem like this may be a breaking change when we
introduced this[0] (mea culpa), there have been a number of follow-up Discussions
reported that have indicated there has been some breakage from the
changes.

Instead of continually fixing forward, we can revert this back to an
opt-in feature.

Once it's stable, we can look at re-enabling it (most likely in a major
release, unless we're confident no breakage should occur).

[0]: https://github.com/renovatebot/renovate/pull/43629#issuecomment-4594201274

(TODO: add references to the Discussions that have come out of this)

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
