### PR TITLE
feat: AWS ECR release timestamps

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -223,6 +223,7 @@ The below is a non-exhaustive list of public registries which support release ti
 | `crate`              | `https://crates.io`                                | ✅        |                                                                  |
 | `rubygems`           | `https://rubygems.org`                             | ✅        |                                                                  |
 | `docker`             | `https://index.docker.io`                          | ✅        |                                                                  |
+| `docker`             | `*.dkr.ecr.*.amazonaws.com` / `public.ecr.aws`     | ✅        | Reads `created` from image config blob                           |
 | `docker`             | (not Docker Hub)                                   | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38656)    |
 | `docker`             | `https://ghcr.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/39064)    |
 | `docker`             | `https://quay.io`                                  | ❌        | [Issue](https://github.com/renovatebot/renovate/issues/38572)    |

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1942,107 +1942,64 @@ describe('modules/datasource/docker/index', () => {
       },
     );
 
-    it.each(amazonHosts)(
-      'returns ECR release timestamps from image config blobs for host $host',
-      async ({ host }) => {
-        httpMock
-          .scope(`https://${host}/v2`)
-          .get('/node/tags/list?n=1000')
-          .reply(200, '', {})
-          .get('/node/tags/list?n=1000')
-          .reply(200, { tags: ['1.0.0', '2.0.0'] }, {})
-          // getCreatedTimestamp('1.0.0') auth + manifest + blob
-          .get('/')
-          .reply(200, '', {})
-          .get('/node/manifests/1.0.0')
-          .reply(200, {
-            schemaVersion: 2,
-            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
-            config: {
-              digest: 'sha256:abc100',
-              mediaType: 'application/vnd.docker.container.image.v1+json',
-            },
-          })
-          .get('/')
-          .reply(200, '', {})
-          .get('/node/blobs/sha256:abc100')
-          .reply(200, {
-            created: '2021-01-01T00:00:00.000Z',
-            architecture: 'amd64',
-            config: { Labels: {} },
-          })
-          // getCreatedTimestamp('2.0.0') auth + manifest + blob
-          .get('/')
-          .reply(200, '', {})
-          .get('/node/manifests/2.0.0')
-          .reply(200, {
-            schemaVersion: 2,
-            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
-            config: {
-              digest: 'sha256:abc200',
-              mediaType: 'application/vnd.docker.container.image.v1+json',
-            },
-          })
-          .get('/')
-          .reply(200, '', {})
-          .get('/node/blobs/sha256:abc200')
-          .reply(200, {
-            created: '2022-01-01T00:00:00.000Z',
-            architecture: 'amd64',
-            config: {
-              Labels: {
-                'org.opencontainers.image.source':
-                  'https://github.com/renovatebot/renovate',
+    describe('postprocessRelease', () => {
+      it.each(amazonHosts)(
+        'fetches ECR release timestamp from image config blob for host $host',
+        async ({ host }) => {
+          httpMock
+            .scope(`https://${host}/v2`)
+            .get('/')
+            .reply(200, '', {})
+            .get('/node/manifests/1.0.0')
+            .reply(200, {
+              schemaVersion: 2,
+              mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+              config: {
+                digest: 'sha256:abc100',
+                mediaType: 'application/vnd.docker.container.image.v1+json',
               },
-            },
-          })
-          // _getLabels('2.0.0') auth + manifest (blob already fetched above)
-          .get('/')
-          .reply(200, '', {})
-          .get('/node/manifests/2.0.0')
-          .reply(200, {
-            schemaVersion: 2,
-            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
-            config: {
-              digest: 'sha256:abc200',
-              mediaType: 'application/vnd.docker.container.image.v1+json',
-            },
-          })
-          .get('/')
-          .reply(200, '', {})
-          .get('/node/blobs/sha256:abc200')
-          .reply(200, {
-            created: '2022-01-01T00:00:00.000Z',
-            architecture: 'amd64',
-            config: {
-              Labels: {
-                'org.opencontainers.image.source':
-                  'https://github.com/renovatebot/renovate',
-              },
-            },
+            })
+            .get('/')
+            .reply(200, '', {})
+            .get('/node/blobs/sha256:abc100')
+            .reply(200, {
+              created: '2021-01-01T00:00:00.000Z',
+              architecture: 'amd64',
+              config: { Labels: {} },
+            });
+          const ds = new DockerDatasource();
+          const result = await ds.postprocessRelease(
+            { packageName: `${host}/node`, registryUrl: null },
+            { version: '1.0.0' },
+          );
+          expect(result).toEqual({
+            version: '1.0.0',
+            releaseTimestamp: '2021-01-01T00:00:00.000Z',
           });
-        expect(
-          await getPkgReleases({
-            datasource: DockerDatasource.id,
-            packageName: `${host}/node`,
-          }),
-        ).toEqual({
-          lookupName: 'node',
-          registryUrl: `https://${host}`,
-          sourceUrl: 'https://github.com/renovatebot/renovate',
-          releases: [
-            {
-              version: '1.0.0',
-              releaseTimestamp: '2021-01-01T00:00:00.000Z',
-            },
-            {
-              version: '2.0.0',
-              releaseTimestamp: '2022-01-01T00:00:00.000Z',
-            },
-          ],
-        });
-      },
-    );
+        },
+      );
+
+      it('skips non-ECR registries', async () => {
+        const ds = new DockerDatasource();
+        const release = { version: '1.0.0' };
+        const result = await ds.postprocessRelease(
+          { packageName: 'library/node', registryUrl: null },
+          release,
+        );
+        expect(result).toBe(release);
+      });
+
+      it('skips non-version tags', async () => {
+        const ds = new DockerDatasource();
+        const release = { version: 'latest' };
+        const [{ host }] = amazonHosts;
+        const result = await ds.postprocessRelease(
+          { packageName: `${host}/node`, registryUrl: null },
+          release,
+        );
+        expect(result).toBe(release);
+      });
+    });
 
     describe('when making requests that interact with an ECR proxy', () => {
       it('resolves requests to ECR proxy', async () => {

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -1942,6 +1942,108 @@ describe('modules/datasource/docker/index', () => {
       },
     );
 
+    it.each(amazonHosts)(
+      'returns ECR release timestamps from image config blobs for host $host',
+      async ({ host }) => {
+        httpMock
+          .scope(`https://${host}/v2`)
+          .get('/node/tags/list?n=1000')
+          .reply(200, '', {})
+          .get('/node/tags/list?n=1000')
+          .reply(200, { tags: ['1.0.0', '2.0.0'] }, {})
+          // getCreatedTimestamp('1.0.0') auth + manifest + blob
+          .get('/')
+          .reply(200, '', {})
+          .get('/node/manifests/1.0.0')
+          .reply(200, {
+            schemaVersion: 2,
+            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+            config: {
+              digest: 'sha256:abc100',
+              mediaType: 'application/vnd.docker.container.image.v1+json',
+            },
+          })
+          .get('/')
+          .reply(200, '', {})
+          .get('/node/blobs/sha256:abc100')
+          .reply(200, {
+            created: '2021-01-01T00:00:00.000Z',
+            architecture: 'amd64',
+            config: { Labels: {} },
+          })
+          // getCreatedTimestamp('2.0.0') auth + manifest + blob
+          .get('/')
+          .reply(200, '', {})
+          .get('/node/manifests/2.0.0')
+          .reply(200, {
+            schemaVersion: 2,
+            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+            config: {
+              digest: 'sha256:abc200',
+              mediaType: 'application/vnd.docker.container.image.v1+json',
+            },
+          })
+          .get('/')
+          .reply(200, '', {})
+          .get('/node/blobs/sha256:abc200')
+          .reply(200, {
+            created: '2022-01-01T00:00:00.000Z',
+            architecture: 'amd64',
+            config: {
+              Labels: {
+                'org.opencontainers.image.source':
+                  'https://github.com/renovatebot/renovate',
+              },
+            },
+          })
+          // _getLabels('2.0.0') auth + manifest (blob already fetched above)
+          .get('/')
+          .reply(200, '', {})
+          .get('/node/manifests/2.0.0')
+          .reply(200, {
+            schemaVersion: 2,
+            mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
+            config: {
+              digest: 'sha256:abc200',
+              mediaType: 'application/vnd.docker.container.image.v1+json',
+            },
+          })
+          .get('/')
+          .reply(200, '', {})
+          .get('/node/blobs/sha256:abc200')
+          .reply(200, {
+            created: '2022-01-01T00:00:00.000Z',
+            architecture: 'amd64',
+            config: {
+              Labels: {
+                'org.opencontainers.image.source':
+                  'https://github.com/renovatebot/renovate',
+              },
+            },
+          });
+        expect(
+          await getPkgReleases({
+            datasource: DockerDatasource.id,
+            packageName: `${host}/node`,
+          }),
+        ).toEqual({
+          lookupName: 'node',
+          registryUrl: `https://${host}`,
+          sourceUrl: 'https://github.com/renovatebot/renovate',
+          releases: [
+            {
+              version: '1.0.0',
+              releaseTimestamp: '2021-01-01T00:00:00.000Z',
+            },
+            {
+              version: '2.0.0',
+              releaseTimestamp: '2022-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      },
+    );
+
     describe('when making requests that interact with an ECR proxy', () => {
       it('resolves requests to ECR proxy', async () => {
         httpMock

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -18,7 +18,10 @@ import {
   parseLinkHeader,
   parseUrl,
 } from '../../../util/url.ts';
-import { id as dockerVersioningId } from '../../versioning/docker/index.ts';
+import {
+  api as dockerVersioning,
+  id as dockerVersioningId,
+} from '../../versioning/docker/index.ts';
 import { Datasource } from '../datasource.ts';
 import type {
   DigestConfig,
@@ -86,7 +89,7 @@ export class DockerDatasource extends Datasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'Only supported on Docker Hub: The release timestamp is determined from the `tag_last_pushed` field in the results. **NOTE**: Currently, digests will receive the same release timestamp as the `tag_last_pushed`, which means that digests may appear newer than they are - see https://github.com/renovatebot/renovate/issues/38659';
+    'Supported on Docker Hub and ECR. For Docker Hub: determined from the `tag_last_pushed` field. For ECR: determined from the `created` field in the image config blob. **NOTE**: Currently, digests will receive the same release timestamp as the `tag_last_pushed`, which means that digests may appear newer than they are - see https://github.com/renovatebot/renovate/issues/38659';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
     'The source URL is determined from the `org.opencontainers.image.source` and `org.label-schema.vcs-url` labels present in the metadata of the **latest stable** image found on the Docker registry.';
@@ -290,6 +293,59 @@ export class DockerDatasource extends Datasource {
       (await this.getManifest(registry, dockerRepository, tag))?.config
         ?.digest ?? null
     );
+  }
+
+  private async getCreatedTimestamp(
+    registryHost: string,
+    dockerRepository: string,
+    tag: string,
+  ): Promise<string | null> {
+    const manifest = await this.getManifest(
+      registryHost,
+      dockerRepository,
+      tag,
+    );
+    /* v8 ignore next 3 -- manifest fetch failure for a valid version tag is not expected */
+    if (!manifest) {
+      return null;
+    }
+
+    const { mediaType, digest } = manifest.config;
+    /* v8 ignore next 5 -- Helm and other non-image configs don't have a created timestamp */
+    if (
+      mediaType !== 'application/vnd.oci.image.config.v1+json' &&
+      mediaType !== 'application/vnd.docker.container.image.v1+json'
+    ) {
+      return null;
+    }
+
+    const headers = await getAuthHeaders(
+      this.http,
+      registryHost,
+      dockerRepository,
+    );
+    /* v8 ignore next 3 -- should never happen */
+    if (!headers) {
+      return null;
+    }
+
+    const url = joinUrlParts(
+      registryHost,
+      'v2',
+      dockerRepository,
+      'blobs',
+      digest,
+    );
+    const { body } = await this.http.getJson(
+      url,
+      { headers, noAuth: true },
+      OciImageConfig,
+    );
+    const created = body.created ?? null;
+    logger.debug(
+      `ECR image config blob created timestamp for ${dockerRepository}:${tag} -> ${created ?? 'null'}`,
+    );
+    return created;
   }
 
   private async getManifest(
@@ -1185,6 +1241,26 @@ export class DockerDatasource extends Datasource {
     if (dockerRepository !== packageName) {
       // This will be reused later if a getDigest() call is made
       ret.lookupName = dockerRepository;
+    }
+
+    if (ecrRegex.test(registryHost) || ecrPublicRegex.test(registryHost)) {
+      const validReleases = releases.filter(({ version }) =>
+        dockerVersioning.isVersion(version),
+      );
+      const createdDates = await Promise.all(
+        validReleases.map(({ version }) =>
+          this.getCreatedTimestamp(registryHost, dockerRepository, version),
+        ),
+      );
+      for (let i = 0; i < validReleases.length; i++) {
+        const ts = asTimestamp(createdDates[i]);
+        /* v8 ignore next 3 -- all valid ECR image versions have a created timestamp */
+        if (!ts) {
+          continue;
+        }
+        const idx = releases.indexOf(validReleases[i]);
+        releases[idx] = { ...releases[idx], releaseTimestamp: ts };
+      }
     }
 
     const tags = releases.map((release) => release.version);

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -26,6 +26,8 @@ import { Datasource } from '../datasource.ts';
 import type {
   DigestConfig,
   GetReleasesConfig,
+  PostprocessReleaseConfig,
+  PostprocessReleaseResult,
   Release,
   ReleaseResult,
 } from '../types.ts';
@@ -346,6 +348,30 @@ export class DockerDatasource extends Datasource {
       `ECR image config blob created timestamp for ${dockerRepository}:${tag} -> ${created ?? 'null'}`,
     );
     return created;
+  }
+
+  override async postprocessRelease(
+    config: PostprocessReleaseConfig,
+    release: Release,
+  ): Promise<PostprocessReleaseResult> {
+    const { packageName, registryUrl } = config;
+    const { registryHost, dockerRepository } = getRegistryRepository(
+      packageName,
+      registryUrl ?? '',
+    );
+    if (
+      !dockerVersioning.isVersion(release.version) ||
+      (!ecrRegex.test(registryHost) && !ecrPublicRegex.test(registryHost))
+    ) {
+      return release;
+    }
+    const created = await this.getCreatedTimestamp(
+      registryHost,
+      dockerRepository,
+      release.version,
+    );
+    const releaseTimestamp = asTimestamp(created);
+    return releaseTimestamp ? { ...release, releaseTimestamp } : release;
   }
 
   private async getManifest(
@@ -1241,26 +1267,6 @@ export class DockerDatasource extends Datasource {
     if (dockerRepository !== packageName) {
       // This will be reused later if a getDigest() call is made
       ret.lookupName = dockerRepository;
-    }
-
-    if (ecrRegex.test(registryHost) || ecrPublicRegex.test(registryHost)) {
-      const validReleases = releases.filter(({ version }) =>
-        dockerVersioning.isVersion(version),
-      );
-      const createdDates = await Promise.all(
-        validReleases.map(({ version }) =>
-          this.getCreatedTimestamp(registryHost, dockerRepository, version),
-        ),
-      );
-      for (let i = 0; i < validReleases.length; i++) {
-        const ts = asTimestamp(createdDates[i]);
-        /* v8 ignore next 3 -- all valid ECR image versions have a created timestamp */
-        if (!ts) {
-          continue;
-        }
-        const idx = releases.indexOf(validReleases[i]);
-        releases[idx] = { ...releases[idx], releaseTimestamp: ts };
-      }
     }
 
     const tags = releases.map((release) => release.version);

--- a/lib/modules/datasource/docker/schema.ts
+++ b/lib/modules/datasource/docker/schema.ts
@@ -40,6 +40,7 @@ const OciPlatform = z
 export const OciImageConfig = z.object({
   // This is required by the spec, but probably not present in the wild.
   architecture: z.string().nullish(),
+  created: z.string().nullish(),
   config: z
     .object({ Labels: z.record(z.string(), z.string()).nullish() })
     .nullish(),


### PR DESCRIPTION
## Changes

For ECR (and ECR Public) registries, `releaseTimestamp` is now populated by reading the `created` field from the image config blob, enabling `minimumReleaseAge` to work correctly with ECR images (a default in v42).

The original approach fetched timestamps for all valid tags in bulk during `getReleases` (via `Promise.all`), which caused ECR to return 429s for repositories with many tags. This has been replaced with a `postprocessRelease` override that fetches timestamps on demand, one per candidate release as it's evaluated, rather than bulk-fetching all tags upfront.

Only tags that pass `dockerVersioning.isVersion()` are processed — so `latest`, SHAs, and arbitrary strings are skipped entirely.

Fixed as discussed in https://github.com/renovatebot/renovate/discussions/39344

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): to help write tests and to understand the timestamp fetching for Docker hub

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/MrLemur/renovate-test