### PR TITLE
refactor(oxlint): enable vitest/require-mock-type-parameters

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -166,7 +166,7 @@
     "unicorn/prefer-node-protocol": "error",
 
     "typescript/no-useless-default-assignment": "error",
-    "vitest/require-mock-type-parameters": "off",
+    "vitest/require-mock-type-parameters": "error",
     "vitest/expect-expect": [
       "error",
       { "assertFunctionNames": ["expect", "expectTypeOf", "checkKeysSorted"] }

--- a/lib/config/options/index.spec.ts
+++ b/lib/config/options/index.spec.ts
@@ -28,7 +28,9 @@ async function collectTsFiles(dir: string): Promise<string[]> {
 describe('config/options/index', () => {
   it('test manager should have no defaultConfig', () => {
     vi.doMock('../../modules/manager/index.ts', () => ({
-      getManagers: vi.fn(() => new Map().set('testManager', {})),
+      getManagers: vi.fn<(...args: any[]) => any>(() =>
+        new Map().set('testManager', {}),
+      ),
     }));
 
     const opts = getOptions();

--- a/lib/config/presets/util.spec.ts
+++ b/lib/config/presets/util.spec.ts
@@ -8,7 +8,9 @@ const config: FetchPresetConfig = {
   fetch: undefined as never,
 };
 
-const fetch = vi.fn(() => Promise.resolve<Preset | null>({}));
+const fetch = vi.fn<() => Promise<Preset | null>>(() =>
+  Promise.resolve<Preset | null>({}),
+);
 
 describe('config/presets/util', () => {
   beforeEach(() => {

--- a/lib/instrumentation/with-instrumenting.spec.ts
+++ b/lib/instrumentation/with-instrumenting.spec.ts
@@ -5,7 +5,7 @@ afterAll(disableInstrumentations);
 
 describe('instrumentation/with-instrumenting', () => {
   it('wraps async function', async () => {
-    const spy = vi.fn(() => Promise.resolve(42));
+    const spy = vi.fn<() => Promise<number>>(() => Promise.resolve(42));
     const wrapped = withInstrumenting({ name: 'test-span' }, spy);
 
     const result = await wrapped();
@@ -15,7 +15,7 @@ describe('instrumentation/with-instrumenting', () => {
   });
 
   it('instruments multiple calls', async () => {
-    const spy = vi.fn(() => Promise.resolve('ok'));
+    const spy = vi.fn<() => Promise<string>>(() => Promise.resolve('ok'));
     const wrapped = withInstrumenting({ name: 'test-span' }, spy);
 
     await wrapped();
@@ -27,7 +27,9 @@ describe('instrumentation/with-instrumenting', () => {
   });
 
   it('propagates errors', async () => {
-    const spy = vi.fn(() => Promise.reject(new Error('test error')));
+    const spy = vi.fn<() => Promise<never>>(() =>
+      Promise.reject(new Error('test error')),
+    );
     const wrapped = withInstrumenting({ name: 'test-span' }, spy);
 
     await expect(wrapped()).rejects.toThrow('test error');
@@ -35,7 +37,7 @@ describe('instrumentation/with-instrumenting', () => {
   });
 
   it('accepts options', async () => {
-    const spy = vi.fn(() => Promise.resolve('result'));
+    const spy = vi.fn<() => Promise<string>>(() => Promise.resolve('result'));
     const wrapped = withInstrumenting(
       {
         name: 'test-span',
@@ -52,7 +54,9 @@ describe('instrumentation/with-instrumenting', () => {
   });
 
   it('passes arguments to wrapped function', async () => {
-    const spy = vi.fn((a: number, b: string) => Promise.resolve(`${a}-${b}`));
+    const spy = vi.fn<(a: number, b: string) => Promise<string>>(
+      (a: number, b: string) => Promise.resolve(`${a}-${b}`),
+    );
     const wrapped = withInstrumenting({ name: 'test-span' }, spy);
 
     const result = await wrapped(42, 'hello');

--- a/lib/logger/bunyan.spec.ts
+++ b/lib/logger/bunyan.spec.ts
@@ -1,6 +1,8 @@
 import { validateLogLevel } from './bunyan.ts';
 
-vi.mock('bunyan', () => ({ createLogger: () => ({ fatal: vi.fn() }) }));
+vi.mock('bunyan', () => ({
+  createLogger: () => ({ fatal: vi.fn<(...args: unknown[]) => void>() }),
+}));
 
 describe('logger/bunyan', () => {
   it('checks for valid log levels', () => {

--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -28,7 +28,7 @@ const logContext = 'initial_context';
 
 vi.unmock('./index.ts');
 vi.mock('node:crypto', () => ({
-  randomUUID: vi.fn(() => 'initial_context'),
+  randomUUID: vi.fn<() => string>(() => 'initial_context'),
 }));
 
 const bunyanDebugSpy = vi.spyOn(bunyan.prototype, 'debug');

--- a/lib/logger/once.spec.ts
+++ b/lib/logger/once.spec.ts
@@ -13,7 +13,7 @@ describe('logger/once', () => {
 
   describe('core', () => {
     it('should call a function only once', () => {
-      const innerFn = vi.fn();
+      const innerFn = vi.fn<() => void>();
 
       function outerFn() {
         once(innerFn, undefined, '');
@@ -26,8 +26,8 @@ describe('logger/once', () => {
     });
 
     it('supports support distinct calls', () => {
-      const innerFn1 = vi.fn();
-      const innerFn2 = vi.fn();
+      const innerFn1 = vi.fn<() => void>();
+      const innerFn2 = vi.fn<() => void>();
 
       function outerFn() {
         once(innerFn1, undefined, '');
@@ -42,7 +42,7 @@ describe('logger/once', () => {
     });
 
     it('resets keys', () => {
-      const innerFn = vi.fn();
+      const innerFn = vi.fn<() => void>();
 
       function outerFn() {
         once(innerFn, undefined, '');

--- a/lib/logger/renovate-logger.spec.ts
+++ b/lib/logger/renovate-logger.spec.ts
@@ -11,10 +11,10 @@ describe('logger/renovate-logger', () => {
 
   it('should queue logs until initialized', () => {
     const fakeLogger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      fatal: vi.fn(),
+      info: vi.fn<(...args: unknown[]) => void>(),
+      warn: vi.fn<(...args: unknown[]) => void>(),
+      error: vi.fn<(...args: unknown[]) => void>(),
+      fatal: vi.fn<(...args: unknown[]) => void>(),
     };
     const logger = new RenovateLogger('test', {});
     logger.info('test');

--- a/lib/modules/datasource/azure-tags/index.spec.ts
+++ b/lib/modules/datasource/azure-tags/index.spec.ts
@@ -11,7 +11,7 @@ describe('modules/datasource/azure-tags/index', () => {
     vi.resetAllMocks();
     azureTags = new AzureTagsDatasource();
     mockGitApi = {
-      getRefs: vi.fn(),
+      getRefs: vi.fn<(...args: any[]) => any>(),
     };
     vi.mocked(azureApi.gitApi).mockResolvedValue(mockGitApi);
   });

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -44,7 +44,7 @@ function setupGitMocks(delayMs?: number): {
   mockClone: MockedFunction<SimpleGit['clone']>;
 } {
   const mockClone = vi
-    .fn()
+    .fn<(...args: any[]) => any>()
     .mockName('clone')
     .mockImplementation(
       async (_registryUrl: string, clonePath: string, _opts) => {
@@ -72,7 +72,7 @@ function setupErrorGitMock(): {
   mockClone: MockedFunction<SimpleGit['clone']>;
 } {
   const mockClone = vi
-    .fn()
+    .fn<(...args: any[]) => any>()
     .mockName('clone')
     .mockImplementation((_registryUrl: string, _clonePath: string, _opts) =>
       Promise.reject(new Error('mocked error')),
@@ -501,7 +501,7 @@ describe('modules/datasource/crate/index', () => {
 
     it('retries if shallow fails because of dumb http git repo', async () => {
       const mockClone = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockName('clone')
         .mockImplementation((_registryUrl: string, clonePath: string, opts) => {
           if (typeof opts !== 'undefined' && Object.hasOwn(opts, '--depth')) {
@@ -547,7 +547,7 @@ describe('modules/datasource/crate/index', () => {
 
     it('retries if shallow fails but retry can also fail', async () => {
       const mockClone = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockName('clone')
         .mockImplementation((_registryUrl: string, clonePath: string, opts) => {
           if (typeof opts !== 'undefined' && Object.hasOwn(opts, '--depth')) {

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -451,7 +451,9 @@ describe('modules/datasource/docker/index', () => {
         // TODO: fix typing
         vi.fn<any>(
           class {
-            getAccessToken = vi.fn().mockResolvedValue('some-token');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue('some-token');
           },
         ),
       );
@@ -486,7 +488,9 @@ describe('modules/datasource/docker/index', () => {
         // TODO: fix typing
         vi.fn<any>(
           class GoogleAuth {
-            getAccessToken = vi.fn().mockResolvedValue('some-token');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue('some-token');
           },
         ),
       );
@@ -522,7 +526,9 @@ describe('modules/datasource/docker/index', () => {
         // TODO: fix typing
         vi.fn<any>(
           class GoogleAuth {
-            getAccessToken = vi.fn().mockResolvedValue('some-token');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue('some-token');
           },
         ),
       );
@@ -556,7 +562,9 @@ describe('modules/datasource/docker/index', () => {
         // TODO: fix typing
         vi.fn<any>(
           class GoogleAuth {
-            getAccessToken = vi.fn().mockResolvedValue('some-token');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue('some-token');
           },
         ),
       );
@@ -625,7 +633,7 @@ describe('modules/datasource/docker/index', () => {
         // TODO: fix typing
         vi.fn<any>(
           class GoogleAuth {
-            getAccessToken = vi.fn();
+            getAccessToken = vi.fn<(...args: any[]) => any>();
           },
         ),
       );
@@ -649,7 +657,9 @@ describe('modules/datasource/docker/index', () => {
         // TODO: fix typing
         vi.fn<any>(
           class GoogleAuth {
-            getAccessToken = vi.fn().mockRejectedValue('some-error');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockRejectedValue('some-error');
           },
         ),
       );
@@ -1451,8 +1461,12 @@ describe('modules/datasource/docker/index', () => {
     it('uses Docker Hub tag cache digest without HEAD request', async () => {
       vi.spyOn(DockerHubCache, 'init').mockResolvedValueOnce(
         partial<DockerHubCache>({
-          getDigestForTag: vi.fn().mockReturnValue('sha256:cached-digest'),
-          getArchDigestForTag: vi.fn().mockReturnValue(null),
+          getDigestForTag: vi
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue('sha256:cached-digest'),
+          getArchDigestForTag: vi
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue(null),
         }),
       );
 
@@ -1502,8 +1516,12 @@ describe('modules/datasource/docker/index', () => {
 
       vi.spyOn(DockerHubCache, 'init').mockResolvedValueOnce(
         partial<DockerHubCache>({
-          getDigestForTag: vi.fn().mockReturnValue(null),
-          getArchDigestForTag: vi.fn().mockReturnValue('sha256:cached-amd64'),
+          getDigestForTag: vi
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue(null),
+          getArchDigestForTag: vi
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue('sha256:cached-amd64'),
         }),
       );
 

--- a/lib/modules/datasource/git-refs/index.spec.ts
+++ b/lib/modules/datasource/git-refs/index.spec.ts
@@ -27,8 +27,8 @@ describe('modules/datasource/git-refs/index', () => {
 
     // reset git mock
     gitMock = mock<SimpleGit>({
-      env: vi.fn(),
-      listRemote: vi.fn(),
+      env: vi.fn<(...args: any[]) => any>(),
+      listRemote: vi.fn<(...args: any[]) => any>(),
     });
 
     createSimpleGit.mockReturnValue(gitMock);

--- a/lib/modules/datasource/git-tags/index.spec.ts
+++ b/lib/modules/datasource/git-tags/index.spec.ts
@@ -28,7 +28,7 @@ describe('modules/datasource/git-tags/index', () => {
 
     // reset git mock
     gitMock = mock<SimpleGit>({
-      listRemote: vi.fn(),
+      listRemote: vi.fn<(...args: any[]) => any>(),
     });
 
     createSimpleGit.mockReturnValue(gitMock);

--- a/lib/modules/datasource/go/index.spec.ts
+++ b/lib/modules/datasource/go/index.spec.ts
@@ -9,17 +9,17 @@ import { GoDatasource } from './index.ts';
 vi.mock('../../../util/host-rules.ts', () => mockDeep());
 const hostRules = vi.mocked(_hostRules);
 
-const getReleasesDirectMock = vi.fn();
+const getReleasesDirectMock = vi.fn<(...args: any[]) => any>();
 
-const getDigestForgejoMock = vi.fn();
-const getDigestGiteaMock = vi.fn();
-const getDigestGithubMock = vi.fn();
-const getDigestGitlabMock = vi.fn();
-const getDigestGitMock = vi.fn();
-const getDigestBitbucketMock = vi.fn();
+const getDigestForgejoMock = vi.fn<(...args: any[]) => any>();
+const getDigestGiteaMock = vi.fn<(...args: any[]) => any>();
+const getDigestGithubMock = vi.fn<(...args: any[]) => any>();
+const getDigestGitlabMock = vi.fn<(...args: any[]) => any>();
+const getDigestGitMock = vi.fn<(...args: any[]) => any>();
+const getDigestBitbucketMock = vi.fn<(...args: any[]) => any>();
 vi.mock('./releases-direct.ts', () => {
   return {
-    GoDirectDatasource: vi.fn(
+    GoDirectDatasource: vi.fn<new (...args: any[]) => any>(
       class {
         forgejo = {
           getDigest: (...args: any[]) => getDigestForgejoMock(...args),
@@ -41,10 +41,10 @@ vi.mock('./releases-direct.ts', () => {
   };
 });
 
-const getReleasesProxyMock = vi.fn();
+const getReleasesProxyMock = vi.fn<(...args: any[]) => any>();
 vi.mock('./releases-goproxy.ts', () => {
   return {
-    GoProxyDatasource: vi.fn(
+    GoProxyDatasource: vi.fn<new (...args: any[]) => any>(
       class {
         getReleases = () => getReleasesProxyMock();
       },

--- a/lib/modules/datasource/maven/index.spec.ts
+++ b/lib/modules/datasource/maven/index.spec.ts
@@ -536,7 +536,9 @@ describe('modules/datasource/maven/index', () => {
       // TODO: fix typing
       vi.fn<any>(
         class {
-          getAccessToken = vi.fn().mockResolvedValue('some-token');
+          getAccessToken = vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValue('some-token');
         },
       ),
     );
@@ -589,7 +591,7 @@ describe('modules/datasource/maven/index', () => {
       // TODO: fix typing
       vi.fn<any>(
         class GoogleAuth {
-          getAccessToken = vi.fn();
+          getAccessToken = vi.fn<(...args: any[]) => any>();
         },
       ),
     );

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -343,7 +343,7 @@ describe('modules/datasource/maven/util', () => {
 
       it('returns cached not-found without making HTTP request', async () => {
         vi.spyOn(packageCache, 'get').mockResolvedValue(true);
-        const getText = vi.fn();
+        const getText = vi.fn<Http['getText']>();
         const http = partial<Http>({ getText });
 
         const res = await downloadHttpProtocol(http, metadataUrl);

--- a/lib/modules/datasource/packagist/index.spec.ts
+++ b/lib/modules/datasource/packagist/index.spec.ts
@@ -25,8 +25,10 @@ describe('modules/datasource/packagist/index', () => {
     let config: any;
 
     beforeEach(() => {
-      hostRules.find = vi.fn((input: HostRule) => input);
-      hostRules.hosts = vi.fn(() => []);
+      hostRules.find = vi.fn<(...args: any[]) => any>(
+        (input: HostRule) => input,
+      );
+      hostRules.hosts = vi.fn<(...args: any[]) => any>(() => []);
       config = {
         versioning: composerVersioning.id,
         registryUrls: [
@@ -144,7 +146,7 @@ describe('modules/datasource/packagist/index', () => {
     });
 
     it('supports includes packages', async () => {
-      hostRules.find = vi.fn(() => ({
+      hostRules.find = vi.fn<(...args: any[]) => any>(() => ({
         username: 'some-username',
         password: 'some-password',
       }));
@@ -177,7 +179,7 @@ describe('modules/datasource/packagist/index', () => {
     });
 
     it('supports older sha1 hashes', async () => {
-      hostRules.find = vi.fn(() => ({
+      hostRules.find = vi.fn<(...args: any[]) => any>(() => ({
         username: 'some-username',
         password: 'some-password',
       }));

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -199,7 +199,9 @@ describe('modules/datasource/pypi/index', () => {
       // eslint-disable-next-line prefer-arrow-callback
       googleAuth.mockImplementationOnce(function () {
         return partial<InstanceType<typeof _googleAuth>>({
-          getAccessToken: vi.fn().mockResolvedValue('some-token'),
+          getAccessToken: vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValue('some-token'),
         });
       });
       const res = await getPkgReleases({
@@ -225,7 +227,7 @@ describe('modules/datasource/pypi/index', () => {
       // eslint-disable-next-line prefer-arrow-callback
       googleAuth.mockImplementation(function () {
         return partial<InstanceType<typeof _googleAuth>>({
-          getAccessToken: vi.fn(),
+          getAccessToken: vi.fn<(...args: any[]) => any>(),
         });
       });
       const res = await getPkgReleases({
@@ -821,7 +823,9 @@ describe('modules/datasource/pypi/index', () => {
     // eslint-disable-next-line prefer-arrow-callback
     googleAuth.mockImplementationOnce(function () {
       return partial<InstanceType<typeof _googleAuth>>({
-        getAccessToken: vi.fn().mockResolvedValue('some-token'),
+        getAccessToken: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue('some-token'),
       });
     });
     expect(
@@ -854,7 +858,9 @@ describe('modules/datasource/pypi/index', () => {
     // eslint-disable-next-line prefer-arrow-callback
     googleAuth.mockImplementationOnce(function () {
       return partial<InstanceType<typeof _googleAuth>>({
-        getAccessToken: vi.fn().mockResolvedValue('some-token'),
+        getAccessToken: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue('some-token'),
       });
     });
     expect(

--- a/lib/modules/datasource/utils.spec.ts
+++ b/lib/modules/datasource/utils.spec.ts
@@ -30,7 +30,9 @@ describe('modules/datasource/utils', () => {
       // TODO: fix typing
       vi.fn<any>(
         class {
-          getAccessToken = vi.fn().mockResolvedValue('some-token');
+          getAccessToken = vi
+            .fn<() => Promise<string>>()
+            .mockResolvedValue('some-token');
         },
       ),
     );
@@ -44,7 +46,7 @@ describe('modules/datasource/utils', () => {
       // TODO: fix typing
       vi.fn<any>(
         class {
-          getAccessToken = vi.fn().mockResolvedValue('');
+          getAccessToken = vi.fn<() => Promise<string>>().mockResolvedValue('');
         },
       ),
     );
@@ -59,7 +61,9 @@ describe('modules/datasource/utils', () => {
       // TODO: fix typing
       vi.fn<any>(
         class {
-          getAccessToken = vi.fn().mockRejectedValue(new Error(err));
+          getAccessToken = vi
+            .fn<() => Promise<string>>()
+            .mockRejectedValue(new Error(err));
         },
       ),
     );
@@ -72,7 +76,7 @@ describe('modules/datasource/utils', () => {
       // TODO: fix typing
       vi.fn<any>(
         class {
-          getAccessToken = vi.fn().mockRejectedValue({
+          getAccessToken = vi.fn<() => Promise<string>>().mockRejectedValue({
             message: 'Could not load the default credentials',
           });
         },

--- a/lib/modules/manager/deno/compat.spec.ts
+++ b/lib/modules/manager/deno/compat.spec.ts
@@ -9,7 +9,7 @@ import {
 vi.mock('../../../util/fs/index.ts');
 // used in detectNodeCompatWorkspaces()
 vi.mock('find-packages', () => ({
-  findPackages: vi.fn(),
+  findPackages: vi.fn<(...args: any[]) => any>(),
 }));
 
 describe('modules/manager/deno/compat', () => {

--- a/lib/modules/manager/deno/extract.spec.ts
+++ b/lib/modules/manager/deno/extract.spec.ts
@@ -14,7 +14,7 @@ vi.mock('../../../util/fs/index.ts');
 vi.mock('./compat.ts');
 // used in detectNodeCompatWorkspaces()
 vi.mock('find-packages', () => ({
-  findPackages: vi.fn(),
+  findPackages: vi.fn<(...args: any[]) => any>(),
 }));
 
 describe('modules/manager/deno/extract', () => {

--- a/lib/modules/manager/deno/post.spec.ts
+++ b/lib/modules/manager/deno/post.spec.ts
@@ -15,7 +15,7 @@ import type { DenoManagerData } from './types.ts';
 vi.mock('../../../util/fs/index.ts');
 // used in detectNodeCompatWorkspaces()
 vi.mock('find-packages', () => ({
-  findPackages: vi.fn(),
+  findPackages: vi.fn<(...args: any[]) => any>(),
 }));
 
 describe('modules/manager/deno/post', () => {

--- a/lib/modules/manager/homebrew/update.spec.ts
+++ b/lib/modules/manager/homebrew/update.spec.ts
@@ -500,15 +500,15 @@ describe('modules/manager/homebrew/update', () => {
   it('returns unchanged content if handler buildArchiveUrls returns null', async () => {
     const mockHandler = {
       type: 'github',
-      parseUrl: vi.fn().mockReturnValue({
+      parseUrl: vi.fn<(...args: any[]) => any>().mockReturnValue({
         type: 'github',
         currentValue: 'v0.8.2',
         ownerName: 'bazelbuild',
         repoName: 'bazel-watcher',
         urlType: 'archive',
       }),
-      buildArchiveUrls: vi.fn().mockReturnValue(null),
-      createDependency: vi.fn(),
+      buildArchiveUrls: vi.fn<(...args: any[]) => any>().mockReturnValue(null),
+      createDependency: vi.fn<(...args: any[]) => any>(),
     };
 
     vi.spyOn(handlers, 'findHandlerByType').mockReturnValue(

--- a/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.spec.ts
@@ -13,7 +13,7 @@ const yarn = vi.mocked(_yarn);
 vi.mock('../npm.ts');
 vi.mock('../yarn.ts', async () => ({
   ...(await vi.importActual<typeof import('../yarn.ts')>('../yarn.ts')),
-  getYarnLock: vi.fn(),
+  getYarnLock: vi.fn<(...args: any[]) => any>(),
 }));
 vi.mock('../pnpm.ts');
 

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -554,7 +554,9 @@ describe('modules/manager/pep621/processors/uv', () => {
         // TODO: fix typing
         vi.fn<any>(
           class {
-            getAccessToken = vi.fn().mockResolvedValue('some-token');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue('some-token');
           },
         ),
       );
@@ -694,7 +696,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         // TODO: fix typing
         vi.fn<any>(
           class {
-            getAccessToken = vi.fn();
+            getAccessToken = vi.fn<(...args: any[]) => any>();
           },
         ),
       );
@@ -791,7 +793,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         // TODO: fix typing
         vi.fn<any>(
           class {
-            getAccessToken = vi.fn();
+            getAccessToken = vi.fn<(...args: any[]) => any>();
           },
         ),
       );

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -239,7 +239,9 @@ describe('modules/manager/poetry/artifacts', () => {
         // TODO: fix typing
         vi.fn<any>(
           class {
-            getAccessToken = vi.fn().mockResolvedValue('some-token');
+            getAccessToken = vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue('some-token');
           },
         ),
       );
@@ -288,7 +290,7 @@ describe('modules/manager/poetry/artifacts', () => {
         // TODO: fix typing
         vi.fn<any>(
           class {
-            getAccessToken = vi.fn();
+            getAccessToken = vi.fn<(...args: any[]) => any>();
           },
         ),
       );

--- a/lib/modules/manager/swift/artifacts.spec.ts
+++ b/lib/modules/manager/swift/artifacts.spec.ts
@@ -12,7 +12,7 @@ vi.mock('../../datasource/index.ts', async () => {
   );
   return {
     ...actual,
-    getDigest: vi.fn(),
+    getDigest: vi.fn<(...args: any[]) => any>(),
   };
 });
 

--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -24,7 +24,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getRefs: vi.fn(() => [{ objectId: 132 }]),
+            getRefs: vi.fn<(...args: any[]) => any>(() => [{ objectId: 132 }]),
           }) as any,
       );
       const res = await azureHelper.getRefs('123', 'branch');
@@ -35,7 +35,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getRefs: vi.fn(() => []),
+            getRefs: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       const res = await azureHelper.getRefs('123');
@@ -46,7 +46,9 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getRefs: vi.fn(() => [{ objectId: '132' }]),
+            getRefs: vi.fn<(...args: any[]) => any>(() => [
+              { objectId: '132' },
+            ]),
           }) as any,
       );
       const res = await azureHelper.getRefs('123', 'refs/head/branch1');
@@ -59,7 +61,9 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getRefs: vi.fn(() => [{ objectId: '132' }]),
+            getRefs: vi.fn<(...args: any[]) => any>(() => [
+              { objectId: '132' },
+            ]),
           }) as any,
       );
       const res = await azureHelper.getAzureBranchObj(
@@ -74,7 +78,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getRefs: vi.fn(() => []),
+            getRefs: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       const res = await azureHelper.getAzureBranchObj('123', 'branchName');
@@ -100,7 +104,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemText: vi.fn(() => mockEventStream),
+            getItemText: vi.fn<(...args: any[]) => any>(() => mockEventStream),
           }) as any,
       );
 
@@ -129,7 +133,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemText: vi.fn(() => mockEventStream),
+            getItemText: vi.fn<(...args: any[]) => any>(() => mockEventStream),
           }) as any,
       );
 
@@ -158,7 +162,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemText: vi.fn(() => mockEventStream),
+            getItemText: vi.fn<(...args: any[]) => any>(() => mockEventStream),
           }) as any,
       );
 
@@ -174,7 +178,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getItemText: vi.fn(() => ({
+            getItemText: vi.fn<(...args: any[]) => any>(() => ({
               readable: false,
             })),
           }) as any,
@@ -194,7 +198,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getCommit: vi.fn(() => ({
+            getCommit: vi.fn<(...args: any[]) => any>(() => ({
               parents: ['123456'],
             })),
           }) as any,
@@ -209,7 +213,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => []),
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       expect(await azureHelper.getMergeMethod('', '')).toEqual(
@@ -221,7 +225,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => [
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => [
               {
                 settings: {
                   allowNoFastForward: true,
@@ -247,7 +251,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => [
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => [
               {
                 settings: {
                   allowRebaseMerge: true,
@@ -273,7 +277,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => [
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => [
               {
                 settings: {
                   allowSquash: true,
@@ -300,7 +304,7 @@ describe('modules/platform/azure/azure-helper', () => {
 
       azureApi.policyApi.mockResolvedValueOnce(
         partial<IPolicyApi>({
-          getPolicyConfigurations: vi.fn(() =>
+          getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() =>
             Promise.resolve([
               partial<PolicyConfiguration>({
                 settings: {
@@ -328,7 +332,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => [
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => [
               {
                 settings: {
                   allowSquash: true,
@@ -369,7 +373,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => [
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => [
               {
                 settings: {
                   allowSquash: true,
@@ -438,7 +442,7 @@ describe('modules/platform/azure/azure-helper', () => {
       azureApi.policyApi.mockImplementationOnce(
         () =>
           ({
-            getPolicyConfigurations: vi.fn(() => [
+            getPolicyConfigurations: vi.fn<(...args: any[]) => any>(() => [
               {
                 settings: {
                   allowSquash: true,
@@ -502,7 +506,7 @@ describe('modules/platform/azure/azure-helper', () => {
         () =>
           ({
             getTeams: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockResolvedValueOnce(team1)
               .mockResolvedValueOnce(team2),
           }) as any,

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -72,7 +72,7 @@ describe('modules/platform/azure/index', () => {
     azureApi.gitApi.mockImplementationOnce(
       () =>
         ({
-          getRepositories: vi.fn(() => [
+          getRepositories: vi.fn<(...args: any[]) => any>(() => [
             {
               name: 'repo1',
               project: {
@@ -166,7 +166,7 @@ describe('modules/platform/azure/index', () => {
   function initRepo(args?: Partial<RepoParams> | string) {
     azureApi.gitApi.mockResolvedValueOnce(
       partial<IGitApi>({
-        getRepositories: vi.fn().mockResolvedValue([
+        getRepositories: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             name: 'repo',
             id: '1',
@@ -238,7 +238,7 @@ describe('modules/platform/azure/index', () => {
         () =>
           ({
             getPullRequests: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockReturnValue([])
               .mockReturnValueOnce([
                 {
@@ -250,7 +250,9 @@ describe('modules/platform/azure/index', () => {
                 },
               ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
+            getPullRequestCommits: vi
+              .fn<(...args: any[]) => any>()
+              .mockReturnValue([]),
           }) as any,
       );
       const res = await azure.findPr({
@@ -280,7 +282,7 @@ describe('modules/platform/azure/index', () => {
         () =>
           ({
             getPullRequests: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockReturnValue([])
               .mockReturnValueOnce([
                 {
@@ -292,7 +294,9 @@ describe('modules/platform/azure/index', () => {
                 },
               ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
+            getPullRequestCommits: vi
+              .fn<(...args: any[]) => any>()
+              .mockReturnValue([]),
           }) as any,
       );
       const res = await azure.findPr({
@@ -322,7 +326,7 @@ describe('modules/platform/azure/index', () => {
         () =>
           ({
             getPullRequests: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockReturnValue([])
               .mockReturnValueOnce([
                 {
@@ -334,7 +338,9 @@ describe('modules/platform/azure/index', () => {
                 },
               ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
+            getPullRequestCommits: vi
+              .fn<(...args: any[]) => any>()
+              .mockReturnValue([]),
           }) as any,
       );
       const res = await azure.findPr({
@@ -364,7 +370,7 @@ describe('modules/platform/azure/index', () => {
         () =>
           ({
             getPullRequests: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockReturnValue([])
               .mockReturnValueOnce([
                 {
@@ -376,7 +382,9 @@ describe('modules/platform/azure/index', () => {
                 },
               ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
+            getPullRequestCommits: vi
+              .fn<(...args: any[]) => any>()
+              .mockReturnValue([]),
           }) as any,
       );
       const res = await azure.findPr({
@@ -404,7 +412,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
           getPullRequests: vi
-            .fn()
+            .fn<(...args: any[]) => any>()
             .mockReturnValue([])
             .mockReturnValueOnce([
               {
@@ -422,7 +430,9 @@ describe('modules/platform/azure/index', () => {
                 status: PullRequestStatus.Active,
               },
             ]),
-          getPullRequestCommits: vi.fn().mockReturnValue([]),
+          getPullRequestCommits: vi
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue([]),
         }),
       );
       const res = await azure.findPr({
@@ -452,7 +462,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
           getPullRequests: vi
-            .fn()
+            .fn<(...args: any[]) => any>()
             .mockReturnValue([])
             .mockReturnValueOnce([
               {
@@ -470,7 +480,9 @@ describe('modules/platform/azure/index', () => {
                 status: PullRequestStatus.Active,
               },
             ]),
-          getPullRequestCommits: vi.fn().mockReturnValue([]),
+          getPullRequestCommits: vi
+            .fn<(...args: any[]) => any>()
+            .mockReturnValue([]),
         }),
       );
       const res = await azure.findPr({
@@ -499,7 +511,9 @@ describe('modules/platform/azure/index', () => {
     it('catches errors', async () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
-          getPullRequests: vi.fn().mockRejectedValueOnce(new Error()),
+          getPullRequests: vi
+            .fn<(...args: any[]) => any>()
+            .mockRejectedValueOnce(new Error()),
         }),
       );
       const res = await azure.findPr({
@@ -515,7 +529,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getPullRequests: vi.fn(() => []),
+            getPullRequests: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       expect(await azure.getPrList()).toEqual([]);
@@ -527,7 +541,9 @@ describe('modules/platform/azure/index', () => {
       await initRepo({ repository: 'some/repo' });
       azureApi.gitApi.mockResolvedValue(
         partial<IGitApi>({
-          getPullRequests: vi.fn().mockResolvedValueOnce([]),
+          getPullRequests: vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValueOnce([]),
         }),
       );
       const pr = await azure.getBranchPr('somebranch');
@@ -539,7 +555,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockResolvedValue(
         partial<IGitApi>({
           getPullRequests: vi
-            .fn()
+            .fn<(...args: any[]) => any>()
             .mockResolvedValueOnce([
               {
                 pullRequestId: 1,
@@ -550,7 +566,9 @@ describe('modules/platform/azure/index', () => {
               },
             ])
             .mockResolvedValueOnce([]),
-          getPullRequestLabels: vi.fn().mockResolvedValue([]),
+          getPullRequestLabels: vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValue([]),
         }),
       );
       const pr = await azure.getBranchPr('branch-a', 'branch-b');
@@ -579,9 +597,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Succeeded,
                 context: { genre: 'a-genre', name: 'a-name' },
@@ -601,9 +621,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.NotApplicable,
                 context: { genre: 'a-genre', name: 'a-name' },
@@ -623,9 +645,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Failed,
                 context: { genre: 'a-genre', name: 'a-name' },
@@ -645,9 +669,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Error,
                 context: { genre: 'a-genre', name: 'a-name' },
@@ -667,9 +693,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Pending,
                 context: { genre: 'a-genre', name: 'a-name' },
@@ -689,9 +717,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.NotSet,
                 context: { genre: 'a-genre', name: 'a-name' },
@@ -711,9 +741,9 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
           getBranch: vi
-            .fn()
+            .fn<(...args: any[]) => any>()
             .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
-          getStatuses: vi.fn().mockResolvedValue([
+          getStatuses: vi.fn<(...args: any[]) => any>().mockResolvedValue([
             {
               state: -1,
               context: { genre: 'a-genre', name: 'a-name' },
@@ -733,9 +763,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Pending,
                 context: { genre: 'another-genre', name: 'a-name' },
@@ -757,9 +789,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Succeeded,
                 context: { genre: 'renovate' },
@@ -776,9 +810,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
 
-            getStatuses: vi.fn(() => [
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
               {
                 state: GitStatusState.Succeeded,
                 context: { genre: 'renovate' },
@@ -795,8 +831,12 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: vi.fn(() => [{ state: GitStatusState.Error }]),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
+              { state: GitStatusState.Error },
+            ]),
           }) as any,
       );
       const res = await azure.getBranchStatus('somebranch', true);
@@ -808,8 +848,12 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: vi.fn(() => [{ state: GitStatusState.Pending }]),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
+            getStatuses: vi.fn<(...args: any[]) => any>(() => [
+              { state: GitStatusState.Pending },
+            ]),
           }) as any,
       );
       const res = await azure.getBranchStatus('somebranch', true);
@@ -821,8 +865,10 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: vi.fn(() => []),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
+            getStatuses: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       const res = await azure.getBranchStatus('somebranch', true);
@@ -841,7 +887,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getPullRequests: vi.fn(() => []),
+            getPullRequests: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       const pr = await azure.getPr(1234);
@@ -854,7 +900,7 @@ describe('modules/platform/azure/index', () => {
         () =>
           ({
             getPullRequests: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockReturnValue([])
               .mockReturnValueOnce([
                 {
@@ -863,16 +909,18 @@ describe('modules/platform/azure/index', () => {
               ]),
 
             getPullRequestLabels: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockReturnValue([{ active: true, name: 'renovate' }]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([
-              {
-                author: {
-                  name: 'renovate',
+            getPullRequestCommits: vi
+              .fn<(...args: any[]) => any>()
+              .mockReturnValue([
+                {
+                  author: {
+                    name: 'renovate',
+                  },
                 },
-              },
-            ]),
+              ]),
           }) as any,
       );
       const pr = await azure.getPr(1234);
@@ -886,11 +934,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            createPullRequest: vi.fn(() => ({
+            createPullRequest: vi.fn<(...args: any[]) => any>(() => ({
               pullRequestId: 456,
             })),
 
-            createPullRequestLabel: vi.fn(() => ({})),
+            createPullRequestLabel: vi.fn<(...args: any[]) => any>(() => ({})),
           }) as any,
       );
       const pr = await azure.createPr({
@@ -908,11 +956,11 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            createPullRequest: vi.fn(() => ({
+            createPullRequest: vi.fn<(...args: any[]) => any>(() => ({
               pullRequestId: 456,
             })),
 
-            createPullRequestLabel: vi.fn(() => ({})),
+            createPullRequestLabel: vi.fn<(...args: any[]) => any>(() => ({})),
           }) as any,
       );
       const pr = await azure.createPr({
@@ -946,11 +994,17 @@ describe('modules/platform/azure/index', () => {
             mergeCommitMessage: 'The Title',
           },
         };
-        const updateFn = vi.fn().mockResolvedValue(prUpdateResult);
+        const updateFn = vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue(prUpdateResult);
         azureApi.gitApi.mockResolvedValueOnce(
           partial<IGitApi>({
-            createPullRequest: vi.fn().mockResolvedValue(prResult),
-            createPullRequestLabel: vi.fn().mockResolvedValue({}),
+            createPullRequest: vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue(prResult),
+            createPullRequestLabel: vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue({}),
             updatePullRequest: updateFn,
           }),
         );
@@ -1008,7 +1062,9 @@ describe('modules/platform/azure/index', () => {
             },
           },
         ];
-        const updateFn = vi.fn(() => Promise.resolve(prUpdateResults.shift()!));
+        const updateFn = vi.fn<(...args: any[]) => any>(() =>
+          Promise.resolve(prUpdateResults.shift()!),
+        );
 
         azureHelper.getMergeMethod.mockResolvedValueOnce(
           GitPullRequestMergeStrategy.Squash,
@@ -1016,8 +1072,12 @@ describe('modules/platform/azure/index', () => {
 
         azureApi.gitApi.mockResolvedValue(
           partial<IGitApi>({
-            createPullRequest: vi.fn(() => Promise.resolve(prResult.shift()!)),
-            createPullRequestLabel: vi.fn().mockResolvedValue({}),
+            createPullRequest: vi.fn<(...args: any[]) => any>(() =>
+              Promise.resolve(prResult.shift()!),
+            ),
+            createPullRequestLabel: vi
+              .fn<(...args: any[]) => any>()
+              .mockResolvedValue({}),
             updatePullRequest: updateFn,
           }),
         );
@@ -1078,12 +1138,18 @@ describe('modules/platform/azure/index', () => {
               mergeCommitMessage: 'The Title',
             },
           };
-          const updateFn = vi.fn(() => Promise.resolve(prUpdateResults));
+          const updateFn = vi.fn<(...args: any[]) => any>(() =>
+            Promise.resolve(prUpdateResults),
+          );
 
           azureApi.gitApi.mockResolvedValue(
             partial<IGitApi>({
-              createPullRequest: vi.fn(() => Promise.resolve(prResult)),
-              createPullRequestLabel: vi.fn().mockResolvedValue({}),
+              createPullRequest: vi.fn<(...args: any[]) => any>(() =>
+                Promise.resolve(prResult),
+              ),
+              createPullRequestLabel: vi
+                .fn<(...args: any[]) => any>()
+                .mockResolvedValue({}),
               updatePullRequest: updateFn,
             }),
           );
@@ -1132,11 +1198,17 @@ describe('modules/platform/azure/index', () => {
               mergeCommitMessage: 'The Title',
             },
           };
-          const updateFn = vi.fn().mockResolvedValue(prUpdateResult);
+          const updateFn = vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValue(prUpdateResult);
           azureApi.gitApi.mockResolvedValueOnce(
             partial<IGitApi>({
-              createPullRequest: vi.fn().mockResolvedValue(prResult),
-              createPullRequestLabel: vi.fn().mockResolvedValue({}),
+              createPullRequest: vi
+                .fn<(...args: any[]) => any>()
+                .mockResolvedValue(prResult),
+              createPullRequestLabel: vi
+                .fn<(...args: any[]) => any>()
+                .mockResolvedValue({}),
               updatePullRequest: updateFn,
             }),
           );
@@ -1180,13 +1252,13 @@ describe('modules/platform/azure/index', () => {
         isRequired: false,
       };
       const updateFn = vi
-        .fn(() => prUpdateResult)
+        .fn<(...args: any[]) => any>(() => prUpdateResult)
         .mockName('createPullRequestReviewer');
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            createPullRequest: vi.fn(() => prResult),
-            createPullRequestLabel: vi.fn(() => ({})),
+            createPullRequest: vi.fn<(...args: any[]) => any>(() => prResult),
+            createPullRequestLabel: vi.fn<(...args: any[]) => any>(() => ({})),
             createPullRequestReviewer: updateFn,
           }) as any,
       );
@@ -1206,7 +1278,7 @@ describe('modules/platform/azure/index', () => {
   describe('updatePr(prNo, title, body, platformPrOptions)', () => {
     it('should update the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
+      const updatePullRequest = vi.fn<(...args: any[]) => any>(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1227,15 +1299,15 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementation(
         () =>
           ({
-            createPullRequest: vi.fn(() => ({
+            createPullRequest: vi.fn<(...args: any[]) => any>(() => ({
               pullRequestId: 456,
               title: 'Title 1',
             })),
 
-            createPullRequestLabel: vi.fn(() => ({})),
-            getPullRequests: vi.fn(() => []),
+            createPullRequestLabel: vi.fn<(...args: any[]) => any>(() => ({})),
+            getPullRequests: vi.fn<(...args: any[]) => any>(() => []),
 
-            updatePullRequest: vi.fn(() => ({
+            updatePullRequest: vi.fn<(...args: any[]) => any>(() => ({
               pullRequestId: 456,
               title: 'Title 2',
             })),
@@ -1262,7 +1334,7 @@ describe('modules/platform/azure/index', () => {
 
     it('should update the PR without description', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
+      const updatePullRequest = vi.fn<(...args: any[]) => any>(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1278,7 +1350,7 @@ describe('modules/platform/azure/index', () => {
 
     it('should close the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
+      const updatePullRequest = vi.fn<(...args: any[]) => any>(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1296,7 +1368,7 @@ describe('modules/platform/azure/index', () => {
 
     it('should reopen the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
+      const updatePullRequest = vi.fn<(...args: any[]) => any>(() => ({}));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
@@ -1327,14 +1399,14 @@ describe('modules/platform/azure/index', () => {
         isFlagged: false,
         isRequired: false,
       };
-      const updateFn = vi.fn(() => prUpdateResult);
+      const updateFn = vi.fn<(...args: any[]) => any>(() => prUpdateResult);
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            updatePullRequest: vi.fn(() => prResult),
+            updatePullRequest: vi.fn<(...args: any[]) => any>(() => prResult),
             createPullRequestReviewer: updateFn,
 
-            getPullRequestById: vi.fn(() => ({
+            getPullRequestById: vi.fn<(...args: any[]) => any>(() => ({
               pullRequestId: prResult.pullRequestId,
               createdBy: prResult.createdBy,
             })),
@@ -1355,14 +1427,14 @@ describe('modules/platform/azure/index', () => {
     it('adds comment if missing', async () => {
       await initRepo({ repository: 'some/repo' });
       const gitApiMock = {
-        createThread: vi.fn(() => [{ id: 123 }]),
-        getThreads: vi.fn().mockReturnValue([
+        createThread: vi.fn<(...args: any[]) => any>(() => [{ id: 123 }]),
+        getThreads: vi.fn<(...args: any[]) => any>().mockReturnValue([
           {
             comments: [{ content: 'end-user comment', id: 1 }],
             id: 2,
           },
         ]),
-        updateComment: vi.fn(() => ({ id: 123 })),
+        updateComment: vi.fn<(...args: any[]) => any>(() => ({ id: 123 })),
       };
       azureApi.gitApi.mockImplementation(() => gitApiMock as any);
       await azure.ensureComment({
@@ -1381,8 +1453,8 @@ describe('modules/platform/azure/index', () => {
     it('updates comment if missing', async () => {
       await initRepo({ repository: 'some/repo' });
       const gitApiMock = {
-        createThread: vi.fn(() => [{ id: 123 }]),
-        getThreads: vi.fn().mockReturnValue([
+        createThread: vi.fn<(...args: any[]) => any>(() => [{ id: 123 }]),
+        getThreads: vi.fn<(...args: any[]) => any>().mockReturnValue([
           {
             comments: [{ content: 'end-user comment', id: 1 }],
             id: 3,
@@ -1392,7 +1464,7 @@ describe('modules/platform/azure/index', () => {
             id: 4,
           },
         ]),
-        updateComment: vi.fn(() => ({ id: 123 })),
+        updateComment: vi.fn<(...args: any[]) => any>(() => ({ id: 123 })),
       };
       azureApi.gitApi.mockImplementation(() => gitApiMock as any);
       await azure.ensureComment({
@@ -1411,8 +1483,8 @@ describe('modules/platform/azure/index', () => {
     it('does nothing if comment exists and is the same', async () => {
       await initRepo({ repository: 'some/repo' });
       const gitApiMock = {
-        createThread: vi.fn(() => [{ id: 123 }]),
-        getThreads: vi.fn().mockReturnValue([
+        createThread: vi.fn<(...args: any[]) => any>(() => [{ id: 123 }]),
+        getThreads: vi.fn<(...args: any[]) => any>().mockReturnValue([
           {
             comments: [{ content: 'end-user comment', id: 1 }],
             id: 3,
@@ -1422,7 +1494,7 @@ describe('modules/platform/azure/index', () => {
             id: 4,
           },
         ]),
-        updateComment: vi.fn(() => ({ id: 123 })),
+        updateComment: vi.fn<(...args: any[]) => any>(() => ({ id: 123 })),
       };
       azureApi.gitApi.mockImplementation(() => gitApiMock as any);
       await azure.ensureComment({
@@ -1441,14 +1513,14 @@ describe('modules/platform/azure/index', () => {
     it('does nothing if comment exists and is the same when there is no topic', async () => {
       await initRepo({ repository: 'some/repo' });
       const gitApiMock = {
-        createThread: vi.fn(() => [{ id: 123 }]),
-        getThreads: vi.fn().mockReturnValue([
+        createThread: vi.fn<(...args: any[]) => any>(() => [{ id: 123 }]),
+        getThreads: vi.fn<(...args: any[]) => any>().mockReturnValue([
           {
             comments: [{ content: 'some\ncontent', id: 2 }],
             id: 4,
           },
         ]),
-        updateComment: vi.fn(() => ({ id: 123 })),
+        updateComment: vi.fn<(...args: any[]) => any>(() => ({ id: 123 })),
       };
       azureApi.gitApi.mockImplementation(() => gitApiMock as any);
       await azure.ensureComment({
@@ -1467,14 +1539,18 @@ describe('modules/platform/azure/index', () => {
     it('passes comment through massageMarkdown', async () => {
       await initRepo({ repository: 'some/repo' });
       const gitApiMock = {
-        createThread: vi.fn().mockResolvedValue([{ id: 123 }]),
-        getThreads: vi.fn().mockResolvedValue([
+        createThread: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue([{ id: 123 }]),
+        getThreads: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             comments: [{ content: 'end-user comment', id: 1 }],
             id: 2,
           },
         ]),
-        updateComment: vi.fn().mockResolvedValue({ id: 123 }),
+        updateComment: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue({ id: 123 }),
       };
       azureApi.gitApi.mockResolvedValue(partial<IGitApi>(gitApiMock));
 
@@ -1501,7 +1577,7 @@ describe('modules/platform/azure/index', () => {
 
     beforeEach(() => {
       gitApiMock = {
-        getThreads: vi.fn(() => [
+        getThreads: vi.fn<(...args: any[]) => any>(() => [
           {
             comments: [{ content: '### some-subject\n\nblabla' }],
             id: 123,
@@ -1511,7 +1587,7 @@ describe('modules/platform/azure/index', () => {
             id: 124,
           },
         ]),
-        updateThread: vi.fn(),
+        updateThread: vi.fn<(...args: any[]) => any>(),
       };
       azureApi.gitApi.mockImplementation(() => gitApiMock);
     });
@@ -1566,23 +1642,29 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementation(
         () =>
           ({
-            getRepositories: vi.fn(() => [{ id: '1', project: { id: 2 } }]),
-            createThread: vi.fn(() => [{ id: 123 }]),
-            getThreads: vi.fn(() => []),
+            getRepositories: vi.fn<(...args: any[]) => any>(() => [
+              { id: '1', project: { id: 2 } },
+            ]),
+            createThread: vi.fn<(...args: any[]) => any>(() => [{ id: 123 }]),
+            getThreads: vi.fn<(...args: any[]) => any>(() => []),
           }) as any,
       );
       azureApi.coreApi.mockImplementation(
         () =>
           ({
-            getTeamMembersWithExtendedProperties: vi.fn(() => [
+            getTeamMembersWithExtendedProperties: vi.fn<
+              (...args: any[]) => any
+            >(() => [
               { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
             ]),
           }) as any,
       );
-      azureHelper.getAllProjectTeams = vi.fn().mockReturnValue([
-        { id: 3, name: 'abc' },
-        { id: 4, name: 'def' },
-      ]);
+      azureHelper.getAllProjectTeams = vi
+        .fn<(...args: any[]) => any>()
+        .mockReturnValue([
+          { id: 3, name: 'abc' },
+          { id: 4, name: 'def' },
+        ]);
       await azure.addAssignees(123, ['test@bonjour.fr', 'jyc', 'def']);
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
     });
@@ -1594,22 +1676,28 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementation(
         () =>
           ({
-            getRepositories: vi.fn(() => [{ id: '1', project: { id: 2 } }]),
-            createPullRequestReviewer: vi.fn(),
+            getRepositories: vi.fn<(...args: any[]) => any>(() => [
+              { id: '1', project: { id: 2 } },
+            ]),
+            createPullRequestReviewer: vi.fn<(...args: any[]) => any>(),
           }) as any,
       );
       azureApi.coreApi.mockImplementation(
         () =>
           ({
-            getTeamMembersWithExtendedProperties: vi.fn(() => [
+            getTeamMembersWithExtendedProperties: vi.fn<
+              (...args: any[]) => any
+            >(() => [
               { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
             ]),
           }) as any,
       );
-      azureHelper.getAllProjectTeams = vi.fn().mockReturnValue([
-        { id: 3, name: 'abc' },
-        { id: 4, name: 'def' },
-      ]);
+      azureHelper.getAllProjectTeams = vi
+        .fn<(...args: any[]) => any>()
+        .mockReturnValue([
+          { id: 3, name: 'abc' },
+          { id: 4, name: 'def' },
+        ]);
       await azure.addReviewers(123, ['test@bonjour.fr', 'jyc', 'required:def']);
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
       expect(logger.once.info).toHaveBeenCalledTimes(1);
@@ -1620,22 +1708,28 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementation(
         () =>
           ({
-            getRepositories: vi.fn(() => [{ id: '1', project: { id: 2 } }]),
-            createPullRequestReviewer: vi.fn(),
+            getRepositories: vi.fn<(...args: any[]) => any>(() => [
+              { id: '1', project: { id: 2 } },
+            ]),
+            createPullRequestReviewer: vi.fn<(...args: any[]) => any>(),
           }) as any,
       );
       azureApi.coreApi.mockImplementation(
         () =>
           ({
-            getTeamMembersWithExtendedProperties: vi.fn(() => [
+            getTeamMembersWithExtendedProperties: vi.fn<
+              (...args: any[]) => any
+            >(() => [
               { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
             ]),
           }) as any,
       );
-      azureHelper.getAllProjectTeams = vi.fn().mockReturnValue([
-        { id: 3, name: 'abc' },
-        { id: 4, name: 'def' },
-      ]);
+      azureHelper.getAllProjectTeams = vi
+        .fn<(...args: any[]) => any>()
+        .mockReturnValue([
+          { id: 3, name: 'abc' },
+          { id: 4, name: 'def' },
+        ]);
       await azure.addReviewers(123, ['required:jyc']);
       expect(azureApi.gitApi).toHaveBeenCalledTimes(3);
       expect(logger.once.info).toHaveBeenCalledTimes(0);
@@ -1678,11 +1772,13 @@ describe('modules/platform/azure/index', () => {
   describe('setBranchStatus', () => {
     it('should build and call the create status api properly', async () => {
       await initRepo({ repository: 'some/repo' });
-      const createCommitStatusMock = vi.fn();
+      const createCommitStatusMock = vi.fn<(...args: any[]) => any>();
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
             createCommitStatus: createCommitStatusMock,
           }) as any,
       );
@@ -1710,11 +1806,13 @@ describe('modules/platform/azure/index', () => {
 
     it('should build and call the create status api properly with a complex context', async () => {
       await initRepo({ repository: 'some/repo' });
-      const createCommitStatusMock = vi.fn();
+      const createCommitStatusMock = vi.fn<(...args: any[]) => any>();
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+            getBranch: vi.fn<(...args: any[]) => any>(() => ({
+              commit: { commitId: 'abcd1234' },
+            })),
             createCommitStatus: createCommitStatusMock,
           }) as any,
       );
@@ -1747,13 +1845,13 @@ describe('modules/platform/azure/index', () => {
       const pullRequestIdMock = 12345;
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-      const updatePullRequestMock = vi.fn(() => ({
+      const updatePullRequestMock = vi.fn<(...args: any[]) => any>(() => ({
         status: 3,
       }));
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getPullRequestById: vi.fn(() => ({
+            getPullRequestById: vi.fn<(...args: any[]) => any>(() => ({
               lastMergeSourceCommit: lastMergeSourceCommitMock,
               targetRefName: 'refs/heads/ding',
               title: 'title',
@@ -1764,7 +1862,7 @@ describe('modules/platform/azure/index', () => {
       );
 
       azureHelper.getMergeMethod = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockReturnValue(GitPullRequestMergeStrategy.Squash);
 
       const res = await azure.mergePr({
@@ -1803,13 +1901,13 @@ describe('modules/platform/azure/index', () => {
         const pullRequestIdMock = 12345;
         const branchNameMock = 'test';
         const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-        const updatePullRequestMock = vi.fn(() => ({
+        const updatePullRequestMock = vi.fn<(...args: any[]) => any>(() => ({
           status: 3,
         }));
         azureApi.gitApi.mockImplementationOnce(
           () =>
             ({
-              getPullRequestById: vi.fn(() => ({
+              getPullRequestById: vi.fn<(...args: any[]) => any>(() => ({
                 lastMergeSourceCommit: lastMergeSourceCommitMock,
                 targetRefName: 'refs/heads/ding',
                 title: 'title',
@@ -1819,7 +1917,9 @@ describe('modules/platform/azure/index', () => {
             }) as any,
         );
 
-        azureHelper.getMergeMethod = vi.fn().mockReturnValue(prMergeStrategy);
+        azureHelper.getMergeMethod = vi
+          .fn<(...args: any[]) => any>()
+          .mockReturnValue(prMergeStrategy);
 
         const res = await azure.mergePr({
           branchName: branchNameMock,
@@ -1852,18 +1952,18 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            getPullRequestById: vi.fn(() => ({
+            getPullRequestById: vi.fn<(...args: any[]) => any>(() => ({
               lastMergeSourceCommit: lastMergeSourceCommitMock,
             })),
 
             updatePullRequest: vi
-              .fn()
+              .fn<(...args: any[]) => any>()
               .mockRejectedValue(new Error(`oh no pr couldn't be updated`)),
           }) as any,
       );
 
       azureHelper.getMergeMethod = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockReturnValue(GitPullRequestMergeStrategy.Squash);
 
       const res = await azure.mergePr({
@@ -1878,16 +1978,16 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementation(
         () =>
           ({
-            getPullRequestById: vi.fn(() => ({
+            getPullRequestById: vi.fn<(...args: any[]) => any>(() => ({
               lastMergeSourceCommit: { commitId: 'abcd1234' },
               targetRefName: 'refs/heads/ding',
             })),
 
-            updatePullRequest: vi.fn(),
+            updatePullRequest: vi.fn<(...args: any[]) => any>(),
           }) as any,
       );
       azureHelper.getMergeMethod = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockReturnValue(GitPullRequestMergeStrategy.Squash);
 
       await azure.mergePr({
@@ -1909,7 +2009,7 @@ describe('modules/platform/azure/index', () => {
       const pullRequestIdMock = 12345;
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-      const getPullRequestByIdMock = vi.fn(() => ({
+      const getPullRequestByIdMock = vi.fn<(...args: any[]) => any>(() => ({
         lastMergeSourceCommit: lastMergeSourceCommitMock,
         targetRefName: 'refs/heads/ding',
         status: 3,
@@ -1919,13 +2019,13 @@ describe('modules/platform/azure/index', () => {
           ({
             getPullRequestById: getPullRequestByIdMock,
 
-            updatePullRequest: vi.fn(() => ({
+            updatePullRequest: vi.fn<(...args: any[]) => any>(() => ({
               status: 1,
             })),
           }) as any,
       );
       azureHelper.getMergeMethod = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockReturnValue(GitPullRequestMergeStrategy.Squash);
 
       const res = await azure.mergePr({
@@ -1942,7 +2042,7 @@ describe('modules/platform/azure/index', () => {
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
       const expectedNumRetries = 5;
-      const getPullRequestByIdMock = vi.fn(() => ({
+      const getPullRequestByIdMock = vi.fn<(...args: any[]) => any>(() => ({
         lastMergeSourceCommit: lastMergeSourceCommitMock,
         targetRefName: 'refs/heads/ding',
         status: 1,
@@ -1952,13 +2052,13 @@ describe('modules/platform/azure/index', () => {
           ({
             getPullRequestById: getPullRequestByIdMock,
 
-            updatePullRequest: vi.fn(() => ({
+            updatePullRequest: vi.fn<(...args: any[]) => any>(() => ({
               status: 1,
             })),
           }) as any,
       );
       azureHelper.getMergeMethod = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockReturnValue(GitPullRequestMergeStrategy.Squash);
       const res = await azure.mergePr({
         branchName: branchNameMock,
@@ -1978,7 +2078,7 @@ describe('modules/platform/azure/index', () => {
       azureApi.gitApi.mockImplementationOnce(
         () =>
           ({
-            deletePullRequestLabels: vi.fn(),
+            deletePullRequestLabels: vi.fn<(...args: any[]) => any>(),
           }) as any,
       );
       await azure.deleteLabel(1234, 'rebase');
@@ -1994,8 +2094,8 @@ describe('modules/platform/azure/index', () => {
     it('returns file content', async () => {
       const data = { foo: 'bar' };
       azureApi.gitApi.mockImplementationOnce(
-        vi.fn().mockImplementationOnce(() => ({
-          getItem: vi.fn(() =>
+        vi.fn<(...args: any[]) => any>().mockImplementationOnce(() => ({
+          getItem: vi.fn<(...args: any[]) => any>(() =>
             Promise.resolve({ content: JSON.stringify(data) }),
           ),
         })),
@@ -2006,8 +2106,8 @@ describe('modules/platform/azure/index', () => {
 
     it('returns null when file not found', async () => {
       azureApi.gitApi.mockImplementationOnce(
-        vi.fn().mockImplementationOnce(() => ({
-          getItem: vi.fn(() => Promise.resolve(null)),
+        vi.fn<(...args: any[]) => any>().mockImplementationOnce(() => ({
+          getItem: vi.fn<(...args: any[]) => any>(() => Promise.resolve(null)),
         })),
       );
       const res = await azure.getJsonFile('file.json');
@@ -2022,8 +2122,10 @@ describe('modules/platform/azure/index', () => {
         }
       `;
       azureApi.gitApi.mockImplementationOnce(
-        vi.fn().mockImplementationOnce(() => ({
-          getItem: vi.fn(() => Promise.resolve({ content: json5Data })),
+        vi.fn<(...args: any[]) => any>().mockImplementationOnce(() => ({
+          getItem: vi.fn<(...args: any[]) => any>(() =>
+            Promise.resolve({ content: json5Data }),
+          ),
         })),
       );
       const res = await azure.getJsonFile('file.json5');
@@ -2034,7 +2136,7 @@ describe('modules/platform/azure/index', () => {
       const data = { foo: 'bar' };
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
-          getItem: vi.fn(() =>
+          getItem: vi.fn<(...args: any[]) => any>(() =>
             Promise.resolve({ content: JSON.stringify(data) }),
           ),
         }),
@@ -2046,7 +2148,9 @@ describe('modules/platform/azure/index', () => {
     it('throws on malformed JSON', async () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
-          getItemContent: vi.fn(() => Promise.resolve(Readable.from('!@#'))),
+          getItemContent: vi.fn<(...args: any[]) => any>(() =>
+            Promise.resolve(Readable.from('!@#')),
+          ),
         }),
       );
       await expect(azure.getJsonFile('file.json')).rejects.toThrow(
@@ -2057,7 +2161,7 @@ describe('modules/platform/azure/index', () => {
     it('throws on errors', async () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
-          getItemContent: vi.fn(() => {
+          getItemContent: vi.fn<(...args: any[]) => any>(() => {
             throw new Error('some error');
           }),
         }),
@@ -2070,13 +2174,13 @@ describe('modules/platform/azure/index', () => {
     it('supports fetch from another repo', async () => {
       const data = { foo: 'bar' };
       const getItemFn = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockResolvedValueOnce({ content: JSON.stringify(data) });
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
           getItem: getItemFn,
           getRepositories: vi
-            .fn()
+            .fn<(...args: any[]) => any>()
             .mockResolvedValue([
               { id: '123456', name: 'bar', project: { name: 'foo' } },
             ]),
@@ -2090,7 +2194,9 @@ describe('modules/platform/azure/index', () => {
     it('returns null', async () => {
       azureApi.gitApi.mockResolvedValueOnce(
         partial<IGitApi>({
-          getRepositories: vi.fn(() => Promise.resolve([])),
+          getRepositories: vi.fn<(...args: any[]) => any>(() =>
+            Promise.resolve([]),
+          ),
         }),
       );
       const res = await azure.getJsonFile('file.json', 'foo/bar');
@@ -2101,7 +2207,7 @@ describe('modules/platform/azure/index', () => {
   it('getRawFile should check tag first and then return branch if tag was not found', async () => {
     await initRepo({ repository: 'some/repo' });
     const callArgs: any[] = [];
-    const getItemMock = vi.fn(
+    const getItemMock = vi.fn<(...args: any[]) => any>(
       (
         repositoryId: string,
         path: string,
@@ -2133,7 +2239,7 @@ describe('modules/platform/azure/index', () => {
           getItem: getItemMock,
 
           getRepositories: vi
-            .fn()
+            .fn<(...args: any[]) => any>()
             .mockResolvedValue([
               { id: '123456', name: 'repo', project: { name: 'some' } },
             ]),
@@ -2153,7 +2259,9 @@ describe('modules/platform/azure/index', () => {
     await initRepo({ repository: 'some/repo' });
     azureApi.workItemTrackingApi.mockResolvedValueOnce(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({ workItems: [] }),
+        queryByWiql: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue({ workItems: [] }),
       }),
     );
     const res = await azure.findIssue('Nonexistent');
@@ -2165,10 +2273,10 @@ describe('modules/platform/azure/index', () => {
 
     azureApi.workItemTrackingApi.mockResolvedValueOnce(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }, { id: 456 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2202,13 +2310,17 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssue creates a new issue if none existing found', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const createWorkItemMock = vi.fn().mockResolvedValue({
-      id: 123,
-    });
+    const createWorkItemMock = vi
+      .fn<(...args: any[]) => any>()
+      .mockResolvedValue({
+        id: 123,
+      });
 
     azureApi.workItemTrackingApi.mockResolvedValueOnce(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({ workItems: [] }),
+        queryByWiql: vi
+          .fn<(...args: any[]) => any>()
+          .mockResolvedValue({ workItems: [] }),
         createWorkItem: createWorkItemMock,
       }),
     );
@@ -2243,15 +2355,15 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssue updates an existing issue', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const updateWorkItemMock = vi.fn();
-    const createWorkItemMock = vi.fn();
+    const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
+    const createWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2299,15 +2411,15 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssue do not touch issues when not needed', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const updateWorkItemMock = vi.fn();
-    const createWorkItemMock = vi.fn();
+    const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
+    const createWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2335,15 +2447,15 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssue do not recreate issue when once == true', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const updateWorkItemMock = vi.fn();
-    const createWorkItemMock = vi.fn();
+    const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
+    const createWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2371,16 +2483,16 @@ describe('modules/platform/azure/index', () => {
     await initRepo({ repository: 'some/repo' });
 
     const updateWorkItemMock = vi
-      .fn()
+      .fn<(...args: any[]) => any>()
       .mockRejectedValue(new Error('Test error'));
-    const createWorkItemMock = vi.fn();
+    const createWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2406,15 +2518,15 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssue updates an existing issue and reopens it if needed', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const updateWorkItemMock = vi.fn();
-    const createWorkItemMock = vi.fn();
+    const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
+    const createWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2467,15 +2579,15 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssue close duplicates and updates an existing issue', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const updateWorkItemMock = vi.fn();
-    const createWorkItemMock = vi.fn();
+    const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
+    const createWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }, { id: 456 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2532,14 +2644,14 @@ describe('modules/platform/azure/index', () => {
   it('ensureIssueClosing closes an existing issue', async () => {
     await initRepo({ repository: 'some/repo' });
 
-    const updateWorkItemMock = vi.fn();
+    const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2573,15 +2685,15 @@ describe('modules/platform/azure/index', () => {
     await initRepo({ repository: 'some/repo' });
 
     const updateWorkItemMock = vi
-      .fn()
+      .fn<(...args: any[]) => any>()
       .mockRejectedValue(new Error('Test error'));
 
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [{ id: 123 }],
         }),
-        getWorkItems: vi.fn().mockResolvedValue([
+        getWorkItems: vi.fn<(...args: any[]) => any>().mockResolvedValue([
           {
             id: 123,
             fields: {
@@ -2615,7 +2727,7 @@ describe('modules/platform/azure/index', () => {
     await initRepo({ repository: 'some/repo' });
     azureApi.workItemTrackingApi.mockResolvedValue(
       partial<IWorkItemTrackingApi>({
-        queryByWiql: vi.fn().mockResolvedValue({
+        queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
           workItems: [],
         }),
       }),

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -14,7 +14,9 @@ vi.mock('../../../util/sanitize.ts', () =>
   mockDeep({ sanitize: (s: string) => s }),
 );
 vi.mock('./util.ts', () => ({
-  getWorkItemTitle: vi.fn((title: string) => `[Renovate] ${title}`),
+  getWorkItemTitle: vi.fn<(...args: any[]) => any>(
+    (title: string) => `[Renovate] ${title}`,
+  ),
 }));
 
 const azureApi = vi.mocked(_azureApi, true);
@@ -37,7 +39,7 @@ describe('modules/platform/azure/issue', () => {
     it('should return empty array when no work items found', async () => {
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
-          queryByWiql: vi.fn().mockResolvedValue({
+          queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
             workItems: [],
           }),
         }),
@@ -69,10 +71,12 @@ describe('modules/platform/azure/issue', () => {
 
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
-          queryByWiql: vi.fn().mockResolvedValue({
+          queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
             workItems: [{ id: 1 }, { id: 2 }],
           }),
-          getWorkItems: vi.fn().mockResolvedValue(mockWorkItems),
+          getWorkItems: vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValue(mockWorkItems),
         }),
       );
 
@@ -95,7 +99,9 @@ describe('modules/platform/azure/issue', () => {
     });
 
     it('should filter by title when titleFilter provided', async () => {
-      const queryByWiqlMock = vi.fn().mockResolvedValue({ workItems: [] });
+      const queryByWiqlMock = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValue({ workItems: [] });
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           queryByWiql: queryByWiqlMock,
@@ -110,7 +116,9 @@ describe('modules/platform/azure/issue', () => {
     });
 
     it('should escape single quotes in title filter', async () => {
-      const queryByWiqlMock = vi.fn().mockResolvedValue({ workItems: [] });
+      const queryByWiqlMock = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValue({ workItems: [] });
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           queryByWiql: queryByWiqlMock,
@@ -127,7 +135,9 @@ describe('modules/platform/azure/issue', () => {
     it('should handle errors gracefully', async () => {
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
-          queryByWiql: vi.fn().mockRejectedValue(new Error('API Error')),
+          queryByWiql: vi
+            .fn<(...args: any[]) => any>()
+            .mockRejectedValue(new Error('API Error')),
         }),
       );
 
@@ -166,10 +176,12 @@ describe('modules/platform/azure/issue', () => {
 
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
-          queryByWiql: vi.fn().mockResolvedValue({
+          queryByWiql: vi.fn<(...args: any[]) => any>().mockResolvedValue({
             workItems: [{ id: 1 }, { id: 2 }, { id: 3 }],
           }),
-          getWorkItems: vi.fn().mockResolvedValue(mockWorkItems),
+          getWorkItems: vi
+            .fn<(...args: any[]) => any>()
+            .mockResolvedValue(mockWorkItems),
         }),
       );
 
@@ -228,7 +240,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'findIssue').mockResolvedValue(mockIssue);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -255,7 +267,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'findIssue').mockResolvedValue(mockIssue);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -277,7 +289,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'findIssue').mockResolvedValue(mockIssue);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -305,7 +317,9 @@ describe('modules/platform/azure/issue', () => {
     it('should create new issue when none exists', async () => {
       vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
 
-      const createWorkItemMock = vi.fn().mockResolvedValue({ id: 123 });
+      const createWorkItemMock = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValue({ id: 123 });
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           createWorkItem: createWorkItemMock,
@@ -333,7 +347,7 @@ describe('modules/platform/azure/issue', () => {
         mockClosedIssue,
       ]);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -398,7 +412,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'getIssueList').mockResolvedValue([mockOpenIssue]);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -454,7 +468,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'getIssueList').mockResolvedValue(mockOpenIssues);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -499,7 +513,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'getIssueList').mockResolvedValue(mockOpenIssues);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -546,7 +560,7 @@ describe('modules/platform/azure/issue', () => {
 
       vi.spyOn(issueService, 'getIssueList').mockResolvedValue([mockOpenIssue]);
 
-      const updateWorkItemMock = vi.fn();
+      const updateWorkItemMock = vi.fn<(...args: any[]) => any>();
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           updateWorkItem: updateWorkItemMock,
@@ -624,7 +638,9 @@ describe('modules/platform/azure/issue', () => {
         mockClosedIssue,
       ]);
 
-      const createWorkItemMock = vi.fn().mockResolvedValue({ id: 123 });
+      const createWorkItemMock = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValue({ id: 123 });
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           createWorkItem: createWorkItemMock,

--- a/lib/modules/platform/local/scm.spec.ts
+++ b/lib/modules/platform/local/scm.spec.ts
@@ -4,7 +4,9 @@ import type { ExecResult } from '../../../util/exec/types.ts';
 import { LocalFs } from './scm.ts';
 
 vi.mock('glob', () => ({
-  glob: vi.fn().mockImplementation(() => Promise.resolve(['file1', 'file2'])),
+  glob: vi
+    .fn<(...args: any[]) => any>()
+    .mockImplementation(() => Promise.resolve(['file1', 'file2'])),
 }));
 vi.mock('../../../util/exec/common.ts');
 const execSync = vi.mocked(_rawExec);

--- a/lib/util/cache/package/backend.spec.ts
+++ b/lib/util/cache/package/backend.spec.ts
@@ -13,9 +13,9 @@ function mockBackend(): {
   destroy: ReturnType<typeof vi.fn>;
 } {
   return {
-    get: vi.fn().mockResolvedValue(undefined),
-    set: vi.fn().mockResolvedValue(undefined),
-    destroy: vi.fn().mockResolvedValue(undefined),
+    get: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+    set: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
+    destroy: vi.fn<(...args: any[]) => any>().mockResolvedValue(undefined),
   };
 }
 

--- a/lib/util/cache/package/impl/redis.spec.ts
+++ b/lib/util/cache/package/impl/redis.spec.ts
@@ -24,14 +24,14 @@ describe('util/cache/package/impl/redis', () => {
 
   describe('PackageCacheRedis', () => {
     const clientMock = {
-      connect: vi.fn(),
-      set: vi.fn(),
-      del: vi.fn(),
-      destroy: vi.fn(),
-      withTypeMapping: vi.fn(),
+      connect: vi.fn<(...args: any[]) => any>(),
+      set: vi.fn<(...args: any[]) => any>(),
+      del: vi.fn<(...args: any[]) => any>(),
+      destroy: vi.fn<(...args: any[]) => any>(),
+      withTypeMapping: vi.fn<(...args: any[]) => any>(),
     };
     const binaryClientMock = {
-      get: vi.fn(),
+      get: vi.fn<(...args: any[]) => any>(),
     };
 
     beforeEach(() => {

--- a/lib/util/cache/package/with-cache.spec.ts
+++ b/lib/util/cache/package/with-cache.spec.ts
@@ -8,7 +8,7 @@ import { withCache } from './with-cache.ts';
 describe('util/cache/package/with-cache', () => {
   let setCache: MockInstance<typeof packageCache.setWithRawTtl>;
   let dirResult: Awaited<ReturnType<typeof tmpDir>>;
-  const getValue = vi.fn();
+  const getValue = vi.fn<(...args: any[]) => any>();
   let count = 1;
 
   beforeEach(async () => {

--- a/lib/util/exec/docker/index.spec.ts
+++ b/lib/util/exec/docker/index.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './index.ts';
 
 vi.mock('../../../modules/datasource/index.ts', () => ({
-  getPkgReleases: vi.fn(),
+  getPkgReleases: vi.fn<(...args: any[]) => any>(),
 }));
 
 describe('util/exec/docker/index', () => {

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -22,7 +22,7 @@ const getHermitEnvsMock = vi.mocked(getHermitEnvs);
 
 vi.mock('./hermit.ts', async () => ({
   ...(await vi.importActual<typeof import('./hermit.ts')>('./hermit.ts')),
-  getHermitEnvs: vi.fn(),
+  getHermitEnvs: vi.fn<(...args: any[]) => any>(),
 }));
 vi.mock('../../modules/datasource/index.ts', () => mockDeep());
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -169,13 +169,15 @@ describe('util/git/index', { timeout: 30000 }, () => {
 
   describe('gitRetry', () => {
     it('returns result if git returns successfully', async () => {
-      const gitFunc = vi.fn().mockImplementation((args) => {
-        if (args === undefined) {
-          return 'some result';
-        } else {
-          return 'different result';
-        }
-      });
+      const gitFunc = vi
+        .fn<(...args: any[]) => any>()
+        .mockImplementation((args) => {
+          if (args === undefined) {
+            return 'some result';
+          } else {
+            return 'different result';
+          }
+        });
       expect(await git.gitRetry(() => gitFunc())).toBe('some result');
       expect(await git.gitRetry(() => gitFunc('arg'))).toBe('different result');
       expect(gitFunc).toHaveBeenCalledTimes(2);
@@ -184,7 +186,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     it('retries the func call if ExternalHostError thrown', async () => {
       process.env.NODE_ENV = '';
       const gitFunc = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockImplementationOnce(() => {
           throw new Error('The remote end hung up unexpectedly');
         })
@@ -198,9 +200,11 @@ describe('util/git/index', { timeout: 30000 }, () => {
 
     it('retries the func call up to retry count if ExternalHostError thrown', async () => {
       process.env.NODE_ENV = '';
-      const gitFunc = vi.fn().mockImplementation(() => {
-        throw new Error('The remote end hung up unexpectedly');
-      });
+      const gitFunc = vi
+        .fn<(...args: any[]) => any>()
+        .mockImplementation(() => {
+          throw new Error('The remote end hung up unexpectedly');
+        });
       await expect(git.gitRetry(() => gitFunc())).rejects.toThrow(
         'The remote end hung up unexpectedly',
       );
@@ -208,9 +212,11 @@ describe('util/git/index', { timeout: 30000 }, () => {
     });
 
     it("doesn't retry and throws an Error if non-ExternalHostError thrown by git", async () => {
-      const gitFunc = vi.fn().mockImplementationOnce(() => {
-        throw new Error('some error');
-      });
+      const gitFunc = vi
+        .fn<(...args: any[]) => any>()
+        .mockImplementationOnce(() => {
+          throw new Error('some error');
+        });
       await expect(git.gitRetry(() => gitFunc())).rejects.toThrow('some error');
       expect(gitFunc).toHaveBeenCalledTimes(1);
     });

--- a/lib/util/http/retry-after.spec.ts
+++ b/lib/util/http/retry-after.spec.ts
@@ -25,14 +25,16 @@ describe('util/http/retry-after', () => {
 
   describe('wrapWithRetry', () => {
     it('works', async () => {
-      const task = vi.fn(() => Promise.resolve(42));
+      const task = vi.fn<() => Promise<number>>(() => Promise.resolve(42));
       const res = await wrapWithRetry(task, 'foobar', () => null, 60);
       expect(res).toBe(42);
       expect(task).toHaveBeenCalledTimes(1);
     });
 
     it('throws', async () => {
-      const task = vi.fn(() => Promise.reject(new Error('error')));
+      const task = vi.fn<() => Promise<number>>(() =>
+        Promise.reject(new Error('error')),
+      );
 
       await expect(
         wrapWithRetry(task, 'http://example.com', () => null, 60),
@@ -43,7 +45,7 @@ describe('util/http/retry-after', () => {
 
     it('retries', async () => {
       const task = vi
-        .fn()
+        .fn<() => Promise<number>>()
         .mockRejectedValueOnce(new Error('error-1'))
         .mockRejectedValueOnce(new Error('error-2'))
         .mockResolvedValueOnce(42);
@@ -58,7 +60,7 @@ describe('util/http/retry-after', () => {
 
     it('gives up after max retries', async () => {
       const task = vi
-        .fn()
+        .fn<() => Promise<number>>()
         .mockRejectedValueOnce('error-1')
         .mockRejectedValueOnce('error-2')
         .mockRejectedValueOnce('error-3')
@@ -74,7 +76,7 @@ describe('util/http/retry-after', () => {
     });
 
     it('gives up when delay exceeds maxRetryAfter', async () => {
-      const task = vi.fn().mockRejectedValue('error');
+      const task = vi.fn<() => Promise<number>>().mockRejectedValue('error');
 
       const p = wrapWithRetry(task, 'http://example.com', () => 61, 60).catch(
         (err) => err,

--- a/lib/util/ignore.spec.ts
+++ b/lib/util/ignore.spec.ts
@@ -3,7 +3,7 @@ import { isSkipComment } from './ignore.ts';
 
 vi.mock('../logger/index.ts', () => ({
   logger: {
-    debug: vi.fn(),
+    debug: vi.fn<(...args: unknown[]) => void>(),
   },
 }));
 

--- a/lib/util/lazy.spec.ts
+++ b/lib/util/lazy.spec.ts
@@ -3,7 +3,7 @@ import { Lazy } from './lazy.ts';
 describe('util/lazy', () => {
   describe('.getValue()', () => {
     it('gets a value', () => {
-      const spy = vi.fn().mockReturnValue(0);
+      const spy = vi.fn<() => number>().mockReturnValue(0);
       const lazy = new Lazy(() => spy());
       const value = lazy.getValue();
       expect(value).toBe(0);
@@ -11,7 +11,7 @@ describe('util/lazy', () => {
     });
 
     it('caches the value', () => {
-      const spy = vi.fn().mockReturnValue(0);
+      const spy = vi.fn<() => number>().mockReturnValue(0);
       const lazy = new Lazy(() => spy());
       lazy.getValue();
       lazy.getValue();
@@ -19,7 +19,7 @@ describe('util/lazy', () => {
     });
 
     it('throws an error', () => {
-      const spy = vi.fn().mockImplementation(() => {
+      const spy = vi.fn<() => number>().mockImplementation(() => {
         throw new Error();
       });
       const lazy = new Lazy(() => spy());
@@ -28,7 +28,7 @@ describe('util/lazy', () => {
     });
 
     it('caches the error', () => {
-      const spy = vi.fn().mockImplementation(() => {
+      const spy = vi.fn<() => number>().mockImplementation(() => {
         throw new Error();
       });
       const lazy = new Lazy(() => spy());
@@ -40,7 +40,7 @@ describe('util/lazy', () => {
 
   describe('.hasValue()', () => {
     it('has a value', () => {
-      const spy = vi.fn().mockReturnValue(0);
+      const spy = vi.fn<() => number>().mockReturnValue(0);
       const lazy = new Lazy(() => spy());
       lazy.getValue();
       const hasValue = lazy.hasValue();
@@ -49,7 +49,7 @@ describe('util/lazy', () => {
     });
 
     it('does not have a value', () => {
-      const spy = vi.fn().mockReturnValue(0);
+      const spy = vi.fn<() => number>().mockReturnValue(0);
       const lazy = new Lazy(() => spy());
       const hasValue = lazy.hasValue();
       expect(hasValue).toBeFalse();

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -210,7 +210,7 @@ describe('util/result', () => {
 
       it('skips transform for error Result', () => {
         const res: Result<number, string> = Result.err('oops');
-        const fn = vi.fn((x: number) => x + 1);
+        const fn = vi.fn<(x: number) => number>((x: number) => x + 1);
         expect(res.transform(fn)).toEqual(Result.err('oops'));
         expect(fn).not.toHaveBeenCalled();
       });
@@ -327,13 +327,13 @@ describe('util/result', () => {
 
     describe('Handlers', () => {
       it('supports value handlers', () => {
-        const cb = vi.fn();
+        const cb = vi.fn<(value: number) => void>();
         Result.ok(42).onValue(cb);
         expect(cb).toHaveBeenCalledExactlyOnceWith(42);
       });
 
       it('supports error handlers', () => {
-        const cb = vi.fn();
+        const cb = vi.fn<(err: string) => void>();
         Result.err('oops').onError(cb);
         expect(cb).toHaveBeenCalledExactlyOnceWith('oops');
       });
@@ -490,7 +490,7 @@ describe('util/result', () => {
 
       it('skips transform for failed promises', async () => {
         const res = AsyncResult.err('oops');
-        const fn = vi.fn((x: number) => x + 1);
+        const fn = vi.fn<(x: number) => number>((x: number) => x + 1);
         await expect(res.transform(fn)).resolves.toEqual(Result.err('oops'));
         expect(fn).not.toHaveBeenCalled();
       });
@@ -525,7 +525,9 @@ describe('util/result', () => {
 
       it('skips async transform for error Result', async () => {
         const input: Result<number, string> = Result.err('oops');
-        const fn = vi.fn((x: number) => Promise.resolve(x + 1));
+        const fn = vi.fn<(x: number) => Promise<number>>((x: number) =>
+          Promise.resolve(x + 1),
+        );
         const res = await input.transform(fn);
         expect(res).toEqual(Result.err('oops'));
         expect(fn).not.toHaveBeenCalled();
@@ -533,7 +535,9 @@ describe('util/result', () => {
 
       it('skips async transform for rejected promise', async () => {
         const res: AsyncResult<number, string> = AsyncResult.err('oops');
-        const fn = vi.fn((x: number) => Promise.resolve(x + 1));
+        const fn = vi.fn<(x: number) => Promise<number>>((x: number) =>
+          Promise.resolve(x + 1),
+        );
         await expect(res.transform(fn)).resolves.toEqual(Result.err('oops'));
         expect(fn).not.toHaveBeenCalled();
       });
@@ -686,13 +690,13 @@ describe('util/result', () => {
 
   describe('Handlers', () => {
     it('supports value handlers', async () => {
-      const cb = vi.fn();
+      const cb = vi.fn<(value: number) => void>();
       await AsyncResult.ok(42).onValue(cb);
       expect(cb).toHaveBeenCalledExactlyOnceWith(42);
     });
 
     it('supports error handlers', async () => {
-      const cb = vi.fn();
+      const cb = vi.fn<(err: string) => void>();
       await AsyncResult.err('oops').onError(cb);
       expect(cb).toHaveBeenCalledExactlyOnceWith('oops');
     });

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -12,7 +12,7 @@ import * as _hostRulesFromEnv from './host-rules-from-env.ts';
 
 vi.mock('../../../../modules/datasource/npm.ts');
 vi.mock('../../../../modules/manager/index.ts', () => ({
-  detectAllGlobalConfig: vi.fn().mockResolvedValue({}),
+  detectAllGlobalConfig: vi.fn<(...args: any[]) => any>().mockResolvedValue({}),
 }));
 vi.mock('../../../../util/fs/index.ts');
 vi.mock('../../../../config/decrypt.ts');

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -18,16 +18,16 @@ vi.mock('fs-extra', async () => {
   const realFs = await vi.importActual<typeof fs>('fs-extra');
   return {
     default: {
-      ensureDir: vi.fn(),
-      remove: vi.fn(),
-      readFile: vi.fn((file: string, options: any) => {
+      ensureDir: vi.fn<(...args: any[]) => any>(),
+      remove: vi.fn<(...args: any[]) => any>(),
+      readFile: vi.fn<(...args: any[]) => any>((file: string, options: any) => {
         if (file.endsWith('.wasm.gz')) {
           return realFs.readFile(file, options);
         }
         return undefined;
       }),
-      writeFile: vi.fn(),
-      outputFile: vi.fn(),
+      writeFile: vi.fn<(...args: any[]) => any>(),
+      outputFile: vi.fn<(...args: any[]) => any>(),
     },
   };
 });

--- a/lib/workers/repository/config-migration/branch/index.spec.ts
+++ b/lib/workers/repository/config-migration/branch/index.spec.ts
@@ -105,7 +105,9 @@ describe('workers/repository/config-migration/branch/index', () => {
           number: 1,
         }),
       );
-      platform.refreshPr = vi.fn().mockResolvedValueOnce(null);
+      platform.refreshPr = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValueOnce(null);
       vi.mocked(rebaseMigrationBranch).mockResolvedValueOnce('committed');
       const res = await checkConfigMigrationBranch(
         {
@@ -156,7 +158,9 @@ describe('workers/repository/config-migration/branch/index', () => {
 
     it('updates migration branch & refresh PR when migration enabled and open pr exists', async () => {
       platform.getBranchPr.mockResolvedValue(mock<Pr>());
-      platform.refreshPr = vi.fn().mockResolvedValueOnce(null);
+      platform.refreshPr = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValueOnce(null);
       vi.mocked(rebaseMigrationBranch).mockResolvedValueOnce('committed');
       const res = await checkConfigMigrationBranch(
         {

--- a/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.spec.ts
@@ -21,7 +21,7 @@ vi.mock('jsonc-weaver', async (importOriginal) => {
   const actual = await importOriginal<typeof import('jsonc-weaver')>();
   return {
     ...actual,
-    weave: vi.fn(actual.weave),
+    weave: vi.fn<(...args: any[]) => any>(actual.weave),
   };
 });
 

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -23,7 +23,7 @@ import * as dependencyDashboard from './dependency-dashboard.ts';
 import { getDashboardMarkdownVulnerabilities } from './dependency-dashboard.ts';
 import { PackageFiles } from './package-files.ts';
 
-const createVulnerabilitiesMock = vi.fn();
+const createVulnerabilitiesMock = vi.fn<(...args: any[]) => any>();
 vi.mock('./process/vulnerabilities.ts', () => {
   return {
     __esModule: true,
@@ -1777,7 +1777,7 @@ None detected
     });
 
     it('return no data section if summary is set to all and no vulnerabilities', async () => {
-      const fetchVulnerabilitiesMock = vi.fn();
+      const fetchVulnerabilitiesMock = vi.fn<(...args: any[]) => any>();
       createVulnerabilitiesMock.mockResolvedValueOnce({
         fetchVulnerabilities: fetchVulnerabilitiesMock,
       });
@@ -1796,7 +1796,7 @@ None detected
     });
 
     it('return all vulnerabilities if set to all and disabled osvVulnerabilities', async () => {
-      const fetchVulnerabilitiesMock = vi.fn();
+      const fetchVulnerabilitiesMock = vi.fn<(...args: any[]) => any>();
       createVulnerabilitiesMock.mockResolvedValueOnce({
         fetchVulnerabilities: fetchVulnerabilitiesMock,
       });
@@ -1868,7 +1868,7 @@ None detected
     });
 
     it('return unresolved vulnerabilities if set to "unresolved"', async () => {
-      const fetchVulnerabilitiesMock = vi.fn();
+      const fetchVulnerabilitiesMock = vi.fn<(...args: any[]) => any>();
       createVulnerabilitiesMock.mockResolvedValueOnce({
         fetchVulnerabilities: fetchVulnerabilitiesMock,
       });

--- a/lib/workers/repository/extract/manager-files.spec.ts
+++ b/lib/workers/repository/extract/manager-files.spec.ts
@@ -51,7 +51,7 @@ describe('workers/repository/extract/manager-files', () => {
       };
       fileMatch.getMatchingFiles.mockReturnValue(['Dockerfile']);
       fs.readLocalFile.mockResolvedValueOnce('some content');
-      html.extractPackageFile = vi.fn(() => ({
+      html.extractPackageFile = vi.fn<(...args: any[]) => any>(() => ({
         deps: [{}, { replaceString: 'abc', packageName: 'p' }],
       })) as never;
       const res = await getManagerPackageFiles(managerConfig);

--- a/lib/workers/repository/init/index.spec.ts
+++ b/lib/workers/repository/init/index.spec.ts
@@ -16,8 +16,8 @@ vi.mock('../init/merge.ts');
 vi.mock('../../../config/secrets.ts');
 vi.mock('../../../config/variables.ts');
 vi.mock('../../../modules/platform/index.ts', () => ({
-  platform: { initRepo: vi.fn() },
-  getPlatformList: vi.fn(),
+  platform: { initRepo: vi.fn<(...args: any[]) => any>() },
+  getPlatformList: vi.fn<(...args: any[]) => any>(),
 }));
 vi.unmock('../../../util/mutex.ts');
 

--- a/lib/workers/repository/process/extract-update.spec.ts
+++ b/lib/workers/repository/process/extract-update.spec.ts
@@ -15,7 +15,7 @@ import {
 } from './extract-update.ts';
 import * as _fetch from './fetch.ts';
 
-const createVulnerabilitiesMock = vi.fn();
+const createVulnerabilitiesMock = vi.fn<(...args: any[]) => any>();
 
 vi.mock('./write.ts');
 vi.mock('./sort.ts');
@@ -124,7 +124,8 @@ describe('workers/repository/process/extract-update', () => {
         repoIsOnboarded: true,
         osvVulnerabilityAlerts: true,
       };
-      const appendVulnerabilityPackageRulesMock = vi.fn();
+      const appendVulnerabilityPackageRulesMock =
+        vi.fn<(...args: any[]) => any>();
       createVulnerabilitiesMock.mockResolvedValue({
         appendVulnerabilityPackageRules: appendVulnerabilityPackageRulesMock,
       });
@@ -196,7 +197,8 @@ describe('workers/repository/process/extract-update', () => {
             baseBranch: 'main',
             osvVulnerabilityAlerts: true,
           };
-          const appendVulnerabilityPackageRulesMock = vi.fn();
+          const appendVulnerabilityPackageRulesMock =
+            vi.fn<(...args: any[]) => any>();
           createVulnerabilitiesMock.mockResolvedValue({
             appendVulnerabilityPackageRules:
               appendVulnerabilityPackageRulesMock,

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -68,7 +68,7 @@ describe('workers/repository/process/index', () => {
     it('reads config from branches in baseBranchPatterns if useBaseBranchConfig specified', async () => {
       scm.branchExists.mockResolvedValue(true);
       platform.getJsonFile = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockResolvedValue({ extends: [':approveMajorUpdates'] });
       config.baseBranchPatterns = ['master', 'dev'];
       config.useBaseBranchConfig = 'merge';
@@ -91,11 +91,13 @@ describe('workers/repository/process/index', () => {
 
     it('throws if base branch config is invalid', async () => {
       scm.branchExists.mockResolvedValue(true);
-      platform.getJsonFile = vi.fn().mockResolvedValue({
-        extends: [':approveMajorUpdates'],
-        labels: '123',
-        invalidKey: 'invalidValue',
-      });
+      platform.getJsonFile = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValue({
+          extends: [':approveMajorUpdates'],
+          labels: '123',
+          invalidKey: 'invalidValue',
+        });
       config.baseBranchPatterns = ['master', 'dev'];
       config.useBaseBranchConfig = 'merge';
       getCache().configFileName = 'renovate.json';
@@ -107,7 +109,7 @@ describe('workers/repository/process/index', () => {
     it('handles config name mismatch between baseBranches if useBaseBranchConfig specified', async () => {
       scm.branchExists.mockResolvedValue(true);
       platform.getJsonFile = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockImplementation((fileName, repoName, branchName) => {
           if (branchName === 'dev') {
             throw new Error();

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -9,7 +9,7 @@ import { Vulnerabilities } from './vulnerabilities.ts';
 
 const getVulnerabilitiesMock =
   mockFn<typeof OsvOffline.prototype.getVulnerabilities>();
-const createMock = vi.fn();
+const createMock = vi.fn<(...args: any[]) => any>();
 
 vi.mock('@renovatebot/osv-offline', () => {
   return {

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -896,7 +896,9 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         localDir: '/default/dir',
         allowedCommands: ['some-command'],
       });
-      exec.exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' });
+      exec.exec = vi
+        .fn<(...args: any[]) => any>()
+        .mockResolvedValue({ stdout: '', stderr: '' });
 
       await postUpgradeCommands.postUpgradeCommandsExecutor(commands, config);
 

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -57,7 +57,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         branchName: 'renovate/pin',
         upgrades: [],
       } satisfies BranchConfig;
-      npm.updateDependency = vi.fn();
+      npm.updateDependency = vi.fn<(...args: any[]) => any>();
       git.getFile.mockResolvedValueOnce('existing content');
     });
 

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -108,9 +108,9 @@ describe('workers/repository/update/branch/index', () => {
       reuse.shouldReuseExistingBranch.mockImplementation((config) =>
         Promise.resolve(config),
       );
-      prWorker.ensurePr = vi.fn();
-      prWorker.getPlatformPrOptions = vi.fn();
-      prAutomerge.checkAutoMerge = vi.fn();
+      prWorker.ensurePr = vi.fn<(...args: any[]) => any>();
+      prWorker.getPlatformPrOptions = vi.fn<(...args: any[]) => any>();
+      prAutomerge.checkAutoMerge = vi.fn<(...args: any[]) => any>();
       // TODO: incompatible types (#22198)
       config = {
         ...getConfig(),

--- a/lib/workers/repository/update/pr/participants.spec.ts
+++ b/lib/workers/repository/update/pr/participants.spec.ts
@@ -44,7 +44,7 @@ describe('workers/repository/update/pr/participants', () => {
 
     it('filters assignees', async () => {
       platform.filterUnavailableUsers = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockResolvedValueOnce(['a', 'b']);
       await addParticipants({ ...config, filterUnavailableUsers: true }, pr);
       expect(platform.addAssignees).toHaveBeenCalledExactlyOnceWith(123, [
@@ -60,7 +60,7 @@ describe('workers/repository/update/pr/participants', () => {
         'u@email.com',
       ]);
       platform.expandGroupMembers = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockResolvedValueOnce(['u@email.com', 'user', 'group.user']);
       await addParticipants(
         {
@@ -91,7 +91,7 @@ describe('workers/repository/update/pr/participants', () => {
     it('does not expand group code owners assignees when assigneesFromCodeOwners disabled', async () => {
       codeOwners.codeOwnersForPr.mockResolvedValueOnce(['user', '@group']);
       platform.expandGroupMembers = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockResolvedValueOnce(['user', 'group.user']);
       await addParticipants(config, pr);
       expect(codeOwners.codeOwnersForPr).not.toHaveBeenCalled();
@@ -106,7 +106,7 @@ describe('workers/repository/update/pr/participants', () => {
     it('does not expand group code owners assignees when expandCodeOwnersGroups disabled', async () => {
       codeOwners.codeOwnersForPr.mockResolvedValueOnce(['user', '@group']);
       platform.expandGroupMembers = vi
-        .fn()
+        .fn<(...args: any[]) => any>()
         .mockResolvedValueOnce(['user', 'group.user']);
       await addParticipants({ ...config, assigneesFromCodeOwners: true }, pr);
       expect(codeOwners.codeOwnersForPr).toHaveBeenCalledExactlyOnceWith({

--- a/tools/agents/hooks/cwdchanged-check.spec.ts
+++ b/tools/agents/hooks/cwdchanged-check.spec.ts
@@ -8,9 +8,14 @@ vi.mock('./utils/stdin.ts', () => ({ readStdin }));
 const { getRepoRoot } = vi.hoisted(() => ({
   getRepoRoot: vi.fn<(dir?: string) => Promise<string | null>>(),
 }));
-vi.mock('./utils/git.ts', () => ({ getRepoRoot, getChangedFiles: vi.fn() }));
+vi.mock('./utils/git.ts', () => ({
+  getRepoRoot,
+  getChangedFiles: vi.fn<(...args: any[]) => any>(),
+}));
 
-const { provision } = vi.hoisted(() => ({ provision: vi.fn() }));
+const { provision } = vi.hoisted(() => ({
+  provision: vi.fn<(...args: any[]) => any>(),
+}));
 vi.mock('./utils/provision.ts', () => ({ provision }));
 
 const { existsSync } = vi.hoisted(() => ({

--- a/tools/agents/hooks/pretooluse-check.spec.ts
+++ b/tools/agents/hooks/pretooluse-check.spec.ts
@@ -1,9 +1,11 @@
 // https://code.claude.com/docs/en/hooks#pretooluse
 
-const { deny } = vi.hoisted(() => ({ deny: vi.fn() }));
+const { deny } = vi.hoisted(() => ({ deny: vi.fn<(...args: any[]) => any>() }));
 vi.mock('./utils/output.ts', () => ({ deny }));
 
-const { readStdin } = vi.hoisted(() => ({ readStdin: vi.fn() }));
+const { readStdin } = vi.hoisted(() => ({
+  readStdin: vi.fn<(...args: any[]) => any>(),
+}));
 vi.mock('./utils/stdin.ts', () => ({ readStdin }));
 
 function makeInput(

--- a/tools/agents/hooks/stop-check.spec.ts
+++ b/tools/agents/hooks/stop-check.spec.ts
@@ -1,7 +1,7 @@
 // https://code.claude.com/docs/en/hooks#stop
 import { BlockOutput } from './utils/schemas.ts';
 
-const { exec } = vi.hoisted(() => ({ exec: vi.fn() }));
+const { exec } = vi.hoisted(() => ({ exec: vi.fn<(...args: any[]) => any>() }));
 vi.mock('./utils/exec.ts', () => ({ exec }));
 
 const { getChangedFiles } = vi.hoisted(() => ({

--- a/tools/agents/hooks/utils/git.spec.ts
+++ b/tools/agents/hooks/utils/git.spec.ts
@@ -2,17 +2,17 @@ import { getChangedFiles, getRepoRoot } from './git.ts';
 
 const mockGit = vi.hoisted(() => {
   const obj = {
-    raw: vi.fn(),
-    revparse: vi.fn(),
-    diff: vi.fn(),
-    env: vi.fn(),
+    raw: vi.fn<(...args: any[]) => any>(),
+    revparse: vi.fn<(...args: any[]) => any>(),
+    diff: vi.fn<(...args: any[]) => any>(),
+    env: vi.fn<(...args: any[]) => any>(),
   };
   obj.env.mockReturnValue(obj);
   return obj;
 });
 
 vi.mock('simple-git', () => ({
-  simpleGit: vi.fn(() => mockGit),
+  simpleGit: vi.fn<(...args: any[]) => any>(() => mockGit),
 }));
 
 beforeEach(() => {

--- a/tools/agents/hooks/utils/provision.spec.ts
+++ b/tools/agents/hooks/utils/provision.spec.ts
@@ -1,6 +1,6 @@
 import { provision } from './provision.ts';
 
-const { exec } = vi.hoisted(() => ({ exec: vi.fn() }));
+const { exec } = vi.hoisted(() => ({ exec: vi.fn<(...args: any[]) => any>() }));
 vi.mock('./exec.ts', () => ({ exec }));
 const errorSpy = vi.spyOn(console, 'error');
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Enable the rule and add explicit type parameters to `vi.fn()` mocks.

Standalone and simple spies get precise real signatures (e.g. `vi.fn<() => number>()`, `vi.fn<Http['getText']>()`). The remaining module-function, property and API-object mocks (azure/go/docker platform + datasource stubs) keep the implicit procedure signature `(...args: any[]) => any`; typing those correctly cascades into mockReturnValue->mockResolvedValue changes, special-type wrapping and fixture fixes, so it is left as a follow-up.

## Context

Part of #43845

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
