### PR TITLE
fix(monorepo): group SPFx packages released together

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -36,7 +36,7 @@
       "@solid-design-system/styles",
       "@solid-design-system/components"
     ],
-    "spfx": ["/^@microsoft/sp-/", "/^@microsoft/eslint-.+-spfx$/"],
+    "spfx": ["/^@microsoft/sp-/", "/^@microsoft/spfx-(?!cli$)/", "/^@microsoft/eslint-.+-spfx$/"],
     "spock": "/^org\\.spockframework:spock-/",
     "syncfusion-dotnet": "/^Syncfusion\\./",
     "testing-library": "/^@testing-library//",


### PR DESCRIPTION
## Changes

Treat @microsoft/spfx-heft-plugins and @microsoft/spfx-web-build-rig as part of the SharePoint Framework, so they are updated together and avoid bad PR behavior.

See:
https://www.npmjs.com/package/@microsoft/spfx-heft-plugins
https://www.npmjs.com/package/@microsoft/spfx-web-build-rig

In the description of both packages, it says: "This package is part of the SharePoint Framework..."

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/exensio-rori/renovate