### PR TITLE
fix(config): normalize migrated package rule matchers

### DIFF
--- a/lib/config/migrate-validate.spec.ts
+++ b/lib/config/migrate-validate.spec.ts
@@ -53,6 +53,31 @@ describe('config/migrate-validate', () => {
       });
     });
 
+    it('validates a legacy package match-all combined with an exclusion', async () => {
+      const input = {
+        packageRules: [
+          {
+            packagePatterns: ['*'],
+            excludePackageNames: ['some-package'],
+            automerge: true,
+          },
+        ],
+      } as RenovateConfig;
+
+      const res = await migrateAndValidate(config, input);
+
+      expect(res).toEqual({
+        packageRules: [
+          {
+            automerge: true,
+            matchPackageNames: ['!some-package'],
+          },
+        ],
+        errors: [],
+        warnings: [],
+      });
+    });
+
     it('handles invalid', async () => {
       // @ts-expect-error -- invalid option
       const input: RenovateConfig = { foo: 'none' };

--- a/lib/config/migrate-validate.spec.ts
+++ b/lib/config/migrate-validate.spec.ts
@@ -37,7 +37,7 @@ describe('config/migrate-validate', () => {
             automerge: true,
           },
         ],
-      } as RenovateConfig;
+      } as unknown as RenovateConfig;
 
       const res = await migrateAndValidate(config, input);
 
@@ -62,7 +62,7 @@ describe('config/migrate-validate', () => {
             automerge: true,
           },
         ],
-      } as RenovateConfig;
+      } as unknown as RenovateConfig;
 
       const res = await migrateAndValidate(config, input);
 

--- a/lib/config/migrate-validate.spec.ts
+++ b/lib/config/migrate-validate.spec.ts
@@ -29,6 +29,30 @@ describe('config/migrate-validate', () => {
       });
     });
 
+    it('migrates a legacy dependency match-all without creating an invalid regex', async () => {
+      const input = {
+        packageRules: [
+          {
+            matchDepPatterns: ['*'],
+            automerge: true,
+          },
+        ],
+      } as RenovateConfig;
+
+      const res = await migrateAndValidate(config, input);
+
+      expect(res).toEqual({
+        packageRules: [
+          {
+            automerge: true,
+            matchDepNames: ['*'],
+          },
+        ],
+        errors: [],
+        warnings: [],
+      });
+    });
+
     it('handles invalid', async () => {
       // @ts-expect-error -- invalid option
       const input: RenovateConfig = { foo: 'none' };

--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -2,6 +2,14 @@ import type { RenovateConfig } from '../../types.ts';
 import { MigrationsService } from '../migrations-service.ts';
 import { PackageRulesMigration, renameMap } from './package-rules-migration.ts';
 
+function configWithPackageRule(
+  packageRule: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    packageRules: [{ ...packageRule, automerge: true }],
+  };
+}
+
 describe('config/migrations/custom/package-rules-migration', () => {
   it('should preserve config order', () => {
     const originalConfig: RenovateConfig = {
@@ -173,6 +181,44 @@ describe('config/migrations/custom/package-rules-migration', () => {
         ],
       },
     );
+  });
+
+  describe('legacy pattern match-all conversion', () => {
+    it.each`
+      legacyField                 | migratedField          | legacyPattern | migratedMatcher
+      ${'matchDepPatterns'}       | ${'matchDepNames'}     | ${'*'}        | ${'*'}
+      ${'matchDepPatterns'}       | ${'matchDepNames'}     | ${'^*$'}      | ${'*'}
+      ${'matchPackagePatterns'}   | ${'matchPackageNames'} | ${'^*$'}      | ${'*'}
+      ${'excludeDepPatterns'}     | ${'matchDepNames'}     | ${'*'}        | ${'!**'}
+      ${'excludeDepPatterns'}     | ${'matchDepNames'}     | ${'^*$'}      | ${'!**'}
+      ${'excludePackagePatterns'} | ${'matchPackageNames'} | ${'*'}        | ${'!**'}
+      ${'excludePackagePatterns'} | ${'matchPackageNames'} | ${'^*$'}      | ${'!**'}
+    `(
+      'migrates $legacyField pattern $legacyPattern to $migratedField matcher $migratedMatcher',
+      async ({
+        legacyField,
+        migratedField,
+        legacyPattern,
+        migratedMatcher,
+      }) => {
+        await expect(PackageRulesMigration).toMigrate(
+          configWithPackageRule({ [legacyField]: [legacyPattern] }),
+          configWithPackageRule({ [migratedField]: [migratedMatcher] }),
+        );
+      },
+    );
+
+    it('preserves an ordinary raw regex that matches every dependency', async () => {
+      await expect(PackageRulesMigration).toMigrate(
+        configWithPackageRule({
+          matchDepPatterns: ['some-dep'],
+          excludeDepPatterns: ['.*'],
+        }),
+        configWithPackageRule({
+          matchDepNames: ['/some-dep/', '!/.*/'],
+        }),
+      );
+    });
   });
 
   it('should migrate all match/exclude when value is of type string', async () => {

--- a/lib/config/migrations/custom/package-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/package-rules-migration.spec.ts
@@ -221,6 +221,179 @@ describe('config/migrations/custom/package-rules-migration', () => {
     });
   });
 
+  describe('normalizing matcher combinations introduced by migration', () => {
+    describe('direct matcher renames containing a match-all glob', () => {
+      it.each`
+        legacyField         | migratedField          | specificMatcher
+        ${'matchFiles'}     | ${'matchFileNames'}    | ${'package.json'}
+        ${'matchPaths'}     | ${'matchFileNames'}    | ${'src/**'}
+        ${'paths'}          | ${'matchFileNames'}    | ${'src/**'}
+        ${'languages'}      | ${'matchCategories'}   | ${'javascript'}
+        ${'matchLanguages'} | ${'matchCategories'}   | ${'javascript'}
+        ${'baseBranchList'} | ${'matchBaseBranches'} | ${'main'}
+        ${'managers'}       | ${'matchManagers'}     | ${'npm'}
+        ${'datasources'}    | ${'matchDatasources'}  | ${'npm'}
+        ${'depTypeList'}    | ${'matchDepTypes'}     | ${'dependencies'}
+        ${'packageNames'}   | ${'matchPackageNames'} | ${'some-package'}
+        ${'updateTypes'}    | ${'matchUpdateTypes'}  | ${'minor'}
+      `(
+        'keeps only match-all when renaming $legacyField to $migratedField',
+        async ({ legacyField, migratedField, specificMatcher }) => {
+          await expect(PackageRulesMigration).toMigrate(
+            configWithPackageRule({
+              [legacyField]: ['*', specificMatcher],
+            }),
+            configWithPackageRule({ [migratedField]: ['*'] }),
+          );
+        },
+      );
+
+      it('recognizes "**" as match-all', async () => {
+        await expect(PackageRulesMigration).toMigrate(
+          configWithPackageRule({ managers: ['**', 'npm'] }),
+          configWithPackageRule({ matchManagers: ['**'] }),
+        );
+      });
+    });
+
+    describe('positive legacy matchers merged with a modern match-all', () => {
+      it.each`
+        legacyField                 | migratedField          | legacyValue
+        ${'matchDepPrefixes'}       | ${'matchDepNames'}     | ${'some-dep'}
+        ${'matchDepPatterns'}       | ${'matchDepNames'}     | ${'some-dep'}
+        ${'matchPackagePrefixes'}   | ${'matchPackageNames'} | ${'some-package'}
+        ${'matchPackagePatterns'}   | ${'matchPackageNames'} | ${'some-package'}
+        ${'packagePatterns'}        | ${'matchPackageNames'} | ${'some-package'}
+        ${'matchSourceUrlPrefixes'} | ${'matchSourceUrls'}   | ${'https://github.com/example'}
+        ${'sourceUrlPrefixes'}      | ${'matchSourceUrls'}   | ${'https://github.com/example'}
+      `(
+        'drops the redundant $legacyField matcher from $migratedField',
+        async ({ legacyField, migratedField, legacyValue }) => {
+          await expect(PackageRulesMigration).toMigrate(
+            configWithPackageRule({
+              [migratedField]: ['*'],
+              [legacyField]: [legacyValue],
+            }),
+            configWithPackageRule({ [migratedField]: ['*'] }),
+          );
+        },
+      );
+    });
+
+    describe('legacy exclusions merged with a modern match-all', () => {
+      it.each`
+        legacyField                 | migratedField          | legacyValue             | migratedMatcher
+        ${'excludeDepNames'}        | ${'matchDepNames'}     | ${'some-dep'}           | ${'!some-dep'}
+        ${'excludeDepPrefixes'}     | ${'matchDepNames'}     | ${'some-dep'}           | ${'!some-dep{/,}**'}
+        ${'excludeDepPatterns'}     | ${'matchDepNames'}     | ${'some-dep'}           | ${'!/some-dep/'}
+        ${'excludePackageNames'}    | ${'matchPackageNames'} | ${'some-package'}       | ${'!some-package'}
+        ${'excludePackagePrefixes'} | ${'matchPackageNames'} | ${'some-package'}       | ${'!some-package{/,}**'}
+        ${'excludePackagePatterns'} | ${'matchPackageNames'} | ${'some-package'}       | ${'!/some-package/'}
+        ${'excludeRepositories'}    | ${'matchRepositories'} | ${'example/repository'} | ${'!example/repository'}
+      `(
+        'keeps the $legacyField exclusion in $migratedField',
+        async ({
+          legacyField,
+          migratedField,
+          legacyValue,
+          migratedMatcher,
+        }) => {
+          await expect(PackageRulesMigration).toMigrate(
+            configWithPackageRule({
+              [migratedField]: ['*'],
+              [legacyField]: [legacyValue],
+            }),
+            configWithPackageRule({ [migratedField]: [migratedMatcher] }),
+          );
+        },
+      );
+
+      it('recognizes "**" as match-all', async () => {
+        await expect(PackageRulesMigration).toMigrate(
+          configWithPackageRule({
+            matchPackageNames: ['**'],
+            excludePackageNames: ['some-package'],
+          }),
+          configWithPackageRule({ matchPackageNames: ['!some-package'] }),
+        );
+      });
+    });
+
+    describe('multiple legacy fields targeting the same modern matcher', () => {
+      it('normalizes package matchers only after all legacy fields are merged', async () => {
+        await expect(PackageRulesMigration).toMigrate(
+          configWithPackageRule({
+            matchPackageNames: ['*'],
+            excludePackageNames: ['some-package'],
+            packagePatterns: ['another-package'],
+          }),
+          configWithPackageRule({
+            matchPackageNames: ['!some-package'],
+          }),
+        );
+      });
+
+      it('removes a dependency match-all combined with an exclusion', async () => {
+        await expect(PackageRulesMigration).toMigrate(
+          configWithPackageRule({
+            matchDepPatterns: ['*'],
+            excludeDepPatterns: ['some-dep'],
+          }),
+          configWithPackageRule({
+            matchDepNames: ['!/some-dep/'],
+          }),
+        );
+      });
+    });
+  });
+
+  describe('migration scope and semantic preservation', () => {
+    it('preserves a negative match-all combined with a positive dependency matcher', async () => {
+      await expect(PackageRulesMigration).toMigrate(
+        configWithPackageRule({
+          matchDepPatterns: ['some-dep'],
+          excludeDepPatterns: ['*'],
+        }),
+        configWithPackageRule({
+          matchDepNames: ['/some-dep/', '!**'],
+        }),
+      );
+    });
+
+    it('leaves modern matcher fields unchanged without legacy fields', async () => {
+      const modernPackageRule = {
+        matchFileNames: ['*', 'package.json'],
+        matchCategories: ['*', 'javascript'],
+        matchBaseBranches: ['*', 'main'],
+        matchPackageNames: ['*', '!some-package'],
+        matchManagers: ['*', 'npm'],
+        matchDatasources: ['*', 'npm'],
+        matchDepTypes: ['*', 'dependencies'],
+        matchUpdateTypes: ['*', 'minor'],
+        matchDepNames: ['**', 'some-dep'],
+        matchSourceUrls: ['**', 'https://github.com/example'],
+        matchRepositories: ['**', 'example/repository'],
+      };
+
+      await expect(PackageRulesMigration).toMigrate(
+        configWithPackageRule(modernPackageRule),
+        configWithPackageRule(structuredClone(modernPackageRule)),
+        false,
+      );
+    });
+
+    it('migrates a standalone repository exclusion', async () => {
+      await expect(PackageRulesMigration).toMigrate(
+        configWithPackageRule({
+          excludeRepositories: ['renovatebot/renovate'],
+        }),
+        configWithPackageRule({
+          matchRepositories: ['!renovatebot/renovate'],
+        }),
+      );
+    });
+  });
+
   it('should migrate all match/exclude when value is of type string', async () => {
     await expect(PackageRulesMigration).toMigrate(
       {

--- a/lib/config/migrations/custom/package-rules-migration.ts
+++ b/lib/config/migrations/custom/package-rules-migration.ts
@@ -19,6 +19,22 @@ export const renameMap = {
 };
 type RenameMapKey = keyof typeof renameMap;
 
+const legacyMatchAllPatterns = new Set(['*', '^*$']);
+
+function migratePattern(pattern: string): string {
+  if (legacyMatchAllPatterns.has(pattern)) {
+    return '*';
+  }
+  return `/${pattern}/`;
+}
+
+function migrateExcludePattern(pattern: string): string {
+  if (legacyMatchAllPatterns.has(pattern)) {
+    return '!**';
+  }
+  return `!/${pattern}/`;
+}
+
 function renameKeys(packageRule: PackageRule): PackageRule {
   const newPackageRule: PackageRule = {};
   for (const [key, val] of Object.entries(packageRule)) {
@@ -47,7 +63,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
         newPackageRule.matchDepNames ??= [];
-        newPackageRule.matchDepNames.push(...patterns.map((v) => `/${v}/`));
+        newPackageRule.matchDepNames.push(...patterns.map(migratePattern));
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchDepPatterns;
@@ -76,7 +92,9 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
         newPackageRule.matchDepNames ??= [];
-        newPackageRule.matchDepNames.push(...patterns.map((v) => `!/${v}/`));
+        newPackageRule.matchDepNames.push(
+          ...patterns.map(migrateExcludePattern),
+        );
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludeDepPatterns;
@@ -97,14 +115,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       // v8 ignore else -- TODO: add test #40625
       if (isArray(patterns, isString)) {
         newPackageRule.matchPackageNames ??= [];
-        newPackageRule.matchPackageNames.push(
-          ...patterns.map((v) => {
-            if (v === '*') {
-              return '*';
-            }
-            return `/${v}/`;
-          }),
-        );
+        newPackageRule.matchPackageNames.push(...patterns.map(migratePattern));
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchPackagePatterns;
@@ -134,7 +145,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchPackageNames ??= [];
         newPackageRule.matchPackageNames.push(
-          ...patterns.map((v) => `!/${v}/`),
+          ...patterns.map(migrateExcludePattern),
         );
       }
       // @ts-expect-error -- TODO: fix me

--- a/lib/config/migrations/custom/package-rules-migration.ts
+++ b/lib/config/migrations/custom/package-rules-migration.ts
@@ -35,17 +35,42 @@ function migrateExcludePattern(pattern: string): string {
   return `!/${pattern}/`;
 }
 
+function normalizeMigratedMatchers(matchers: string[]): string[] {
+  const matchAll = matchers.find(
+    (matcher) => matcher === '*' || matcher === '**',
+  );
+  if (!matchAll) {
+    return matchers;
+  }
+
+  const negativeMatchers = matchers.filter((matcher) =>
+    matcher.startsWith('!'),
+  );
+  return negativeMatchers.length ? negativeMatchers : [matchAll];
+}
+
 function renameKeys(packageRule: PackageRule): PackageRule {
   const newPackageRule: PackageRule = {};
   for (const [key, val] of Object.entries(packageRule)) {
+    const renamedKey = renameMap[key as RenameMapKey];
+    const renamedValue =
+      renamedKey &&
+      renamedKey !== 'matchPackagePatterns' &&
+      renamedKey !== 'matchSourceUrlPrefixes' &&
+      isArray(val, isString)
+        ? normalizeMigratedMatchers(val)
+        : val;
     // @ts-expect-error -- TODO: fix me
-    newPackageRule[renameMap[key as RenameMapKey] ?? key] = val;
+    newPackageRule[renamedKey ?? key] = renamedValue;
   }
   return newPackageRule;
 }
 
 function mergeMatchers(packageRule: PackageRule): PackageRule {
   const newPackageRule: PackageRule = { ...packageRule };
+  let migratedDepMatchers = false;
+  let migratedPackageMatchers = false;
+
   for (const [key, val] of Object.entries(packageRule)) {
     const patterns = isString(val) ? [val] : val;
 
@@ -55,6 +80,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchDepNames ??= [];
         newPackageRule.matchDepNames.push(...patterns.map((v) => `${v}{/,}**`));
+        migratedDepMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchDepPrefixes;
@@ -64,6 +90,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchDepNames ??= [];
         newPackageRule.matchDepNames.push(...patterns.map(migratePattern));
+        migratedDepMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchDepPatterns;
@@ -73,6 +100,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchDepNames ??= [];
         newPackageRule.matchDepNames.push(...patterns.map((v) => `!${v}`));
+        migratedDepMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludeDepNames;
@@ -84,6 +112,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchDepNames.push(
           ...patterns.map((v) => `!${v}{/,}**`),
         );
+        migratedDepMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludeDepPrefixes;
@@ -95,6 +124,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchDepNames.push(
           ...patterns.map(migrateExcludePattern),
         );
+        migratedDepMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludeDepPatterns;
@@ -107,6 +137,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchPackageNames.push(
           ...patterns.map((v) => `${v}{/,}**`),
         );
+        migratedPackageMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchPackagePrefixes;
@@ -116,6 +147,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchPackageNames ??= [];
         newPackageRule.matchPackageNames.push(...patterns.map(migratePattern));
+        migratedPackageMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchPackagePatterns;
@@ -125,6 +157,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchPackageNames ??= [];
         newPackageRule.matchPackageNames.push(...patterns.map((v) => `!${v}`));
+        migratedPackageMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludePackageNames;
@@ -136,6 +169,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchPackageNames.push(
           ...patterns.map((v) => `!${v}{/,}**`),
         );
+        migratedPackageMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludePackagePrefixes;
@@ -147,6 +181,7 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchPackageNames.push(
           ...patterns.map(migrateExcludePattern),
         );
+        migratedPackageMatchers = true;
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludePackagePatterns;
@@ -159,6 +194,9 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
         newPackageRule.matchSourceUrls.push(
           ...patterns.map((v) => `${v}{/,}**`),
         );
+        newPackageRule.matchSourceUrls = normalizeMigratedMatchers(
+          newPackageRule.matchSourceUrls,
+        );
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.matchSourceUrlPrefixes;
@@ -169,11 +207,26 @@ function mergeMatchers(packageRule: PackageRule): PackageRule {
       if (isArray(patterns, isString)) {
         newPackageRule.matchRepositories ??= [];
         newPackageRule.matchRepositories.push(...patterns.map((v) => `!${v}`));
+        newPackageRule.matchRepositories = normalizeMigratedMatchers(
+          newPackageRule.matchRepositories,
+        );
       }
       // @ts-expect-error -- TODO: fix me
       delete newPackageRule.excludeRepositories;
     }
   }
+
+  if (migratedDepMatchers) {
+    newPackageRule.matchDepNames = normalizeMigratedMatchers(
+      newPackageRule.matchDepNames!,
+    );
+  }
+  if (migratedPackageMatchers) {
+    newPackageRule.matchPackageNames = normalizeMigratedMatchers(
+      newPackageRule.matchPackageNames!,
+    );
+  }
+
   return newPackageRule;
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This addresses https://github.com/renovatebot/renovate/discussions/43936.

In summary, the current matcher normalization causes some configurations to fail when evaluated against the recently tightened matcher validations.
This changes the normalization of matchers to comply with the new requirements.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
