### PR TITLE
refactor(util): decouple Result from Zod

### DIFF
--- a/docs/development/zod.md
+++ b/docs/development/zod.md
@@ -353,15 +353,16 @@ It supports the `.transform()` method, which is similar to Zod's, and `.onValue(
 
 After all result manipulations are done, call `.unwrap()`, `.unwrapOr()` or `.unwrapOrThrow()` to get the underlying result value.
 
-`Result` is validator-agnostic through its structural `SafeParser` interface. Every Zod schema implements this interface, so use `Result.parse(input, schema)` or `.parse(schema)` as the explicit bridge between schema validation and a result chain:
+`Result` is validator-agnostic through its structural `SafeParser` interface. Every Zod schema with non-nullish output implements this interface, so use `Result.parse(input, schema)` or `.parse(schema)` as the explicit bridge between schema validation and a result chain:
 
 ```ts
-const { val, err } = Result.parse(url, z.url())
+const { val, err } = await Result.parse(url, z.url())
   .transform((url) => http.get(url))
   .onError((err) => {
     logger.warn({ err }, 'Failed to fetch something important');
   })
-  .transform((res) => res.body);
+  .transform((res) => res.body)
+  .unwrap();
 ```
 
 Schemas passed to `Result.parse()` must produce non-nullish output. Chain `.transform(nonNullish)` after optional-field extractors to convert absent output into a parse error.

--- a/docs/development/zod.md
+++ b/docs/development/zod.md
@@ -349,16 +349,14 @@ Release.parse('{"version":"1.0.0","releaseTimestamp":null}');
 
 The `Result` (and `AsyncResult`) class represents the result of an operation, like `Result.ok(200)` or `Result.err(404)`.
 
-It supports the `.transform()` method, which is similar to `zod`'s.
+It supports the `.transform()` method, which is similar to Zod's, and `.onValue()` and `.onError()` methods for side-effectful result inspection.
 
-It also supports `.onResult()` and `.onError()` methods for side-effectful result inspection.
+After all result manipulations are done, call `.unwrap()`, `.unwrapOr()` or `.unwrapOrThrow()` to get the underlying result value.
 
-After all result manipulations are done, you may call `.unwrap()`, `.unwrapOrElse()` or `.unwrapOrThrow()` methods to get the underlying result value.
-
-You can wrap the schema parsing result into the `Result` class:
+`Result` is validator-agnostic through its structural `SafeParser` interface. Every Zod schema implements this interface, so use `Result.parse(input, schema)` or `.parse(schema)` as the explicit bridge between schema validation and a result chain:
 
 ```ts
-const { val, err } = Result.parse(url, z.string().url())
+const { val, err } = Result.parse(url, z.url())
   .transform((url) => http.get(url))
   .onError((err) => {
     logger.warn({ err }, 'Failed to fetch something important');
@@ -366,15 +364,20 @@ const { val, err } = Result.parse(url, z.string().url())
   .transform((res) => res.body);
 ```
 
-You can use schema parsing in the middle of the `Result` transform chain:
+Schemas passed to `Result.parse()` must produce non-nullish output. Chain `.transform(nonNullish)` after optional-field extractors to convert absent output into a parse error.
+
+You can also parse in the middle of an asynchronous result chain:
 
 ```ts
 const UserConfig = z.object({
   /* ... */
 });
 
-const config = await Result.wrap(readLocalFile('config.json'))
-  .transform((content) => Json.pipe(UserConfig).safeParse(content))
+const config = await Result.wrapNullable(
+  readLocalFile('config.json'),
+  new Error('config file not found'),
+)
+  .parse(Json.pipe(UserConfig))
   .unwrapOrThrow();
 ```
 
@@ -408,5 +411,5 @@ const users = await http
   .onError((err) => {
     logger.warn({ err }, 'Failed to fetch users');
   })
-  .unwrapOrElse([]);
+  .unwrapOr([]);
 ```

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -136,7 +136,7 @@ export class RubygemsDatasource extends Datasource {
     const url = `${path}?${query}`;
     const bufPromise = this.http.getBuffer(url);
     return Result.wrap(bufPromise).transform(({ body }) =>
-      MarshalledVersionInfo.safeParse(Marshal.parse(body)),
+      Result.parse(Marshal.parse(body), MarshalledVersionInfo),
     );
   }
 }

--- a/lib/modules/manager/pixi/extract.ts
+++ b/lib/modules/manager/pixi/extract.ts
@@ -5,6 +5,7 @@ import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getSiblingFileName, localPathExists } from '../../../util/fs/index.ts';
 import { Result } from '../../../util/result.ts';
+import { nonNullish } from '../../../util/schema-utils/index.ts';
 import {
   ensureTrailingSlash,
   isHttpUrl,
@@ -50,7 +51,10 @@ export function getUserPixiConfig(
 
   const { val, err } = Result.parse(
     content,
-    z.union([PixiFile, PixiPyProject.transform((p) => p.tool?.pixi)]),
+    z.union([
+      PixiFile,
+      PixiPyProject.transform((p) => p.tool?.pixi).transform(nonNullish),
+    ]),
   ).unwrap();
 
   if (err) {

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -16,6 +16,7 @@ import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
 import { find } from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
 import { Result } from '../../../util/result.ts';
+import { nonNullish } from '../../../util/schema-utils/index.ts';
 import {
   massage as massageToml,
   parse as parseToml,
@@ -38,7 +39,7 @@ export function getPythonConstraint(
       ({ packageFileContent }) =>
         packageFileContent.deps.find((dep) => dep.depName === 'python')
           ?.currentValue,
-    ),
+    ).transform(nonNullish),
   ).unwrapOrNull();
   if (pyprojectPythonConstraint) {
     logger.debug('Using python version from pyproject.toml');
@@ -47,7 +48,9 @@ export function getPythonConstraint(
 
   const lockfilePythonConstraint = Result.parse(
     existingLockFileContent,
-    Lockfile.transform(({ pythonVersions }) => pythonVersions),
+    Lockfile.transform(({ pythonVersions }) => pythonVersions).transform(
+      nonNullish,
+    ),
   ).unwrapOrNull();
   if (lockfilePythonConstraint) {
     logger.debug('Using python version from poetry.lock');
@@ -74,7 +77,9 @@ export function getPoetryRequirement(
 
   const { val: lockfilePoetryConstraint } = Result.parse(
     existingLockFileContent,
-    Lockfile.transform(({ poetryConstraint }) => poetryConstraint),
+    Lockfile.transform(({ poetryConstraint }) => poetryConstraint).transform(
+      nonNullish,
+    ),
   ).unwrap();
   if (lockfilePoetryConstraint) {
     logger.debug(
@@ -85,7 +90,9 @@ export function getPoetryRequirement(
 
   const { val: pyprojectPoetryConstraint } = Result.parse(
     massageToml(pyProjectContent),
-    PoetryPyProject.transform(({ poetryRequirement }) => poetryRequirement),
+    PoetryPyProject.transform(
+      ({ poetryRequirement }) => poetryRequirement,
+    ).transform(nonNullish),
   ).unwrap();
   if (pyprojectPoetryConstraint) {
     logger.debug(

--- a/lib/modules/manager/poetry/update-locked.spec.ts
+++ b/lib/modules/manager/poetry/update-locked.spec.ts
@@ -32,7 +32,19 @@ describe('modules/manager/poetry/update-locked', () => {
     expect(updateLockedDependency(config).status).toBe('unsupported');
   });
 
-  it('returns unsupported for mising locked content', () => {
+  it('returns unsupported for missing dependency', () => {
+    const config: UpdateLockedConfig = {
+      packageFile,
+      lockFile,
+      lockFileContent,
+      depName: 'missing',
+      newVersion: '1.0.0',
+      currentVersion: '0.9.0',
+    };
+    expect(updateLockedDependency(config).status).toBe('unsupported');
+  });
+
+  it('returns unsupported for missing locked content', () => {
     const config: UpdateLockedConfig = {
       packageFile,
       lockFile,

--- a/lib/modules/manager/poetry/update-locked.ts
+++ b/lib/modules/manager/poetry/update-locked.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../../logger/index.ts';
 import { Result } from '../../../util/result.ts';
+import { nonNullish } from '../../../util/schema-utils/index.ts';
 import type { UpdateLockedConfig, UpdateLockedResult } from '../types.ts';
 import { Lockfile } from './schema.ts';
 
@@ -12,7 +13,9 @@ export function updateLockedDependency(
     `poetry.updateLockedDependency: ${depName}@${currentVersion} -> ${newVersion} [${lockFile}]`,
   );
 
-  const LockedVersion = Lockfile.transform(({ lock }) => lock[depName]);
+  const LockedVersion = Lockfile.transform(
+    ({ lock }) => lock[depName],
+  ).transform(nonNullish);
   return Result.parse(lockFileContent, LockedVersion)
     .transform(
       (lockedVersion): UpdateLockedResult =>

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -219,6 +219,27 @@ describe('util/result', () => {
         );
       });
 
+      it('preserves uncaught errors through chained transforms', () => {
+        const error = new Error('oops');
+        const handler = vi.fn(() => Result.ok(0));
+        const result = Result.ok(42)
+          .transform((): number => {
+            throw error;
+          })
+          .transform((value) => value + 1)
+          .catch(handler);
+
+        let thrown: unknown;
+        try {
+          result.unwrap();
+        } catch (err) {
+          thrown = err;
+        }
+
+        expect(thrown).toBe(error);
+        expect(handler).not.toHaveBeenCalled();
+      });
+
       it('parses values explicitly in transform chains', () => {
         const schema = z.string().transform((x) => x.toUpperCase());
         const res = Result.ok('foo').parse(schema);

--- a/lib/util/result.spec.ts
+++ b/lib/util/result.spec.ts
@@ -4,7 +4,17 @@
 
 import { z } from 'zod/v4';
 import { logger } from '~test/util.ts';
-import { AsyncResult, Result } from './result.ts';
+import { AsyncResult, Result, type SafeParser } from './result.ts';
+
+function assertTypes(): void {
+  // @ts-expect-error - schemas with nullable output are rejected
+  Result.parse('foo', z.string().nullable());
+  // @ts-expect-error - raw safeParse results must go through .parse()
+  Result.ok('foo').transform((x) => z.string().safeParse(x));
+  // @ts-expect-error - unwrapOrThrow requires an Error-typed channel
+  Result.err('oops' as const).unwrapOrThrow();
+}
+void assertTypes;
 
 describe('util/result', () => {
   describe('Result', () => {
@@ -72,15 +82,6 @@ describe('util/result', () => {
         expect(res).toEqual(Result.err('oops'));
       });
 
-      it('distincts between null and undefined callback results', () => {
-        expect(Result.wrapNullable(() => null, 'null', 'undefined')).toEqual(
-          Result.err('null'),
-        );
-        expect(
-          Result.wrapNullable(() => undefined, 'null', 'undefined'),
-        ).toEqual(Result.err('undefined'));
-      });
-
       it('handles nullable callback error', () => {
         const res = Result.wrapNullable(() => {
           throw 'oops';
@@ -101,16 +102,6 @@ describe('util/result', () => {
       it('wraps nullable value undefined', () => {
         const res = Result.wrapNullable(undefined, 'oops');
         expect(res).toEqual(Result.err('oops'));
-      });
-
-      it('wraps zod parse result', () => {
-        const schema = z.string().transform((x) => x.toUpperCase());
-        expect(Result.wrap(schema.safeParse('foo'))).toEqual(Result.ok('FOO'));
-        expect(Result.wrap(schema.safeParse(42))).toMatchObject(
-          Result.err({
-            issues: [{ code: 'invalid_type', expected: 'string' }],
-          }),
-        );
       });
     });
 
@@ -169,8 +160,9 @@ describe('util/result', () => {
       });
 
       it('throws error for unwrapOrThrow on error result', () => {
-        const res = Result.err('oops');
-        expect(() => res.unwrapOrThrow()).toThrow('oops');
+        const error = new Error('oops');
+        const res = Result.err(error);
+        expect(() => res.unwrapOrThrow()).toThrow(error);
       });
 
       it('unwrapOrNull returns value for ok-result', () => {
@@ -227,9 +219,9 @@ describe('util/result', () => {
         );
       });
 
-      it('automatically converts zod values', () => {
+      it('parses values explicitly in transform chains', () => {
         const schema = z.string().transform((x) => x.toUpperCase());
-        const res = Result.ok('foo').transform((x) => schema.safeParse(x));
+        const res = Result.ok('foo').parse(schema);
         expect(res).toEqual(Result.ok('FOO'));
       });
     });
@@ -238,7 +230,6 @@ describe('util/result', () => {
       it('bypasses ok result', () => {
         const res = Result.ok(42);
         expect(res.catch(() => Result.ok(0))).toEqual(Result.ok(42));
-        expect(res.catch(() => Result.ok(0))).toBe(res);
       });
 
       it('bypasses uncaught transform errors', () => {
@@ -246,7 +237,6 @@ describe('util/result', () => {
           throw 'oops';
         });
         expect(res.catch(() => Result.ok(0))).toEqual(Result._uncaught('oops'));
-        expect(res.catch(() => Result.ok(0))).toBe(res);
       });
 
       it('converts error to Result', () => {
@@ -264,12 +254,9 @@ describe('util/result', () => {
     });
 
     describe('Parsing', () => {
-      it('parses Zod schema', () => {
-        const schema = z
-          .string()
-          .transform((x) => x.toUpperCase())
-          .nullish();
+      const schema = z.string().transform((x) => x.toUpperCase());
 
+      it('parses a schema', () => {
         expect(Result.parse('foo', schema)).toEqual(Result.ok('FOO'));
 
         expect(Result.parse(42, schema).unwrap()).toMatchObject({
@@ -281,34 +268,37 @@ describe('util/result', () => {
             ]),
           }),
         });
-
-        expect(Result.parse(undefined, schema).unwrap()).toMatchObject({
-          err: {
-            issues: [
-              {
-                message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
-              },
-            ],
-          },
-        });
-
-        expect(Result.parse(null, schema).unwrap()).toMatchObject({
-          err: {
-            issues: [
-              {
-                message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
-              },
-            ],
-          },
-        });
       });
 
-      it('parses Zod schema by piping from Result', () => {
-        const schema = z
-          .string()
-          .transform((x) => x.toUpperCase())
-          .nullish();
+      it('supports non-Zod parsers', () => {
+        const evenParser: SafeParser<number, 'odd'> = {
+          safeParse: (input) =>
+            typeof input === 'number' && input % 2 === 0
+              ? { success: true, data: input }
+              : { success: false, error: 'odd' },
+        };
 
+        expect(Result.parse(2, evenParser)).toEqual(Result.ok(2));
+        expect(Result.parse(3, evenParser)).toEqual(Result.err('odd'));
+      });
+
+      it('routes nullish output from a lying parser to the uncaught channel', () => {
+        const lyingParser: SafeParser<string, Error> = {
+          safeParse: () => ({ success: true, data: null as never }),
+        };
+
+        const result = Result.parse('foo', lyingParser);
+
+        expect(() => result.unwrap()).toThrow(
+          new TypeError('Result.parse: schema output must not be nullish'),
+        );
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { err: expect.any(TypeError) },
+          'Result: nullish schema output',
+        );
+      });
+
+      it('parses a schema by piping from Result', () => {
         expect(Result.ok('foo').parse(schema)).toEqual(Result.ok('FOO'));
 
         expect(Result.ok(42).parse(schema).unwrap()).toMatchObject({
@@ -338,18 +328,40 @@ describe('util/result', () => {
         expect(cb).toHaveBeenCalledExactlyOnceWith('oops');
       });
 
+      it('skips value handlers for errors', () => {
+        const cb = vi.fn();
+        Result.err('oops').onValue(cb);
+        expect(cb).not.toHaveBeenCalled();
+      });
+
+      it('skips error handlers for values', () => {
+        const cb = vi.fn();
+        Result.ok(42).onError(cb);
+        expect(cb).not.toHaveBeenCalled();
+      });
+
       it('handles error thrown in value handler', () => {
         const res = Result.ok(42).onValue(() => {
           throw 'oops';
         });
+
         expect(res).toEqual(Result._uncaught('oops'));
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { err: 'oops' },
+          'Result: unexpected error in onValue callback',
+        );
       });
 
       it('handles error thrown in error handler', () => {
         const res = Result.err('oops').onError(() => {
           throw 'oops';
         });
+
         expect(res).toEqual(Result._uncaught('oops'));
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { err: 'oops' },
+          'Result: unexpected error in onError callback',
+        );
       });
     });
   });
@@ -393,16 +405,6 @@ describe('util/result', () => {
       it('wraps promise returning undefined', async () => {
         const res = Result.wrapNullable(Promise.resolve(undefined), 'oops');
         await expect(res).resolves.toEqual(Result.err('oops'));
-      });
-
-      it('distincts between null and undefined promise results', async () => {
-        await expect(
-          Result.wrapNullable(Promise.resolve(null), 'null', 'undefined'),
-        ).resolves.toEqual(Result.err('null'));
-
-        await expect(
-          Result.wrapNullable(Promise.resolve(undefined), 'null', 'undefined'),
-        ).resolves.toEqual(Result.err('undefined'));
       });
 
       it('handles rejected nullable promise', async () => {
@@ -605,19 +607,17 @@ describe('util/result', () => {
         expect(res).toEqual(Result.ok('F-O-O'));
       });
 
-      it('asynchronously transforms Result to zod values', async () => {
+      it('asynchronously transforms Result before parsing', async () => {
         const schema = z.string().transform((x) => x.toUpperCase());
-        const res = await Result.ok('foo').transform((x) =>
-          Promise.resolve(schema.safeParse(x)),
-        );
+        const res = await Result.ok('foo')
+          .transform((x) => Promise.resolve(x))
+          .parse(schema);
         expect(res).toEqual(Result.ok('FOO'));
       });
 
-      it('transforms AsyncResult to zod values', async () => {
+      it('transforms AsyncResult before parsing', async () => {
         const schema = z.string().transform((x) => x.toUpperCase());
-        const res = await AsyncResult.ok('foo').transform((x) =>
-          schema.safeParse(x),
-        );
+        const res = await AsyncResult.ok('foo').parse(schema);
         expect(res).toEqual(Result.ok('FOO'));
       });
     });
@@ -648,15 +648,25 @@ describe('util/result', () => {
         const result = await error.catch(() => AsyncResult.ok<number>(42));
         expect(result).toEqual(Result.ok(42));
       });
+
+      it('bypasses uncaught AsyncResult errors', async () => {
+        const error = new Error('oops');
+        const handler = vi.fn(() => AsyncResult.ok(0));
+        const result = AsyncResult.ok(42)
+          .transform(() => {
+            throw error;
+          })
+          .catch(handler);
+
+        await expect(result.unwrap()).rejects.toBe(error);
+        expect(handler).not.toHaveBeenCalled();
+      });
     });
   });
 
   describe('Parsing', () => {
-    it('parses Zod schema by piping from AsyncResult', async () => {
-      const schema = z
-        .string()
-        .transform((x) => x.toUpperCase())
-        .nullish();
+    it('parses a schema by piping from AsyncResult', async () => {
+      const schema = z.string().transform((x) => x.toUpperCase());
 
       expect(await AsyncResult.ok('foo').parse(schema)).toEqual(
         Result.ok('FOO'),
@@ -671,6 +681,16 @@ describe('util/result', () => {
           ]),
         }),
       });
+    });
+
+    it('rejects when an async lying parser produces nullish output', async () => {
+      const lyingParser: SafeParser<string, Error> = {
+        safeParse: () => ({ success: true, data: undefined as never }),
+      };
+
+      await expect(
+        AsyncResult.ok('foo').parse(lyingParser).unwrap(),
+      ).rejects.toThrow('Result.parse: schema output must not be nullish');
     });
 
     it('handles uncaught error thrown in the steps before parsing', async () => {
@@ -701,14 +721,24 @@ describe('util/result', () => {
       const res = await AsyncResult.ok(42).onValue(() => {
         throw 'oops';
       });
+
       expect(res).toEqual(Result._uncaught('oops'));
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: 'oops' },
+        'Result: unexpected error in onValue callback',
+      );
     });
 
     it('handles error thrown in error handler', async () => {
       const res = await AsyncResult.err('oops').onError(() => {
         throw 'oops';
       });
+
       expect(res).toEqual(Result._uncaught('oops'));
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: 'oops' },
+        'Result: unexpected error in onError callback',
+      );
     });
   });
 });

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -1,12 +1,7 @@
-import type { ZodError, output as ZodOutput, ZodType } from 'zod/v4';
-import { NEVER } from 'zod/v4';
 import { logger } from '../logger/index.ts';
 import type { Nullish } from '../types/index.ts';
 
 type Val = NonNullable<unknown>;
-
-// ZodSafeParseResult is not exported from zod/v4 public API, derive from safeParse return type
-type ZodSafeParseResult<T> = ReturnType<ZodType<T>['safeParse']>;
 
 interface Ok<T extends Val> {
   readonly ok: true;
@@ -20,7 +15,7 @@ interface Err<E extends Val> {
   readonly val?: never;
 
   /**
-   * Internal flag to indicate that the error was thrown during `.transform()`
+   * Internal flag: the error was thrown inside a callback
    * and will be re-thrown on `.unwrap()`.
    */
   readonly _uncaught?: true;
@@ -28,63 +23,47 @@ interface Err<E extends Val> {
 
 type Res<T extends Val, E extends Val> = Ok<T> | Err<E>;
 
-function isZodResult<Output extends Val>(
-  input: unknown,
-): input is ZodSafeParseResult<Output> {
-  if (
-    typeof input !== 'object' ||
-    input === null ||
-    Object.keys(input).length !== 2 ||
-    !('success' in input) ||
-    typeof input.success !== 'boolean'
-  ) {
-    return false;
-  }
-
-  if (input.success) {
-    return (
-      'data' in input &&
-      typeof input.data !== 'undefined' &&
-      input.data !== null
-    );
-  } else {
-    return 'error' in input;
-  }
+/**
+ * Structural interface for schema validators.
+ * Keeps this module independent from any particular validation library:
+ * anything exposing a compatible `safeParse` works with `Result.parse()`.
+ *
+ * Note: `T extends Val` means schemas with nullable or optional output are
+ * rejected at compile time. Apply the `nonNullish` transform from
+ * `lib/util/schema-utils` to turn nullish output into a parse error.
+ */
+export interface SafeParser<T extends Val, E extends Val> {
+  safeParse(
+    input: unknown,
+  ):
+    | { readonly success: true; readonly data: T }
+    | { readonly success: false; readonly error: E };
 }
 
-function fromZodResult<ZodOutput extends Val>(
-  input: ZodSafeParseResult<ZodOutput>,
-): Result<ZodOutput, ZodError<unknown>> {
-  return input.success ? Result.ok(input.data) : Result.err(input.error);
-}
+type SafeParseShape =
+  | { readonly success: true; readonly data: unknown }
+  | { readonly success: false; readonly error: unknown };
 
 /**
- * All non-nullable values that also are not Promises nor Zod results.
- * It's useful for restricting Zod results to not return `null` or `undefined`.
+ * All non-nullable values that also are not Promises nor safeParse results.
+ * Promises are excluded to route them into the async overloads; safeParse
+ * results are excluded so that schema validation must go through `.parse()`
+ * explicitly instead of relying on shape sniffing.
  */
-type RawValue<T extends Val> = Exclude<
-  T,
-  ZodSafeParseResult<T> | Promise<unknown>
->;
+type RawValue<T extends Val> = Exclude<T, Promise<unknown> | SafeParseShape>;
 
-function fromNullable<
-  T extends Val,
-  ErrForNull extends Val,
-  ErrForUndefined extends Val,
->(
+function fromNullable<T extends Val, E extends Val>(
   input: Nullish<T>,
-  errForNull: ErrForNull,
-  errForUndefined: ErrForUndefined,
-): Result<T, ErrForNull | ErrForUndefined> {
-  if (input === null) {
-    return Result.err(errForNull);
-  }
+  errForNullable: E,
+): Result<T, E> {
+  return input === null || input === undefined
+    ? Result.err(errForNullable)
+    : Result.ok(input);
+}
 
-  if (input === undefined) {
-    return Result.err(errForUndefined);
-  }
-
-  return Result.ok(input);
+function rethrowUncaught(err: unknown): never {
+  // oxlint-disable-next-line typescript/only-throw-error -- the foreign value thrown inside a callback is re-thrown verbatim to preserve its identity
+  throw err;
 }
 
 /**
@@ -110,8 +89,18 @@ export class Result<T extends Val, E extends Val = Error> {
     return new Result({ ok: false, err });
   }
 
-  static _uncaught<E extends Val>(err: E): Result<never, E> {
-    return new Result({ ok: false, err, _uncaught: true });
+  /**
+   * Internal channel for programmer errors thrown inside callbacks.
+   * Deliberately type-invisible: `Result<never, never>` is assignable to every
+   * `Result<T, E>`, because uncaught errors bypass the typed error channel —
+   * they skip `.catch()` and re-throw at unwrap points.
+   */
+  static _uncaught(err: unknown): Result<never, never> {
+    return new Result<never, never>({
+      ok: false,
+      err: err as never,
+      _uncaught: true,
+    });
   }
 
   /**
@@ -143,9 +132,6 @@ export class Result<T extends Val, E extends Val = Error> {
    *
    *   ```
    */
-  static wrap<T extends Val>(
-    zodResult: ZodSafeParseResult<T>,
-  ): Result<T, ZodError<unknown>>;
   static wrap<T extends Val, E extends Val = Error>(
     callback: () => RawValue<T>,
   ): Result<T, E>;
@@ -160,18 +146,13 @@ export class Result<T extends Val, E extends Val = Error> {
   ): AsyncResult<T, E>;
   static wrap<T extends Val, E extends Val = Error, EE extends Val = never>(
     input:
-      | ZodSafeParseResult<T>
       | (() => RawValue<T>)
       | (() => Promise<RawValue<T>>)
       | Promise<Result<T, EE>>
       | Promise<RawValue<T>>,
-  ): Result<T, ZodError<unknown>> | Result<T, E | EE> | AsyncResult<T, E | EE> {
-    if (isZodResult<T>(input)) {
-      return fromZodResult<T>(input);
-    }
-
+  ): Result<T, E | EE> | AsyncResult<T, E | EE> {
     if (input instanceof Promise) {
-      return AsyncResult.wrap(input as never);
+      return AsyncResult.wrap(input);
     }
 
     try {
@@ -242,31 +223,11 @@ export class Result<T extends Val, E extends Val = Error> {
   static wrapNullable<
     T extends Val,
     E extends Val = Error,
-    ErrForNull extends Val = Error,
-    ErrForUndefined extends Val = Error,
-  >(
-    callback: () => Nullish<T>,
-    errForNull: ErrForNull,
-    errForUndefined: ErrForUndefined,
-  ): Result<T, E | ErrForNull | ErrForUndefined>;
-  static wrapNullable<
-    T extends Val,
-    E extends Val = Error,
     ErrForNullable extends Val = Error,
   >(
     promise: Promise<Nullish<T>>,
     errForNullable: ErrForNullable,
   ): AsyncResult<T, E | ErrForNullable>;
-  static wrapNullable<
-    T extends Val,
-    E extends Val = Error,
-    ErrForNull extends Val = Error,
-    ErrForUndefined extends Val = Error,
-  >(
-    promise: Promise<Nullish<T>>,
-    errForNull: ErrForNull,
-    errForUndefined: ErrForUndefined,
-  ): AsyncResult<T, E | ErrForNull | ErrForUndefined>;
   static wrapNullable<
     T extends Val,
     E extends Val = Error,
@@ -278,42 +239,52 @@ export class Result<T extends Val, E extends Val = Error> {
   static wrapNullable<
     T extends Val,
     E extends Val = Error,
-    ErrForNull extends Val = Error,
-    ErrForUndefined extends Val = Error,
-  >(
-    value: Nullish<T>,
-    errForNull: ErrForNull,
-    errForUndefined: ErrForUndefined,
-  ): Result<T, E | ErrForNull | ErrForUndefined>;
-  static wrapNullable<
-    T extends Val,
-    E extends Val = Error,
-    ErrForNull extends Val = Error,
-    ErrForUndefined extends Val = Error,
+    ErrForNullable extends Val = Error,
   >(
     input: (() => Nullish<T>) | Promise<Nullish<T>> | Nullish<T>,
-    arg2: ErrForNull,
-    arg3?: ErrForUndefined,
-  ):
-    | Result<T, E | ErrForNull | ErrForUndefined>
-    | AsyncResult<T, E | ErrForNull | ErrForUndefined> {
-    const errForNull = arg2;
-    const errForUndefined = arg3 ?? arg2;
-
+    errForNullable: ErrForNullable,
+  ): Result<T, E | ErrForNullable> | AsyncResult<T, E | ErrForNullable> {
     if (input instanceof Promise) {
-      return AsyncResult.wrapNullable(input, errForNull, errForUndefined);
+      return AsyncResult.wrapNullable(input, errForNullable);
     }
 
     if (input instanceof Function) {
       try {
-        const result = input();
-        return fromNullable(result, errForNull, errForUndefined);
+        return fromNullable(input(), errForNullable);
       } catch (error) {
         return Result.err(error);
       }
     }
 
-    return fromNullable(input, errForNull, errForUndefined);
+    return fromNullable(input, errForNullable);
+  }
+
+  /**
+   * Given a `schema` and `input`, returns a `Result` with `val` being the
+   * parsed value. The schema's output type must be non-nullable — this is
+   * enforced at compile time via `SafeParser`. If a schema lies about its
+   * output type and produces a nullish value at runtime, that is a programmer
+   * error and is routed to the `_uncaught` channel.
+   */
+  static parse<T extends Val, E extends Val>(
+    input: unknown,
+    schema: SafeParser<T, E>,
+  ): Result<T, E> {
+    const result = schema.safeParse(input);
+
+    if (!result.success) {
+      return Result.err(result.error);
+    }
+
+    if (result.data === null || result.data === undefined) {
+      const err = new TypeError(
+        'Result.parse: schema output must not be nullish',
+      );
+      logger.warn({ err }, 'Result: nullish schema output');
+      return Result._uncaught(err);
+    }
+
+    return Result.ok(result.data);
   }
 
   /**
@@ -329,14 +300,8 @@ export class Result<T extends Val, E extends Val = Error> {
    *   ```
    */
   unwrap(): Res<T, E> {
-    if (this.res.ok) {
-      return this.res;
-    }
-
-    if (this.res._uncaught) {
-      // TODO: fix, should only allow `Error` type
-      // oxlint-disable-next-line typescript/only-throw-error
-      throw this.res.err;
+    if (!this.res.ok && this.res._uncaught) {
+      rethrowUncaught(this.res.err);
     }
 
     return this.res;
@@ -359,24 +324,22 @@ export class Result<T extends Val, E extends Val = Error> {
     }
 
     if (this.res._uncaught) {
-      // TODO: fix, should only allow `Error` type
-      // oxlint-disable-next-line typescript/only-throw-error
-      throw this.res.err;
+      rethrowUncaught(this.res.err);
     }
 
     return fallback;
   }
 
   /**
-   * Returns the ok-value or throw the error.
+   * Returns the ok-value or throws the error.
+   * Only available when the error channel is `Error`-typed —
+   * results with plain-value errors must be consumed via `unwrap()` instead.
    */
-  unwrapOrThrow(): T {
+  unwrapOrThrow(this: Result<T, Error>): T {
     if (this.res.ok) {
       return this.res.val;
     }
 
-    // TODO: fix, should only allow `Error` type
-    // oxlint-disable-next-line typescript/only-throw-error
     throw this.res.err;
   }
 
@@ -390,9 +353,7 @@ export class Result<T extends Val, E extends Val = Error> {
     }
 
     if (this.res._uncaught) {
-      // TODO: fix, should only allow `Error` type
-      // oxlint-disable-next-line typescript/only-throw-error
-      throw this.res.err;
+      rethrowUncaught(this.res.err);
     }
 
     return null;
@@ -405,7 +366,7 @@ export class Result<T extends Val, E extends Val = Error> {
    * Uncaught errors are logged and wrapped to `Result._uncaught()`,
    * which leads to re-throwing them in `unwrap()`.
    *
-   * Zod `.safeParse()` results are converted automatically.
+   * Use `.parse(schema)` for schema validation in a transform chain.
    *
    *   ```ts
    *
@@ -430,12 +391,6 @@ export class Result<T extends Val, E extends Val = Error> {
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => AsyncResult<U, E | EE>,
   ): AsyncResult<U, E | EE>;
-  transform<U extends Val>(
-    fn: (value: T) => ZodSafeParseResult<NonNullable<U>>,
-  ): Result<U, E | ZodError<unknown>>;
-  transform<U extends Val>(
-    fn: (value: T) => Promise<ZodSafeParseResult<NonNullable<U>>>,
-  ): AsyncResult<U, E | ZodError<unknown>>;
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => Promise<Result<U, E | EE>>,
   ): AsyncResult<U, E | EE>;
@@ -449,14 +404,10 @@ export class Result<T extends Val, E extends Val = Error> {
     ) =>
       | Result<U, E | EE>
       | AsyncResult<U, E | EE>
-      | ZodSafeParseResult<NonNullable<U>>
-      | Promise<ZodSafeParseResult<NonNullable<U>>>
       | Promise<Result<U, E | EE>>
       | Promise<RawValue<U>>
       | RawValue<U>,
-  ):
-    | Result<U, E | EE | ZodError<unknown>>
-    | AsyncResult<U, E | EE | ZodError<unknown>> {
+  ): Result<U, E | EE> | AsyncResult<U, E | EE> {
     if (!this.res.ok) {
       return Result.err(this.res.err);
     }
@@ -470,10 +421,6 @@ export class Result<T extends Val, E extends Val = Error> {
 
       if (result instanceof AsyncResult) {
         return result;
-      }
-
-      if (isZodResult<U>(result)) {
-        return fromZodResult<U>(result);
       }
 
       if (result instanceof Promise) {
@@ -501,13 +448,16 @@ export class Result<T extends Val, E extends Val = Error> {
   ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
     fn: (err: E) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
+  ): Result<T | U, EE> | AsyncResult<T | U, EE>;
+  catch<U extends Val = T, EE extends Val = E>(
+    fn: (err: E) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
   ): Result<T | U, EE> | AsyncResult<T | U, EE> {
     if (this.res.ok) {
-      return this as never;
+      return Result.ok(this.res.val);
     }
 
     if (this.res._uncaught) {
-      return this as never;
+      return Result._uncaught(this.res.err);
     }
 
     try {
@@ -531,56 +481,20 @@ export class Result<T extends Val, E extends Val = Error> {
   }
 
   /**
-   * Given a `schema` and `input`, returns a `Result` with `val` being the parsed value.
-   * Additionally, `null` and `undefined` values are converted into Zod error.
-   */
-  static parse<Schema extends ZodType<any, any, any>>(
-    input: unknown,
-    schema: Schema,
-  ): Result<NonNullable<ZodOutput<Schema>>, ZodError<unknown>> {
-    const parseResult = schema
-      .transform((result, ctx): NonNullable<ZodOutput<Schema>> => {
-        if (result === undefined) {
-          ctx.addIssue({
-            code: 'custom',
-            message: `Result can't accept nullish values, but input was parsed by Zod schema to undefined`,
-          });
-          return NEVER;
-        }
-
-        if (result === null) {
-          ctx.addIssue({
-            code: 'custom',
-            message: `Result can't accept nullish values, but input was parsed by Zod schema to null`,
-          });
-          return NEVER;
-        }
-
-        return result;
-      })
-      .safeParse(input);
-
-    return fromZodResult<NonNullable<ZodOutput<Schema>>>(parseResult);
-  }
-
-  /**
    * Given a `schema`, returns a `Result` with `val` being the parsed value.
-   * Additionally, `null` and `undefined` values are converted into Zod error.
    */
-  parse<Schema extends ZodType<any, any, any>>(
-    schema: Schema,
-  ): Result<NonNullable<ZodOutput<Schema>>, E | ZodError<unknown>> {
+  parse<U extends Val, EE extends Val>(
+    schema: SafeParser<U, EE>,
+  ): Result<U, E | EE> {
     if (this.res.ok) {
       return Result.parse(this.res.val, schema);
     }
 
-    const err = this.res.err;
-
     if (this.res._uncaught) {
-      return Result._uncaught(err);
+      return Result._uncaught(this.res.err);
     }
 
-    return Result.err(err);
+    return Result.err(this.res.err);
   }
 
   /**
@@ -591,6 +505,7 @@ export class Result<T extends Val, E extends Val = Error> {
       try {
         fn(this.res.val);
       } catch (err) {
+        logger.warn({ err }, 'Result: unexpected error in onValue callback');
         return Result._uncaught(err);
       }
     }
@@ -606,6 +521,7 @@ export class Result<T extends Val, E extends Val = Error> {
       try {
         fn(this.res.err);
       } catch (err) {
+        logger.warn({ err }, 'Result: unexpected error in onError callback');
         return Result._uncaught(err);
       }
     }
@@ -642,30 +558,17 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
     return new AsyncResult(Promise.resolve(Result.ok(val)));
   }
 
-  static err<E extends Val>(err: NonNullable<E>): AsyncResult<never, E> {
+  static err<E extends Val>(err: E): AsyncResult<never, E> {
     return new AsyncResult(Promise.resolve(Result.err(err)));
   }
 
   static wrap<T extends Val, E extends Val = Error, EE extends Val = never>(
-    promise:
-      | Promise<ZodSafeParseResult<T>>
-      | Promise<Result<T, EE>>
-      | Promise<RawValue<T>>,
-    onErr?: (err: NonNullable<E>) => Result<T, E>,
+    promise: Promise<Result<T, EE>> | Promise<RawValue<T>>,
+    onErr?: (err: E) => Result<T, E>,
   ): AsyncResult<T, E | EE> {
     return new AsyncResult(
       promise
-        .then((value) => {
-          if (value instanceof Result) {
-            return value;
-          }
-
-          if (isZodResult<T>(value)) {
-            return fromZodResult<T>(value);
-          }
-
-          return Result.ok(value);
-        })
+        .then((value) => (value instanceof Result ? value : Result.ok(value)))
         .catch((err) => {
           if (onErr) {
             return onErr(err);
@@ -675,19 +578,13 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
     );
   }
 
-  static wrapNullable<
-    T extends Val,
-    E extends Val,
-    ErrForNull extends Val,
-    ErrForUndefined extends Val,
-  >(
+  static wrapNullable<T extends Val, E extends Val, ErrForNullable extends Val>(
     promise: Promise<Nullish<T>>,
-    errForNull: NonNullable<ErrForNull>,
-    errForUndefined: NonNullable<ErrForUndefined>,
-  ): AsyncResult<T, E | ErrForNull | ErrForUndefined> {
+    errForNullable: ErrForNullable,
+  ): AsyncResult<T, E | ErrForNullable> {
     return new AsyncResult(
       promise
-        .then((value) => fromNullable(value, errForNull, errForUndefined))
+        .then((value) => fromNullable(value, errForNullable))
         .catch((err) => Result.err(err)),
     );
   }
@@ -723,9 +620,9 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
   }
 
   /**
-   * Returns the ok-value or throw the error.
+   * Returns the ok-value or throws the error.
    */
-  async unwrapOrThrow(): Promise<T> {
+  async unwrapOrThrow(this: AsyncResult<T, Error>): Promise<T> {
     const result = await this.asyncResult;
     return result.unwrapOrThrow();
   }
@@ -744,7 +641,7 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
    * Uncaught errors are logged and wrapped to `Result._uncaught()`,
    * which leads to re-throwing them in `unwrap()`.
    *
-   * Zod `.safeParse()` results are converted automatically.
+   * Use `.parse(schema)` for schema validation in a transform chain.
    *
    *   ```ts
    *
@@ -762,12 +659,6 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => AsyncResult<U, E | EE>,
   ): AsyncResult<U, E | EE>;
-  transform<U extends Val>(
-    fn: (value: T) => ZodSafeParseResult<NonNullable<U>>,
-  ): AsyncResult<U, E | ZodError<unknown>>;
-  transform<U extends Val>(
-    fn: (value: T) => Promise<ZodSafeParseResult<NonNullable<U>>>,
-  ): AsyncResult<U, E | ZodError<unknown>>;
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => Promise<Result<U, E | EE>>,
   ): AsyncResult<U, E | EE>;
@@ -781,12 +672,10 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
     ) =>
       | Result<U, E | EE>
       | AsyncResult<U, E | EE>
-      | ZodSafeParseResult<NonNullable<U>>
-      | Promise<ZodSafeParseResult<NonNullable<U>>>
       | Promise<Result<U, E | EE>>
       | Promise<RawValue<U>>
       | RawValue<U>,
-  ): AsyncResult<U, E | EE | ZodError<unknown>> {
+  ): AsyncResult<U, E | EE> {
     return new AsyncResult(
       this.asyncResult
         .then((oldResult) => {
@@ -806,12 +695,8 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
               return result;
             }
 
-            if (isZodResult<U>(result)) {
-              return fromZodResult<U>(result);
-            }
-
             if (result instanceof Promise) {
-              return AsyncResult.wrap(result, (err) => {
+              return AsyncResult.wrap<U, E | EE, E | EE>(result, (err) => {
                 logger.warn(
                   { err },
                   'AsyncResult: unhandled async transform error',
@@ -834,37 +719,41 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
   }
 
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: NonNullable<E>) => Result<U, EE>,
+    fn: (err: E) => Result<U, EE>,
   ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: NonNullable<E>) => AsyncResult<U, EE>,
+    fn: (err: E) => AsyncResult<U, EE>,
   ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (err: NonNullable<E>) => Promise<Result<U, EE>>,
+    fn: (err: E) => Promise<Result<U, EE>>,
   ): AsyncResult<T | U, EE>;
   catch<U extends Val = T, EE extends Val = E>(
-    fn: (
-      err: NonNullable<E>,
-    ) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
+    fn: (err: E) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
+  ): AsyncResult<T | U, EE>;
+  catch<U extends Val = T, EE extends Val = E>(
+    fn: (err: E) => Result<U, EE> | AsyncResult<U, EE> | Promise<Result<U, EE>>,
   ): AsyncResult<T | U, EE> {
-    const caughtAsyncResult: Promise<Result<T, EE>> = this.asyncResult.then(
-      (result) => result.catch(fn as never),
+    return new AsyncResult(
+      this.asyncResult
+        .then((result) => result.catch(fn))
+        .catch(
+          /* v8 ignore next -- should never happen */
+          (err) => Result.err(err),
+        ),
     );
-    return AsyncResult.wrap(caughtAsyncResult);
   }
 
   /**
    * Given a `schema`, returns a `Result` with `val` being the parsed value.
-   * Additionally, `null` and `undefined` values are converted into Zod error.
    */
-  parse<Schema extends ZodType<any, any, any>>(
-    schema: Schema,
-  ): AsyncResult<NonNullable<ZodOutput<Schema>>, E | ZodError<unknown>> {
+  parse<U extends Val, EE extends Val>(
+    schema: SafeParser<U, EE>,
+  ): AsyncResult<U, E | EE> {
     return new AsyncResult(
       this.asyncResult
         .then((oldResult) => oldResult.parse(schema))
         .catch(
-          /* istanbul ignore next: should never happen */
+          /* v8 ignore next -- should never happen */
           (err) => Result._uncaught(err),
         ),
     );
@@ -875,7 +764,7 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
       this.asyncResult
         .then((result) => result.onValue(fn))
         .catch(
-          /* istanbul ignore next: should never happen */
+          /* v8 ignore next -- should never happen */
           (err) => Result._uncaught(err),
         ),
     );
@@ -886,7 +775,7 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
       this.asyncResult
         .then((result) => result.onError(fn))
         .catch(
-          /* istanbul ignore next: should never happen */
+          /* v8 ignore next -- should never happen */
           (err) => Result._uncaught(err),
         ),
     );

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -31,6 +31,8 @@ type Res<T extends Val, E extends Val> = Ok<T> | Err<E>;
  * Note: `T extends Val` means schemas with nullable or optional output are
  * rejected at compile time. Apply the `nonNullish` transform from
  * `lib/util/schema-utils` to turn nullish output into a parse error.
+ * Implementations must return a safe-parse result instead of throwing;
+ * thrown errors propagate to the caller.
  */
 export interface SafeParser<T extends Val, E extends Val> {
   safeParse(
@@ -409,7 +411,9 @@ export class Result<T extends Val, E extends Val = Error> {
       | RawValue<U>,
   ): Result<U, E | EE> | AsyncResult<U, E | EE> {
     if (!this.res.ok) {
-      return Result.err(this.res.err);
+      return this.res._uncaught
+        ? Result._uncaught(this.res.err)
+        : Result.err(this.res.err);
     }
 
     try {

--- a/lib/util/schema-utils/index.spec.ts
+++ b/lib/util/schema-utils/index.spec.ts
@@ -17,6 +17,7 @@ import {
   Yaml,
   isEmailAdress,
   multidocYaml,
+  nonNullish,
   withDebugMessage,
   withDepType,
   withTraceMessage,
@@ -141,6 +142,30 @@ describe('util/schema-utils/index', () => {
             path: ['bbb', 'foo', 'bar'],
           },
         ],
+      });
+    });
+  });
+
+  describe('nonNullish', () => {
+    it('passes through non-nullish values and preserves their type', () => {
+      const schema = z.string().nullable().transform(nonNullish);
+
+      expect(schema.parse('value')).toBe('value');
+      expectTypeOf<z.output<typeof schema>>().toEqualTypeOf<string>();
+    });
+
+    it.each([null, undefined])('rejects %s output', (value) => {
+      const result = z
+        .string()
+        .nullish()
+        .transform(nonNullish)
+        .safeParse(value);
+
+      expect(result).toMatchObject({
+        success: false,
+        error: {
+          issues: [{ code: 'custom', message: 'Expected non-nullish value' }],
+        },
       });
     });
   });

--- a/lib/util/schema-utils/index.ts
+++ b/lib/util/schema-utils/index.ts
@@ -201,6 +201,23 @@ export function Nullish<Schema extends z.ZodTypeAny>(
     .optional();
 }
 
+/**
+ * Zod transform callback that turns nullish output into a parse error. Useful
+ * after a transform that extracts an optional field, e.g. together with
+ * `Result.parse()`, which requires non-nullable output.
+ */
+export function nonNullish<T>(value: T, ctx: z.RefinementCtx): NonNullable<T> {
+  if (value === null || value === undefined) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'Expected non-nullish value',
+    });
+    return z.NEVER;
+  }
+
+  return value;
+}
+
 function deepNullishRewrite(node: z.ZodTypeAny): z.ZodTypeAny {
   if (node instanceof z.ZodOptional) {
     return Nullish(deepNullishRewrite(node.unwrap() as z.ZodTypeAny));


### PR DESCRIPTION
## Changes

- Replace the direct Zod dependency in `Result` with a structural `SafeParser` interface.
- Remove safe-parse-result shape detection and implicit conversion in `wrap()` and `transform()`.
- Reject nullable schema output at compile time.
- Constrain `unwrapOrThrow()` to `Error`-typed result channels.
- Simplify uncaught-error propagation and nullable wrapping overloads.
- Update the affected Pixi, Poetry, and Rubygems consumers.
- Update the Result/Zod development documentation.

For optional-field extractors, this adds the `nonNullish` Zod transform callback:

```ts
schema.transform(nonNullish)
```

Normal Zod integration remains available through `Result.parse(input, schema)` and `.parse(schema)`.

A parser that claims to return a non-nullish value but produces `null` or `undefined` at runtime is now treated as a programmer error and routed through the uncaught-error channel.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Fable 5 assisted with planning. GPT-5.6 Sol, used through the Zed coding agent, assisted with implementation, tests, and documentation.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
