### PR TITLE
fix(npm): allow rename when replacement value is unchanged

### DIFF
--- a/lib/modules/manager/npm/update/dependency/index.spec.ts
+++ b/lib/modules/manager/npm/update/dependency/index.spec.ts
@@ -211,6 +211,56 @@ describe('modules/manager/npm/update/dependency/index', () => {
       expect(testContent).toEqual(input01Content);
     });
 
+    it('replaces when version is not changing', () => {
+      const upgrade = {
+        depType: 'peerDependencies',
+        depName: 'request',
+        newValue: '>=2.0.0',
+        newName: 'got',
+      };
+      const packageContent = `{
+        "peerDependencies": {
+          "request": ">=2.0.0"
+        }
+      }`;
+      const expected = `{
+        "peerDependencies": {
+          "got": ">=2.0.0"
+        }
+      }`;
+      const testContent = npmUpdater.updateDependency({
+        fileContent: packageContent,
+        packageFile: 'package.json',
+        upgrade,
+      });
+      expect(testContent).toEqual(expected);
+    });
+
+    it('handles the case when version and name are not changing', () => {
+      const upgrade = {
+        depType: 'peerDependencies',
+        depName: 'got',
+        newValue: '>=2.0.0',
+        newName: 'got',
+      };
+      const packageContent = `{
+        "peerDependencies": {
+          "got": ">=2.0.0"
+        }
+      }`;
+      const expected = `{
+        "peerDependencies": {
+          "got": ">=2.0.0"
+        }
+      }`;
+      const testContent = npmUpdater.updateDependency({
+        fileContent: packageContent,
+        packageFile: 'package.json',
+        upgrade,
+      });
+      expect(testContent).toEqual(expected);
+    });
+
     it('returns null if throws error', () => {
       const upgrade = {
         depType: 'blah',

--- a/lib/modules/manager/npm/update/dependency/index.ts
+++ b/lib/modules/manager/npm/update/dependency/index.ts
@@ -176,7 +176,10 @@ export function updateDependency({
     } else {
       oldVersion = parsedContents[depType as NpmDepType]![depName] as string;
     }
-    if (oldVersion === newValue) {
+    if (
+      oldVersion === newValue &&
+      (!upgrade.newName || upgrade.newName === depName)
+    ) {
       logger.trace('Version is already updated');
       return fileContent;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This change adds an additional condition so that replacement updates can proceed if the name changes but the version value does not.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: https://github.com/renovatebot/renovate/discussions/44426

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
