### PR TITLE
fix(config): normalize migrated package rule matchers

### DIFF
--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -325,7 +325,7 @@ describe('config/migrations/custom/package-rules-migration', () => {
           },
           {
             matchDepPatterns: ['some-dep'],
-            excludeDepPatterns: ['!*'],
+            excludeDepPatterns: ['.*'],
             automerge: true,
           },
         ],
@@ -341,7 +341,7 @@ describe('config/migrations/custom/package-rules-migration', () => {
             automerge: true,
           },
           {
-            matchDepNames: ['!**'],
+            matchDepNames: ['/some-dep/', '!/.*/'],
             automerge: true,
           },
         ],

--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -175,6 +175,201 @@ describe('config/migrations/custom/package-rules-migration', () => {
     );
   });
 
+  it.each`
+    pattern
+    ${'*'}
+    ${'**'}
+    ${'!*'}
+    ${'!**'}
+  `(
+    'should migrate packagePatterns $pattern with excludePackagePatterns to negative matchPackageNames',
+    async ({ pattern }) => {
+      await expect(PackageRulesMigration).toMigrate(
+        {
+          packageRules: [
+            {
+              packagePatterns: [pattern],
+              excludePackagePatterns: ['some-package'],
+              automerge: true,
+            },
+          ],
+        },
+        {
+          packageRules: [
+            {
+              automerge: true,
+              matchPackageNames: ['!/some-package/'],
+            },
+          ],
+        },
+      );
+    },
+  );
+
+  it.each`
+    pattern
+    ${'*'}
+    ${'**'}
+    ${'!*'}
+    ${'!**'}
+  `(
+    'should migrate excludePackagePatterns $pattern to a negative match-all matcher',
+    async ({ pattern }) => {
+      await expect(PackageRulesMigration).toMigrate(
+        {
+          packageRules: [
+            {
+              packagePatterns: ['some-package'],
+              excludePackagePatterns: [pattern],
+              automerge: true,
+            },
+          ],
+        },
+        {
+          packageRules: [
+            {
+              automerge: true,
+              matchPackageNames: ['!**'],
+            },
+          ],
+        },
+      );
+    },
+  );
+
+  it('should normalize matchPackageNames containing match-all patterns', async () => {
+    await expect(PackageRulesMigration).toMigrate(
+      {
+        packageRules: [
+          {
+            matchPackageNames: ['*', '!/some-package/'],
+            automerge: true,
+          },
+          {
+            matchPackageNames: ['**', 'some-package'],
+            automerge: true,
+          },
+          {
+            matchPackageNames: ['!*', 'some-package'],
+            automerge: true,
+          },
+          {
+            matchPackageNames: ['!**', 'some-package'],
+            automerge: true,
+          },
+        ],
+      },
+      {
+        packageRules: [
+          {
+            matchPackageNames: ['!/some-package/'],
+            automerge: true,
+          },
+          {
+            matchPackageNames: ['**'],
+            automerge: true,
+          },
+          {
+            matchPackageNames: ['!*', 'some-package'],
+            automerge: true,
+          },
+          {
+            matchPackageNames: ['!**'],
+            automerge: true,
+          },
+        ],
+      },
+    );
+  });
+
+  it('should normalize regex-or-glob package rule matchers containing match-all patterns', async () => {
+    await expect(PackageRulesMigration).toMigrate(
+      {
+        packageRules: [
+          {
+            matchManagers: ['*', 'npm'],
+            matchDatasources: ['*', '!docker'],
+            matchRepositories: ['!**', 'renovatebot/renovate'],
+            matchSourceUrls: ['**', '!https://github.com/renovatebot/renovate'],
+            automerge: true,
+          },
+        ],
+      },
+      {
+        packageRules: [
+          {
+            matchManagers: ['*'],
+            matchDatasources: ['!docker'],
+            matchRepositories: ['!**'],
+            matchSourceUrls: ['!https://github.com/renovatebot/renovate'],
+            automerge: true,
+          },
+        ],
+      },
+    );
+  });
+
+  it('should migrate match-all dep patterns to matchDepNames', async () => {
+    await expect(PackageRulesMigration).toMigrate(
+      {
+        packageRules: [
+          {
+            matchDepPatterns: ['*'],
+            excludeDepPatterns: ['some-dep'],
+            automerge: true,
+          },
+          {
+            matchDepPatterns: ['some-dep'],
+            excludeDepPatterns: ['**'],
+            automerge: true,
+          },
+          {
+            matchDepPatterns: ['some-dep'],
+            excludeDepPatterns: ['!*'],
+            automerge: true,
+          },
+        ],
+      },
+      {
+        packageRules: [
+          {
+            matchDepNames: ['!/some-dep/'],
+            automerge: true,
+          },
+          {
+            matchDepNames: ['!**'],
+            automerge: true,
+          },
+          {
+            matchDepNames: ['!**'],
+            automerge: true,
+          },
+        ],
+      },
+    );
+  });
+
+  it('should migrate excludeRepositories to matchRepositories', async () => {
+    await expect(PackageRulesMigration).toMigrate(
+      {
+        packageRules: [
+          {
+            excludeRepositories: ['renovatebot/renovate'],
+            automerge: true,
+          },
+        ],
+      },
+      {
+        packageRules: [
+          {
+            automerge: true,
+            matchRepositories: ['!renovatebot/renovate'],
+          },
+        ],
+      },
+    );
+  });
+
   it('should migrate all match/exclude when value is of type string', async () => {
     await expect(PackageRulesMigration).toMigrate(
       {

--- a/lib/config/migrations/custom/package-rules-migration.ts
+++ b/lib/config/migrations/custom/package-rules-migration.ts
@@ -19,6 +19,88 @@ export const renameMap = {
 };
 type RenameMapKey = keyof typeof renameMap;
 
+const positiveMatchAllMatchers = new Set(['*', '**']);
+const legacyMatchAllPatterns = new Set(['*', '**', '!*', '!**']);
+const negativeMatchAllMatchers = new Set(['!**']);
+const regexOrGlobPackageRuleMatchers = [
+  'matchBaseBranches',
+  'matchCategories',
+  'matchDatasources',
+  'matchDepNames',
+  'matchDepTypes',
+  'matchFileNames',
+  'matchManagers',
+  'matchPackageNames',
+  'matchRegistryUrls',
+  'matchRepositories',
+  'matchSourceUrls',
+  'matchUpdateTypes',
+] satisfies (keyof PackageRule)[];
+
+function isPositiveMatchAll(matcher: string): boolean {
+  return positiveMatchAllMatchers.has(matcher);
+}
+
+function isNegativeMatchAll(matcher: string): boolean {
+  return negativeMatchAllMatchers.has(matcher);
+}
+
+function migratePattern(pattern: string): string {
+  if (legacyMatchAllPatterns.has(pattern)) {
+    return '*';
+  }
+  return `/${pattern}/`;
+}
+
+function migrateExcludePattern(pattern: string): string {
+  if (legacyMatchAllPatterns.has(pattern)) {
+    return '!**';
+  }
+  return `!/${pattern}/`;
+}
+
+function migrateExcludePatterns(patterns: string[]): string[] {
+  const matchers: string[] = [];
+  for (const pattern of patterns) {
+    matchers.push(migrateExcludePattern(pattern));
+  }
+  return matchers;
+}
+
+function normalizeMatchers(matchers: string[]): string[] {
+  const negativeMatchAll = matchers.find(isNegativeMatchAll);
+  if (negativeMatchAll) {
+    return [negativeMatchAll];
+  }
+
+  const positiveMatchAll = matchers.find(isPositiveMatchAll);
+  if (!positiveMatchAll) {
+    return matchers;
+  }
+
+  const negativeMatchers = matchers.filter((matcher) =>
+    matcher.startsWith('!'),
+  );
+  if (negativeMatchers.length) {
+    return negativeMatchers;
+  }
+
+  return [positiveMatchAll];
+}
+
+function normalizeRegexOrGlobMatchers(packageRule: PackageRule): PackageRule {
+  const newPackageRule = { ...packageRule };
+
+  for (const key of regexOrGlobPackageRuleMatchers) {
+    const matchers = newPackageRule[key];
+    if (isArray(matchers, isString)) {
+      Object.assign(newPackageRule, { [key]: normalizeMatchers(matchers) });
+    }
+  }
+
+  return newPackageRule;
+}
+
 function renameKeys(packageRule: PackageRule): PackageRule {
   const newPackageRule: PackageRule = {};
   for (const [key, val] of Object.entries(packageRule)) {
@@ -47,7 +129,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
         newPackageRule.matchDepNames ??= [];
-        newPackageRule.matchDepNames.push(...patterns.map((v) => `/${v}/`));
+        newPackageRule.matchDepNames.push(...patterns.map(migratePattern));
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchDepPatterns;
@@ -75,8 +157,11 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
     if (key === 'excludeDepPatterns') {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
-        newPackageRule.matchDepNames ??= [];
-        newPackageRule.matchDepNames.push(...patterns.map((v) => `!/${v}/`));
+        const matchers = migrateExcludePatterns(patterns);
+        if (matchers.length) {
+          newPackageRule.matchDepNames ??= [];
+          newPackageRule.matchDepNames.push(...matchers);
+        }
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludeDepPatterns;
@@ -97,14 +182,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
         newPackageRule.matchPackageNames ??= [];
-        newPackageRule.matchPackageNames.push(
-          ...patterns.map((v) => {
-            if (v === '*') {
-              return '*';
-            }
-            return `/${v}/`;
-          }),
-        );
+        newPackageRule.matchPackageNames.push(...patterns.map(migratePattern));
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchPackagePatterns;
@@ -132,10 +210,11 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
     if (key === 'excludePackagePatterns') {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
-        newPackageRule.matchPackageNames ??= [];
-        newPackageRule.matchPackageNames.push(
-          ...patterns.map((v) => `!/${v}/`),
-        );
+        const matchers = migrateExcludePatterns(patterns);
+        if (matchers.length) {
+          newPackageRule.matchPackageNames ??= [];
+          newPackageRule.matchPackageNames.push(...matchers);
+        }
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludePackagePatterns;
@@ -163,7 +242,8 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       delete newPackageRule.excludeRepositories;
     }
   }
-  return newPackageRule;
+
+  return normalizeRegexOrGlobMatchers(newPackageRule);
 }
 
 export class PackageRulesMigration extends AbstractMigration {


### PR DESCRIPTION
## Summary
- Normalize migrated package-rule matchers that include match-all values
- Convert legacy package/dependency pattern match-all values into current matcher syntax
- Clarify the dep-pattern migration fixture to use an explicit raw regex match-all

## Validation
- mise exec -- pnpm check --all lib/config/migrations/custom/package-rules-migration.spec.ts