### PR TITLE
feat(manager/github-actions): support parallel steps

### DIFF
--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1118,6 +1118,83 @@ describe('modules/manager/github-actions/extract', () => {
         `;
       expect(extractPackageFile(yamlContent, 'action.yml')).toBeNull();
     });
+
+    it('extracts actions and with-version inputs nested in a parallel block', () => {
+      const yamlContent = codeBlock`
+        jobs:
+          build:
+            steps:
+              - uses: actions/checkout@v4
+              - parallel:
+                  - name: Setup Node.js
+                    uses: actions/setup-node@v5
+                    with:
+                      node-version: '20.0.0'
+                  - name: Setup Go
+                    uses: actions/setup-go@v5
+                    with:
+                      go-version: '1.23'
+              - run: npm test
+        `;
+
+      const res = extractPackageFile(yamlContent, 'workflow.yml');
+      expect(res?.deps).toMatchObject([
+        { depName: 'actions/checkout', depType: 'action' },
+        { depName: 'actions/setup-node', depType: 'action' },
+        { depName: 'actions/setup-go', depType: 'action' },
+        { depName: 'node', depType: 'uses-with', currentValue: '20.0.0' },
+        { depName: 'go', depType: 'uses-with', currentValue: '1.23' },
+      ]);
+    });
+
+    it('extracts community action with-inputs nested in a parallel block', () => {
+      const yamlContent = codeBlock`
+        jobs:
+          build:
+            steps:
+              - parallel:
+                  - uses: astral-sh/setup-uv@v8.2.0
+                    with:
+                      version: '0.4.x'
+        `;
+
+      const res = extractPackageFile(yamlContent, 'workflow.yml');
+      expect(res?.deps).toMatchObject([
+        { depName: 'astral-sh/setup-uv', depType: 'action' },
+        {
+          depName: 'astral-sh/uv',
+          depType: 'uses-with',
+          currentValue: '0.4.x',
+          datasource: 'github-releases',
+        },
+      ]);
+    });
+
+    it('extracts steps nested in nested parallel blocks', () => {
+      const yamlContent = codeBlock`
+        jobs:
+          build:
+            steps:
+              - parallel:
+                  - name: Setup Node.js
+                    uses: actions/setup-node@v5
+                    with:
+                      node-version: '18.0.0'
+                  - parallel:
+                      - name: Setup Go
+                        uses: actions/setup-go@v5
+                        with:
+                          go-version: '1.22'
+        `;
+
+      const res = extractPackageFile(yamlContent, 'workflow.yml');
+      expect(res?.deps).toMatchObject([
+        { depName: 'actions/setup-node', depType: 'action' },
+        { depName: 'actions/setup-go', depType: 'action' },
+        { depName: 'node', depType: 'uses-with', currentValue: '18.0.0' },
+        { depName: 'go', depType: 'uses-with', currentValue: '1.22' },
+      ]);
+    });
   });
 
   it.each([

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -24,7 +24,7 @@ import type {
 import { CommunityActions } from './community.ts';
 import type { DockerReference, RepositoryReference } from './parse.ts';
 import { isSha, isShortSha, parseUsesLine, versionLikeRe } from './parse.ts';
-import type { Steps } from './schema.ts';
+import type { UsesStep } from './schema.ts';
 import { Workflow } from './schema.ts';
 
 // detects if we run against a Github Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
@@ -258,7 +258,7 @@ const versionedActions: Record<string, string> = {
   // - java
 };
 
-function extractVersionedAction(step: Steps): PackageDependency | null {
+function extractVersionedAction(step: UsesStep): PackageDependency | null {
   for (const [action, versioning] of Object.entries(versionedActions)) {
     const actionName = `actions/setup-${action}`;
     if (step.uses !== actionName && !step.uses?.startsWith(`${actionName}@`)) {
@@ -284,7 +284,7 @@ function extractVersionedAction(step: Steps): PackageDependency | null {
   return null;
 }
 
-function extractSteps(steps: Steps[]): PackageDependency[] {
+function extractSteps(steps: UsesStep[]): PackageDependency[] {
   const deps: PackageDependency[] = [];
 
   for (const step of steps) {

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -65,6 +65,26 @@ When pinning, Renovate adds a comment to preserve the original ref:
 Non-semver ref support is currently limited to GitHub-hosted actions.
 Gitea and Forgejo support the same ref types, but Renovate does not yet handle them for these platforms.
 
+### Steps nested in `parallel:` blocks
+
+Renovate extracts dependencies from steps nested inside a [`parallel:`](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-running-steps-in-parallel) block, just as it does for regular sequential steps.
+This includes both the action reference itself and any supported `with:` version inputs.
+
+```yaml
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - parallel:
+          - uses: actions/setup-node@v5
+            with:
+              node-version: '20.0.0'
+          - uses: actions/setup-go@v5
+            with:
+              go-version: '1.23'
+```
+
 ### Non-support of Variables
 
 Renovate ignores any GitHub runners which are configured in variables.

--- a/lib/modules/manager/github-actions/schema.ts
+++ b/lib/modules/manager/github-actions/schema.ts
@@ -6,13 +6,29 @@ import {
   withDebugMessage,
 } from '../../../util/schema-utils/index.ts';
 
-const Steps = z.object({
+const UsesStep = z.object({
   uses: z.string(),
   with: LooseRecord(
     z.union([z.string(), z.number().transform((s) => s.toString())]),
   ),
 });
-export type Steps = z.infer<typeof Steps>;
+export type UsesStep = z.infer<typeof UsesStep>;
+
+// A `parallel:` group flattens its (recursively resolved) sub-steps into leaf steps.
+// See: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-running-steps-in-parallel
+const ParallelStep: z.ZodType<UsesStep[]> = z
+  .object({ parallel: LooseArray(z.lazy(() => Step)) })
+  .transform(({ parallel }) => parallel.flat());
+
+// A step resolves to a flat list of `uses:` steps: a normal step yields itself,
+// a `parallel:` group yields its flattened sub-steps.
+const Step: z.ZodType<UsesStep[]> = z.union([
+  UsesStep.transform((step) => [step]),
+  ParallelStep,
+]);
+
+// Flatten the per-element `UsesStep[]` groups into a single `UsesStep[]`.
+const Steps = LooseArray(Step).transform((groups) => groups.flat());
 
 const WorkFlowJobs = z.object({
   jobs: LooseRecord(
@@ -35,7 +51,7 @@ const WorkFlowJobs = z.object({
       'runs-on': z
         .union([z.string().transform((v) => [v]), z.array(z.string())])
         .catch([]),
-      steps: LooseArray(Steps).catch([]),
+      steps: Steps.catch([]),
     }),
   ),
 });
@@ -43,7 +59,7 @@ const WorkFlowJobs = z.object({
 const Actions = z.object({
   runs: z.object({
     using: z.string(),
-    steps: LooseArray(Steps).optional().catch([]),
+    steps: Steps.optional().catch([]),
   }),
 });
 export const Workflow = Yaml.pipe(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Add support to `parallel` GitHub actions 

https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idstepsparallel

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
