### PR TITLE
fix(http/github): handle Github got errors containing falsely an object

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -557,7 +557,7 @@ describe('util/http/github', () => {
         ).rejects.toThrow(EXTERNAL_HOST_ERROR);
       });
 
-      it('should throw on repository change with a non-array error', async () => {
+      it('should throw on repository change with a non-array error with code `invalid`', async () => {
         await expect(
           fail(422, {
             message: 'foobar',
@@ -566,7 +566,7 @@ describe('util/http/github', () => {
         ).rejects.toThrow(REPOSITORY_CHANGED);
       });
 
-      it('should throw platform failure on 422 response with non-array errors', async () => {
+      it('should throw platform failure on 422 response with an unrecognized non-array errors', async () => {
         await expect(
           fail(422, {
             message: 'foobar',

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -557,6 +557,24 @@ describe('util/http/github', () => {
         ).rejects.toThrow(EXTERNAL_HOST_ERROR);
       });
 
+      it('should throw on repository change with a non-array error', async () => {
+        await expect(
+          fail(422, {
+            message: 'foobar',
+            errors: { code: 'invalid' },
+          }),
+        ).rejects.toThrow(REPOSITORY_CHANGED);
+      });
+
+      it('should throw platform failure on 422 response with non-array errors', async () => {
+        await expect(
+          fail(422, {
+            message: 'foobar',
+            errors: 'Validation Failed',
+          }),
+        ).rejects.toThrow(EXTERNAL_HOST_ERROR);
+      });
+
       it('should throw original error when failed to add reviewers', async () => {
         await expect(
           fail(422, {

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -180,13 +180,24 @@ function handleGotError(
       message.includes('Review cannot be requested from pull request author')
     ) {
       return err;
-    } else if (err.body?.errors?.find((e: any) => e.field === 'milestone')) {
+    }
+
+    // GitHub usually returns `errors` as an array, but not always - normalize
+    const rawErrors = err.body?.errors;
+    let errors: unknown[] = [];
+    if (isArray(rawErrors)) {
+      errors = rawErrors;
+    } else if (!isNullOrUndefined(rawErrors)) {
+      errors = [rawErrors];
+    }
+
+    if (errors.find((e: any) => e.field === 'milestone')) {
       return err;
-    } else if (err.body?.errors?.find((e: any) => e.code === 'invalid')) {
+    } else if (errors.find((e: any) => e.code === 'invalid')) {
       logger.debug({ err }, 'Received invalid response - aborting');
       return new Error(REPOSITORY_CHANGED);
     } else if (
-      err.body?.errors?.find((e: any) =>
+      errors.find((e: any) =>
         e.message?.startsWith('A pull request already exists'),
       )
     ) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Normalize errors in the Github error response body to arrays 

## Context

Logs
```
Caught error setting branch status - aborting
POST https://api.github.com/repos/foo/bar/statuses/02ac0098c19c30e8c940b02e0d6a876db3f7a799 = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=422 retryCount=0, duration=192)

{"logContext":"01ca76ad-2573-4b82-8f30-34af1cf7ef05","repository":"foo/bar","branch":"renovate/oxfmt-0.x"}
{"logContext":"01ca76ad-2573-4b82-8f30-34af1cf7ef05","repository":"foo/bar","branch":"renovate/oxfmt-0.x","err":{
"message":"err.body?.errors?.find is not a function","stack":"TypeError: err.body?.errors?.find is not a function\n at handleGotError (file:///usr/local/renovate/lib/util/http/github.ts:183:34)\n at GithubHttp.handleError 
(file:///usr/local/renovate/lib/util/http/github.ts:383:11)\n at GithubHttp.request 
(file:///usr/local/renovate/lib/util/http/http.ts:272:12)\n at processTicksAndRejections 
(node:internal/process/task_queues:104:5)\n at GithubHttp.requestJsonUnsafe 
(file:///usr/local/renovate/lib/util/http/github.ts:397:20)\n at GithubHttp.requestJson 
(file:///usr/local/renovate/lib/util/http/http.ts:388:17)\n at Proxy.setBranchStatus 
(file:///usr/local/renovate/lib/modules/platform/github/index.ts:1320:5)\n at setStatusCheck 
(file:///usr/local/renovate/lib/workers/repository/update/branch/status-checks.ts:56:5)\n at setStability 
(file:///usr/local/renovate/lib/workers/repository/update/branch/status-checks.ts:109:3)\n at setBranchStatusChecks 
(file:///usr/local/renovate/lib/workers/repository/update/branch/index.ts:64:3)\n at processBranch 
(file:///usr/local/renovate/lib/workers/repository/update/branch/index.ts:779:5)\n at instrument.attributes 
(file:///usr/local/renovate/lib/workers/repository/process/write.ts:188:21)\n at writeUpdates 
(file:///usr/local/renovate/lib/workers/repository/process/write.ts:161:17)\n at update 
(file:///usr/local/renovate/lib/workers/repository/process/extract-update.ts:304:11)\n at renovateRepository 
(file:///usr/local/renovate/lib/workers/repository/index.ts:142:21)\n at instrument.attributes 
(file:///usr/local/renovate/lib/workers/global/index.ts:235:11)\n at start 
(file:///usr/local/renovate/lib/workers/global/index.ts:220:7)\n at 
file:///usr/local/renovate/lib/renovate.ts:26:22"},"url":"repos/foo/bar/statuses/02ac0098c19c30e8c940b02e0d6a876db3f7a799"}
```

Response received: 
```json
{
  "message": "Validation Failed",
  "errors": "Validation failed: State is not included in the list",
  "documentation_url": "...",
  "status": "422"
}
```

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
