### PR TITLE
fix(cache): keep PR comment cache runtime-only

### DIFF
--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -27,6 +27,9 @@ export abstract class RepoCacheBase implements RepoCache {
 
   private static parseData(input: string): RepoCacheData {
     const data: RepoCacheData = JSON.parse(input);
+    // Comment assurance hashes describe mutable platform-side state. Do not
+    // restore them from repository cache across runs.
+    delete data.prComments;
     // istanbul ignore next
     if (data.branches) {
       for (const branch of data.branches) {
@@ -37,6 +40,18 @@ export abstract class RepoCacheBase implements RepoCache {
       }
     }
     return data;
+  }
+
+  private static prepareDataForPersistence(
+    data: RepoCacheData,
+    cleanHttpCache = false,
+  ): RepoCacheData {
+    const persistedData = { ...data };
+    delete persistedData.prComments;
+    if (cleanHttpCache) {
+      cleanupHttpCache(persistedData);
+    }
+    return persistedData;
   }
 
   private async restore(oldCache: RepoCacheRecord): Promise<void> {
@@ -78,8 +93,11 @@ export abstract class RepoCacheBase implements RepoCache {
   }
 
   async save(): Promise<void> {
-    cleanupHttpCache(this.data);
-    const jsonStr = safeStringify(this.data);
+    const persistedData = RepoCacheBase.prepareDataForPersistence(
+      this.data,
+      true,
+    );
+    const jsonStr = safeStringify(persistedData);
     const hashedJsonStr = hash(jsonStr);
     if (hashedJsonStr === this.oldHash) {
       return;
@@ -108,7 +126,8 @@ export abstract class RepoCacheBase implements RepoCache {
     if (!this.oldHash) {
       return undefined;
     }
-    const jsonStr = safeStringify(this.data);
+    const persistedData = RepoCacheBase.prepareDataForPersistence(this.data);
+    const jsonStr = safeStringify(persistedData);
     return hash(jsonStr) !== this.oldHash;
   }
 }

--- a/lib/util/cache/repository/impl/local.spec.ts
+++ b/lib/util/cache/repository/impl/local.spec.ts
@@ -104,6 +104,28 @@ describe('util/cache/repository/impl/local', () => {
     expect(localRepoCache.isModified()).toBeFalse();
   });
 
+  it('drops persisted PR comment cache entries when loading', async () => {
+    const cacheRecord = await createCacheRecord({
+      semanticCommits: 'enabled',
+      prComments: {
+        1: {
+          warning: 'cached-content-hash',
+        },
+      },
+    });
+    fs.readCacheFile.mockResolvedValue(JSON.stringify(cacheRecord));
+    const localRepoCache = CacheFactory.get(
+      'some/repo',
+      '0123456789abcdef',
+      'local',
+    );
+
+    await localRepoCache.load();
+
+    expect(localRepoCache.getData()).toEqual({ semanticCommits: 'enabled' });
+    expect(localRepoCache.isModified()).toBeTrue();
+  });
+
   it('resets if fingerprint does not match', async () => {
     const data: RepoCacheData = { semanticCommits: 'enabled' };
     const cacheRecord: RepoCacheRecord = {
@@ -224,6 +246,31 @@ describe('util/cache/repository/impl/local', () => {
 
     await localRepoCache.load();
     expect(localRepoCache.getData()).toEqual({ semanticCommits: 'enabled' });
+    expect(localRepoCache.isModified()).toBeFalse();
+
+    await localRepoCache.save();
+
+    expect(fs.outputCacheFile).not.toHaveBeenCalledExactlyOnceWith();
+  });
+
+  it('does not persist runtime PR comment cache entries', async () => {
+    const oldCacheRecord = await createCacheRecord({
+      semanticCommits: 'enabled',
+    });
+    fs.readCacheFile.mockResolvedValueOnce(JSON.stringify(oldCacheRecord));
+    const localRepoCache = CacheFactory.get(
+      'some/repo',
+      '0123456789abcdef',
+      'local',
+    );
+
+    await localRepoCache.load();
+    localRepoCache.getData().prComments = {
+      1: {
+        warning: 'cached-content-hash',
+      },
+    };
+
     expect(localRepoCache.isModified()).toBeFalse();
 
     await localRepoCache.save();


### PR DESCRIPTION
## Changes

Repository cache comment hashes are now treated as runtime-only state.

- Drop persisted `prComments` entries when repository cache data is loaded
- Exclude runtime `prComments` entries when repository cache data is saved
- Preserve the existing within-run duplicate suppression in `ensureComment()`
- Add regression coverage for loading old persisted comment hashes and for not serializing runtime comment hashes

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

`ensureComment()` uses `repoCache.prComments` to avoid repeating the same platform comment write for the same PR/topic/content hash.
That is fine as a runtime optimization, but repository cache can also be persisted across runs.
When a hash from a previous run is restored, Renovate can treat the cached hash as proof that the remote platform comment still exists and still has the expected body.

Platform comments are mutable remote state, so they can be edited or deleted outside Renovate.
If that happens while the persisted hash still matches the desired content, Renovate skips `platform.ensureComment()` and returns success without re-checking the remote comment.

This keeps the cache useful inside one run, while avoiding carrying comment assurance state across runs.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI GPT-5/Codex was used to inspect the cache/comment code path and draft the code and test changes. I reviewed the final diff and ran the validation below.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

Validation run locally with Node 24.18.0 and pnpm 11.8.0:

- `pnpm vitest lib/util/cache/repository/impl/local.spec.ts --coverage=false`
- `pnpm vitest lib/modules/platform/comment.spec.ts --coverage=false`
- `pnpm check lib/util/cache/repository/impl/base.ts lib/util/cache/repository/impl/local.spec.ts`
- `pnpm type-check`
- `pnpm test-schema`

I also tried the full `pnpm test` gate.
It stopped before patch-related tests at local `ls-lint`; standalone `ls-lint` exits without diagnostics, the direct darwin-arm64 binary exits 137, and local metadata checks for that binary report `Operation not permitted`.
