### PR TITLE
fix(gomod): pseudo-version digest updates produce no change when module is absent from go proxy

### DIFF
--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -400,6 +400,33 @@ describe('modules/manager/gomod/update', () => {
       expect(res).not.toContain('knative.dev/pkg 4a022ed9999a');
     });
 
+    it('falls back to bare hash when newValue equals currentValue', () => {
+      const fileContent = codeBlock`
+        module example.com/test
+        require (
+          example.private.com/org/module v0.0.0-20250312035536-b7bbf4be5dbd
+        )
+      `;
+      const upgrade = {
+        depName: 'example.private.com/org/module',
+        managerData: { lineNumber: 2, multiLine: true },
+        updateType: 'digest' as const,
+        currentValue: 'v0.0.0-20250312035536-b7bbf4be5dbd',
+        currentDigest: 'b7bbf4be5dbd',
+        newValue: 'v0.0.0-20250312035536-b7bbf4be5dbd',
+        newDigest: '4a022ed9999a',
+        depType: 'require',
+      };
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'go.mod',
+        upgrade,
+      });
+      // Should fall back to bare hash since newValue === currentValue
+      expect(res).toContain('example.private.com/org/module 4a022ed9999a');
+      expect(res).not.toContain('b7bbf4be5dbd');
+    });
+
     it('handles multiline mismatch', () => {
       const upgrade = {
         depName: 'github.com/fatih/color',

--- a/lib/modules/manager/gomod/update.spec.ts
+++ b/lib/modules/manager/gomod/update.spec.ts
@@ -422,7 +422,6 @@ describe('modules/manager/gomod/update', () => {
         packageFile: 'go.mod',
         upgrade,
       });
-      // Should fall back to bare hash since newValue === currentValue
       expect(res).toContain('example.private.com/org/module 4a022ed9999a');
       expect(res).not.toContain('b7bbf4be5dbd');
     });

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -83,7 +83,13 @@ export function updateDependency({
       // Since the 2024 goproxy datasource changes, newValue and newDigest are
       // both extracted from the same proxy version string and always reference
       // the same commit, so newValue can be written directly for pseudo-versions.
-      if (upgrade.newValue?.startsWith('v0.0.0-')) {
+      // However, for private modules (GONOPROXY / direct datasource), the proxy
+      // has no data and newValue may equal currentValue. In that case, fall
+      // through to the bare hash path so that gomodTidy can resolve it.
+      if (
+        upgrade.newValue?.startsWith('v0.0.0-') &&
+        upgrade.newValue !== upgrade.currentValue
+      ) {
         logger.debug(
           { depName: currentName, lineToChange, newValue: upgrade.newValue },
           'gomod: updating pseudo-version digest',
@@ -94,10 +100,10 @@ export function updateDependency({
           `$<depPart>$<divider>${upgrade.newValue}`,
         );
       } else {
-        // Defensive fallback for non-pseudo-version digest updates.
-        // Unreachable for gomod in practice: currentDigest is only extracted
-        // for pseudo-versions, and the gomod override in lookup/index.ts that
-        // sets updateType='digest' requires newValue to start with 'v0.0.0-'.
+        // Fallback for private modules where the proxy could not resolve a new
+        // pseudo-version, or non-pseudo-version digest updates.
+        // Writes the bare hash so that postUpdateOptions like gomodTidy can
+        // normalize it into a valid pseudo-version via `go get`.
         const newDigestRightSized = upgrade.newDigest!.substring(
           0,
           upgrade.currentDigest!.length,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Since Renovate version 43.167.0 (which includes PR https://github.com/renovatebot/renovate/pull/41588), digest updates for Go modules with pseudo-versions no longer produce file changes, if the repository is unavailable in the goproxy (for example repos on github enterprise instances, private repositories, etc).
The update process detects a newer commit, but only for newDigest.
The lookup for the new commit on proxy.golang.org fails, which causes upgrade.newValue in gomod.update to be equal to the current (old) value.

However, since current value is a pseudo-version, the version starts with v0.0.0-and gomod.update goes into the new [code path](https://github.com/renovatebot/renovate/pull/41588/changes#diff-151b09eb827bff39ad60faf8e7dee58cc94ce8732d3d9a1079a2e85d793b3b8bR86)

      if (upgrade.newValue?.startsWith('v0.0.0-')) {
added by the above PR, but since newVersion is the old version, no file changes occur.

This PR ensures the old behavior is triggered, if newValue and oldValue are identical, which handles the case where goproxy is unavailable.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44455 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
  I used claude opus for the writing the test and the code change, but did some manual edits.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
