### PR TITLE
fix(workers/branch): preserve caller-set rebaseRequested through rebaseCheck

### DIFF
--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -445,6 +445,28 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('does not skip edited PR when caller pinned rebaseRequested', async () => {
+      schedule.isScheduledNow.mockReturnValueOnce(false);
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          state: 'open',
+          // no rebase-triggering title or label — rebaseCheck() would return false
+        }),
+      );
+      scm.isBranchModified.mockResolvedValueOnce(true);
+      const res = await branchWorker.processBranch({
+        ...config,
+        rebaseRequested: true,
+      });
+      expect(res).toEqual({
+        branchExists: true,
+        prNo: undefined,
+        commitSha: null,
+        result: 'error',
+      });
+    });
+
     it('skips branch if edited PR found', async () => {
       const pr = partial<Pr>({
         state: 'open',

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -175,7 +175,9 @@ export async function processBranch(
   logger.debug(`branchExists=${branchExists}`);
   logger.debug(`dependencyDashboardCheck=${dependencyDashboardCheck!}`);
   if (branchPr) {
-    config.rebaseRequested = await rebaseCheck(config, branchPr);
+    if (config.rebaseRequested !== true) {
+      config.rebaseRequested = await rebaseCheck(config, branchPr);
+    }
     logger.debug(`PR rebase requested=${config.rebaseRequested}`);
   }
   const keepUpdatedLabel = config.keepUpdatedLabel;


### PR DESCRIPTION
## Changes

`processBranch` unconditionally overwrites `config.rebaseRequested` with the result of `rebaseCheck()`. A caller that pins `rebaseRequested: true` — either via `RENOVATE_FORCE='{"rebaseRequested":true}'` or by setting the field on the config passed in — loses that value whenever the PR has no `"rebase!"` title prefix and no configured `rebaseLabel`, because `rebaseCheck()` returns `false` in that case and clobbers the pin.

This change preserves the caller-set value: only consult `rebaseCheck()` when `config.rebaseRequested` isn't already `true`. `rebaseCheck()`'s existing behavior (auto-detect a rebase intent from PR title/label) is unchanged when the caller hasn't pinned anything.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Claude (Anthropic) drafted the code change and the accompanying test case.

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Newly added/modified unit tests, or

The public repository: n/a