### PR TITLE
fix(manager/ansible-galaxy): don't include comments in `depName`

### DIFF
--- a/lib/modules/manager/ansible-galaxy/collections.ts
+++ b/lib/modules/manager/ansible-galaxy/collections.ts
@@ -17,7 +17,7 @@ function interpretLine(
 ): void {
   const localDependency = dependency;
   const key = lineMatch[2];
-  const value = lineMatch[3].replace(regEx(/["']/g), '');
+  const value = lineMatch[3].replace(regEx(/["']/g), '').split(' ', 2)[0];
   switch (key) {
     case 'name': {
       localDependency.managerData.name = value;

--- a/lib/modules/manager/ansible-galaxy/extract.spec.ts
+++ b/lib/modules/manager/ansible-galaxy/extract.spec.ts
@@ -38,6 +38,16 @@ describe('modules/manager/ansible-galaxy/extract', () => {
       expect(res?.deps[0].currentValue).toBe('1.1.3');
     });
 
+    // via #44240
+    it('extracts dependencies from requirements.yml with a comment', () => {
+      const yamlFile = codeBlock`collections:
+      - name: community.aws       # obtains secrets from AWS SM
+      version: 7.1.0`;
+      const res = extractPackageFile(yamlFile, 'requirements.yml');
+      expect(res?.deps).toHaveLength(1);
+      expect(res?.deps[0].depName).toEqual('community.aws');
+    });
+
     it('extracts git@ dependencies', () => {
       const yamlFile = codeBlock`collections:
       - name: community.docker


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As noted in #44240, the way we parse line-by-line means we're including
comments at the end of lines.

For now, we can introduce a hacky solution for this, but in the future
we'll refactor this to YAML parse (https://github.com/renovatebot/renovate/issues/44253).

<!-- Describe what behavior is changed by this PR. -->
## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
