### PR TITLE
feat(gitlab): Add platformCommit support for GitLab

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4072,14 +4072,35 @@ To learn how to use GitHub's Merge Queue feature with Renovate, read our [GitHub
 
 ## `platformCommit`
 
-Only use this option if you run Renovate as a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps).
-It does not apply when you use a Personal Access Token as credential.
+`platformCommit` tells Renovate to create commits through the platform API instead of creating local git commits and pushing them.
 
-When `platformCommit` is enabled, Renovate will create commits with GitHub's API instead of using `git` directly.
-This way Renovate can use GitHub's [Commit signing support for bots and other GitHub Apps](https://github.blog/2019-08-15-commit-signing-support-for-bots-and-other-github-apps/) feature.
+**GitHub**
+
+Use this option only when running Renovate as a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps).
+It does not apply when using a Personal Access Token.
+
+When `platformCommit=enabled`, Renovate creates commits via GitHub's API.
+This allows GitHub's [commit signing support for bots and GitHub Apps](https://github.blog/2019-08-15-commit-signing-support-for-bots-and-other-github-apps/).
+
+**GitLab**
+
+When `platformCommit=enabled`, Renovate creates commits using GitLab's [Commits API](https://docs.gitlab.com/api/commits/#create-a-commit-with-multiple-files-and-actions) instead of pushing with `git`.
+This lets Renovate commit without requiring configured `gitAuthor` or `gitPrivateKey`, because GitLab signs and attributes commits server-side.
+
+Renovate recreates the branch from the base branch on each update so the branch remains a single fresh commit instead of accumulating prior Renovate commits.
+
+To verify behavior in logs, set `LOG_LEVEL=debug` and look for:
+
+- `GitLab platformCommit enabled: using platform API commit path`
+- `GitLab platformCommit: preparing commit via GitLab API`
+- `GitLab platformCommit: created commit via GitLab API`
+
+If you see this message instead, Renovate used the regular `git` commit/push path:
+
+- `GitLab platformCommit disabled or auto: using git push commit path`
 
 !!! note
-  When using platform commits, GitHub determines the git author string to use and Renovate's own gitAuthor is ignored.
+  For GitHub platform commits, GitHub determines the git author string and Renovate's own `gitAuthor` is ignored.
 
 ## `postUpdateOptions`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3422,7 +3422,7 @@ const options: Readonly<RenovateOptions>[] = [
     type: 'string',
     default: 'auto',
     allowedValues: ['auto', 'disabled', 'enabled'],
-    supportedPlatforms: ['github'],
+    supportedPlatforms: ['github', 'gitlab'],
   },
   {
     name: 'branchNameStrict',

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -519,6 +519,383 @@ describe('modules/platform/gitlab/index', () => {
     });
   });
 
+  describe('commitFiles', () => {
+    const preparedParentSha = fakeSha('gitlab-prepared-parent');
+    const preparedCommitSha = fakeSha('gitlab-prepared-commit');
+    const fetchedSha = fakeSha('gitlab-fetched-sha');
+
+    beforeEach(async () => {
+      await initRepo();
+      git.getCurrentBranch.mockReturnValue('master');
+      git.prepareCommit.mockImplementation((commitConfig) =>
+        Promise.resolve({
+          parentCommitSha: preparedParentSha,
+          commitSha: preparedCommitSha,
+          files: commitConfig.files,
+        }),
+      );
+      git.fetchBranch.mockResolvedValue(fetchedSha);
+    });
+
+    it('returns null when prepareCommit returns null', async () => {
+      git.prepareCommit.mockResolvedValueOnce(null);
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'new.txt',
+            contents: 'created',
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(res).toBeNull();
+      expect(git.getFile).not.toHaveBeenCalled();
+      expect(git.resetToCommit).not.toHaveBeenCalled();
+      expect(git.fetchBranch).not.toHaveBeenCalled();
+    });
+
+    it('returns null when no actions are generated', async () => {
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [],
+        message: 'msg',
+      });
+
+      expect(res).toBeNull();
+      expect(git.prepareCommit).toHaveBeenCalled();
+      expect(git.resetToCommit).not.toHaveBeenCalled();
+      expect(git.fetchBranch).not.toHaveBeenCalled();
+    });
+
+    it('returns null when prepareCommit filters all changes out', async () => {
+      git.prepareCommit.mockResolvedValueOnce({
+        parentCommitSha: preparedParentSha,
+        commitSha: preparedCommitSha,
+        files: [],
+      });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'new.txt',
+            contents: 'created',
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(res).toBeNull();
+      expect(git.prepareCommit).toHaveBeenCalled();
+      expect(git.getFile).not.toHaveBeenCalled();
+      expect(git.resetToCommit).not.toHaveBeenCalled();
+      expect(git.fetchBranch).not.toHaveBeenCalled();
+    });
+
+    it('creates a commit via the GitLab API for create, update and delete actions', async () => {
+      // First file exists on the branch (update), second does not (create).
+      git.getFile.mockResolvedValueOnce('existing').mockResolvedValueOnce(null);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits', {
+          branch: 'some-branch',
+          start_branch: 'master',
+          commit_message: 'title\n\nbody',
+          actions: [
+            {
+              action: 'update',
+              file_path: 'existing.txt',
+              content: 'updated',
+            },
+            {
+              action: 'create',
+              file_path: 'new.txt',
+              content: 'created',
+            },
+            {
+              action: 'delete',
+              file_path: 'old.txt',
+            },
+          ],
+          force: true,
+        })
+        .reply(201, {
+          id: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'existing.txt',
+            contents: 'updated',
+          },
+          {
+            type: 'addition',
+            path: 'new.txt',
+            contents: 'created',
+          },
+          {
+            type: 'deletion',
+            path: 'old.txt',
+          },
+        ],
+        message: ['title', 'body'],
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(git.prepareCommit).toHaveBeenCalled();
+      expect(git.resetToCommit).toHaveBeenCalledWith(preparedParentSha);
+      expect(git.fetchBranch).toHaveBeenCalledWith('some-branch');
+      expect(git.getFile).toHaveBeenNthCalledWith(1, 'existing.txt', 'master');
+      expect(git.getFile).toHaveBeenNthCalledWith(2, 'new.txt', 'master');
+      expect(res).toBe(fetchedSha);
+    });
+
+    it('returns the API sha for a single create action', async () => {
+      git.getFile.mockResolvedValueOnce(null);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits', {
+          branch: 'some-branch',
+          start_branch: 'master',
+          commit_message: 'msg',
+          actions: [
+            {
+              action: 'create',
+              file_path: 'new.txt',
+              content: 'created',
+            },
+          ],
+          force: true,
+        })
+        .reply(201, {
+          id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'new.txt',
+            contents: 'created',
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(git.resetToCommit).toHaveBeenCalledWith(preparedParentSha);
+      expect(git.fetchBranch).toHaveBeenCalledWith('some-branch');
+      expect(res).toBe(fetchedSha);
+    });
+
+    it('falls back to current branch when baseBranch is undefined', async () => {
+      git.getCurrentBranch.mockReturnValue('release/1.x');
+      git.getFile.mockResolvedValueOnce(null);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits', {
+          branch: 'some-branch',
+          start_branch: 'release/1.x',
+          commit_message: 'msg',
+          actions: [
+            {
+              action: 'create',
+              file_path: 'new.txt',
+              content: 'created',
+            },
+          ],
+          force: true,
+        })
+        .reply(201, {
+          id: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'new.txt',
+            contents: 'created',
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(git.getFile).toHaveBeenCalledWith('new.txt', 'release/1.x');
+      expect(git.resetToCommit).toHaveBeenCalledWith(preparedParentSha);
+      expect(git.fetchBranch).toHaveBeenCalledWith('some-branch');
+      expect(res).toBe(fetchedSha);
+    });
+
+    it('base64 encodes binary file contents', async () => {
+      git.getFile.mockResolvedValueOnce(null);
+      const contents = Buffer.from([0x00, 0x01, 0x02, 0x03]);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits', {
+          branch: 'some-branch',
+          start_branch: 'master',
+          commit_message: 'msg',
+          actions: [
+            {
+              action: 'create',
+              file_path: 'binary.bin',
+              content: contents.toString('base64'),
+              encoding: 'base64',
+            },
+          ],
+          force: true,
+        })
+        .reply(201, {
+          id: 'cccccccccccccccccccccccccccccccccccccccc',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'binary.bin',
+            contents,
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(git.resetToCommit).toHaveBeenCalledWith(preparedParentSha);
+      expect(git.fetchBranch).toHaveBeenCalledWith('some-branch');
+      expect(res).toBe(fetchedSha);
+    });
+
+    it('sets execute_filemode for executable files and recreates the branch from the base branch', async () => {
+      git.getFile.mockResolvedValueOnce(null);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits', {
+          branch: 'some-branch',
+          start_branch: 'develop',
+          commit_message: 'msg',
+          actions: [
+            {
+              action: 'create',
+              file_path: 'script.sh',
+              content: 'echo hi',
+              execute_filemode: true,
+            },
+          ],
+          force: true,
+        })
+        .reply(201, {
+          id: 'dddddddddddddddddddddddddddddddddddddddd',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'script.sh',
+            contents: 'echo hi',
+            isExecutable: true,
+          },
+        ],
+        message: 'msg',
+        baseBranch: 'develop',
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(git.getFile).toHaveBeenCalledWith('script.sh', 'develop');
+      expect(git.resetToCommit).toHaveBeenCalledWith(preparedParentSha);
+      expect(git.fetchBranch).toHaveBeenCalledWith('some-branch');
+      expect(res).toBe(fetchedSha);
+    });
+
+    it('handles null contents as an empty file', async () => {
+      git.getFile.mockResolvedValueOnce(null);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits', {
+          branch: 'some-branch',
+          start_branch: 'master',
+          commit_message: 'msg',
+          actions: [
+            {
+              action: 'create',
+              file_path: 'empty.txt',
+              content: '',
+            },
+          ],
+          force: true,
+        })
+        .reply(201, {
+          id: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'empty.txt',
+            contents: null,
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(git.resetToCommit).toHaveBeenCalledWith(preparedParentSha);
+      expect(git.fetchBranch).toHaveBeenCalledWith('some-branch');
+      expect(res).toBe(fetchedSha);
+    });
+
+    it('returns null and logs a warning when the API call fails', async () => {
+      git.getFile.mockResolvedValueOnce(null);
+
+      const scope = httpMock
+        .scope(gitlabApiHost)
+        .post('/api/v4/projects/some%2Frepo/repository/commits')
+        .reply(400, {
+          message: 'bad request',
+        });
+
+      const res = await gitlab.commitFiles({
+        branchName: 'some-branch',
+        files: [
+          {
+            type: 'addition',
+            path: 'new.txt',
+            contents: 'created',
+          },
+        ],
+        message: 'msg',
+      });
+
+      expect(scope.isDone()).toBeTrue();
+      expect(res).toBeNull();
+      expect(git.resetToCommit).not.toHaveBeenCalled();
+      expect(git.fetchBranch).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getBranchForceRebase', () => {
     it('should return false for merge_method=merge', async () => {
       await initRepo(

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -24,6 +24,7 @@ import { coerceArray } from '../../../util/array.ts';
 import { noLeadingAtSymbol, parseJson } from '../../../util/common.ts';
 import { getEnv } from '../../../util/env.ts';
 import * as git from '../../../util/git/index.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
 import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
 import type { GitlabHttpOptions } from '../../../util/http/gitlab.ts';
 import { setBaseUrl } from '../../../util/http/gitlab.ts';
@@ -32,6 +33,8 @@ import { parseInteger } from '../../../util/number.ts';
 import * as p from '../../../util/promises.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
+import { toLongCommitSha } from '../../../util/schema-utils/git.ts';
 import type { EmailAddress } from '../../../util/schema-utils/index.ts';
 import {
   ensureTrailingSlash,
@@ -74,6 +77,8 @@ import type { GitLabMergeRequest } from './schema.ts';
 import { LastPipelineId } from './schema.ts';
 import type {
   GitlabComment,
+  GitlabCommitAction,
+  GitlabCommitResponse,
   GitlabIssue,
   GitlabPr,
   MergeMethod,
@@ -85,6 +90,9 @@ import {
   defaults,
   getRepoUrl,
   prInfo,
+  toAdditionAction,
+  toCommitMessage,
+  toDeletionAction,
 } from './utils.ts';
 
 export { extractRulesFromCodeOwnersLines } from './code-owners.ts';
@@ -270,6 +278,75 @@ export async function getJsonFile(
 ): Promise<any> {
   const raw = await getRawFile(fileName, repoName, branchOrTag);
   return parseJson(raw, fileName);
+}
+
+export async function commitFiles(
+  commitConfig: CommitFilesConfig,
+): Promise<LongCommitSha | null> {
+  const { baseBranch, branchName, files, message } = commitConfig;
+  const startBranch = baseBranch ?? git.getCurrentBranch();
+
+  const commitResult = await git.prepareCommit(commitConfig);
+  if (!commitResult) {
+    logger.debug(
+      { branchName, files: files.map(({ path }) => path) },
+      'GitLab platformCommit: unable to prepare for commit',
+    );
+    return null;
+  }
+
+  logger.debug(
+    { branchName, fileCount: commitResult.files.length },
+    'GitLab platformCommit: preparing commit via GitLab API',
+  );
+
+  const actions: GitlabCommitAction[] = [];
+  for (const file of commitResult.files) {
+    if (file.type === 'deletion') {
+      actions.push(toDeletionAction(file.path));
+    } else {
+      actions.push(await toAdditionAction(file, startBranch));
+    }
+  }
+
+  if (isEmptyArray(actions)) {
+    logger.debug(
+      { branchName },
+      'GitLab platformCommit: no file changes to commit',
+    );
+    return null;
+  }
+
+  try {
+    const res = await gitlabApi.postJson<GitlabCommitResponse>(
+      `projects/${config.repository}/repository/commits`,
+      {
+        body: {
+          branch: branchName,
+          start_branch: startBranch,
+          commit_message: toCommitMessage(message),
+          actions,
+          force: true,
+        },
+      },
+    );
+
+    const commitSha = toLongCommitSha(res.body.id);
+    logger.debug(
+      { branchName, commitSha, startBranch },
+      'GitLab platformCommit: created commit via GitLab API',
+    );
+    // Keep local branch state in sync with the platform-created commit,
+    // matching the GitHub platform-commit flow.
+    await git.resetToCommit(commitResult.parentCommitSha);
+    return await git.fetchBranch(branchName);
+  } catch (err) {
+    logger.warn(
+      { err, branchName, startBranch },
+      'GitLab platformCommit: failed to create commit via GitLab API',
+    );
+    return null;
+  }
 }
 
 // Initialize GitLab by getting base branch

--- a/lib/modules/platform/gitlab/scm.spec.ts
+++ b/lib/modules/platform/gitlab/scm.spec.ts
@@ -1,0 +1,61 @@
+import { fakeSha, git } from '~test/util.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
+import * as _gitlab from './index.ts';
+import { GitlabScm } from './scm.ts';
+
+vi.mock('./index.ts');
+const gitlab = vi.mocked(_gitlab);
+
+describe('modules/platform/gitlab/scm', () => {
+  beforeEach(() => {
+    git.commitFiles.mockResolvedValue(fakeSha('gitlab-scm-commit-files'));
+  });
+
+  const gitlabScm = new GitlabScm();
+
+  const commitObj = {
+    baseBranch: 'main',
+    branchName: 'branch',
+    files: [],
+    message: 'msg',
+  } satisfies CommitFilesConfig;
+
+  it('platformCommit = disabled => delegate to git', async () => {
+    await gitlabScm.commitAndPush({
+      ...commitObj,
+      platformCommit: 'disabled',
+    });
+
+    expect(git.commitFiles).toHaveBeenCalledExactlyOnceWith({
+      ...commitObj,
+      platformCommit: 'disabled',
+    });
+    expect(gitlab.commitFiles).not.toHaveBeenCalled();
+  });
+
+  it('platformCommit = enabled => delegate to gitlab', async () => {
+    await gitlabScm.commitAndPush({
+      ...commitObj,
+      platformCommit: 'enabled',
+    });
+
+    expect(git.commitFiles).not.toHaveBeenCalled();
+    expect(gitlab.commitFiles).toHaveBeenCalledExactlyOnceWith({
+      ...commitObj,
+      platformCommit: 'enabled',
+    });
+  });
+
+  it('platformCommit = auto => delegate to git', async () => {
+    await gitlabScm.commitAndPush({
+      ...commitObj,
+      platformCommit: 'auto',
+    });
+
+    expect(git.commitFiles).toHaveBeenCalledExactlyOnceWith({
+      ...commitObj,
+      platformCommit: 'auto',
+    });
+    expect(gitlab.commitFiles).not.toHaveBeenCalled();
+  });
+});

--- a/lib/modules/platform/gitlab/scm.ts
+++ b/lib/modules/platform/gitlab/scm.ts
@@ -1,0 +1,32 @@
+import { logger } from '../../../logger/index.ts';
+import * as git from '../../../util/git/index.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
+import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
+import { DefaultGitScm } from '../default-scm.ts';
+import { commitFiles } from './index.ts';
+
+export class GitlabScm extends DefaultGitScm {
+  override commitAndPush(
+    commitConfig: CommitFilesConfig,
+  ): Promise<LongCommitSha | null> {
+    if (commitConfig.platformCommit === 'enabled') {
+      logger.debug(
+        {
+          branchName: commitConfig.branchName,
+          platformCommit: commitConfig.platformCommit,
+        },
+        'GitLab platformCommit enabled: using platform API commit path',
+      );
+      return commitFiles(commitConfig);
+    }
+
+    logger.debug(
+      {
+        branchName: commitConfig.branchName,
+        platformCommit: commitConfig.platformCommit,
+      },
+      'GitLab platformCommit disabled or auto: using git push commit path',
+    );
+    return git.commitFiles(commitConfig);
+  }
+}

--- a/lib/modules/platform/gitlab/types.ts
+++ b/lib/modules/platform/gitlab/types.ts
@@ -68,3 +68,15 @@ export interface GitlabPrCacheData {
   updated_at: string | null;
   author: string | null;
 }
+
+export interface GitlabCommitAction {
+  action: 'create' | 'update' | 'delete';
+  file_path: string;
+  content?: string;
+  encoding?: 'base64';
+  execute_filemode?: boolean;
+}
+
+export interface GitlabCommitResponse {
+  id: string;
+}

--- a/lib/modules/platform/gitlab/utils.ts
+++ b/lib/modules/platform/gitlab/utils.ts
@@ -1,15 +1,17 @@
 import url from 'node:url';
-import { isNonEmptyArray, isNonEmptyString } from '@sindresorhus/is';
+import { isArray, isNonEmptyArray, isNonEmptyString } from '@sindresorhus/is';
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { getEnv } from '../../../util/env.ts';
+import * as git from '../../../util/git/index.ts';
+import type { FileAddition } from '../../../util/git/types.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import type { HttpResponse } from '../../../util/http/types.ts';
 import { parseUrl } from '../../../util/url.ts';
 import { getPrBodyStruct } from '../pr-body.ts';
 import type { GitUrlOption } from '../types.ts';
 import type { GitLabMergeRequest } from './schema.ts';
-import type { GitlabPr, RepoResponse } from './types.ts';
+import type { GitlabCommitAction, GitlabPr, RepoResponse } from './types.ts';
 
 export const DRAFT_PREFIX = 'Draft: ';
 export const DRAFT_PREFIX_DEPRECATED = 'WIP: ';
@@ -118,4 +120,44 @@ export function getRepoUrl(
   repoUrl.username = 'oauth2';
   repoUrl.password = opts.token!;
   return repoUrl.toString();
+}
+
+export function toCommitMessage(message: string | string[]): string {
+  return isArray(message) ? message.join('\n\n') : message;
+}
+
+export async function toAdditionAction(
+  file: FileAddition,
+  startBranch: string,
+): Promise<GitlabCommitAction> {
+  // The GitLab API requires the caller to declare whether a file is being
+  // created or updated, so we check whether it already exists on the parent
+  // branch reference used by start_branch.
+  const fileExists = (await git.getFile(file.path, startBranch)) !== null;
+
+  const action: GitlabCommitAction = {
+    action: fileExists ? 'update' : 'create',
+    file_path: file.path,
+    content: Buffer.isBuffer(file.contents)
+      ? file.contents.toString('base64')
+      : (file.contents ?? ''),
+  };
+
+  // Binary content must be base64 encoded so it survives the JSON round-trip.
+  if (Buffer.isBuffer(file.contents)) {
+    action.encoding = 'base64';
+  }
+
+  if (file.isExecutable) {
+    action.execute_filemode = true;
+  }
+
+  return action;
+}
+
+export function toDeletionAction(filePath: string): GitlabCommitAction {
+  return {
+    action: 'delete',
+    file_path: filePath,
+  };
 }

--- a/lib/modules/platform/scm.ts
+++ b/lib/modules/platform/scm.ts
@@ -4,6 +4,7 @@ import type { PlatformId } from '../../constants/index.ts';
 import { DefaultGitScm } from './default-scm.ts';
 import { GerritScm } from './gerrit/scm.ts';
 import { GithubScm } from './github/scm.ts';
+import { GitlabScm } from './gitlab/scm.ts';
 import { LocalFs } from './local/scm.ts';
 import type { PlatformScm } from './types.ts';
 
@@ -16,7 +17,7 @@ platformScmImpls.set('forgejo', DefaultGitScm);
 platformScmImpls.set('gerrit', GerritScm);
 platformScmImpls.set('gitea', DefaultGitScm);
 platformScmImpls.set('github', GithubScm);
-platformScmImpls.set('gitlab', DefaultGitScm);
+platformScmImpls.set('gitlab', GitlabScm);
 platformScmImpls.set('local', LocalFs);
 platformScmImpls.set('scm-manager', DefaultGitScm);
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -371,6 +371,12 @@ describe('util/git/index', { timeout: 30000 }, () => {
     });
   });
 
+  describe('getCurrentBranch()', () => {
+    it('should return the current branch', () => {
+      expect(git.getCurrentBranch()).toBe(defaultBranch);
+    });
+  });
+
   describe('getBranchList()', () => {
     it('should return all branches', () => {
       const res = git.getBranchList();

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -655,6 +655,10 @@ export function branchExists(branchName: string): boolean {
   return !!config.branchCommits[branchName];
 }
 
+export function getCurrentBranch(): string {
+  return config.currentBranch;
+}
+
 // Return the commit SHA for a branch
 export function getBranchCommit(branchName: string): LongCommitSha | null {
   return config.branchCommits?.[branchName] || null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR implements the platformCommit: 'enabled' option for the GitLab platform, allowing Renovate to create commits via the GitLab Commits API instead of using git push.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44225 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
