### PR TITLE
feat(datasource/dart): Added support for constraints extraction

### DIFF
--- a/lib/modules/datasource/dart/index.spec.ts
+++ b/lib/modules/datasource/dart/index.spec.ts
@@ -90,5 +90,60 @@ describe('modules/datasource/dart/index', () => {
       });
       expect(res).toMatchSnapshot();
     });
+
+    it('includes constraints from pubspec environment', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/test_pkg')
+        .reply(200, {
+          versions: [
+            {
+              version: '1.0.0',
+              published: '2023-01-01T00:00:00.000Z',
+              pubspec: {
+                environment: {
+                  sdk: '>=2.19.0 <3.0.0',
+                },
+              },
+            },
+            {
+              version: '2.0.0',
+              published: '2024-01-01T00:00:00.000Z',
+              pubspec: {
+                environment: {
+                  sdk: '^3.0.0',
+                  flutter: '>=3.10.0',
+                },
+              },
+            },
+            {
+              version: '3.0.0',
+              published: '2024-06-01T00:00:00.000Z',
+            },
+          ],
+          latest: {
+            pubspec: {},
+          },
+        });
+      const res = await getPkgReleases({
+        datasource: DartDatasource.id,
+        packageName: 'test_pkg',
+        constraintsFiltering: 'strict',
+        constraints: { dart: '>=2.19.0 <3.0.0' },
+      });
+      expect(res).toEqual({
+        registryUrl: 'https://pub.dartlang.org',
+        releases: [
+          {
+            version: '1.0.0',
+            releaseTimestamp: '2023-01-01T00:00:00.000Z',
+          },
+          {
+            version: '3.0.0',
+            releaseTimestamp: '2024-06-01T00:00:00.000Z',
+          },
+        ],
+      });
+    });
   });
 });

--- a/lib/modules/datasource/dart/index.ts
+++ b/lib/modules/datasource/dart/index.ts
@@ -1,8 +1,10 @@
+import { isEmptyObject, isNonEmptyString } from '@sindresorhus/is';
+import type { ConstraintName } from '../../../util/exec/types.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import { ensureTrailingSlash } from '../../../util/url.ts';
 import { id as npmId } from '../../versioning/npm/index.ts';
 import { Datasource } from '../datasource.ts';
-import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
+import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
 import { DartResult } from './schema.ts';
 
 export class DartDatasource extends Datasource {
@@ -49,10 +51,25 @@ export class DartDatasource extends Datasource {
       const { versions, latest } = body;
       const releases = versions
         ?.filter(({ retracted }) => !retracted)
-        ?.map(({ version, published }) => ({
-          version,
-          releaseTimestamp: asTimestamp(published),
-        }));
+        ?.map(({ version, published, pubspec }) => {
+          const release: Release = {
+            version,
+            releaseTimestamp: asTimestamp(published),
+          };
+
+          const constraints: Partial<Record<ConstraintName, string[]>> = {};
+          if (isNonEmptyString(pubspec?.environment?.sdk)) {
+            constraints.dart = [pubspec.environment.sdk];
+          }
+          if (isNonEmptyString(pubspec?.environment?.flutter)) {
+            constraints.flutter = [pubspec.environment.flutter];
+          }
+          if (!isEmptyObject(constraints)) {
+            release.constraints = constraints;
+          }
+
+          return release;
+        });
       if (releases && latest) {
         result = { releases };
 

--- a/lib/modules/datasource/dart/schema.ts
+++ b/lib/modules/datasource/dart/schema.ts
@@ -5,6 +5,16 @@ const DartVersionEntry = z.object({
   version: z.string(),
   published: z.string().optional(),
   retracted: z.boolean().optional(),
+  pubspec: z
+    .object({
+      environment: z
+        .object({
+          sdk: z.string().optional(),
+          flutter: z.string().optional(),
+        })
+        .optional(),
+    })
+    .optional(),
 });
 
 const DartLatest = z.object({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Splits out the `datasource/dart` changes from https://github.com/renovatebot/renovate/pull/44171, into its own PR as per the [request from @jamietanna](https://github.com/renovatebot/renovate/pull/44171#pullrequestreview-4551178771)

Implements the ability to extract dart and flutter sdk versions from the dart datasource for later support for `constraintsFilter`

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe):
  - An agent was handed the discussion post and additional context that I gave it. All changes were personally combed over, and a few of the implementation details were manually changed to align better with other constraintsFiltering implementations (rubygem and npm were used as examples)
  - Unit tests were created using the agent, and also verified to be accurate manually

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required
  - Documentation update will happen in the followup PR where constraintsFilter is implemented in the pub manager

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository
  - Tested using the changes in https://github.com/renovatebot/renovate/pull/44171

The public repository: https://github.com/matthewnitschke-wk/renovate_pub_constraintFiltering

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
