### PR TITLE
refactor(oxlint): enable vitest/no-conditional-expect

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -168,7 +168,7 @@
     "typescript/no-useless-default-assignment": "off",
     "vitest/require-mock-type-parameters": "off",
     "vitest/expect-expect": "off",
-    "vitest/no-conditional-expect": "off",
+    "vitest/no-conditional-expect": "error",
     "vitest/no-standalone-expect": "off",
     "vitest/prefer-snapshot-hint": "off",
     "vitest/require-to-throw-message": "off"

--- a/lib/data/index.spec.ts
+++ b/lib/data/index.spec.ts
@@ -24,13 +24,12 @@ function checkKeysSorted(
   firstKeys?: string[],
 ): void {
   let keys = Object.keys(obj);
-  if (depth === 0 && firstKeys?.length) {
-    expect(
-      keys.slice(0, firstKeys.length),
-      `${path} should start with [${firstKeys.join(', ')}]`,
-    ).toStrictEqual(firstKeys);
-    keys = keys.slice(firstKeys.length);
-  }
+  const expectedFirst = depth === 0 ? (firstKeys ?? []) : [];
+  expect(
+    keys.slice(0, expectedFirst.length),
+    `${path} should start with [${expectedFirst.join(', ')}]`,
+  ).toStrictEqual(expectedFirst);
+  keys = keys.slice(expectedFirst.length);
   expect(keys, `${path} keys should be sorted alphabetically`).toStrictEqual(
     [...keys].sort(),
   );


### PR DESCRIPTION
Make the `checkKeysSorted` first-keys assertion unconditional by defaulting the expected prefix to an empty array, so `expect` is no longer nested inside an `if`.

Part of #43845

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
