### PR TITLE
feat(replacements): corentinmusard/otel-cicd-action transferred to dash0hq

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -257,7 +257,7 @@
     "description": "`corentinmusard/otel-cicd-action` was transferred to `dash0hq/otel-cicd-action`.",
     "packageRules": [
       {
-        "matchDatasources": ["github-tags"],
+        "matchDatasources": ["github-releases", "github-tags"],
         "matchPackageNames": ["corentinmusard/otel-cicd-action"],
         "replacementName": "dash0hq/otel-cicd-action",
         "replacementVersion": "4.0.1"

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -253,6 +253,17 @@
       }
     ]
   },
+  "corentinmusard-otel-cicd-action-to-dash0hq": {
+    "description": "`corentinmusard/otel-cicd-action` was transferred to `dash0hq/otel-cicd-action`.",
+    "packageRules": [
+      {
+        "matchDatasources": ["github-tags"],
+        "matchPackageNames": ["corentinmusard/otel-cicd-action"],
+        "replacementName": "dash0hq/otel-cicd-action",
+        "replacementVersion": "4.0.1"
+      }
+    ]
+  },
   "cpx-to-maintenance-fork": {
     "description": "Maintenance fork of `cpx`",
     "packageRules": [


### PR DESCRIPTION
## Changes

Adds a replacement preset entry for `corentinmusard/otel-cicd-action`, which was transferred to `dash0hq/otel-cicd-action`.

Evidence of the transfer:

- The new repository: https://github.com/dash0hq/otel-cicd-action
- The old path https://github.com/corentinmusard/otel-cicd-action redirects to the new location
- Announcement discussion: https://github.com/dash0hq/otel-cicd-action/discussions/72

The action is maintained under its new home by Dash0 (`dash0hq` is the GitHub org of Dash0).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR (the JSON entry, the commit, and this description) was authored and submitted by Claude Code (model: Claude Fable 5), acting on the instructions of the account owner as part of the repository-transfer runbook. The account owner will follow up on review feedback.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The replacements documentation is generated from `lib/data/replacements.json`.

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The entry mirrors existing `github-tags` replacement entries (e.g. `google-github-action-release-please-to-googleapis`) and is inserted in alphabetical order.