### PR TITLE
feat: respect disabled host rules across datasources and managers

### DIFF
--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -7,6 +7,7 @@ import {
 } from '../../constants/error-messages.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
 import * as _packageCache from '../../util/cache/package/index.ts';
+import * as hostRules from '../../util/host-rules.ts';
 import { loadModules } from '../../util/modules.ts';
 import datasources from './api.ts';
 import { getDefaultVersioning } from './common.ts';
@@ -143,6 +144,10 @@ vi.mock('../../util/cache/package/index.ts');
 const packageCache = vi.mocked(_packageCache);
 
 describe('modules/datasource/index', () => {
+  beforeEach(() => {
+    hostRules.clear();
+  });
+
   afterEach(() => {
     datasources.delete(datasource);
   });
@@ -249,6 +254,22 @@ describe('modules/datasource/index', () => {
         'Custom registries are not allowed for this datasource and will be ignored',
       );
       expect(res).toMatchObject({ releases: [{ version: '1.2.3' }] });
+    });
+
+    it('filters out disabled registry URLs', async () => {
+      datasources.set(datasource, new DummyDatasource());
+      hostRules.add({
+        hostType: 'dummy',
+        matchHost: 'https://reg1.com',
+        enabled: false,
+      });
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName,
+      });
+
+      expect(res).toBeNull();
     });
   });
 

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -17,6 +17,7 @@ import * as packageCache from '../../util/cache/package/index.ts';
 import type { PackageCacheNamespace } from '../../util/cache/package/types.ts';
 import { clone } from '../../util/clone.ts';
 import { filterMap } from '../../util/filter-map.ts';
+import { isRegistryDisabled } from '../../util/host-rules.ts';
 import { AsyncResult, Result } from '../../util/result.ts';
 import { DatasourceCacheStats } from '../../util/stats.ts';
 import { trimTrailingSlash } from '../../util/url.ts';
@@ -297,7 +298,23 @@ function resolveRegistryUrls(
   registryUrls: string[] | undefined | null,
   additionalRegistryUrls: string[] | undefined,
 ): string[] {
-  if (!datasource.customRegistrySupport) {
+  let resolvedUrls: string[] = [];
+  if (datasource.customRegistrySupport) {
+    const customUrls = registryUrls?.filter(Boolean);
+    if (isNonEmptyArray(customUrls)) {
+      resolvedUrls = [...customUrls];
+    } else if (isNonEmptyArray(defaultRegistryUrls)) {
+      resolvedUrls = [...defaultRegistryUrls];
+      resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
+    } else if (isFunction(datasource.defaultRegistryUrls)) {
+      resolvedUrls = [...datasource.defaultRegistryUrls()];
+      resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
+    } else if (isNonEmptyArray(datasource.defaultRegistryUrls)) {
+      resolvedUrls = [...datasource.defaultRegistryUrls];
+      resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
+    }
+    resolvedUrls = massageRegistryUrls(resolvedUrls);
+  } else {
     if (
       isNonEmptyArray(registryUrls) ||
       isNonEmptyArray(defaultRegistryUrls) ||
@@ -313,25 +330,11 @@ function resolveRegistryUrls(
         'Custom registries are not allowed for this datasource and will be ignored',
       );
     }
-    return isFunction(datasource.defaultRegistryUrls)
+    resolvedUrls = isFunction(datasource.defaultRegistryUrls)
       ? datasource.defaultRegistryUrls()
       : (datasource.defaultRegistryUrls ?? []);
   }
-  const customUrls = registryUrls?.filter(Boolean);
-  let resolvedUrls: string[] = [];
-  if (isNonEmptyArray(customUrls)) {
-    resolvedUrls = [...customUrls];
-  } else if (isNonEmptyArray(defaultRegistryUrls)) {
-    resolvedUrls = [...defaultRegistryUrls];
-    resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
-  } else if (isFunction(datasource.defaultRegistryUrls)) {
-    resolvedUrls = [...datasource.defaultRegistryUrls()];
-    resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
-  } else if (isNonEmptyArray(datasource.defaultRegistryUrls)) {
-    resolvedUrls = [...datasource.defaultRegistryUrls];
-    resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
-  }
-  return massageRegistryUrls(resolvedUrls);
+  return resolvedUrls.filter((url) => !isRegistryDisabled(url, datasource.id));
 }
 
 function applyReplacements(

--- a/lib/modules/manager/npm/post-update/rules.spec.ts
+++ b/lib/modules/manager/npm/post-update/rules.spec.ts
@@ -187,5 +187,32 @@ describe('modules/manager/npm/post-update/rules', () => {
         },
       });
     });
+
+    it('skips disabled host rules', () => {
+      hostRules.add({
+        hostType: 'npm',
+        matchHost: 'registry.company.com',
+        token: 'sometoken',
+      });
+      hostRules.add({
+        hostType: 'npm',
+        matchHost: 'registry.other.org',
+        enabled: false,
+      });
+      const res = processHostRules();
+      expect(res).toEqual({
+        additionalNpmrcContent: [
+          '//registry.company.com/:_authToken=sometoken',
+        ],
+
+        additionalYarnRcYml: {
+          npmRegistries: {
+            '//registry.company.com/': {
+              npmAuthToken: 'sometoken',
+            },
+          },
+        },
+      });
+    });
   });
 });

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -41,6 +41,11 @@ export function processHostRules(): HostRulesResult {
     `Found ${effectiveHostRules.length} effective npm host rule(s) after deduplication`,
   );
   for (const hostRule of effectiveHostRules) {
+    if (hostRule.enabled === false) {
+      logger.debug('Skipping disabled host rule');
+      continue;
+    }
+
     if (!hostRule.resolvedHost) {
       logger.debug('Skipping host rule without resolved host');
       continue;

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -14,6 +14,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import { getFiles } from '../../../util/git/index.ts';
+import { isRegistryDisabled } from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
 import type {
   UpdateArtifact,
@@ -53,7 +54,9 @@ async function createCachedNuGetConfigFile(
     (url) => ({ url }),
   );
 
-  const combinedRegistries = [...registries, ...updatedDepsRegistries];
+  const combinedRegistries = [...registries, ...updatedDepsRegistries].filter(
+    (reg) => !isRegistryDisabled(reg.url),
+  );
 
   const contents = createNuGetConfigXml(combinedRegistries);
 

--- a/lib/modules/manager/pip-compile/common.spec.ts
+++ b/lib/modules/manager/pip-compile/common.spec.ts
@@ -259,6 +259,18 @@ describe('modules/manager/pip-compile/common', () => {
       });
     });
 
+    it('skips disabled registry credentials', () => {
+      hostRules.isRegistryDisabled.mockReturnValueOnce(true);
+      expect(
+        getRegistryCredVarsFromPackageFiles([
+          {
+            deps: [],
+            registryUrls: ['https://example.com/pypi/simple'],
+          },
+        ]),
+      ).toEqual({});
+    });
+
     it('handles multiple additionalRegistryUrls', () => {
       hostRules.find.mockReturnValueOnce({
         username: 'user1',

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -349,9 +349,6 @@ function getRegistryCredEnvVars(
   index: number,
 ): Record<string, string> {
   const hostRule = hostRules.find({ url: url.href });
-  if (hostRule.enabled === false) {
-    return {};
-  }
   logger.debug(hostRule, `Found host rule for url ${url.href}`);
   const ret: Record<string, string> = {};
   if (!!hostRule.username || !!hostRule.password) {

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -349,6 +349,9 @@ function getRegistryCredEnvVars(
   index: number,
 ): Record<string, string> {
   const hostRule = hostRules.find({ url: url.href });
+  if (hostRule.enabled === false) {
+    return {};
+  }
   logger.debug(hostRule, `Found host rule for url ${url.href}`);
   const ret: Record<string, string> = {};
   if (!!hostRule.username || !!hostRule.password) {
@@ -382,7 +385,10 @@ export function getRegistryCredVarsFromPackageFiles(
   logger.debug(urls, 'Extracted registry URLs from package files');
 
   const uniqueHosts = new Set<URL>(
-    urls.map(cleanUrl).filter(isNotNullOrUndefined),
+    urls
+      .map(cleanUrl)
+      .filter(isNotNullOrUndefined)
+      .filter((url) => !hostRules.isRegistryDisabled(url.href)),
   );
 
   let allCreds: ExtraEnv<string> = {};

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -1142,6 +1142,11 @@ describe('modules/manager/pipenv/artifacts', () => {
     expect(getMatchingHostRule('')).toBeNull();
   });
 
+  it('returns null if matching rule is disabled', () => {
+    find.mockReturnValueOnce({ enabled: false });
+    expect(getMatchingHostRule('https://pypi.org/simple')).toBeNull();
+  });
+
   it.each`
     credential                      | result
     ${'$USERNAME'}                  | ${'USERNAME'}

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -32,7 +32,14 @@ export function getMatchingHostRule(url: string): HostRule | null {
     parsedUrl.password = '';
     const urlWithoutCredentials = parsedUrl.toString();
 
-    return find({ hostType: PypiDatasource.id, url: urlWithoutCredentials });
+    const rule = find({
+      hostType: PypiDatasource.id,
+      url: urlWithoutCredentials,
+    });
+    if (rule?.enabled === false) {
+      return null;
+    }
+    return rule;
   }
   return null;
 }

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -226,6 +226,38 @@ describe('modules/manager/poetry/artifacts', () => {
       ]);
     });
 
+    it('skips disabled registry credentials', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('poetry.lock');
+      fs.readLocalFile.mockResolvedValueOnce(null);
+      fs.getSiblingFileName.mockReturnValueOnce('pyproject.lock');
+      fs.readLocalFile.mockResolvedValueOnce('[metadata]\n');
+      const execSnapshots = mockExecAll();
+      fs.readLocalFile.mockResolvedValueOnce('New poetry.lock');
+      hostRules.find.mockReturnValueOnce({
+        enabled: false,
+      });
+      const updatedDeps = [{ depName: 'dep1' }];
+      expect(
+        await updateArtifacts({
+          packageFileName: 'pyproject.toml',
+          updatedDeps,
+          newPackageFileContent: pyproject10toml,
+          config,
+        }),
+      ).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pyproject.lock',
+            contents: 'New poetry.lock',
+          },
+        },
+      ]);
+      expect(execSnapshots[0].options?.env).not.toHaveProperty(
+        'POETRY_HTTP_BASIC_ONE_USERNAME',
+      );
+    });
+
     it('passes Google Artifact Registry credentials environment vars', async () => {
       // poetry.lock
       fs.getSiblingFileName.mockReturnValueOnce('poetry.lock');

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -123,6 +123,9 @@ function getPoetrySources(content: string, fileName: string): PoetrySource[] {
 async function getMatchingHostRule(url: string | undefined): Promise<HostRule> {
   const scopedMatch = find({ hostType: PypiDatasource.id, url });
   const hostRule = isNonEmptyObject(scopedMatch) ? scopedMatch : find({ url });
+  if (hostRule?.enabled === false) {
+    return {};
+  }
   if (hostRule && Object.keys(hostRule).length !== 0) {
     return hostRule;
   }

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -7,6 +7,7 @@ import {
   getAll,
   hostType,
   hosts,
+  isRegistryDisabled,
 } from './host-rules.ts';
 
 describe('util/host-rules', () => {
@@ -481,6 +482,38 @@ describe('util/host-rules', () => {
           url: 'https://gitlab.example.com/chalk/chalk',
         }),
       ).toBeNull();
+    });
+  });
+
+  describe('isRegistryDisabled()', () => {
+    it('returns true if registry is disabled', () => {
+      add({
+        hostType: 'nuget',
+        matchHost: 'https://api.nuget.org',
+        enabled: false,
+      });
+      expect(isRegistryDisabled('https://api.nuget.org', 'nuget')).toBe(true);
+    });
+
+    it('returns false if registry is enabled', () => {
+      add({
+        hostType: 'nuget',
+        matchHost: 'https://api.nuget.org',
+        enabled: true,
+      });
+      expect(isRegistryDisabled('https://api.nuget.org', 'nuget')).toBe(false);
+    });
+
+    it('returns false if registry has no rule', () => {
+      expect(isRegistryDisabled('https://api.nuget.org', 'nuget')).toBe(false);
+    });
+
+    it('works with optional hostType', () => {
+      add({
+        matchHost: 'https://api.nuget.org',
+        enabled: false,
+      });
+      expect(isRegistryDisabled('https://api.nuget.org')).toBe(true);
     });
   });
 });

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -218,3 +218,17 @@ export function clear(): void {
   hostRules = [];
   sanitize.clearRepoSanitizedSecretsList();
 }
+
+/**
+ * Checks if a registry is disabled
+ * @param url The URL of the registry
+ * @param hostType The type of host
+ * @returns True if the registry is disabled, false otherwise
+ */
+export function isRegistryDisabled(url: string, hostType?: string): boolean {
+  const rule = find({
+    hostType,
+    url,
+  });
+  return rule.enabled === false;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Introduce the ability to cleanly disable and filter out default public registries globally at the datasource layer and within package manager artifact workflows when a matching `hostRules` has `enabled: false`.
1. **Global Datasource Filtering**: Added `isRegistryDisabled` and updated `resolveRegistryUrls` to globally filter out disabled registry hosts before lookups/digests are resolved.
2. **NuGet Manager**: Omit disabled registries from the generated temporary `nuget.config` file used for `dotnet restore`.
3. **npm Manager**: Skip disabled host rules in `processHostRules` when generating ephemeral `.npmrc` / `.yarnrc.yml` lines.
4. **Python Managers (Pipenv, Poetry, pip-compile)**: Prevent credentials and keyring environment variables from being set for disabled registries.

Relates to https://github.com/renovatebot/renovate/discussions/44346

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
