### PR TITLE
fix(stats): avoid max argument overflow

### DIFF
--- a/lib/util/stats.spec.ts
+++ b/lib/util/stats.spec.ts
@@ -50,6 +50,20 @@ describe('util/stats', () => {
         totalMs: 700,
       });
     });
+
+    it('does not overflow the call stack for large datasets', () => {
+      const res = makeTimingReport(
+        Array.from<number>({ length: 200_000 }).fill(1),
+      );
+
+      expect(res).toEqual({
+        avgMs: 1,
+        count: 200_000,
+        maxMs: 1,
+        medianMs: 1,
+        totalMs: 200_000,
+      });
+    });
   });
 
   describe('LookupStats', () => {

--- a/lib/util/stats.ts
+++ b/lib/util/stats.ts
@@ -17,7 +17,10 @@ export function makeTimingReport(data: number[]): TimingStatsReport {
   const count = data.length;
   const totalMs = data.reduce((a, c) => a + c, 0);
   const avgMs = count ? Math.round(totalMs / count) : 0;
-  const maxMs = Math.max(0, ...data);
+  let maxMs = 0;
+  for (const duration of data) {
+    maxMs = Math.max(maxMs, duration);
+  }
   const sorted = data.sort((a, b) => a - b);
   const medianMs = count ? sorted[Math.floor(count / 2)] : 0;
   return { count, avgMs, medianMs, maxMs, totalMs };


### PR DESCRIPTION
## Changes

`makeTimingReport()` spread every timing value into `Math.max()`. Large datasets could exceed JavaScript’s argument limit and terminate Renovate while repository statistics were being reported.

Calculate the maximum iteratively and add a regression test with 200,000 samples. This removes the argument-count limit while preserving existing behavior.

Reported in [Discussion #44135](https://github.com/renovatebot/renovate/discussions/44135).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5) was used to investigate the report, inspect the relevant code, implement and review the fix and regression test, and draft this pull request body.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable.