### PR TITLE
test(regex): Support environments without RE2

### DIFF
--- a/lib/util/regex.spec.ts
+++ b/lib/util/regex.spec.ts
@@ -1,10 +1,16 @@
-import RE2 from 're2';
 import { CONFIG_VALIDATION } from '../constants/error-messages.ts';
-import { regEx } from './regex.ts';
+import { regEx, regexEngineStatus } from './regex.ts';
 
 describe('util/regex', () => {
-  it('uses RE2', () => {
-    expect(regEx('foo')).toBeInstanceOf(RE2);
+  it('uses the available regex engine', async () => {
+    const regex = regEx('foo');
+    // Import RE2 only after Renovate confirms its native addon can be loaded.
+    const ExpectedRegExp =
+      regexEngineStatus.type === 'available'
+        ? (await import('re2')).default
+        : RegExp;
+
+    expect(regex).toBeInstanceOf(ExpectedRegExp);
   });
 
   it('throws unsafe 2', () => {
@@ -12,7 +18,8 @@ describe('util/regex', () => {
   });
 
   it('reuses flags from regex', () => {
-    expect(regEx(/foo/i).flags).toBe('iu');
+    const expectedFlags = regexEngineStatus.type === 'available' ? 'iu' : 'i';
+    expect(regEx(/foo/i).flags).toBe(expectedFlags);
   });
 
   it('caches non-stateful regex', () => {
@@ -25,8 +32,10 @@ describe('util/regex', () => {
     expect(regEx(/bar/g)).not.toBe(/bar/g);
   });
 
-  it('Falls back to RegExp', async () => {
+  it('falls back to RegExp', async () => {
     vi.resetModules();
+    // Exercise a load failure even if RENOVATE_X_IGNORE_RE2 is set externally.
+    vi.doMock('./env.ts', () => ({ getEnv: () => ({}) }));
     vi.doMock('../expose.ts', () => ({
       re2: () => {
         throw new Error();
@@ -34,6 +43,7 @@ describe('util/regex', () => {
     }));
 
     const regex = await import('./regex.ts');
+    expect(regex.regexEngineStatus.type).toBe('unavailable');
     expect(regex.regEx('foo')).toBeInstanceOf(RegExp);
   });
 });

--- a/lib/util/regex.spec.ts
+++ b/lib/util/regex.spec.ts
@@ -2,24 +2,21 @@ import { CONFIG_VALIDATION } from '../constants/error-messages.ts';
 import { regEx, regexEngineStatus } from './regex.ts';
 
 describe('util/regex', () => {
-  it('uses the available regex engine', async () => {
-    const regex = regEx('foo');
-    // Import RE2 only after Renovate confirms its native addon can be loaded.
-    const ExpectedRegExp =
-      regexEngineStatus.type === 'available'
-        ? (await import('re2')).default
-        : RegExp;
+  describe.skipIf(regexEngineStatus.type !== 'available')('with RE2', () => {
+    it('uses RE2', async () => {
+      // Import lazily so skipped runtimes never load the incompatible native addon.
+      const { default: RE2 } = await import('re2');
 
-    expect(regex).toBeInstanceOf(ExpectedRegExp);
+      expect(regEx('foo')).toBeInstanceOf(RE2);
+    });
+
+    it('reuses flags from regex', () => {
+      expect(regEx(/foo/i).flags).toBe('iu');
+    });
   });
 
   it('throws unsafe 2', () => {
     expect(() => regEx(`x++`)).toThrow(CONFIG_VALIDATION);
-  });
-
-  it('reuses flags from regex', () => {
-    const expectedFlags = regexEngineStatus.type === 'available' ? 'iu' : 'i';
-    expect(regEx(/foo/i).flags).toBe(expectedFlags);
   });
 
   it('caches non-stateful regex', () => {


### PR DESCRIPTION
## Changes

Renovate already falls back to JavaScript's `RegExp` when the native RE2 addon is unavailable. The regex spec bypasses that loader by importing `re2` at module load, so runtimes with an incompatible native ABI fail before the fallback can be tested.

This PR makes the spec follow the production loader's behavior:

- Skip the RE2-specific test group when `regexEngineStatus` reports that RE2 is unavailable.
- Import `re2` lazily so skipped runtimes never load the incompatible native addon.
- Keep the mocked load-failure test deterministic when `RENOVATE_X_IGNORE_RE2` is set externally.

This changes no production behavior. Under Bun, the RE2-specific assertions are skipped while the remaining regex and fallback tests continue to run.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GPT-5.6 Sol implemented the test compatibility change.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A