### PR TITLE
fix(manager/mise): install resolver tools during mise lock

### DIFF
--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -202,40 +202,6 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
-  it('uses constraints.go for the golang resolver tool', async () => {
-    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fs.readLocalFile
-      .mockResolvedValueOnce('existing content')
-      .mockResolvedValueOnce('existing content');
-    const execSnapshots = mockExecAll();
-
-    await updateArtifacts({
-      packageFileName: 'mise.toml',
-      updatedDeps: [{ depName: 'node' }],
-      newPackageFileContent: '',
-      config: {
-        constraints: {
-          mise: '2026.6.12',
-          node: '24.16.0',
-          npm: '11.4.2',
-          go: '1.24.4',
-          golang: '1.23.0',
-          ruby: '3.4.3',
-        },
-      },
-    });
-
-    expect(execSnapshots).toMatchObject([
-      { cmd: 'install-tool mise 2026.6.12' },
-      { cmd: 'install-tool node 24.16.0' },
-      { cmd: 'install-tool npm 11.4.2' },
-      { cmd: 'install-tool golang 1.24.4' },
-      { cmd: 'install-tool ruby 3.4.3' },
-      { cmd: trustCmd },
-      { cmd: updateToolCmd },
-    ]);
-  });
-
   it('injects GITHUB_TOKEN when host rule found', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -208,7 +208,41 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
-  it('installs resolver tools before running mise lock with dynamic installs', async () => {
+  it('looks up latest versions for tool versions before `mise lock`, if not set', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+
+    for (const version of ['1.2.3', '2.3.4', '3.4.5', '4.5.6', '5.6.7']) {
+      datasource.getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: version }],
+      });
+    }
+
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('existing content');
+    const execSnapshots = mockExecAll();
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config: {
+        // no constraints
+      },
+    });
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool mise 1.2.3' },
+      { cmd: 'install-tool node 2.3.4' },
+      { cmd: 'install-tool npm 3.4.5' },
+      { cmd: 'install-tool golang 4.5.6' },
+      { cmd: 'install-tool ruby 5.6.7' },
+      { cmd: trustCmd },
+      { cmd: updateToolCmd },
+    ]);
+  });
+
+  it('uses constraints to specify tool versions before `mise lock`, if set', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -1,15 +1,20 @@
 import upath from 'upath';
+import { mockDeep } from 'vitest-mock-extended';
 import { envMock, mockExecAll, mockExecSequence } from '~test/exec-util.ts';
 import { env, fs, hostRules } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type { RepoGlobalConfig } from '../../../config/types.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import * as docker from '../../../util/exec/docker/index.ts';
+import * as _datasource from '../../datasource/index.ts';
 import type { UpdateArtifactsConfig } from '../types.ts';
 import { updateArtifacts } from './artifacts.ts';
 import * as lockfile from './lockfile.ts';
 import { updateLockedDependency } from './update-locked.ts';
 
+const datasource = vi.mocked(_datasource);
+
+vi.mock('../../datasource/index.ts', () => mockDeep());
 vi.mock('../../../util/exec/env.ts');
 vi.mock('../../../util/fs/index.ts');
 
@@ -45,6 +50,7 @@ describe('modules/manager/mise/artifacts', () => {
     GlobalConfig.set(adminConfig);
     docker.resetPrefetchedImages();
     hostRules.clear();
+    datasource.getPkgReleases.mockReset();
   });
 
   it('returns null if lock file does not exist', async () => {
@@ -234,6 +240,53 @@ describe('modules/manager/mise/artifacts', () => {
       { cmd: updateToolCmd },
     ]);
   });
+
+  it.each`
+    depName                              | oldVersion    | newVersion    | newPackageFileContent
+    ${'npm:renovate'}                    | ${'43.220.0'} | ${'43.233.3'} | ${`[tools]\n"npm:renovate" = "43.233.3"\n`}
+    ${'go:github.com/DarthSim/hivemind'} | ${'1.0.0'}    | ${'1.1.0'}    | ${`[tools]\n"go:github.com/DarthSim/hivemind" = { version = "1.1.0", install_env = { GOPROXY = "direct" } }\n`}
+    ${'gem:rubocop'}                     | ${'1.75.0'}   | ${'1.76.0'}   | ${`[tools]\n"gem:rubocop" = "1.76.0"\n`}
+  `(
+    'updates mise.lock for $depName with dynamic installs and no constraints',
+    async ({ depName, oldVersion, newVersion, newPackageFileContent }) => {
+      GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+      datasource.getPkgReleases.mockResolvedValue({
+        releases: [{ version: '1.0.0' }],
+      });
+      const oldLockFileContent = `[[tools."${depName}"]]\nversion = "${oldVersion}"\nbackend = "${depName}"\n`;
+      const newLockFileContent = `[[tools."${depName}"]]\nversion = "${newVersion}"\nbackend = "${depName}"\n`;
+      fs.readLocalFile
+        .mockResolvedValueOnce(oldLockFileContent)
+        .mockResolvedValueOnce(newLockFileContent);
+      const execSnapshots = mockExecAll();
+
+      const res = await updateArtifacts({
+        packageFileName: 'mise.toml',
+        updatedDeps: [{ depName }],
+        newPackageFileContent,
+        config,
+      });
+
+      expect(res).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'mise.lock',
+            contents: newLockFileContent,
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'install-tool mise 1.0.0' },
+        { cmd: 'install-tool node 1.0.0' },
+        { cmd: 'install-tool npm 1.0.0' },
+        { cmd: 'install-tool golang 1.0.0' },
+        { cmd: 'install-tool ruby 1.0.0' },
+        { cmd: trustCmd },
+        { cmd: `mise lock ${depName}` },
+      ]);
+    },
+  );
 
   it('injects GITHUB_TOKEN when host rule found', async () => {
     fs.readLocalFile

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -202,6 +202,40 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
+  it('uses constraints.go for the golang resolver tool', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('existing content');
+    const execSnapshots = mockExecAll();
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config: {
+        constraints: {
+          mise: '2026.6.12',
+          node: '24.16.0',
+          npm: '11.4.2',
+          go: '1.24.4',
+          golang: '1.23.0',
+          ruby: '3.4.3',
+        },
+      },
+    });
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool mise 2026.6.12' },
+      { cmd: 'install-tool node 24.16.0' },
+      { cmd: 'install-tool npm 11.4.2' },
+      { cmd: 'install-tool golang 1.24.4' },
+      { cmd: 'install-tool ruby 3.4.3' },
+      { cmd: trustCmd },
+      { cmd: updateToolCmd },
+    ]);
+  });
+
   it('injects GITHUB_TOKEN when host rule found', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -202,6 +202,39 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
+  it('installs resolver tools before running mise lock with dynamic installs', async () => {
+    GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('existing content');
+    const execSnapshots = mockExecAll();
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config: {
+        constraints: {
+          mise: '2026.6.12',
+          node: '24.16.0',
+          npm: '11.4.2',
+          go: '1.24.4',
+          ruby: '3.4.3',
+        },
+      },
+    });
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool mise 2026.6.12' },
+      { cmd: 'install-tool node 24.16.0' },
+      { cmd: 'install-tool npm 11.4.2' },
+      { cmd: 'install-tool golang 1.24.4' },
+      { cmd: 'install-tool ruby 3.4.3' },
+      { cmd: trustCmd },
+      { cmd: updateToolCmd },
+    ]);
+  });
+
   it('injects GITHUB_TOKEN when host rule found', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -18,9 +18,10 @@ import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getConfigType, getLockFileName } from './lockfile.ts';
 
 /**
- * Resolver tools that mise may invoke while running `mise lock` (version listing).
+ * Resolver tools that mise may invoke while running `mise lock`, for instance to convert an inexact version like `1` against the npm registry.
  *
  * NOTE: this will install all relevant tools, regardless of what the given mise configuration uses.
+ *
  * @see https://mise.jdx.dev/dev-tools/backends/npm.html
  * @see https://mise.jdx.dev/dev-tools/backends/go.html
  * @see https://mise.jdx.dev/dev-tools/backends/gem.html

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -18,9 +18,9 @@ import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getConfigType, getLockFileName } from './lockfile.ts';
 
 /**
- * Resolver tools that mise may invoke while running `mise lock` (version listing),
- * regardless of which tools are being locked.
- *
+ * Resolver tools that mise may invoke while running `mise lock` (version listing).
+ * 
+ * NOTE: this will install all relevant tools, regardless of what the given mise configuration uses.
  * @see https://mise.jdx.dev/dev-tools/backends/npm.html
  * @see https://mise.jdx.dev/dev-tools/backends/go.html
  * @see https://mise.jdx.dev/dev-tools/backends/gem.html

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -6,11 +6,36 @@ import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { findGithubToken } from '../../../util/check-token.ts';
 import { exec } from '../../../util/exec/index.ts';
-import type { ExecOptions, ExtraEnv } from '../../../util/exec/types.ts';
+import type {
+  ConstraintName,
+  ExecOptions,
+  ExtraEnv,
+  ToolConstraint,
+} from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getConfigType, getLockFileName } from './lockfile.ts';
+
+/**
+ * Resolver tools that mise may invoke while running `mise lock` (version listing),
+ * regardless of which tools are being locked.
+ *
+ * @see https://mise.jdx.dev/dev-tools/backends/npm.html
+ * @see https://mise.jdx.dev/dev-tools/backends/go.html
+ * @see https://mise.jdx.dev/dev-tools/backends/gem.html
+ */
+function getMiseLockToolConstraints(
+  constraints?: Partial<Record<ConstraintName, string>> | null,
+): ToolConstraint[] {
+  return [
+    { toolName: 'mise', constraint: constraints?.mise },
+    { toolName: 'node', constraint: constraints?.node },
+    { toolName: 'npm', constraint: constraints?.npm },
+    { toolName: 'golang', constraint: constraints?.golang },
+    { toolName: 'ruby', constraint: constraints?.ruby },
+  ];
+}
 
 /**
  * Updates mise lock files when dependencies are updated.
@@ -70,12 +95,7 @@ export async function updateArtifacts({
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     extraEnv,
-    toolConstraints: [
-      {
-        toolName: 'mise',
-        constraint: config.constraints?.mise,
-      },
-    ],
+    toolConstraints: getMiseLockToolConstraints(config.constraints),
     docker: {},
   };
 

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -32,7 +32,7 @@ function getMiseLockToolConstraints(
     { toolName: 'mise', constraint: constraints?.mise },
     { toolName: 'node', constraint: constraints?.node },
     { toolName: 'npm', constraint: constraints?.npm },
-    { toolName: 'golang', constraint: constraints?.golang },
+    { toolName: 'golang', constraint: constraints?.go },
     { toolName: 'ruby', constraint: constraints?.ruby },
   ];
 }

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -19,7 +19,7 @@ import { getConfigType, getLockFileName } from './lockfile.ts';
 
 /**
  * Resolver tools that mise may invoke while running `mise lock` (version listing).
- * 
+ *
  * NOTE: this will install all relevant tools, regardless of what the given mise configuration uses.
  * @see https://mise.jdx.dev/dev-tools/backends/npm.html
  * @see https://mise.jdx.dev/dev-tools/backends/go.html


### PR DESCRIPTION
## Changes

### Problem

When `binarySource=install` is running in Containerbase, Renovate prepends `install-tool ...` commands generated from `toolConstraints` before artifact update commands. The mise lockfile update path runs `mise trust` and `mise lock`, but previously listed only `mise`, so resolver CLIs that `mise lock` may invoke were not provisioned in Renovate's container/sandbox environment.

This is the issue reported in https://github.com/jdx/mise/discussions/10563: if `node`/`npm` are unavailable, `mise lock` can warn and leave stale or missing lock entries for `npm:` tools, including registry shorthands that resolve to the npm backend.

### Fixed Resolver Tools

This change uses a fixed resolver-tool set for every mise lock run: `mise`, `node`, `npm`, `golang`, and `ruby`. All of these tool names are already available through the Renovate/Containerbase image and dynamic-install layer, so this PR only changes Renovate's `toolConstraints`; it does not require a base-image or Containerbase change.

### Mise Lock Call Path

Renovate runs `mise trust <config>` and then `mise lock` or `mise lock <tools>` during the artifact update. Inside `mise lock`, mise resolves the requested tools from project config, aliases, registry entries, and enabled backends, then asks each resolved backend for remote version information before writing lockfile metadata. Some of those backend version-listing paths call external CLIs.

### Why These Tools Are Needed

- `node`/`npm`: [mise's npm backend](https://mise.en.dev/dev-tools/backends/npm.html) lists remote versions with `npm view <package> versions time --json`. It uses the npm CLI so custom registry configuration is honored, for example `.npmrc`, npm config, or npm-related environment variables. `npm` requires `node`, and Renovate's npm manager also includes `node` in its npm lockfile update `toolConstraints` for this reason.
- `golang`: [mise's go backend](https://mise.en.dev/dev-tools/backends/go.html) first queries `$GOPROXY` over HTTP, matching Go module resolution. If no proxy is configured for querying, for example `GOPROXY=direct`, it falls back to `go list -m -versions`, so `go` can be needed during lock-time version resolution. Unset or empty `GOPROXY` is treated as Go's default, not as direct-only.
- `ruby`: [mise's gem backend](https://mise.en.dev/dev-tools/backends/gem.html) uses `gem sources` from the mise-managed Ruby environment to determine the primary RubyGems-compatible source, then queries that source's HTTP API for versions. That makes Ruby needed for source discovery.

### Why This Is Unconditional

A mise tool name is not enough to reliably derive the backend Renovate must provision for.

Examples:

- A registry shorthand can point at a package-manager backend, so a plain tool name like `prettier` can still require the npm backend's `npm view` path.
- A user can configure `tool_alias` so a local name resolves to a different backend than Renovate would infer from the dependency name alone.
- A user can configure `disable_backends`, which can change which backend is eligible for a tool.

Renovate could theoretically invoke `mise` first to resolve backend choices before deciding `toolConstraints`, but that adds another mise execution path and still needs enough tooling available to evaluate project config. A small fixed resolver-tool set is simpler and matches the current lock-time external CLI usage.

### Other Backends

Other backends like [mise's pipx backend](https://mise.en.dev/dev-tools/backends/pipx.html), [mise's cargo backend](https://mise.en.dev/dev-tools/backends/cargo.html), and [mise's SwiftPM backend](https://mise.en.dev/dev-tools/backends/spm.html) do not require external CLI calls to list versions. Their install paths may require tools such as `cargo` or `swift`, but their lock-time version listing is HTTP/API based.

### Npm Package-Manager Settings

mise supports `aube`, `bun`, and `pnpm` for npm-package installation, but version metadata is still queried with `npm view` today. `bun` is not used for this because its info command requires a `package.json`; modern pnpm has related commands, but mise currently avoids depending on package-manager-specific version-query behavior and standardizes on `npm view`.

### Contributor Context

I'm also a mise contributor, and the resolver-tool set above is based on checking mise's current backend behavior/source. This PR addresses Renovate's provisioning gap; it does not change mise's behavior when a resolver CLI is missing.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Cursor (AI assistant) to investigate mise lock behavior, review upstream mise source, implement the change, and draft this PR description.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/risu729/renovate-mise-npm-lock-repro

Ran `pnpm check --all lib/modules/manager/mise/` locally. Added unit tests covering the dynamic-install command sequence for the mise resolver tools before `mise trust`/`mise lock`, plus unconstrained npm/go/gem lockfile update cases that assert `mise.lock` is returned when `mise lock` changes it.

Also ran this PR branch locally inside the official Renovate Containerbase runtime against the public reproduction repository with `binarySource=install` and `allowedUnsafeExecutions=["mise"]`. The released Renovate behavior is shown in https://github.com/risu729/renovate-mise-npm-lock-repro/pull/2: the PR updates only `mise.toml`, leaving `mise.lock` stale. With this fix, the fresh run created https://github.com/risu729/renovate-mise-npm-lock-repro/pull/4, which correctly updates both `mise.toml` and `mise.lock`; the `jdx/mise-action` workflow passed.



