### PR TITLE
refactor(oxlint): enable typescript/no-useless-default-assignment

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -165,7 +165,7 @@
     "typescript/no-unsafe-function-type": "error",
     "unicorn/prefer-node-protocol": "error",
 
-    "typescript/no-useless-default-assignment": "off",
+    "typescript/no-useless-default-assignment": "error",
     "vitest/require-mock-type-parameters": "off",
     "vitest/expect-expect": "off",
     "vitest/no-conditional-expect": "off",

--- a/lib/config/presets/forgejo/index.ts
+++ b/lib/config/presets/forgejo/index.ts
@@ -67,7 +67,7 @@ export function getPreset({
   repo,
   presetName = 'default',
   presetPath,
-  tag = undefined,
+  tag,
 }: PresetConfig): Promise<Nullish<Preset>> {
   return getPresetFromEndpoint(repo, presetName, presetPath, Endpoint, tag);
 }

--- a/lib/config/presets/gitea/index.ts
+++ b/lib/config/presets/gitea/index.ts
@@ -53,7 +53,7 @@ export function getPreset({
   repo,
   presetName = 'default',
   presetPath,
-  tag = undefined,
+  tag,
 }: PresetConfig): Promise<Nullish<Preset>> {
   return getPresetFromEndpoint(repo, presetName, presetPath, Endpoint, tag);
 }

--- a/lib/config/presets/gitlab/index.ts
+++ b/lib/config/presets/gitlab/index.ts
@@ -79,7 +79,7 @@ export function getPreset({
   repo,
   presetPath,
   presetName = 'default',
-  tag = undefined,
+  tag,
 }: PresetConfig): Promise<Nullish<Preset>> {
   return getPresetFromEndpoint(repo, presetName, presetPath, Endpoint, tag);
 }

--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -84,9 +84,7 @@ function infoMock(
 }
 
 describe('modules/platform/bitbucket-server/utils', () => {
-  function createError(
-    body: Partial<BitbucketErrorResponse> | undefined = undefined,
-  ) {
+  function createError(body?: Partial<BitbucketErrorResponse>) {
     return partial<BitbucketError>({
       response: partial<Response<BitbucketErrorResponse>>({ body }),
     });

--- a/lib/util/github/graphql/datasource-fetcher.spec.ts
+++ b/lib/util/github/graphql/datasource-fetcher.spec.ts
@@ -63,7 +63,7 @@ const adapter: GithubGraphqlDatasourceAdapter<
 function resp(
   isRepoPrivate: boolean | undefined,
   nodes: TestAdapterInput[],
-  cursor: string | undefined = undefined,
+  cursor?: string,
 ): GithubGraphqlResponse<GithubGraphqlRepoResponse<TestAdapterInput>> {
   const data: GithubGraphqlRepoResponse<TestAdapterInput> = {
     repository: {

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -32,8 +32,8 @@ export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   constructor({
     namespace,
     softTtlMinutes = 15,
-    checkCacheControlHeader = false,
-    checkAuthorizationHeader = false,
+    checkCacheControlHeader,
+    checkAuthorizationHeader,
     writeSchema,
   }: PackageHttpCacheProviderOptions) {
     super();

--- a/lib/util/http/gerrit.ts
+++ b/lib/util/http/gerrit.ts
@@ -24,10 +24,7 @@ export class GerritHttp extends HttpBase {
     super('gerrit', options);
   }
 
-  override resolveUrl(
-    requestUrl: string | URL,
-    options: HttpOptions | undefined = undefined,
-  ): URL {
+  override resolveUrl(requestUrl: string | URL, options?: HttpOptions): URL {
     // ensure trailing slash for gerrit
     return super.resolveUrl(
       isHttpUrl(requestUrl) ? requestUrl : `${baseUrl}${requestUrl}`,

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -319,7 +319,7 @@ describe('util/http/github', () => {
       });
       async function fail(
         code: number,
-        body: any = undefined,
+        body?: any,
         headers: httpMock.ReplyHeaders = {},
       ) {
         const url = '/some-url';
@@ -436,7 +436,7 @@ describe('util/http/github', () => {
       it('when the rate limit is exceeded to GitHub Enterprise, but no host rules are set, a warn is logged', async () => {
         async function fail(
           code: number,
-          body: any = undefined,
+          body?: any,
           headers: httpMock.ReplyHeaders = {},
         ) {
           const url = '/some-url';

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -222,8 +222,8 @@ function handleGotError(
 }
 
 interface GraphqlPaginatedContent<T = unknown> {
-  nodes: T[];
-  edges: T[];
+  nodes?: T[];
+  edges?: T[];
   pageInfo: { hasNextPage: boolean; endCursor: string };
 }
 

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -297,10 +297,7 @@ export abstract class HttpBase<
     throw err;
   }
 
-  resolveUrl(
-    requestUrl: string | URL,
-    options: HttpOptions | undefined = undefined,
-  ): URL {
+  resolveUrl(requestUrl: string | URL, options?: HttpOptions): URL {
     let url = requestUrl;
 
     if (url instanceof URL) {

--- a/lib/workers/repository/update/pr/changelog/github/index.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.ts
@@ -32,7 +32,7 @@ export async function getReleaseNotesMd(
   logger.trace('github.getReleaseNotesMd()');
   const apiPrefix = `${ensureTrailingSlash(apiBaseUrl)}repos/${repository}`;
   const { default_branch: defaultBranch = 'HEAD' } = (
-    await http.getJsonUnchecked<{ default_branch: string }>(apiPrefix, {
+    await http.getJsonUnchecked<{ default_branch?: string }>(apiPrefix, {
       cacheProvider: memCacheProvider,
     })
   ).body;

--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -20,7 +20,7 @@ import { generateVersioning } from './versioning.ts';
 export async function generateDocs(
   root = 'tmp',
   pack = true,
-  version: string | undefined = undefined,
+  version?: string,
 ): Promise<void> {
   try {
     const dist = `${root}/docs`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

- Convert `param: T | undefined = undefined` to optional `param?: T`.
- Drop dead `= false` defaults on the required cache-provider options.
- Make `GraphqlPaginatedContent.nodes/edges` optional so the `= []` fallbacks (load-bearing for partial GraphQL connections) are valid.
- Type the unchecked `default_branch` response field as optional so the `'HEAD'` fallback is retained.
- Drop `tag = undefined` from the Forgejo/Gitea/GitLab preset configs.

<!-- Describe what behavior is changed by this PR. -->

## Context

Part of #43845

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
