### PR TITLE
docs: document GitLab auth for private Go modules

### DIFF
--- a/docs/usage/getting-started/private-packages.md
+++ b/docs/usage/getting-started/private-packages.md
@@ -141,6 +141,8 @@ Assume this config is used on the `github.com/some-other-org` repo:
 }
 ```
 
+If you use private Go modules hosted on GitLab, read [private Go modules hosted on GitLab](../golang.md#private-go-modules-hosted-on-gitlab) to learn how to authenticate the module resolution requests.
+
 ## Looking up changelogs
 
 When Renovate creates Pull Requests, its default behavior is to locate and embed release notes/changelogs of packages.

--- a/docs/usage/golang.md
+++ b/docs/usage/golang.md
@@ -97,3 +97,33 @@ module.exports = {
   ],
 };
 ```
+
+### Private Go modules hosted on GitLab
+
+For private GitLab projects, Renovate must authenticate the `?go-get=1` requests it uses to resolve the source repository of a module.
+Add a host rule with `hostType` set to `go` that uses `username` and `password`:
+
+```js
+module.exports = {
+  hostRules: [
+    {
+      matchHost: 'gitlab.company.com',
+      hostType: 'go',
+      username: 'renovate-bot',
+      password: process.env.GITLAB_PAT,
+    },
+  ],
+};
+```
+
+The `password` must be a personal access token with the `read_api` scope.
+The `username` can be any non-empty string when the password is a personal access token.
+
+!!! warning
+  Use `username` and `password` in the `go` host rule, not `token`.
+  [GitLab only supports Basic authentication for `?go-get=1` requests](https://docs.gitlab.com/development/go_guide/dependencies/#authenticating), and a `token` results in a `Bearer` authorization header.
+
+If you do not run Renovate with GitLab as its platform, you also need a host rule with `hostType` set to `gitlab` to authenticate the GitLab tags API.
+
+Without the `go` host rule, GitLab responds to the unauthenticated `?go-get=1` request with a truncated `go-import` path, so Renovate resolves the wrong repository.
+Lookups then fail with a 404 response for a tags URL with a truncated project path, for example: `https://gitlab.company.com/api/v4/projects/group%2Fsubgroup/repository/tags?per_page=100`.


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

- Updates documentation to describe required setup for resolving modules in private gitlab repositories

<!-- Describe what behavior is changed by this PR. -->

## Context

Private GitLab projects need a `hostType: "go"` host rule with a username and password so Renovate can authenticate the go-get request it uses to resolve a module's source repository. Without it GitLab returns a truncated go-import path for the unauthenticated request and the version lookup 404s.

Came up in discussion #37624 after the resolution change in #36963.

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe):
Used to verify what I wrote was accurate since it's been a while since I looked at this area - e.g. quick tests of the ?go-get behaviour. I did carefully review the output and have cut down a lot of what was written to what I considered useful to a user.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

No code changes - verified documentation as part of investigation in the linked discussion.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
