### PR TITLE
feat(config): detect and warn unwrapped regex

### DIFF
--- a/lib/config/validation-helpers/regex-glob-matchers.spec.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.spec.ts
@@ -6,7 +6,7 @@ describe('config/validation-helpers/regex-glob-matchers', () => {
       val: ['*', '**'],
       currentPath: 'hostRules[0].allowedHeaders',
     });
-    expect(res).toHaveLength(1);
+    expect(res.errors).toHaveLength(1);
   });
 
   it('should error for invalid regex', () => {
@@ -14,7 +14,7 @@ describe('config/validation-helpers/regex-glob-matchers', () => {
       val: ['[', '/[/', '/.*[/'],
       currentPath: 'hostRules[0].allowedHeaders',
     });
-    expect(res).toHaveLength(2);
+    expect(res.errors).toHaveLength(2);
   });
 
   it('should error for non-strings', () => {
@@ -22,12 +22,46 @@ describe('config/validation-helpers/regex-glob-matchers', () => {
       val: ['*', 2],
       currentPath: 'hostRules[0].allowedHeaders',
     });
-    expect(res).toMatchObject([
+    expect(res.errors).toMatchObject([
       {
         message:
           'hostRules[0].allowedHeaders: should be an array of strings. You have included object.',
         topic: 'Configuration Error',
       },
     ]);
+  });
+
+  it('should warn for unwrapped regex-like patterns', () => {
+    const res = check({
+      val: ['package.json', '\\.html?$', '^Dockerfile', '\\d+/foo'],
+      currentPath: 'npm.managerFilePatterns',
+    });
+    expect(res.errors).toBeEmptyArray();
+    expect(res.warnings).toMatchObject([
+      {
+        message:
+          'npm.managerFilePatterns: the pattern `\\.html?$` looks like a regex but is not wrapped in `/.../`, so it is treated as a glob. Wrap it in slashes if you intended a regex.',
+        topic: 'Configuration Warning',
+      },
+      {
+        message:
+          'npm.managerFilePatterns: the pattern `^Dockerfile` looks like a regex but is not wrapped in `/.../`, so it is treated as a glob. Wrap it in slashes if you intended a regex.',
+        topic: 'Configuration Warning',
+      },
+      {
+        message:
+          'npm.managerFilePatterns: the pattern `\\d+/foo` looks like a regex but is not wrapped in `/.../`, so it is treated as a glob. Wrap it in slashes if you intended a regex.',
+        topic: 'Configuration Warning',
+      },
+    ]);
+  });
+
+  it('should not warn for valid wrapped regex or plain globs', () => {
+    const res = check({
+      val: ['/\\.html?$/', '**/*.json', 'package.json'],
+      currentPath: 'npm.managerFilePatterns',
+    });
+    expect(res.errors).toBeEmptyArray();
+    expect(res.warnings).toBeEmptyArray();
   });
 });

--- a/lib/config/validation-helpers/regex-glob-matchers.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.ts
@@ -1,46 +1,68 @@
 import { isArray, isString } from '@sindresorhus/is';
+import { regEx } from '../../util/regex.ts';
 import { getRegexPredicate, isRegexMatch } from '../../util/string-match.ts';
 import type { ValidationMessage } from '../types.ts';
 import type { CheckMatcherArgs } from './types.ts';
 
+// Tokens meaningful in a RegExp but not in a glob, signalling a pattern that is
+// likely an unwrapped regex (i.e. one missing the surrounding `/.../`):
+// a `^` anchor at the start, a `$` anchor at the end, or a `\d`/`\w`/`\s`/`\b`
+// character-class escape.
+const regexOnlyTokens = regEx(/^\^|\$$|\\[dwsbDWSB]/);
+
+// Returns a plain boolean (not a type guard) so the caller's `matcher` keeps its
+// `string` type — isRegexMatch's `is string` predicate would otherwise narrow it.
+function looksLikeUnwrappedRegex(matcher: string): boolean {
+  return !isRegexMatch(matcher) && regexOnlyTokens.test(matcher);
+}
+
 /**
- * Only if type condition or context condition violated then errors array will be mutated to store metadata
+ * Returns validation errors (hard failures) and warnings (heuristics) for a
+ * list of regex-or-glob matchers.
  */
-export function check({
-  val: matchers,
-  currentPath,
-}: CheckMatcherArgs): ValidationMessage[] {
-  const res: ValidationMessage[] = [];
+export function check({ val: matchers, currentPath }: CheckMatcherArgs): {
+  errors: ValidationMessage[];
+  warnings: ValidationMessage[];
+} {
+  const errors: ValidationMessage[] = [];
+  const warnings: ValidationMessage[] = [];
 
   if (isArray(matchers, isString)) {
     if (
       (matchers.includes('*') || matchers.includes('**')) &&
       matchers.length > 1
     ) {
-      res.push({
+      errors.push({
         topic: 'Configuration Error',
         message: `${currentPath}: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.`,
       });
     }
     for (const matcher of matchers) {
+      // The matcher is not wrapped in `/.../`, so it is treated as a glob, but it
+      // contains regex-only tokens and so was probably meant to be a regex.
+      if (looksLikeUnwrappedRegex(matcher)) {
+        warnings.push({
+          topic: 'Configuration Warning',
+          message: `${currentPath}: the pattern \`${matcher}\` looks like a regex but is not wrapped in \`/.../\`, so it is treated as a glob. Wrap it in slashes if you intended a regex.`,
+        });
+        continue;
+      }
       // Validate regex pattern
       // No need to validate if the string is a glob
       // minimatch allows any string as glob
-      if (isRegexMatch(matcher)) {
-        if (!getRegexPredicate(matcher)) {
-          res.push({
-            topic: 'Configuration Error',
-            message: `Failed to parse regex pattern for ${currentPath}: ${matcher}`,
-          });
-        }
+      if (isRegexMatch(matcher) && !getRegexPredicate(matcher)) {
+        errors.push({
+          topic: 'Configuration Error',
+          message: `Failed to parse regex pattern for ${currentPath}: ${matcher}`,
+        });
       }
     }
   } else {
-    res.push({
+    errors.push({
       topic: 'Configuration Error',
       message: `${currentPath}: should be an array of strings. You have included ${typeof matchers}.`,
     });
   }
 
-  return res;
+  return { errors, warnings };
 }

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -878,6 +878,26 @@ describe('config/validation', () => {
       ]);
     });
 
+    it('warns for unwrapped regex-like managerFilePatterns', async () => {
+      const config = {
+        npm: {
+          managerFilePatterns: ['package.json', '\\.html?$'],
+        },
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        // @ts-expect-error -- TODO: managers, datasources and versionings are not defined on RenovateConfig
+        config,
+      );
+      expect(errors).toBeEmptyArray();
+      expect(warnings).toMatchObject([
+        {
+          message:
+            'npm.managerFilePatterns: the pattern `\\.html?$` looks like a regex but is not wrapped in `/.../`, so it is treated as a glob. Wrap it in slashes if you intended a regex.',
+        },
+      ]);
+    });
+
     it('validates regEx for each managerFilePatterns of format regex', async () => {
       const config: RenovateConfig = {
         customManagers: [

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -391,12 +391,12 @@ export async function validateConfig(
                   }
                 }
                 if (isRegexOrGlobOption(key)) {
-                  errors.push(
-                    ...regexOrGlobValidator.check({
-                      val,
-                      currentPath,
-                    }),
-                  );
+                  const regexOrGlobResult = regexOrGlobValidator.check({
+                    val,
+                    currentPath,
+                  });
+                  errors.push(...regexOrGlobResult.errors);
+                  warnings.push(...regexOrGlobResult.warnings);
                 }
                 if (key === 'extends') {
                   for (const subval of val) {
@@ -1122,11 +1122,13 @@ async function validateGlobalConfig(
         }
 
         if (isRegexOrGlobOption(key)) {
+          const regexOrGlobResult = regexOrGlobValidator.check({
+            val,
+            currentPath: currentPath!,
+          });
           warnings.push(
-            ...regexOrGlobValidator.check({
-              val,
-              currentPath: currentPath!,
-            }),
+            ...regexOrGlobResult.errors,
+            ...regexOrGlobResult.warnings,
           );
         }
         if (key === 'gitNoVerify') {


### PR DESCRIPTION
## Changes

`managerFilePatterns` (and other regex-or-glob options) accept both globs and regexes, where a regex must be wrapped in `/.../`. When a user writes a pattern that is clearly a regex but forgets the slashes, it is silently treated as a glob and never matches — with no feedback (see discussion #43741).

This adds a config validation **warning** when an unwrapped matcher contains regex-only tokens (a `^` start anchor, a `$` end anchor, or a `\d`/`\w`/`\s`/`\b` character-class escape) that have no meaning in a glob, e.g.:

> npm.managerFilePatterns: the pattern `\.html?$` looks like a regex but is not wrapped in `/.../`, so it is treated as a glob. Wrap it in slashes if you intended a regex.

It's a warning (not an error) because the heuristic can't be certain, and legitimate globs should keep working.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Addresses discussion https://github.com/renovatebot/renovate/discussions/43741

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). Tool: Claude Code (Claude Opus 4.8).

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests
