### PR TITLE
feat(onboarding): add a summary for detected package files

### DIFF
--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -32,6 +32,7 @@ import {
 } from '../common.ts';
 import { getBaseBranchDesc } from './base-branch.ts';
 import { getConfigDesc } from './config-description.ts';
+import { getPackageFilesDesc } from './package-files.ts';
 import { getExpectedPrList } from './pr-list.ts';
 
 /**
@@ -187,17 +188,9 @@ If you need any further assistance then you can also [request help here](${
   );
   prTemplate += rebaseCheckBox;
   let prBody = prTemplate;
-  if (packageFiles && Object.entries(packageFiles).length) {
-    let files: string[] = [];
-    for (const [manager, managerFiles] of Object.entries(packageFiles)) {
-      files = files.concat(
-        managerFiles.map((file) => ` * \`${file.packageFile}\` (${manager})`),
-      );
-    }
-    prBody = `${prBody.replace(
-      '{{PACKAGE FILES}}',
-      `### Detected Package Files\n\n${files.join('\n')}`,
-    )}\n`;
+  const packageFilesDesc = getPackageFilesDesc(packageFiles);
+  if (packageFilesDesc) {
+    prBody = `${prBody.replace('{{PACKAGE FILES}}', packageFilesDesc)}\n`;
   } else {
     prBody = prBody.replace('{{PACKAGE FILES}}\n', '');
   }

--- a/lib/workers/repository/onboarding/pr/package-files.spec.ts
+++ b/lib/workers/repository/onboarding/pr/package-files.spec.ts
@@ -1,0 +1,71 @@
+import { partial } from '~test/util.ts';
+import type { PackageFile } from '../../../../modules/manager/types.ts';
+import { getPackageFilesDesc } from './package-files.ts';
+
+describe('workers/repository/onboarding/pr/package-files', () => {
+  describe('getPackageFilesDesc()', () => {
+    it('returns empty string when packageFiles is null', () => {
+      expect(getPackageFilesDesc(null)).toBeEmptyString();
+    });
+
+    it('returns empty string when packageFiles is empty', () => {
+      expect(getPackageFilesDesc({})).toBeEmptyString();
+    });
+
+    it('returns formatted markdown for a single manager', () => {
+      const res = getPackageFilesDesc({
+        npm: [partial<PackageFile>({ packageFile: 'package.json' })],
+      });
+      expect(res).toBe('### Detected Package Files\n\n * `package.json` (npm)');
+    });
+
+    it('returns formatted markdown for multiple managers', () => {
+      const res = getPackageFilesDesc({
+        npm: [
+          partial<PackageFile>({ packageFile: 'package.json' }),
+          partial<PackageFile>({ packageFile: 'a/package.json' }),
+        ],
+        dockerfile: [partial<PackageFile>({ packageFile: 'Dockerfile' })],
+      });
+      expect(res).toBe(
+        '### Detected Package Files\n\n * `package.json` (npm)\n * `a/package.json` (npm)\n * `Dockerfile` (dockerfile)',
+      );
+    });
+
+    it('returns formatted markdown for many files across managers, including a file handled by multiple managers', () => {
+      const res = getPackageFilesDesc({
+        npm: [
+          partial<PackageFile>({ packageFile: 'package.json' }),
+          partial<PackageFile>({ packageFile: 'frontend/package.json' }),
+          partial<PackageFile>({ packageFile: 'backend/package.json' }),
+        ],
+        dockerfile: [
+          partial<PackageFile>({ packageFile: 'Dockerfile' }),
+          partial<PackageFile>({ packageFile: 'services/api/Dockerfile' }),
+        ],
+        'docker-compose': [
+          partial<PackageFile>({ packageFile: 'docker-compose.yml' }),
+        ],
+        'github-actions': [
+          partial<PackageFile>({ packageFile: '.github/workflows/ci.yml' }),
+          partial<PackageFile>({
+            packageFile: '.github/workflows/release.yml',
+          }),
+        ],
+        regex: [partial<PackageFile>({ packageFile: 'Dockerfile' })],
+      });
+      expect(res).toBe(
+        '### Detected Package Files\n\n' +
+          ' * `package.json` (npm)\n' +
+          ' * `frontend/package.json` (npm)\n' +
+          ' * `backend/package.json` (npm)\n' +
+          ' * `Dockerfile` (dockerfile)\n' +
+          ' * `services/api/Dockerfile` (dockerfile)\n' +
+          ' * `docker-compose.yml` (docker-compose)\n' +
+          ' * `.github/workflows/ci.yml` (github-actions)\n' +
+          ' * `.github/workflows/release.yml` (github-actions)\n' +
+          ' * `Dockerfile` (regex)',
+      );
+    });
+  });
+});

--- a/lib/workers/repository/onboarding/pr/package-files.spec.ts
+++ b/lib/workers/repository/onboarding/pr/package-files.spec.ts
@@ -88,6 +88,52 @@ describe('workers/repository/onboarding/pr/package-files', () => {
       expect(res).toBe('#### npm\n\n * `package.json`');
     });
 
+    it('groups files under a nested list when a directory has 3 or more files', () => {
+      const res = getPackageFilesSummary({
+        'github-actions': [
+          partial<PackageFile>({
+            packageFile: '.github/workflows/ci.yml',
+          }),
+          partial<PackageFile>({
+            packageFile: '.github/workflows/release.yml',
+          }),
+          partial<PackageFile>({
+            packageFile: '.github/workflows/lint.yml',
+          }),
+        ],
+      });
+      expect(res).toBe(
+        '#### github-actions\n\n' +
+          ' * `.github/workflows/`\n' +
+          '   * `ci.yml`\n' +
+          '   * `release.yml`\n' +
+          '   * `lint.yml`',
+      );
+    });
+
+    it('lists files individually when a directory has fewer than 3 files, and groups when it meets the threshold', () => {
+      const res = getPackageFilesSummary({
+        'github-actions': [
+          partial<PackageFile>({ packageFile: '.github/workflows/ci.yml' }),
+          partial<PackageFile>({
+            packageFile: '.github/workflows/release.yml',
+          }),
+          partial<PackageFile>({
+            packageFile: '.github/workflows/lint.yml',
+          }),
+          partial<PackageFile>({ packageFile: '.github/dependabot.yml' }),
+        ],
+      });
+      expect(res).toBe(
+        '#### github-actions\n\n' +
+          ' * `.github/workflows/`\n' +
+          '   * `ci.yml`\n' +
+          '   * `release.yml`\n' +
+          '   * `lint.yml`\n' +
+          ' * `.github/dependabot.yml`',
+      );
+    });
+
     it('returns grouped markdown for many files across managers, including a file handled by multiple managers', () => {
       const res = getPackageFilesSummary({
         npm: [

--- a/lib/workers/repository/onboarding/pr/package-files.spec.ts
+++ b/lib/workers/repository/onboarding/pr/package-files.spec.ts
@@ -1,6 +1,9 @@
 import { partial } from '~test/util.ts';
 import type { PackageFile } from '../../../../modules/manager/types.ts';
-import { getPackageFilesDesc } from './package-files.ts';
+import {
+  getPackageFilesDesc,
+  getPackageFilesSummary,
+} from './package-files.ts';
 
 describe('workers/repository/onboarding/pr/package-files', () => {
   describe('getPackageFilesDesc()', () => {
@@ -65,6 +68,63 @@ describe('workers/repository/onboarding/pr/package-files', () => {
           ' * `.github/workflows/ci.yml` (github-actions)\n' +
           ' * `.github/workflows/release.yml` (github-actions)\n' +
           ' * `Dockerfile` (regex)',
+      );
+    });
+  });
+
+  describe('getPackageFilesSummary()', () => {
+    it('returns empty string when packageFiles is null', () => {
+      expect(getPackageFilesSummary(null)).toBeEmptyString();
+    });
+
+    it('returns empty string when packageFiles is empty', () => {
+      expect(getPackageFilesSummary({})).toBeEmptyString();
+    });
+
+    it('returns grouped markdown for a single manager', () => {
+      const res = getPackageFilesSummary({
+        npm: [partial<PackageFile>({ packageFile: 'package.json' })],
+      });
+      expect(res).toBe('#### npm\n\n * `package.json`');
+    });
+
+    it('returns grouped markdown for many files across managers, including a file handled by multiple managers', () => {
+      const res = getPackageFilesSummary({
+        npm: [
+          partial<PackageFile>({ packageFile: 'package.json' }),
+          partial<PackageFile>({ packageFile: 'frontend/package.json' }),
+          partial<PackageFile>({ packageFile: 'backend/package.json' }),
+        ],
+        dockerfile: [
+          partial<PackageFile>({ packageFile: 'Dockerfile' }),
+          partial<PackageFile>({ packageFile: 'services/api/Dockerfile' }),
+        ],
+        'docker-compose': [
+          partial<PackageFile>({ packageFile: 'docker-compose.yml' }),
+        ],
+        'github-actions': [
+          partial<PackageFile>({ packageFile: '.github/workflows/ci.yml' }),
+          partial<PackageFile>({
+            packageFile: '.github/workflows/release.yml',
+          }),
+        ],
+        regex: [partial<PackageFile>({ packageFile: 'Dockerfile' })],
+      });
+      expect(res).toBe(
+        '#### npm\n\n' +
+          ' * `package.json`\n' +
+          ' * `frontend/package.json`\n' +
+          ' * `backend/package.json`\n\n' +
+          '#### dockerfile\n\n' +
+          ' * `Dockerfile`\n' +
+          ' * `services/api/Dockerfile`\n\n' +
+          '#### docker-compose\n\n' +
+          ' * `docker-compose.yml`\n\n' +
+          '#### github-actions\n\n' +
+          ' * `.github/workflows/ci.yml`\n' +
+          ' * `.github/workflows/release.yml`\n\n' +
+          '#### regex\n\n' +
+          ' * `Dockerfile`',
       );
     });
   });

--- a/lib/workers/repository/onboarding/pr/package-files.ts
+++ b/lib/workers/repository/onboarding/pr/package-files.ts
@@ -1,0 +1,16 @@
+import type { PackageFile } from '../../../../modules/manager/types.ts';
+
+export function getPackageFilesDesc(
+  packageFiles: Record<string, PackageFile[]> | null,
+): string {
+  if (!packageFiles || !Object.entries(packageFiles).length) {
+    return '';
+  }
+  let files: string[] = [];
+  for (const [manager, managerFiles] of Object.entries(packageFiles)) {
+    files = files.concat(
+      managerFiles.map((file) => ` * \`${file.packageFile}\` (${manager})`),
+    );
+  }
+  return `### Detected Package Files\n\n${files.join('\n')}`;
+}

--- a/lib/workers/repository/onboarding/pr/package-files.ts
+++ b/lib/workers/repository/onboarding/pr/package-files.ts
@@ -1,5 +1,19 @@
 import type { PackageFile } from '../../../../modules/manager/types.ts';
 
+export function getPackageFilesSummary(
+  packageFiles: Record<string, PackageFile[]> | null,
+): string {
+  if (!packageFiles || !Object.entries(packageFiles).length) {
+    return '';
+  }
+  const sections: string[] = [];
+  for (const [manager, managerFiles] of Object.entries(packageFiles)) {
+    const lines = managerFiles.map((file) => ` * \`${file.packageFile}\``);
+    sections.push(`#### ${manager}\n\n${lines.join('\n')}`);
+  }
+  return sections.join('\n\n');
+}
+
 export function getPackageFilesDesc(
   packageFiles: Record<string, PackageFile[]> | null,
 ): string {

--- a/lib/workers/repository/onboarding/pr/package-files.ts
+++ b/lib/workers/repository/onboarding/pr/package-files.ts
@@ -1,5 +1,38 @@
 import type { PackageFile } from '../../../../modules/manager/types.ts';
 
+const GROUP_THRESHOLD = 3;
+
+function formatManagerFiles(files: PackageFile[]): string {
+  const byDir = new Map<string, string[]>();
+  for (const { packageFile } of files) {
+    const lastSlash = packageFile.lastIndexOf('/');
+    const dir = lastSlash >= 0 ? packageFile.slice(0, lastSlash + 1) : '';
+    const name =
+      lastSlash >= 0 ? packageFile.slice(lastSlash + 1) : packageFile;
+    const existing = byDir.get(dir);
+    if (existing) {
+      existing.push(name);
+    } else {
+      byDir.set(dir, [name]);
+    }
+  }
+
+  const lines: string[] = [];
+  for (const [dir, names] of byDir) {
+    if (dir && names.length >= GROUP_THRESHOLD) {
+      lines.push(` * \`${dir}\``);
+      for (const name of names) {
+        lines.push(`   * \`${name}\``);
+      }
+    } else {
+      for (const name of names) {
+        lines.push(` * \`${dir}${name}\``);
+      }
+    }
+  }
+  return lines.join('\n');
+}
+
 export function getPackageFilesSummary(
   packageFiles: Record<string, PackageFile[]> | null,
 ): string {
@@ -8,8 +41,7 @@ export function getPackageFilesSummary(
   }
   const sections: string[] = [];
   for (const [manager, managerFiles] of Object.entries(packageFiles)) {
-    const lines = managerFiles.map((file) => ` * \`${file.packageFile}\``);
-    sections.push(`#### ${manager}\n\n${lines.join('\n')}`);
+    sections.push(`#### ${manager}\n\n${formatManagerFiles(managerFiles)}`);
   }
   return sections.join('\n\n');
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As part of future changes in #41502, we're introducing a
Platform-limit-aware onboarding/reconfigure flow that will provide a
summary where appropriate.

Before we do so, we can introduce the new functionality - but not
integrate it right now - to incrementally add support.

As a slightly better interface when we have a large list of detected
package files, we can provide a summary per Manager.

Where we have 3+ package files under the same directory, we group them as a list.

The use of `3` as the lower bound was chosen without any research or too much
thought put into it.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
