### PR TITLE
feat(npm/yarn): Add support for loading config from inherited yarnrc.yml files

### DIFF
--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -32,6 +32,7 @@ describe('modules/manager/npm/extract/index', () => {
       );
       fs.readLocalFile.mockResolvedValue(null);
       fs.localPathExists.mockResolvedValue(false);
+      fs.findLocalSiblingAndParents.mockResolvedValue([]);
       fs.getSiblingFileName.mockImplementation(realFs.getSiblingFileName);
     });
 
@@ -318,14 +319,7 @@ describe('modules/manager/npm/extract/index', () => {
     });
 
     it('reads registryUrls from .yarnrc.yml', async () => {
-      fs.findLocalSiblingOrParent.mockImplementation(
-        (packageFile, otherFile): Promise<string | null> => {
-          if (packageFile === 'package.json' && otherFile === '.yarnrc.yml') {
-            return Promise.resolve('.yarnrc.yml');
-          }
-          return Promise.resolve(null);
-        },
-      );
+      fs.findLocalSiblingAndParents.mockResolvedValue(['.yarnrc.yml']);
 
       fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
         if (fileName === '.yarnrc.yml') {
@@ -343,6 +337,58 @@ describe('modules/manager/npm/extract/index', () => {
       expect(
         res?.deps.flatMap((dep) => dep.registryUrls),
       ).toBeArrayIncludingOnly(['https://registry.example.com']);
+    });
+
+    it('reads registryUrls from inherited .yarnrc.yml files', async () => {
+      fs.findLocalSiblingAndParents.mockResolvedValue([
+        'nested/.yarnrc.yml',
+        '.yarnrc.yml',
+      ]);
+
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === '.yarnrc.yml') {
+          return Promise.resolve(
+            codeBlock`
+              npmRegistryServer: https://default.example.com
+              npmScopes:
+                parent:
+                  npmRegistryServer: https://parent.example.com
+            `,
+          );
+        }
+        if (fileName === 'nested/.yarnrc.yml') {
+          return Promise.resolve(
+            codeBlock`
+              npmScopes:
+                leaf:
+                  npmRegistryServer: https://leaf.example.com
+            `,
+          );
+        }
+        return Promise.resolve(null);
+      });
+
+      const res = await npmExtract.extractPackageFile(
+        JSON.stringify({
+          dependencies: {
+            '@leaf/pkg': '1.0.0',
+            '@parent/pkg': '1.0.0',
+            lodash: '1.0.0',
+          },
+        }),
+        'nested/package.json',
+        {},
+      );
+
+      const depRegistryUrls = Object.fromEntries(
+        (res?.deps ?? []).map((dep) => [dep.depName, dep.registryUrls]),
+      );
+
+      expect(depRegistryUrls).toEqual({
+        '@leaf/pkg': ['https://leaf.example.com'],
+        '@parent/pkg': ['https://parent.example.com'],
+        lodash: ['https://default.example.com'],
+      });
     });
 
     it('reads registryUrls from .yarnrc', async () => {
@@ -373,14 +419,7 @@ describe('modules/manager/npm/extract/index', () => {
     });
 
     it('resolves registry URLs using the package name if set', async () => {
-      fs.findLocalSiblingOrParent.mockImplementation(
-        (packageFile, otherFile): Promise<string | null> => {
-          if (packageFile === 'package.json' && otherFile === '.yarnrc.yml') {
-            return Promise.resolve('.yarnrc.yml');
-          }
-          return Promise.resolve(null);
-        },
-      );
+      fs.findLocalSiblingAndParents.mockResolvedValue(['.yarnrc.yml']);
 
       fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
         if (fileName === '.yarnrc.yml') {
@@ -1386,6 +1425,7 @@ describe('modules/manager/npm/extract/index', () => {
 
   describe('.extractAllPackageFiles()', () => {
     it('runs', async () => {
+      fs.findLocalSiblingAndParents.mockResolvedValue([]);
       fs.readLocalFile.mockResolvedValueOnce(input02Content);
       const res = await extractAllPackageFiles(defaultExtractConfig, [
         'package.json',

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -34,6 +34,7 @@ import { postExtract } from './post/index.ts';
 import type { NpmPackage } from './types.ts';
 import { extractYarnCatalogs, isZeroInstall } from './yarn.ts';
 import {
+  loadConfigFromInheritedYarnrcYml,
   loadConfigFromLegacyYarnrc,
   loadConfigFromYarnrcYml,
   resolveRegistryUrl,
@@ -108,13 +109,8 @@ export async function extractPackageFile(
     ? await isZeroInstall(yarnrcYmlFileName)
     : false;
 
-  let yarnrcConfig: YarnConfig | null = null;
-  const repoYarnrcYml = yarnrcYmlFileName
-    ? await readLocalFile(yarnrcYmlFileName, 'utf8')
-    : null;
-  if (isString(repoYarnrcYml) && repoYarnrcYml.trim().length > 0) {
-    yarnrcConfig = loadConfigFromYarnrcYml(repoYarnrcYml);
-  }
+  let yarnrcConfig: YarnConfig | null =
+    await loadConfigFromInheritedYarnrcYml(packageFile);
 
   const legacyYarnrcFileName = await findLocalSiblingOrParent(
     packageFile,

--- a/lib/modules/manager/npm/extract/yarnrc.spec.ts
+++ b/lib/modules/manager/npm/extract/yarnrc.spec.ts
@@ -1,11 +1,21 @@
 import { codeBlock } from 'common-tags';
+import { fs } from '~test/util.ts';
 import {
+  loadConfigFromInheritedYarnrcYml,
   loadConfigFromLegacyYarnrc,
   loadConfigFromYarnrcYml,
+  mergeYarnConfigs,
   resolveRegistryUrl,
 } from './yarnrc.ts';
 
+vi.mock('../../../../util/fs/index.ts');
+
 describe('modules/manager/npm/extract/yarnrc', () => {
+  beforeEach(() => {
+    fs.findLocalSiblingAndParents.mockResolvedValue([]);
+    fs.readLocalFile.mockResolvedValue(null);
+  });
+
   describe('resolveRegistryUrl()', () => {
     it('considers default registry', () => {
       const registryUrl = resolveRegistryUrl('a-package', {
@@ -157,6 +167,199 @@ describe('modules/manager/npm/extract/yarnrc', () => {
       const config = loadConfigFromLegacyYarnrc(legacyYarnrc);
 
       expect(config).toEqual(expectedConfig);
+    });
+  });
+
+  describe('mergeYarnConfigs()', () => {
+    it('returns child when parent config is null', () => {
+      const mergedConfig = mergeYarnConfigs(null, {
+        npmRegistryServer: 'https://child.example.com',
+      });
+
+      expect(mergedConfig).toEqual({
+        npmRegistryServer: 'https://child.example.com',
+      });
+    });
+
+    it('returns parent when child config is null', () => {
+      const mergedConfig = mergeYarnConfigs(
+        {
+          npmRegistryServer: 'https://parent.example.com',
+        },
+        null,
+      );
+
+      expect(mergedConfig).toEqual({
+        npmRegistryServer: 'https://parent.example.com',
+      });
+    });
+
+    it('merges child config on top of parent config preserving child catalog(s)', () => {
+      const mergedConfig = mergeYarnConfigs(
+        {
+          npmRegistryServer: 'https://default.example.com',
+          npmScopes: {
+            root: {
+              npmRegistryServer: 'https://root.example.com',
+            },
+            shared: {
+              npmRegistryServer: 'https://shared-root.example.com',
+            },
+          },
+          catalog: {
+            typescript: '^5.0.0',
+            eslint: '^8.0.0',
+          },
+          catalogs: {
+            ci: {
+              vitest: '^2.0.0',
+              eslint: '^8.0.0',
+            },
+          },
+        },
+        {
+          npmScopes: {
+            leaf: {
+              npmRegistryServer: 'https://leaf.example.com',
+            },
+            shared: {
+              npmRegistryServer: 'https://shared-leaf.example.com',
+            },
+          },
+          catalog: {
+            eslint: '^9.0.0',
+            prettier: '^3.0.0',
+          },
+          catalogs: {
+            ci: {
+              eslint: '^9.0.0',
+              '@types/node': '^22.0.0',
+            },
+            test: {
+              vitest: '^3.0.0',
+            },
+          },
+        },
+      );
+
+      expect(mergedConfig).toEqual({
+        npmRegistryServer: 'https://default.example.com',
+        npmScopes: {
+          root: {
+            npmRegistryServer: 'https://root.example.com',
+          },
+          leaf: {
+            npmRegistryServer: 'https://leaf.example.com',
+          },
+          shared: {
+            npmRegistryServer: 'https://shared-leaf.example.com',
+          },
+        },
+        catalog: {
+          eslint: '^9.0.0',
+          prettier: '^3.0.0',
+        },
+        catalogs: {
+          ci: {
+            eslint: '^9.0.0',
+            '@types/node': '^22.0.0',
+          },
+          test: {
+            vitest: '^3.0.0',
+          },
+        },
+      });
+    });
+  });
+
+  describe('loadConfigFromInheritedYarnrcYml()', () => {
+    it('returns null when no inherited .yarnrc.yml files are found', async () => {
+      fs.findLocalSiblingAndParents.mockResolvedValue([]);
+
+      const config = await loadConfigFromInheritedYarnrcYml(
+        'packages/foo/package.json',
+      );
+
+      expect(config).toBeNull();
+    });
+
+    it('returns null for absolute package file path', async () => {
+      fs.findLocalSiblingAndParents.mockResolvedValue([]);
+
+      const config = await loadConfigFromInheritedYarnrcYml(
+        '/absolute/package.json',
+      );
+
+      expect(config).toBeNull();
+    });
+
+    it('loads and merges inherited files from parent to child', async () => {
+      fs.findLocalSiblingAndParents.mockResolvedValue([
+        'packages/.yarnrc.yml',
+        '.yarnrc.yml',
+      ]);
+
+      fs.readLocalFile.mockImplementation((path): Promise<any> => {
+        if (path === '.yarnrc.yml') {
+          return Promise.resolve(codeBlock`
+            npmRegistryServer: https://parent.example.com
+            npmScopes:
+              parent:
+                npmRegistryServer: https://scope-parent.example.com
+          `);
+        }
+        if (path === 'packages/.yarnrc.yml') {
+          return Promise.resolve(codeBlock`
+            npmScopes:
+              leaf:
+                npmRegistryServer: https://scope-leaf.example.com
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const config = await loadConfigFromInheritedYarnrcYml(
+        'packages/foo/package.json',
+      );
+
+      expect(config).toEqual({
+        npmRegistryServer: 'https://parent.example.com',
+        npmScopes: {
+          parent: {
+            npmRegistryServer: 'https://scope-parent.example.com',
+          },
+          leaf: {
+            npmRegistryServer: 'https://scope-leaf.example.com',
+          },
+        },
+      });
+    });
+
+    it('skips empty inherited files', async () => {
+      fs.findLocalSiblingAndParents.mockResolvedValue([
+        'packages/.yarnrc.yml',
+        '.yarnrc.yml',
+      ]);
+
+      fs.readLocalFile.mockImplementation((path): Promise<any> => {
+        if (path === '.yarnrc.yml') {
+          return Promise.resolve('   \n');
+        }
+        if (path === 'packages/.yarnrc.yml') {
+          return Promise.resolve(
+            'npmRegistryServer: https://child.example.com',
+          );
+        }
+        return Promise.resolve(null);
+      });
+
+      const config = await loadConfigFromInheritedYarnrcYml(
+        'packages/foo/package.json',
+      );
+
+      expect(config).toEqual({
+        npmRegistryServer: 'https://child.example.com',
+      });
     });
   });
 });

--- a/lib/modules/manager/npm/extract/yarnrc.ts
+++ b/lib/modules/manager/npm/extract/yarnrc.ts
@@ -1,5 +1,9 @@
 import { isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../../logger/index.ts';
+import {
+  findLocalSiblingAndParents,
+  readLocalFile,
+} from '../../../../util/fs/index.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
 import { YarnConfig } from '../schema.ts';
@@ -35,6 +39,48 @@ export function loadConfigFromYarnrcYml(yarnrcYml: string): YarnConfig | null {
       logger.warn({ yarnrcYml, err }, `Failed to load yarnrc file`);
     })
     .unwrapOrNull();
+}
+
+export function mergeYarnConfigs(
+  parentConfig: YarnConfig | null,
+  childConfig: YarnConfig | null,
+): YarnConfig | null {
+  if (!parentConfig) {
+    return childConfig;
+  }
+  if (!childConfig) {
+    return parentConfig;
+  }
+
+  return {
+    ...childConfig,
+    npmRegistryServer:
+      childConfig.npmRegistryServer ?? parentConfig.npmRegistryServer,
+    npmScopes: {
+      ...parentConfig.npmScopes,
+      ...childConfig.npmScopes,
+    },
+  };
+}
+
+export async function loadConfigFromInheritedYarnrcYml(
+  packageFile: string,
+): Promise<YarnConfig | null> {
+  const yarnrcFileNames =
+    (await findLocalSiblingAndParents(packageFile, '.yarnrc.yml')) ?? [];
+
+  let yarnrcConfig: YarnConfig | null = null;
+  for (const yarnrcFileName of yarnrcFileNames.reverse()) {
+    const repoYarnrcYml = await readLocalFile(yarnrcFileName, 'utf8');
+    if (repoYarnrcYml?.trim().length) {
+      yarnrcConfig = mergeYarnConfigs(
+        yarnrcConfig,
+        loadConfigFromYarnrcYml(repoYarnrcYml),
+      );
+    }
+  }
+
+  return yarnrcConfig;
 }
 
 export function resolveRegistryUrl(

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -15,6 +15,13 @@ Please post feedback to the Renovate repository "Discussions" if you're needing 
 
 If Renovate detects a `packageManager` setting for Yarn in `package.json` then it will use Corepack to install Yarn.
 
+#### Yarn RC Discovery
+
+For Yarn 2+ projects, Renovate reads inherited `.yarnrc.yml` files from the current package directory up through parent directories, with nearer files taking precedence.
+This means you do not need to duplicate `.yarnrc.yml` next to every `yarn.lock` or `package.json` just for registry-related settings.
+
+For legacy `.yarnrc`, Renovate still reads the nearest matching file.
+
 #### HTTP Proxy Support
 
 Yarn itself does not natively recognize/support the `HTTP_PROXY` and `HTTPS_PROXY` environment variables.

--- a/lib/util/fs/index.ts
+++ b/lib/util/fs/index.ts
@@ -149,6 +149,36 @@ export function isValidLocalPath(path: string): boolean {
 }
 
 /**
+ * Finds `otherFileName` in the directory where `existingFileNameWithPath` is,
+ * then in its parent directory, then in the grandparent,
+ * until we reach the top-level directory and found all files.
+ * All paths must be relative to `localDir`.
+ */
+export async function findLocalSiblingAndParents(
+  existingFileNameWithPath: string,
+  otherFileName: string,
+): Promise<string[]> {
+  if (upath.isAbsolute(existingFileNameWithPath)) {
+    return [];
+  }
+  if (upath.isAbsolute(otherFileName)) {
+    return [];
+  }
+
+  const fileNames: string[] = [];
+  let current = existingFileNameWithPath;
+  while (current !== '') {
+    current = getParentDir(current);
+    const candidate = upath.join(current, otherFileName);
+    if (await localPathExists(candidate)) {
+      fileNames.push(candidate);
+    }
+  }
+
+  return fileNames;
+}
+
+/**
  * Tries to find `otherFileName` in the directory where
  * `existingFileNameWithPath` is, then in its parent directory, then in the
  * grandparent, until we reach the top-level directory. All paths
@@ -158,23 +188,11 @@ export async function findLocalSiblingOrParent(
   existingFileNameWithPath: string,
   otherFileName: string,
 ): Promise<string | null> {
-  if (upath.isAbsolute(existingFileNameWithPath)) {
-    return null;
-  }
-  if (upath.isAbsolute(otherFileName)) {
-    return null;
-  }
-
-  let current = existingFileNameWithPath;
-  while (current !== '') {
-    current = getParentDir(current);
-    const candidate = upath.join(current, otherFileName);
-    if (await localPathExists(candidate)) {
-      return candidate;
-    }
-  }
-
-  return null;
+  return (
+    (
+      await findLocalSiblingAndParents(existingFileNameWithPath, otherFileName)
+    )[0] ?? null
+  );
 }
 
 /**


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Enables renovate in mono repos/projects that rely on inherited config, e.g.

`yarnrc.yml`:
```yml
npmMinimalAgeGate: '3d'

npmScopes:
  example-org:
    npmAlwaysAuth: true
    npmRegistryServer: 'https://npm.pkg.github.com'
```

`packages/foo/yarnrc.yml`:
```yml
npmPreapprovedPackages:
  - 'example@1.2.3'
```

The inheritance may be useful for enforcing minimum age gates or centrally configuring private package registries.

The issue is described in more depth here: https://github.com/renovatebot/renovate/discussions/41615

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/simpleclub-extended/renovate-yarn-inherited-private-packages-mvce

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
