### PR TITLE
fix(datasource/helm): correctly determine latest release

### DIFF
--- a/lib/modules/datasource/helm/__fixtures__/sample.yaml
+++ b/lib/modules/datasource/helm/__fixtures__/sample.yaml
@@ -101,6 +101,18 @@ entries:
       urls:
         - https://charts.example.com/private-chart-1.2.3.tgz
       version: 1.2.3
+  ascending-releases:
+  - created: "2021-01-01T00:00:00.000000000Z"
+    urls:
+    - https://charts.example.com/ascending-releases-1.0.0.tgz
+    version: 1.0.0
+  - created: "2021-06-01T00:00:00.000000000Z"
+    home: https://github.com/some-org/helm-charts
+    sources:
+    - https://github.com/some-org/helm-charts
+    urls:
+    - https://charts.example.com/ascending-releases-2.0.0.tgz
+    version: 2.0.0
   dummy:
   - home:
     urls:

--- a/lib/modules/datasource/helm/schema.spec.ts
+++ b/lib/modules/datasource/helm/schema.spec.ts
@@ -33,6 +33,10 @@ describe('modules/datasource/helm/schema', () => {
           sourceUrl:
             'https://gitlab.example.com/some/group/charts/-/tree/master/private-chart',
         },
+        'ascending-releases': {
+          homepage: 'https://github.com/some-org/helm-charts',
+          sourceUrl: 'https://github.com/some-org/helm-charts',
+        },
       });
     });
   });

--- a/lib/modules/datasource/helm/schema.ts
+++ b/lib/modules/datasource/helm/schema.ts
@@ -4,6 +4,7 @@ import { parseGitUrl } from '../../../util/git/url.ts';
 import { regEx } from '../../../util/regex.ts';
 import { LooseRecord } from '../../../util/schema-utils/index.ts';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
+import { api as helmVersioning } from '../../versioning/helm/index.ts';
 import type { Release } from '../types.ts';
 
 const HelmRelease = z.object({
@@ -60,7 +61,11 @@ export const HelmRepository = z
       HelmRelease.array()
         .min(1)
         .transform((helmReleases) => {
-          const latestRelease = helmReleases[0];
+          const latestRelease = helmReleases.reduce((latest, release) =>
+            helmVersioning.isGreaterThan(release.version, latest.version)
+              ? release
+              : latest,
+          );
           const homepage = latestRelease.home;
           const sourceUrl = getSourceUrl(latestRelease);
           const releases = helmReleases.map(


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #43929, in the case where Sonatype Repository Manager is
used, the releases are returned in ascending, not descending, order.

We can correctly determine the latest release by using the `helm`
versioning scheme.

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
