### PR TITLE
fix(cache): send TLS SNI when connecting to rediss:// package cache

### DIFF
--- a/lib/util/cache/package/impl/redis.spec.ts
+++ b/lib/util/cache/package/impl/redis.spec.ts
@@ -72,6 +72,46 @@ describe('util/cache/package/impl/redis', () => {
         );
       });
 
+      it('sets socket.servername for rediss:// with a hostname', async () => {
+        await PackageCacheRedis.create('rediss://cache.example.com:6380', '');
+
+        expect(createClient).toHaveBeenCalledWith(
+          expect.objectContaining({
+            socket: expect.objectContaining({
+              servername: 'cache.example.com',
+            }),
+          }),
+        );
+      });
+
+      it('does not set socket.servername for rediss:// with an IPv4 address', async () => {
+        await PackageCacheRedis.create('rediss://127.0.0.1:6380', '');
+
+        const [config] = vi.mocked(createClient).mock.calls[0];
+        expect(config?.socket).not.toHaveProperty('servername');
+      });
+
+      it('does not set socket.servername for rediss:// with an IPv6 address', async () => {
+        await PackageCacheRedis.create('rediss://[::1]:6380', '');
+
+        const [config] = vi.mocked(createClient).mock.calls[0];
+        expect(config?.socket).not.toHaveProperty('servername');
+      });
+
+      it('does not set socket.servername for redis:// (non-TLS)', async () => {
+        await PackageCacheRedis.create('redis://cache.example.com:6379', '');
+
+        const [config] = vi.mocked(createClient).mock.calls[0];
+        expect(config?.socket).not.toHaveProperty('servername');
+      });
+
+      it('does not set socket.servername when URL cannot be parsed', async () => {
+        await PackageCacheRedis.create('not-a-valid-url', '');
+
+        const [config] = vi.mocked(createClient).mock.calls[0];
+        expect(config?.socket).not.toHaveProperty('servername');
+      });
+
       it('initializes cluster client', async () => {
         await PackageCacheRedis.create('redis+cluster://host', '');
 

--- a/lib/util/cache/package/impl/redis.ts
+++ b/lib/util/cache/package/impl/redis.ts
@@ -1,3 +1,4 @@
+import { isIP } from 'node:net';
 import type { RedisClusterOptions } from '@redis/client';
 import { RESP_TYPES, createClient, createCluster } from '@redis/client';
 import { logger } from '../../../../logger/index.ts';
@@ -29,10 +30,16 @@ export class PackageCacheRedis extends PackageCacheBase {
     const rewrittenUrl = normalizeRedisUrl(url);
     const clusteredMode = rewrittenUrl !== url;
 
+    const parsedUrl = parseUrl(rewrittenUrl);
+    const rawHostname =
+      parsedUrl?.hostname.replace(regEx(/^\[(.+)\]$/), '$1') ?? '';
     const config = {
       url: rewrittenUrl,
       socket: {
         reconnectStrategy: (retries: number) => Math.min(retries * 100, 3000),
+        ...(parsedUrl?.protocol === 'rediss:' && !isIP(rawHostname)
+          ? { servername: parsedUrl.hostname }
+          : {}),
       },
       pingInterval: 30000,
     };
@@ -42,7 +49,6 @@ export class PackageCacheRedis extends PackageCacheBase {
     if (clusteredMode) {
       const clusterConfig: RedisClusterOptions = { rootNodes: [config] };
 
-      const parsedUrl = parseUrl(rewrittenUrl);
       if (parsedUrl?.username) {
         clusterConfig.defaults = {
           username: parsedUrl.username,


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

On Node.js, `tls.connect({host})` does not automatically set the SNI servername from the host. `@redis/client` spreads caller socket options directly into `tls.connect` without injecting `servername`, so a plain `createClient({url: 'rediss://...'})` sends no SNI.

On SNI-routed endpoints (e.g. Aiven Privatelink, where many hostnames share a single IP:port), the TLS handshake is rejected and the client gets `ECONNRESET before secure TLS connection was established`.

Fix: set `socket.servername` to the URL hostname when the scheme is `rediss:` and the hostname is not an IP literal (RFC 6066 forbids IP addresses in SNI). Bracketed IPv6 literals (`[::1]`) are correctly excluded by stripping the brackets before the `isIP` check.

The `parsedUrl` call is hoisted above the config object so the cluster path can reuse it without a second parse. Placing `servername` in `config.socket` means it is also passed to cluster `rootNodes`; note that dynamically-discovered cluster nodes may still lack per-node SNI (out of scope for this fix).

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44461 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: not a public repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
