### PR TITLE
fix(versioning/debian): keep numeric value on dated codename update

### DIFF
--- a/lib/modules/versioning/debian/index.spec.ts
+++ b/lib/modules/versioning/debian/index.spec.ts
@@ -381,17 +381,19 @@ describe('modules/versioning/debian/index', () => {
   );
 
   it.each`
-    currentValue      | rangeStrategy | currentVersion | newVersion    | expected
-    ${undefined}      | ${undefined}  | ${undefined}   | ${'foobar'}   | ${'foobar'}
-    ${'stretch'}      | ${undefined}  | ${undefined}   | ${'11'}       | ${'bullseye'}
-    ${'stretch'}      | ${undefined}  | ${undefined}   | ${'bullseye'} | ${'bullseye'}
-    ${'stretch'}      | ${undefined}  | ${undefined}   | ${'stable'}   | ${'bookworm'}
-    ${'9'}            | ${undefined}  | ${undefined}   | ${'11'}       | ${'11'}
-    ${'oldoldstable'} | ${undefined}  | ${undefined}   | ${'12'}       | ${'stable'}
-    ${'oldstable'}    | ${undefined}  | ${undefined}   | ${'12'}       | ${'stable'}
-    ${'9'}            | ${undefined}  | ${undefined}   | ${'stable'}   | ${'12'}
-    ${'oldstable'}    | ${undefined}  | ${undefined}   | ${'12'}       | ${'stable'}
-    ${'oldstable'}    | ${undefined}  | ${undefined}   | ${'3'}        | ${'3'}
+    currentValue      | rangeStrategy | currentVersion | newVersion             | expected
+    ${undefined}      | ${undefined}  | ${undefined}   | ${'foobar'}            | ${'foobar'}
+    ${'stretch'}      | ${undefined}  | ${undefined}   | ${'11'}                | ${'bullseye'}
+    ${'stretch'}      | ${undefined}  | ${undefined}   | ${'bullseye'}          | ${'bullseye'}
+    ${'stretch'}      | ${undefined}  | ${undefined}   | ${'stable'}            | ${'bookworm'}
+    ${'9'}            | ${undefined}  | ${undefined}   | ${'11'}                | ${'11'}
+    ${'oldoldstable'} | ${undefined}  | ${undefined}   | ${'12'}                | ${'stable'}
+    ${'oldstable'}    | ${undefined}  | ${undefined}   | ${'12'}                | ${'stable'}
+    ${'9'}            | ${undefined}  | ${undefined}   | ${'stable'}            | ${'12'}
+    ${'oldstable'}    | ${undefined}  | ${undefined}   | ${'12'}                | ${'stable'}
+    ${'oldstable'}    | ${undefined}  | ${undefined}   | ${'3'}                 | ${'3'}
+    ${'12'}           | ${undefined}  | ${undefined}   | ${'bookworm-20230816'} | ${'12'}
+    ${'bullseye'}     | ${undefined}  | ${undefined}   | ${'bookworm-20230816'} | ${'bookworm'}
   `(
     'getNewValue("$currentValue", "$rangeStrategy", "$currentVersion", "$newVersion") === "$expected"',
     ({ currentValue, rangeStrategy, currentVersion, newVersion, expected }) => {

--- a/lib/modules/versioning/debian/index.ts
+++ b/lib/modules/versioning/debian/index.ts
@@ -63,7 +63,7 @@ export class DebianVersioningApi extends GenericVersioningApi {
 
     if (this._distroInfo.isCodename(currentValue)) {
       const di = this._rollingReleases.schedule(newVersion);
-      let ver = newVersion;
+      let ver = this._getBaseVersion(newVersion);
       if (di) {
         ver = di.version;
       }
@@ -75,6 +75,12 @@ export class DebianVersioningApi extends GenericVersioningApi {
     if (this._rollingReleases.has(newVersion)) {
       // should never `undefined` if it exists
       return this._rollingReleases.schedule(newVersion)!.version;
+    }
+
+    // current value is numeric, so keep a dated codename (e.g. trixie-20260406)
+    // as its numeric version rather than switching format
+    if (isDatedCodeName(newVersion, this._distroInfo)) {
+      return this._getBaseVersion(newVersion);
     }
 
     return this._distroInfo.getVersionByCodename(newVersion);


### PR DESCRIPTION
## Changes

- Resolve a dated `newVersion` to its numeric base version before formatting, preserving the current value's format:
- numeric current (`13`) → `13` (equals current → no update)
- codename current (`bookworm`) → `trixie`

## Context

Reported in discussion https://github.com/renovatebot/renovate/discussions/42443

<details>

<summary> Explanation </summary>
Debian's Docker images now publish dated tags such as `trixie-20260406`. These sort greater than a plain numeric tag like `13` (same major, plus a date component), so lookup selects the dated tag as `newVersion`.

`getNewValue` then fell through to `getVersionByCodename("trixie-20260406")`, which returns the string unchanged (a dated codename is not a registered codename). 

Resulting in a user pinned to `debian:13` was rewritten to `debian:trixie-20260406`, and one tracking `bookworm` would get `trixie-20260406` instead of `trixie`.

</details>

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI (Claude Opus) drafted the diagnosis, code fix, and unit tests; reviewed and verified by me.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A