### PR TITLE
feat(datasource/pypi): support json and html simple pypi api

### DIFF
--- a/lib/modules/datasource/pypi/__fixtures__/versions-simple.json
+++ b/lib/modules/datasource/pypi/__fixtures__/versions-simple.json
@@ -1,0 +1,85 @@
+{
+  "meta": { "api-version": "1.0" },
+  "name": "dj-database-url",
+  "files": [
+    {
+      "filename": "dj-database-url-0.1.2.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/04/89/dj-database-url-0.1.2.tar.gz",
+      "hashes": { "sha256": "6169f2c272326e3cced6999effb19013365ea73f6ed6c731efa4e346711d8969" },
+      "upload-time": "2014-09-09T14:13:32.281Z"
+    },
+    {
+      "filename": "dj-database-url-0.1.3.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/bd/80/dj-database-url-0.1.3.tar.gz",
+      "hashes": { "sha256": "222744896dcbe939aa940217c940a8a95981be13beb9af639a1da024be4f9411" }
+    },
+    {
+      "filename": "dj-database-url-0.1.4.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/3e/78/dj-database-url-0.1.4.tar.gz",
+      "hashes": { "sha256": "14faa143247e267aefd807490e1e89e3ad9fac0a06c4aee3f9fe328849bd15cf" }
+    },
+    {
+      "filename": "dj-database-url-0.2.0.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/d6/cb/dj-database-url-0.2.0.tar.gz",
+      "hashes": { "sha256": "5edd253ccb407a0bd19e91c4c9bbe164632639767086b4a38f2d20e00010488b" }
+    },
+    {
+      "filename": "dj-database-url-0.2.1.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/a6/94/dj-database-url-0.2.1.tar.gz",
+      "hashes": { "sha256": "f95c0b2e9e70cc246bd101720e1be492524ecf0dd5ea39241b51ef142faefecc" }
+    },
+    {
+      "filename": "dj-database-url-0.2.2.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/19/11/dj-database-url-0.2.2.tar.gz",
+      "hashes": { "sha256": "492a7294b85ad8ac1b13be0b7337f381d2d44c4da185f289ab7c26dd765ef6cb" }
+    },
+    {
+      "filename": "dj-database-url-0.3.0.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/e1/0e/dj-database-url-0.3.0.tar.gz",
+      "hashes": { "sha256": "f2e273ed34acbb560962d5cf12917936d8df02297df09bd3089b8546d4584138" }
+    },
+    {
+      "filename": "dj_database_url-0.3.0-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/ef/b6/dj_database_url-0.3.0-py2.py3-none-any.whl",
+      "hashes": { "sha256": "ca01768fdecde134301f3170743226f60edff5c3935f12437378ebd911506353" }
+    },
+    {
+      "filename": "dj-database-url-0.4.0.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/64/d9/dj-database-url-0.4.0.tar.gz",
+      "hashes": { "sha256": "858312abb7b330ea875733a65806a36ad04d7b8451c6ce8835118a2fa10d6870" }
+    },
+    {
+      "filename": "dj-database-url-0.4.1.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/39/9f/dj-database-url-0.4.1.tar.gz",
+      "hashes": { "sha256": "7f4c78d2a090df8dfaf56d5d3ff7bbee17360436e4879558317e2314424864cd" }
+    },
+    {
+      "filename": "dj-database-url-0.4.2.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/c8/4b/dj-database-url-0.4.2.tar.gz",
+      "hashes": { "sha256": "a6832d8445ee9d788c5baa48aef8130bf61fdc442f7d9a548424d25cd85c9f08" }
+    },
+    {
+      "filename": "dj_database_url-0.4.2-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/91/84/dj_database_url-0.4.2-py2.py3-none-any.whl",
+      "hashes": { "sha256": "e16d94c382ea0564c48038fa7fe8d9c890ef1ab1a8ec4cb48e732c124b9482fd" },
+      "yanked": false
+    },
+    {
+      "filename": "dj-database-url-0.5.0.tar.gz",
+      "url": "https://files.pythonhosted.org/packages/01/c4/dj-database-url-0.5.0.tar.gz",
+      "hashes": { "sha256": "4aeaeb1f573c74835b0686a2b46b85990571159ffc21aa57ecd4d1e1cb334163" },
+      "requires-python": ">=3.5"
+    },
+    {
+      "filename": "dj_database_url-0.5.0-py2.py3-none-any.whl",
+      "url": "https://files.pythonhosted.org/packages/d4/a6/dj_database_url-0.5.0-py2.py3-none-any.whl",
+      "hashes": { "sha256": "851785365761ebe4994a921b433062309eb882fedd318e1b0fcecc607ed02da9" },
+      "yanked": "security issue"
+    },
+    {
+      "filename": "unrelated-file.txt",
+      "url": "https://files.pythonhosted.org/packages/zz/zz/unrelated-file.txt",
+      "hashes": { "sha256": "0000000000000000000000000000000000000000000000000000000000000000" }
+    }
+  ]
+}

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -12,6 +12,7 @@ const googleAuth = vi.mocked(_googleAuth);
 
 const res1 = Fixtures.get('azure-cli-monitor.json');
 const htmlResponse = Fixtures.get('versions-html.html');
+const jsonSimpleResponse = Fixtures.get('versions-simple.json');
 const mixedCaseResponse = Fixtures.get('versions-html-mixed-case.html');
 const withPeriodsResponse = Fixtures.get('versions-html-with-periods.html');
 
@@ -463,6 +464,54 @@ describe('modules/datasource/pypi/index', () => {
           packageName: 'dj-database-url',
         }),
       ).toMatchSnapshot();
+    });
+
+    it('process data from JSON simple endpoint (PEP 691)', async () => {
+      httpMock
+        .scope('https://some.registry.org/simple/')
+        .get('/dj-database-url/')
+        .reply(200, jsonSimpleResponse, {
+          'content-type': 'application/vnd.pypi.simple.v1+json',
+        });
+      const config = {
+        registryUrls: ['https://some.registry.org/simple/'],
+      };
+      const res = await getPkgReleases({
+        datasource,
+        ...config,
+        packageName: 'dj-database-url',
+      });
+      expect(res?.releases).toMatchObject([
+        { version: '0.1.2', releaseTimestamp: '2014-09-09T14:13:32.281Z' },
+        { version: '0.1.3' },
+        { version: '0.1.4' },
+        { version: '0.2.0' },
+        { version: '0.2.1' },
+        { version: '0.2.2' },
+        { version: '0.3.0' },
+        { version: '0.4.0' },
+        { version: '0.4.1' },
+        { version: '0.4.2' },
+        { isDeprecated: true, version: '0.5.0' },
+      ]);
+    });
+
+    it('returns empty releases for malformed JSON simple endpoint response', async () => {
+      httpMock
+        .scope('https://some.registry.org/simple/')
+        .get('/dj-database-url/')
+        .reply(200, 'not json', {
+          'content-type': 'application/vnd.pypi.simple.v1+json',
+        });
+      const config = {
+        registryUrls: ['https://some.registry.org/simple/'],
+      };
+      const res = await getPkgReleases({
+        datasource,
+        ...config,
+        packageName: 'dj-database-url',
+      });
+      expect(res).toBeNull();
     });
 
     it('sets private simple if authorization provided', async () => {

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -14,7 +14,7 @@ import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
 import { getGoogleAuthToken } from '../util.ts';
 import { isGitHubRepo, normalizePythonDepName } from './common.ts';
 import type { PypiRelease } from './schema.ts';
-import { PypiResponse } from './schema.ts';
+import { PypiResponse, PypiSimpleJson } from './schema.ts';
 import type { Releases } from './types.ts';
 
 export class PypiDatasource extends Datasource {
@@ -38,7 +38,7 @@ export class PypiDatasource extends Datasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'The relase timestamp is determined from the `upload_time` field in the results. This field is not available when using the simple API.';
+    'The release timestamp is determined from the `upload_time` field in the results. This field is not available when using the HTML simple API.';
   override readonly sourceUrlSupport = 'release';
   override readonly sourceUrlNote =
     'The source URL is determined from the `homepage` field if it is a github repository, else we use the `project_urls` field.';
@@ -278,7 +278,15 @@ export class PypiDatasource extends Datasource {
     const dependency: ReleaseResult = { releases: [] };
     const { headers, lookupUrl: sanitizedUrl } =
       await this.getAuthHeaders(lookupUrl);
-    const response = await this.http.getText(sanitizedUrl, { headers });
+    const response = await this.http.getText(sanitizedUrl, {
+      headers: {
+        ...headers,
+        // Request the JSON serialization (PEP 691), falling back to the
+        // legacy HTML serialization (PEP 503) via content negotiation.
+        Accept:
+          'application/vnd.pypi.simple.v1+json, application/vnd.pypi.simple.v1+html;q=0.2, text/html;q=0.01',
+      },
+    });
     const dep = response?.body;
     if (!dep) {
       logger.trace({ dependency: packageName }, 'pip package not found');
@@ -287,7 +295,40 @@ export class PypiDatasource extends Datasource {
     if (response.authorization) {
       dependency.isPrivate = true;
     }
-    const root = parse(PypiDatasource.cleanSimpleHtml(dep));
+    const contentType = response.headers['content-type'];
+    const releases =
+      contentType === 'application/vnd.pypi.simple.v1+json'
+        ? PypiDatasource.getSimpleReleasesFromJson(dep, packageName)
+        : PypiDatasource.getSimpleReleasesFromHtml(dep, packageName);
+    const versions = Object.keys(releases);
+    dependency.releases = versions.map((version) => {
+      const versionReleases = coerceArray(releases[version]);
+      const isDeprecated = versionReleases.some(({ yanked }) => yanked);
+      const result: Release = { version };
+      const releaseTimestamp = asTimestamp(versionReleases[0]?.upload_time);
+      if (releaseTimestamp) {
+        result.releaseTimestamp = releaseTimestamp;
+      }
+      if (isDeprecated) {
+        result.isDeprecated = isDeprecated;
+      }
+      // There may be multiple releases with different requires_python, so we return all in an array
+      result.constraints = {
+        // TODO: string[] isn't allowed here
+        python: versionReleases.map(
+          ({ requires_python }) => requires_python,
+        ) as any,
+      };
+      return result;
+    });
+    return dependency;
+  }
+
+  private static getSimpleReleasesFromHtml(
+    html: string,
+    packageName: string,
+  ): Releases {
+    const root = parse(PypiDatasource.cleanSimpleHtml(html));
     const links = root.querySelectorAll('a');
     const releases: Releases = {};
     for (const link of Array.from(links)) {
@@ -309,23 +350,45 @@ export class PypiDatasource extends Datasource {
         releases[version].push(release);
       }
     }
-    const versions = Object.keys(releases);
-    dependency.releases = versions.map((version) => {
-      const versionReleases = coerceArray(releases[version]);
-      const isDeprecated = versionReleases.some(({ yanked }) => yanked);
-      const result: Release = { version };
-      if (isDeprecated) {
-        result.isDeprecated = isDeprecated;
+    return releases;
+  }
+
+  private static getSimpleReleasesFromJson(
+    json: string,
+    packageName: string,
+  ): Releases {
+    const releases: Releases = {};
+    const parsed = PypiSimpleJson.safeParse(json);
+    if (!parsed.success) {
+      logger.debug(
+        { packageName, err: parsed.error },
+        'Failed to parse PyPI simple JSON response',
+      );
+      return releases;
+    }
+    for (const file of parsed.data.files) {
+      const version = PypiDatasource.extractVersionFromLinkText(
+        file.filename.trim(),
+        packageName,
+      );
+      if (version) {
+        const release: PypiRelease = {
+          yanked: Boolean(file.yanked),
+        };
+        const requiresPython = file['requires-python'];
+        if (requiresPython) {
+          release.requires_python = requiresPython;
+        }
+        const uploadTime = file['upload-time'];
+        if (uploadTime) {
+          release.upload_time = uploadTime;
+        }
+        if (!releases[version]) {
+          releases[version] = [];
+        }
+        releases[version].push(release);
       }
-      // There may be multiple releases with different requires_python, so we return all in an array
-      result.constraints = {
-        // TODO: string[] isn't allowed here
-        python: versionReleases.map(
-          ({ requires_python }) => requires_python,
-        ) as any,
-      };
-      return result;
-    });
-    return dependency;
+    }
+    return releases;
   }
 }

--- a/lib/modules/datasource/pypi/readme.md
+++ b/lib/modules/datasource/pypi/readme.md
@@ -4,3 +4,6 @@ This datasource uses the following logic to determine lookup URLs:
 - Otherwise, the JSON API will be tried first
 - If the JSON API returns a result, it will be used
 - If the JSON API throws an error (e.g. 403, 404) then the simple API will be tried
+
+The simple API supports both the HTML serialization ([PEP 503](https://peps.python.org/pep-0503/)) and the JSON serialization ([PEP 691](https://peps.python.org/pep-0691/)).
+Content negotiation is used to prefer the JSON serialization, falling back to HTML.

--- a/lib/modules/datasource/pypi/schema.ts
+++ b/lib/modules/datasource/pypi/schema.ts
@@ -1,5 +1,9 @@
 import { z } from 'zod/v4';
-import { DeepNullish } from '../../../util/schema-utils/index.ts';
+import {
+  DeepNullish,
+  Json,
+  LooseArray,
+} from '../../../util/schema-utils/index.ts';
 
 export const PypiRelease = DeepNullish(
   z.object({
@@ -10,6 +14,26 @@ export const PypiRelease = DeepNullish(
 );
 
 export type PypiRelease = z.infer<typeof PypiRelease>;
+
+// JSON serialization of the simple API (PEP 691)
+export const PypiSimpleFile = z.object({
+  filename: z.string(),
+  'requires-python': z.string().nullish(),
+  // `upload-time` is exposed by the simple API since PEP 700
+  'upload-time': z.string().nullish(),
+  // `yanked` may be a boolean or a non-empty string with the yank reason
+  yanked: z.union([z.boolean(), z.string()]).nullish(),
+});
+
+export type PypiSimpleFile = z.infer<typeof PypiSimpleFile>;
+
+export const PypiSimpleJson = Json.pipe(
+  z.object({
+    files: LooseArray(PypiSimpleFile),
+  }),
+);
+
+export type PypiSimpleJson = z.infer<typeof PypiSimpleJson>;
 
 export const PypiResponse = DeepNullish(
   z.object({


### PR DESCRIPTION
## Changes

Add support for the JSON-based Simple API for Python Package Indexes (PEP 691). See https://peps.python.org/pep-0691/ for the spec.

This JSON-based Simple API contains the `upload-time`, which is used as `releaseTimestamp`. The change is backwards compatible;
the previous HTML parser is used if the response does not contain the JSON content-type header.

## Context

Third party registries that only support the simple api did not contain the `releaseTimestamp`.

Please select one of the following:

- [X] This closes an existing Issue, Closes: #20070

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
