### PR TITLE
feat(versioning/node): support Semver pre-release versions for Node 27

### DIFF
--- a/lib/modules/versioning/node/index.spec.ts
+++ b/lib/modules/versioning/node/index.spec.ts
@@ -13,13 +13,16 @@ describe('modules/versioning/node/index', () => {
   });
 
   it.each`
-    currentValue | rangeStrategy | currentVersion | newVersion   | expected
-    ${'1.0.0'}   | ${'replace'}  | ${'1.0.0'}     | ${'v1.1.0'}  | ${'1.1.0'}
-    ${'~8.0.0'}  | ${'replace'}  | ${'8.0.2'}     | ${'v8.2.0'}  | ${'~8.2.0'}
-    ${'erbium'}  | ${'replace'}  | ${'12.0.0'}    | ${'v14.1.4'} | ${'fermium'}
-    ${'Fermium'} | ${'replace'}  | ${'14.0.0'}    | ${'v16.1.6'} | ${'gallium'}
-    ${'gallium'} | ${'bump'}     | ${'16.0.0'}    | ${'v16.1.6'} | ${'gallium'}
-    ${'gallium'} | ${'auto'}     | ${'16.1.6'}    | ${'v16.1.6'} | ${'gallium'}
+    currentValue        | rangeStrategy | currentVersion      | newVersion           | expected
+    ${'1.0.0'}          | ${'replace'}  | ${'1.0.0'}          | ${'v1.1.0'}          | ${'1.1.0'}
+    ${'~8.0.0'}         | ${'replace'}  | ${'8.0.2'}          | ${'v8.2.0'}          | ${'~8.2.0'}
+    ${'erbium'}         | ${'replace'}  | ${'12.0.0'}         | ${'v14.1.4'}         | ${'fermium'}
+    ${'Fermium'}        | ${'replace'}  | ${'14.0.0'}         | ${'v16.1.6'}         | ${'gallium'}
+    ${'gallium'}        | ${'bump'}     | ${'16.0.0'}         | ${'v16.1.6'}         | ${'gallium'}
+    ${'gallium'}        | ${'auto'}     | ${'16.1.6'}         | ${'v16.1.6'}         | ${'gallium'}
+    ${'27.0.0-alpha.1'} | ${'replace'}  | ${'27.0.0-alpha.1'} | ${'v27.0.0-alpha.2'} | ${'27.0.0-alpha.2'}
+    ${'27.0.0-alpha.1'} | ${'replace'}  | ${'27.0.0-alpha.1'} | ${'v27.0.0'}         | ${'27.0.0'}
+    ${'gallium'}        | ${'replace'}  | ${'16.0.0'}         | ${'v27.0.0'}         | ${'^27.0.0'}
   `(
     'getNewValue($currentValue, $rangeStrategy, $currentVersion, $newVersion, $expected) === $expected',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {
@@ -35,22 +38,31 @@ describe('modules/versioning/node/index', () => {
 
   const t1 = DateTime.fromISO('2020-09-01');
   const t2 = DateTime.fromISO('2021-06-01');
+  // Node 27 schedule (new shape): alpha 2026-10-28, Current from 2027-04-22,
+  // LTS (maintenance) from 2027-10-20.
+  const t3 = DateTime.fromISO('2027-06-01'); // Current phase, not yet LTS
+  const t4 = DateTime.fromISO('2027-11-01'); // LTS phase
 
   it.each`
-    version       | time  | expected
-    ${'16.0.0'}   | ${t1} | ${false}
-    ${'15.0.0'}   | ${t1} | ${false}
-    ${'14.9.0'}   | ${t1} | ${false}
-    ${'14.0.0'}   | ${t2} | ${true}
-    ${'12.0.3'}   | ${t1} | ${true}
-    ${'v12.0.3'}  | ${t1} | ${true}
-    ${'12.0.3a'}  | ${t1} | ${false}
-    ${'11.0.0'}   | ${t1} | ${false}
-    ${'10.0.0'}   | ${t1} | ${true}
-    ${'10.0.999'} | ${t1} | ${true}
-    ${'10.1.0'}   | ${t1} | ${true}
-    ${'10.0.0a'}  | ${t1} | ${false}
-    ${'9.0.0'}    | ${t1} | ${false}
+    version             | time  | expected
+    ${'16.0.0'}         | ${t1} | ${false}
+    ${'15.0.0'}         | ${t1} | ${false}
+    ${'14.9.0'}         | ${t1} | ${false}
+    ${'14.0.0'}         | ${t2} | ${true}
+    ${'12.0.3'}         | ${t1} | ${true}
+    ${'v12.0.3'}        | ${t1} | ${true}
+    ${'12.0.3a'}        | ${t1} | ${false}
+    ${'11.0.0'}         | ${t1} | ${false}
+    ${'10.0.0'}         | ${t1} | ${true}
+    ${'10.0.999'}       | ${t1} | ${true}
+    ${'10.1.0'}         | ${t1} | ${true}
+    ${'10.0.0a'}        | ${t1} | ${false}
+    ${'9.0.0'}          | ${t1} | ${false}
+    ${'1.0.0'}          | ${t1} | ${false}
+    ${'27.0.0'}         | ${t3} | ${false}
+    ${'27.0.0'}         | ${t4} | ${true}
+    ${'v27.0.0'}        | ${t4} | ${true}
+    ${'27.0.0-alpha.1'} | ${t4} | ${false}
   `('isStable("$version") === $expected', ({ version, time, expected }) => {
     DateTime.local = (...args: any[]) =>
       args.length ? dtLocal.apply(DateTime, args) : time;
@@ -58,15 +70,25 @@ describe('modules/versioning/node/index', () => {
   });
 
   it.each`
-    version       | expected
-    ${'16.0.0'}   | ${true}
-    ${'erbium'}   | ${true}
-    ${'bogus'}    | ${false}
-    ${'^10.0.0'}  | ${true}
-    ${'10.x'}     | ${true}
-    ${'10.9.8.7'} | ${false}
+    version             | expected
+    ${'16.0.0'}         | ${true}
+    ${'erbium'}         | ${true}
+    ${'bogus'}          | ${false}
+    ${'^10.0.0'}        | ${true}
+    ${'10.x'}           | ${true}
+    ${'10.9.8.7'}       | ${false}
+    ${'27.0.0-alpha.1'} | ${true}
   `('isValid("$version") === $expected', ({ version, expected }) => {
     expect(nodever.isValid(version as string)).toBe(expected);
+  });
+
+  it('treats Semver pre-release versions as valid but unstable', () => {
+    expect(nodever.isVersion('27.0.0-alpha.1')).toBe(true);
+    expect(nodever.isStable('27.0.0-alpha.1')).toBe(false);
+    expect(nodever.isGreaterThan('27.0.0', '27.0.0-alpha.1')).toBe(true);
+    expect(nodever.isGreaterThan('27.0.0-alpha.2', '27.0.0-alpha.1')).toBe(
+      true,
+    );
   });
 
   it.each`

--- a/lib/modules/versioning/node/index.ts
+++ b/lib/modules/versioning/node/index.ts
@@ -49,14 +49,31 @@ export function isValid(version: string): boolean {
 }
 
 export function isStable(version: string): boolean {
-  if (npm.isStable(version)) {
-    const schedule = findScheduleForVersion(version);
-    if (schedule?.lts) {
-      // TODO: use the exact release that started LTS (#9716)
-      return DateTime.local() > DateTime.fromISO(schedule.lts);
-    }
+  if (!npm.isStable(version)) {
+    return false;
   }
-  return false;
+
+  const schedule = findScheduleForVersion(version);
+  if (!schedule) {
+    return false;
+  }
+
+  // Node 27+ reworked the release schedule: the dedicated LTS date was dropped
+  // (every line now eventually becomes LTS), so the LTS-promotion point is read
+  // from a different milestone for those newer entries.
+  let ltsStart = schedule.lts;
+  if (schedule.alpha) {
+    ltsStart = schedule.maintenance;
+  }
+  if (!ltsStart) {
+    return false;
+  }
+
+  // We only track when a major line as a whole reached LTS, not which specific
+  // release started it — so every release of that major counts as stable once
+  // that date passes, even an early one like 18.0.0 that shipped before Node
+  // 18's first LTS release (18.12.0). This coarse granularity is intentional.
+  return DateTime.local() > DateTime.fromISO(ltsStart);
 }
 
 export function matches(version: string, range: string): boolean {

--- a/lib/modules/versioning/node/readme.md
+++ b/lib/modules/versioning/node/readme.md
@@ -1,10 +1,13 @@
 Renovate's Node.js versioning is a wrapper around npm versioning.
 But Renovate removes any `v` prefixes from semantic versions when replacing.
 
-Its primary purpose is to add Node.js LTS awareness, e.g.:
+Its primary purpose is to add Node.js LTS awareness:
 
-- Odd releases are unstable
-- Even releases do not reach stability (LTS) immediately
+- A new major release is not treated as stable immediately; it becomes stable once its release line reaches LTS.
+- Pre-release versions such as `27.0.0-alpha.1` are always treated as unstable.
+
+Up to Node.js 26 the release lines followed an odd/even scheme, where odd-numbered majors never reached LTS.
+From Node.js 27 onwards [the schedule changed](https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule): every major eventually becomes LTS, so stability is derived from the release schedule rather than the major number being odd or even.
 
 You can _not_ use `node` versioning to replace `docker` versioning if you are using node tags with suffixes like `-alpine`.
 This is because npm versioning treats these suffixes as implying pre-releases/instability.

--- a/lib/modules/versioning/node/schedule.ts
+++ b/lib/modules/versioning/node/schedule.ts
@@ -3,6 +3,7 @@ import type { Nullish } from '../../../types/index.ts';
 import semver from '../semver/index.ts';
 
 interface NodeJsSchedule {
+  alpha?: string;
   lts?: string;
   maintenance?: string;
   end: string;


### PR DESCRIPTION
## Changes

Node 27 changes how Node.js is released, and this updates the `node` versioning to match.

- Pre-release versions like `27.0.0-alpha.1` parse correctly and count as unstable, so they aren't offered to users by default.
- Node's schedule data dropped the `lts` field for Node 27+ and marks the LTS date a different way. `isStable` reads this new shape, so a Node 27 line counts as stable once it reaches LTS. Without this, Node 27 would never be seen as stable, so updates to it would never be offered.
- Added unit tests for the pre-release versions and the new schedule shape.
- Updated the readme — the old odd/even stability rule only applies up to Node 26.

Not included: actually discovering the alpha versions. Node hasn't published the alpha download channel yet and the exact version format isn't finalized, so teaching the datasource to fetch them is a separate follow-up.

This also closes #9716. `isStable` marks a whole major as stable from its LTS date, not from the exact release that started LTS. That is intentional and now documented in a comment.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41820
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
