### PR TITLE
fix(manager/pub): Always populate pub extracted constraints

### DIFF
--- a/lib/modules/manager/pub/extract.ts
+++ b/lib/modules/manager/pub/extract.ts
@@ -1,4 +1,4 @@
-import { isEmptyObject, isObject, isString } from '@sindresorhus/is';
+import { isObject, isString } from '@sindresorhus/is';
 import type { SkipReason } from '../../../types/index.ts';
 import type { ConstraintName } from '../../../util/exec/types.ts';
 import { DartDatasource } from '../../datasource/dart/index.ts';
@@ -142,8 +142,6 @@ export function extractPackageFile(
     return null;
   }
 
-  const extractedConstraints = extractConstraints(pubspec);
-
   return {
     deps: [
       ...extractFromSection(pubspec, 'dependencies'),
@@ -151,6 +149,6 @@ export function extractPackageFile(
       ...extractDart(pubspec),
       ...extractFlutter(pubspec),
     ],
-    ...(!isEmptyObject(extractedConstraints) && { extractedConstraints }),
+    extractedConstraints: extractConstraints(pubspec),
   };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Followup from code review that was submitted after https://github.com/renovatebot/renovate/pull/44171 was merged (see: https://github.com/renovatebot/renovate/pull/44171#discussion_r3465951305)

Since `sdk` is always populated within a pubspec.yaml, we can cleanup the extractedConstraints empty object check

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
