### PR TITLE
fix(manager/bun): write resolved npmrc so scoped registries authenticate

### DIFF
--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -232,6 +232,29 @@ describe('modules/manager/bun/artifacts', () => {
         ]);
       });
 
+      it('writes the resolved npmrc so scoped registries resolve', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        updateArtifact.config.npmrc =
+          '@scope:registry=https://example.com/api/v4/packages/npm/\n';
+        const oldLock = Buffer.from('old');
+        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        // no repo .npmrc
+        fs.readFile.mockResolvedValueOnce(null as never);
+        const newLock = Buffer.from('new');
+        fs.readFile.mockResolvedValueOnce(newLock as never);
+
+        await updateArtifacts(updateArtifact);
+
+        expect(fs.outputFile).toHaveBeenCalledWith(
+          expect.stringMatching(/\.npmrc$/),
+          expect.stringContaining(
+            '@scope:registry=https://example.com/api/v4/packages/npm/',
+          ),
+        );
+      });
+
       it('supports lockFileMaintenance', async () => {
         updateArtifact.updatedDeps = [
           { manager: 'bun', lockFiles: ['bun.lock'] },

--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -234,6 +234,29 @@ describe('modules/manager/bun/artifacts', () => {
         ]);
       });
 
+      it('writes the resolved npmrc so scoped registries resolve', async () => {
+        updateArtifact.updatedDeps = [
+          { manager: 'bun', lockFiles: ['bun.lock'] },
+        ];
+        updateArtifact.config.npmrc =
+          '@scope:registry=https://example.com/api/v4/packages/npm/\n';
+        const oldLock = Buffer.from('old');
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+        // no repo .npmrc
+        fs.readLocalFile.mockResolvedValueOnce(null);
+        const newLock = Buffer.from('new');
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
+
+        await updateArtifacts(updateArtifact);
+
+        expect(fs.writeLocalFile).toHaveBeenCalledWith(
+          '.npmrc',
+          expect.stringContaining(
+            '@scope:registry=https://example.com/api/v4/packages/npm/',
+          ),
+        );
+      });
+
       it('supports lockFileMaintenance', async () => {
         updateArtifact.updatedDeps = [
           { manager: 'bun', lockFiles: ['bun.lock'] },

--- a/lib/modules/manager/bun/artifacts.ts
+++ b/lib/modules/manager/bun/artifacts.ts
@@ -51,6 +51,10 @@ export async function updateArtifacts(
   const pkgFileDir = upath.dirname(packageFileName);
   const npmrcContent = await getNpmrcContent(pkgFileDir);
   const { additionalNpmrcContent } = processHostRules();
+  // processHostRules() only adds auth; scope/registry mappings live in npmrc.
+  if (config.npmrc) {
+    additionalNpmrcContent.unshift(config.npmrc);
+  }
   await updateNpmrcContent(pkgFileDir, npmrcContent, additionalNpmrcContent);
 
   try {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -55,6 +55,7 @@ export interface UpdateArtifactsConfig {
   skipArtifactsUpdate?: boolean;
   lockFiles?: string[];
   toolSettings?: ToolSettingsOptions;
+  npmrc?: string;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -56,6 +56,7 @@ export interface UpdateArtifactsConfig {
   lockFiles?: string[];
   toolSettings?: RepoToolSettingsOptions;
   minimumReleaseAge?: Nullish<string>;
+  npmrc?: string;
 }
 
 export interface RangeConfig<T = Record<string, any>> extends ManagerData<T> {


### PR DESCRIPTION
## Changes

The bun artifact updater wrote only hostRules auth lines to `.npmrc`, not the scope/registry mappings from the resolved `npmrc`. Scoped packages pinned to a registry URL in `bun.lock` were therefore installed without credentials and failed (404/401). Now writes `config.npmrc` alongside the auth lines, matching the npm/yarn/pnpm post-update.

## Context

Related: #41593, #43255. Completes the npmrc support added in #30926.
