### PR TITLE
fix(manager/swift): don't rewrite Package.resolved pins in unrelated packages

### DIFF
--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -873,4 +873,173 @@ describe('modules/manager/swift/artifacts', () => {
       'v5.10.0',
     );
   });
+
+  it('skips a pin in an unrelated package whose version does not match the from-version (exact spec)', async () => {
+    // Package that depends on Yams directly and pins it at the from-version.
+    const directFixture = JSON.stringify(
+      {
+        pins: [
+          {
+            identity: 'yams',
+            kind: 'remoteSourceControl',
+            location: 'https://github.com/jpsim/Yams.git',
+            state: {
+              revision: '0e75dd8ccd5e3f27e4def2a7f0dd0ef5e3af5e2e',
+              version: '6.2.1',
+            },
+          },
+        ],
+        version: 2,
+      },
+      null,
+      2,
+    );
+    // Unrelated package: Yams is only a transitive pin (via XcodeGen, which
+    // requires `from: "5.0.0"`, i.e. < 6.0.0), so 6.x must not be written here.
+    const transitiveFixture = JSON.stringify(
+      {
+        pins: [
+          {
+            identity: 'yams',
+            kind: 'remoteSourceControl',
+            location: 'https://github.com/jpsim/Yams.git',
+            state: {
+              revision: '01835dc202670b5bb90d07f3eae41867e9ed29f6',
+              version: '5.0.1',
+            },
+          },
+        ],
+        version: 2,
+      },
+      null,
+      2,
+    );
+
+    scm.getFileList.mockResolvedValue([
+      'Package.resolved',
+      'tools/Package.resolved',
+    ]);
+    fs.readLocalFile
+      .mockResolvedValueOnce(directFixture)
+      .mockResolvedValueOnce(transitiveFixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue(
+      'a27b21e0c81c5bf42049b897a62aaf387e80f279',
+    );
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'jpsim/Yams',
+          datasource: GithubTagsDatasource.id,
+          currentValue: '6.2.1',
+          currentVersion: '6.2.1',
+          newVersion: '6.2.2',
+          newValue: '6.2.2',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    // Only the direct dependent (pinned at the from-version 6.2.1) is updated;
+    // the unrelated package's transitive pin (5.0.1) is left untouched.
+    expect(result).toHaveLength(1);
+    expect(result![0].file!.path).toBe('Package.resolved');
+    const { contents } = result![0].file as { contents: string };
+    expect(contents).toContain('"version": "6.2.2"');
+    expect(contents).toContain(
+      '"revision": "a27b21e0c81c5bf42049b897a62aaf387e80f279"',
+    );
+  });
+
+  it('updates a pin whose version matches the from-version (exact spec)', async () => {
+    const fixture = JSON.stringify(
+      {
+        pins: [
+          {
+            identity: 'yams',
+            kind: 'remoteSourceControl',
+            location: 'https://github.com/jpsim/Yams.git',
+            state: {
+              revision: '0e75dd8ccd5e3f27e4def2a7f0dd0ef5e3af5e2e',
+              version: '6.2.1',
+            },
+          },
+        ],
+        version: 2,
+      },
+      null,
+      2,
+    );
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue(
+      'a27b21e0c81c5bf42049b897a62aaf387e80f279',
+    );
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'jpsim/Yams',
+          datasource: GithubTagsDatasource.id,
+          currentValue: '6.2.1',
+          newVersion: '6.2.2',
+          newValue: '6.2.2',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toHaveLength(1);
+    const { contents } = result![0].file as { contents: string };
+    expect(contents).toContain('"version": "6.2.2"');
+  });
+
+  it('updates a pin for a range spec regardless of its current version (guard applies only to exact specs)', async () => {
+    const fixture = JSON.stringify(
+      {
+        pins: [
+          {
+            identity: 'yams',
+            kind: 'remoteSourceControl',
+            location: 'https://github.com/jpsim/Yams.git',
+            state: {
+              revision: '01835dc202670b5bb90d07f3eae41867e9ed29f6',
+              version: '5.0.1',
+            },
+          },
+        ],
+        version: 2,
+      },
+      null,
+      2,
+    );
+    scm.getFileList.mockResolvedValue(['Package.resolved']);
+    fs.readLocalFile.mockResolvedValue(fixture);
+    vi.mocked(datasource.getDigest).mockResolvedValue(
+      '11b8e57b8cc07be48e5d1e35c9e2f7abdfd3c81b',
+    );
+
+    const result = await updateArtifacts({
+      packageFileName: 'Package.swift',
+      updatedDeps: [
+        {
+          depName: 'jpsim/Yams',
+          datasource: GithubTagsDatasource.id,
+          currentValue: 'from: "5.0.0"',
+          newVersion: '5.1.0',
+          newValue: 'from: "5.0.0"',
+        },
+      ],
+      newPackageFileContent: '',
+      config: {},
+    });
+
+    expect(result).toHaveLength(1);
+    const { contents } = result![0].file as { contents: string };
+    expect(contents).toContain('"version": "5.1.0"');
+  });
 });

--- a/lib/modules/manager/swift/artifacts.ts
+++ b/lib/modules/manager/swift/artifacts.ts
@@ -6,6 +6,7 @@ import { trimTrailingSlash } from '../../../util/url.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { getDigest } from '../../datasource/index.ts';
 import { scm } from '../../platform/scm.ts';
+import { api as swiftVersioning } from '../../versioning/swift/index.ts';
 import type {
   PackageDependency,
   UpdateArtifact,
@@ -221,6 +222,34 @@ export async function updateArtifacts({
           'swift: no matching pin found in Package.resolved',
         );
         continue;
+      }
+
+      // Only rewrite a pin we can confidently attribute to the dependency being
+      // upgraded. For exact (single-version) specs the pin to update is the one
+      // currently at the from-version; a pin at any other version belongs to a
+      // different constraint — e.g. a transitive dependency in an unrelated
+      // package — and must be left untouched, otherwise we may write a version
+      // that package does not allow.
+      // https://github.com/renovatebot/renovate/issues/44312
+      if (
+        dep.currentValue &&
+        swiftVersioning.isSingleVersion(dep.currentValue)
+      ) {
+        const fromVersion = (dep.currentVersion ?? dep.currentValue).replace(
+          regEx(/^v/),
+          '',
+        );
+        if (pin.state.version !== fromVersion) {
+          logger.debug(
+            {
+              depName: dep.depName,
+              pinVersion: pin.state.version,
+              currentValue: dep.currentValue,
+            },
+            'swift: pin does not match the upgraded-from version; skipping to avoid touching an unrelated pin',
+          );
+          continue;
+        }
       }
 
       const resolvedVersion = dep.newVersion.replace(regEx(/^v/), '');


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes
For exact (single-version) specs, only update a pin whose current version matches the version being upgraded from. This prevents the repo-wide Package.resolved sweep from rewriting a same-named transitive pin in an unrelated package to a version that package's constraints don't allow.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44312
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude (via Claude Code): Claude Opus 4.8 for the investigation, the fix design, and drafting the code/tests; Claude Sonnet 5 for applying the changes to the working tree and running the test/lint verification. All output was reviewed by a human before submission.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
