### PR TITLE
fix(platform/gitlab): retry MR creation on transient source_branch race.

### DIFF
--- a/lib/util/http/gitlab.spec.ts
+++ b/lib/util/http/gitlab.spec.ts
@@ -201,4 +201,68 @@ describe('util/http/gitlab', () => {
       );
     });
   });
+
+  describe('handles 400 source_branch errors', () => {
+    let NODE_ENV: string | undefined;
+
+    beforeAll(() => {
+      // Unset NODE_ENV so that we can test the retry logic
+      NODE_ENV = process.env.NODE_ENV;
+      delete process.env.NODE_ENV;
+    });
+
+    afterAll(() => {
+      process.env.NODE_ENV = NODE_ENV;
+    });
+
+    it('retries the request when source branch does not yet exist', async () => {
+      const body = { message: { source_branch: ['does not exist'] } };
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(400, body);
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(200, {});
+      const res = await gitlabApi.postJson('some-url', {});
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('does not retry more than twice when source branch does not exist', async () => {
+      const body = { message: { source_branch: ['does not exist'] } };
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(400, body);
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(400, body);
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(400, body);
+      await expect(gitlabApi.postJson('some-url', {})).rejects.toThrow(
+        HTTPError,
+      );
+    });
+
+    it('does not retry for unrelated 400 errors', async () => {
+      const body = { message: { base: ['Another error'] } };
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(400, body);
+      await expect(gitlabApi.postJson('some-url', {})).rejects.toThrow(
+        HTTPError,
+      );
+    });
+
+    it('does not retry for other source_branch 400 errors', async () => {
+      const body = { message: { source_branch: ['is invalid'] } };
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(400, body);
+      await expect(gitlabApi.postJson('some-url', {})).rejects.toThrow(
+        HTTPError,
+      );
+    });
+
+    it('does not retry other POST error codes', async () => {
+      const body = { message: 'Forbidden' };
+      httpMock.scope(gitlabApiHost).post('/api/v4/some-url').reply(403, body);
+      await expect(gitlabApi.postJson('some-url', {})).rejects.toThrow(
+        HTTPError,
+      );
+    });
+
+    it('does not retry non-POST requests', async () => {
+      const body = { message: { source_branch: ['does not exist'] } };
+      httpMock.scope(gitlabApiHost).get('/api/v4/some-url').reply(400, body);
+      await expect(gitlabApi.getJsonUnchecked('some-url')).rejects.toThrow(
+        HTTPError,
+      );
+    });
+  });
 });

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -119,8 +119,7 @@ export class GitlabHttp extends HttpBase<GitlabHttpOptions> {
     if (
       attemptCount <= retryOptions.limit &&
       error.options.method === 'POST' &&
-      error.response?.statusCode === 409 &&
-      error.response.rawBody.toString().includes('Resource lock')
+      isRetryablePostError(error)
     ) {
       const noise = Math.random() * 100;
       return 2 ** (attemptCount - 1) * 1000 + noise;
@@ -128,4 +127,29 @@ export class GitlabHttp extends HttpBase<GitlabHttpOptions> {
 
     return super.calculateRetryDelay(retryObject);
   }
+}
+
+/**
+ * Detects transient GitLab errors on POST requests that are safe to retry:
+ *
+ * - `409` with a `Resource lock` message, which happens when concurrent
+ *   requests conflict.
+ * - `400` with a `source_branch does not exist` message, which happens when a
+ *   freshly pushed branch is not yet visible to the API due to Gitaly eventual
+ *   consistency.
+ */
+function isRetryablePostError(error: RequestError): boolean {
+  const { response } = error;
+  if (response?.statusCode === 409) {
+    return response.rawBody.toString().includes('Resource lock');
+  }
+
+  if (response?.statusCode === 400) {
+    const rawBody = response.rawBody.toString();
+    return (
+      rawBody.includes('source_branch') && rawBody.includes('does not exist')
+    );
+  }
+
+  return false;
 }


### PR DESCRIPTION
## Changes

GitLab occasionally rejects a merge request POST with `400 {"message":{"source_branch":["does not exist"]}}` immediately after a branch push succeeds, because the freshly pushed ref is not yet visible to the API due to Gitaly eventual consistency. The request was not retried, leaving an orphaned branch until the next run.

Extend the existing `calculateRetryDelay` hook (which already retries transient `409 Resource lock` POST errors) to also retry this `400 source_branch does not exist` case, reusing got's bounded exponential backoff.

Closes #44498

Note: Original suggestion was to wrap with `wrapWithRetry`. This just extends the existing precedent but I'm happy to switch to `wrapWithRetry` if preferred.

## Context

Please select one of the following:

- [ X ] This closes an existing Issue, Closes: #44498
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request? Yes

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ X ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ X ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ X ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository