### PR TITLE
fix(terraform): strictly strip ".git" suffix from source URLs

### DIFF
--- a/lib/modules/manager/terraform/extractors/others/modules.spec.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.spec.ts
@@ -339,4 +339,132 @@ describe('modules/manager/terraform/extractors/others/modules', () => {
       });
     });
   });
+
+  describe('extract git-tags modules with .git in domain or repo name', () => {
+    describe('SSH URL with .git in domain and standard path', () => {
+      const source =
+        'git::ssh://git@test.git.example.git.com/modules/foo-module.git//bar?ref=v1.0.0';
+
+      it('should extract the correct depName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          depName: 'test.git.example.git.com/modules/foo-module',
+          currentValue: 'v1.0.0',
+          datasource: 'git-tags',
+        });
+      });
+
+      it('should extract the correct packageName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          packageName: 'ssh://git@test.git.example.git.com/modules/foo-module',
+        });
+      });
+    });
+
+    describe('SSH URL with .git in domain and colon-separated path', () => {
+      const source =
+        'git::ssh://git@test.git.example.git.com:modules/foo-module.git//bar?ref=v2.0.0';
+
+      it('should extract the correct depName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          depName: 'test.git.example.git.com:modules/foo-module',
+          currentValue: 'v2.0.0',
+          datasource: 'git-tags',
+        });
+      });
+
+      it('should extract the correct packageName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          packageName: 'ssh://git@test.git.example.git.com:modules/foo-module',
+        });
+      });
+    });
+
+    describe('HTTPS URL with .git in domain and no trailing .git', () => {
+      const source =
+        'git::https://git@test.git.example.git.com/modules/foo-module?ref=v3.0.0';
+
+      it('should extract the correct depName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          depName: 'test.git.example.git.com/modules/foo-module',
+          currentValue: 'v3.0.0',
+          datasource: 'git-tags',
+        });
+      });
+
+      it('should extract the correct packageName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          packageName:
+            'https://git@test.git.example.git.com/modules/foo-module',
+        });
+      });
+    });
+
+    describe('HTTPS URL with .git in repo name', () => {
+      const source =
+        'git::https://git@test.example.com/modules.git-repo/foo-module?ref=v3.0.0';
+
+      it('should extract the correct depName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          depName: 'test.example.com/modules.git-repo/foo-module',
+          currentValue: 'v3.0.0',
+          datasource: 'git-tags',
+        });
+      });
+
+      it('should extract the correct packageName', () => {
+        const res = extractor.extract(
+          { module: { foo: [{ source }] } },
+          [],
+          {},
+        );
+        expect(res).toHaveLength(1);
+        expect(res[0]).toMatchObject({
+          packageName:
+            'https://git@test.example.com/modules.git-repo/foo-module',
+        });
+      });
+    });
+  });
 });

--- a/lib/modules/manager/terraform/extractors/others/modules.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.ts
@@ -107,8 +107,8 @@ export class ModuleExtractor extends DependencyExtractor {
       if (gitTagsRefMatch.groups.subfolder) {
         logger.debug('Terraform module contains subdirectory');
       }
-      dep.depName = gitTagsRefMatch.groups.path.replace('.git', '');
-      dep.packageName = gitTagsRefMatch.groups.url.replace('.git', '');
+      dep.depName = gitTagsRefMatch.groups.path.replace(regEx(/\.git$/), '');
+      dep.packageName = gitTagsRefMatch.groups.url.replace(regEx(/\.git$/), '');
       dep.currentValue = gitTagsRefMatch.groups.tag;
       dep.datasource = GitTagsDatasource.id;
     } else if (source) {


### PR DESCRIPTION
Fixes #44332

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: # 44332
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: private hosted repo

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
