### PR TITLE
fix(datasource/repology): honor abortOnError instead of aborting the run on every error

### DIFF
--- a/lib/modules/datasource/repology/index.spec.ts
+++ b/lib/modules/datasource/repology/index.spec.ts
@@ -153,7 +153,7 @@ describe('modules/datasource/repology/index', () => {
       ).rejects.toThrow(EXTERNAL_HOST_ERROR);
     });
 
-    it('throws error on API request timeout', async () => {
+    it('skips package instead of aborting the run on API request timeout', async () => {
       mockResolverCall('debian_stable', 'nginx', 'binname', {
         status: 200,
         body: '[]',
@@ -169,10 +169,28 @@ describe('modules/datasource/repology/index', () => {
           versioning,
           packageName: 'debian_stable/nginx',
         }),
-      ).rejects.toThrow(EXTERNAL_HOST_ERROR);
+      ).resolves.toBeNull();
     });
 
-    it('throws error on Resolver request timeout', async () => {
+    it('skips package instead of aborting the run on Resolver request timeout', async () => {
+      mockResolverCall('debian_stable', 'nginx', 'binname', {
+        code: 'ETIMEDOUT',
+      });
+
+      await expect(
+        getPkgReleases({
+          datasource,
+          versioning,
+          packageName: 'debian_stable/nginx',
+        }),
+      ).resolves.toBeNull();
+    });
+
+    it('aborts the run on timeout when abortOnError is enabled for the host', async () => {
+      // With hostRules abortOnError: true, the HTTP layer wraps the timeout as
+      // an ExternalHostError, which handleGenericErrors re-throws, so the run
+      // still aborts. This preserves the documented opt-in behavior.
+      hostRules.add({ matchHost: 'repology.org', abortOnError: true });
       mockResolverCall('debian_stable', 'nginx', 'binname', {
         code: 'ETIMEDOUT',
       });

--- a/lib/modules/datasource/repology/index.ts
+++ b/lib/modules/datasource/repology/index.ts
@@ -237,7 +237,7 @@ export class RepologyDatasource extends Datasource {
         );
       }
 
-      throw new ExternalHostError(err);
+      this.handleGenericErrors(err);
     }
   }
 }

--- a/lib/modules/datasource/repology/index.ts
+++ b/lib/modules/datasource/repology/index.ts
@@ -231,7 +231,7 @@ export class RepologyDatasource extends Datasource {
       if (err.message === HOST_DISABLED) {
         logger.trace({ packageName, err }, 'Host disabled');
       } else {
-        logger.warn(
+        logger.once.warn(
           { packageName, err },
           'Repology lookup failed with unexpected error',
         );


### PR DESCRIPTION
Resolves #44329

### What

The repology datasource's `getReleases()` catch block unconditionally does `throw new ExternalHostError(err)`, which aborts the entire Renovate run on any error, including transient `repology.org` timeouts, and ignores `hostRules[].abortOnError`. This routes it through the shared `Datasource.handleGenericErrors()` like every other datasource.

### Why

`repology.org` is frequently slow and returns `ETIMEDOUT`. When it does, `result: external-host-error` aborts the whole repo run during lookup, so no branches are rebased and no PRs are created. Users report that `hostRules: [{ matchHost: "repology.org", abortOnError: false }]` has no effect, because the datasource wraps the error itself, upstream of the HTTP layer's `abortOnError` check (`lib/util/http/http.ts`). See discussion https://github.com/renovatebot/renovate/discussions/38091.

### Behavior after this change (now consistent with all other datasources)

- Transient/timeout error with default config: the package is skipped and the run continues (no more repo-wide abort).
- `429` / `5xx`: still aborts (via `handleGenericErrors`).
- `hostRules[].abortOnError: true`: still aborts (opt-in preserved; added a regression test).

### Tests

Updated the two repology timeout tests to assert a skip instead of an abort, and added a test proving `abortOnError: true` still aborts on timeout.

### AI assistance disclosure

This PR was written with the assistance of Claude Code (code and tests). The change was reviewed against the surrounding source before submitting.

