### PR TITLE
feat(monorepo): group ng-packagr with angular-cli

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -55,7 +55,10 @@
     "algoliasearch-client-javascript": "https://github.com/algolia/algoliasearch-client-javascript",
     "analog": "https://github.com/analogjs/analog",
     "angular": "https://github.com/angular/angular",
-    "angular-cli": "https://github.com/angular/angular-cli",
+    "angular-cli": [
+      "https://github.com/angular/angular-cli",
+      "https://github.com/ng-packagr/ng-packagr"
+    ],
     "angular-eslint": "https://github.com/angular-eslint/angular-eslint",
     "angularfire": "https://github.com/angular/angularfire",
     "angularjs": "https://github.com/angular/angular.js",


### PR DESCRIPTION
## Changes

Add `ng-packagr` to the `angular-cli` monorepo group by converting the `repoGroups` entry from a string to an array, matching the existing pattern used by `aspire`, `algolia-instantsearch`, and others.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

`ng-packagr` is the official Angular library compiler. It follows the Angular CLI release cycle — same major versions, same upgrade cadence — but lives in a separate repository ([ng-packagr/ng-packagr](https://github.com/ng-packagr/ng-packagr)). Without this change, Renovate creates separate PRs for Angular CLI and ng-packagr updates, which then need to be upgraded and tested together manually.

## AI assistance disclosure

- [x] Yes — substantive assistance. This PR was written by an AI agent (GLM-5.2 via opencode). The change was identified and implemented by the agent at the user's direction.

## Documentation

- [x] No documentation update is required

## How I've tested this work

- [x] Code inspection only

The monorepo preset spec (`monorepos.spec.ts`) only validates preset name format, not individual group entries. The JSON schema for `repoGroups` explicitly allows arrays of URIs, and several existing entries already use arrays.