### PR TITLE
fix(gitlab): handle object status error messages

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1176,6 +1176,33 @@ describe('modules/platform/gitlab/index', () => {
       );
     });
 
+    it('logs and resolves when GitLab returns an object error message', async () => {
+      const scope = await initRepo();
+      scope
+        .post(
+          '/api/v4/projects/some%2Frepo/statuses/0d9c7726c3d628b7e28af234595cfd20febdbf8e',
+        )
+        .reply(400, { message: { status: ['is invalid'] } })
+        .get(
+          '/api/v4/projects/some%2Frepo/repository/commits/0d9c7726c3d628b7e28af234595cfd20febdbf8e',
+        )
+        .reply(200, { last_pipeline: { id: 123 } });
+
+      await expect(
+        gitlab.setBranchStatus({
+          branchName: 'some-branch',
+          context: 'some-context',
+          description: 'some-description',
+          state: 'green',
+          url: 'some-url',
+        }),
+      ).toResolve();
+
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        'Failed to set branch status',
+      );
+    });
+
     it.each(states)('sets branch status %s', async (state) => {
       const scope = await initRepo();
       scope

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1,5 +1,10 @@
 import { setTimeout } from 'node:timers/promises';
-import { isArray, isEmptyArray, isNonEmptyArray } from '@sindresorhus/is';
+import {
+  isArray,
+  isEmptyArray,
+  isNonEmptyArray,
+  isString,
+} from '@sindresorhus/is';
 import pMap from 'p-map';
 import semver from 'semver';
 import { GlobalConfig } from '../../../config/global.ts';
@@ -1044,7 +1049,8 @@ export async function setBranchStatus({
     await getStatus(branchName, false);
   } catch (err) /* v8 ignore next */ {
     if (
-      err.body?.message?.startsWith(
+      isString(err.body?.message) &&
+      err.body.message.startsWith(
         'Cannot transition status via :enqueue from :pending',
       )
     ) {


### PR DESCRIPTION
## Changes

GitLab can return a structured object in a commit-status error's `message` field. `setBranchStatus()` previously called `startsWith()` on that value, causing a secondary `TypeError` instead of following the existing warning path.

Guard the known string-only transition check with `isString()`. Structured and other unknown errors are still logged as `Failed to set branch status`. A regression test covers an object-shaped GitLab validation error.

Validation: `pnpm vitest lib/modules/platform/gitlab/index.spec.ts` (168 tests passed) and `pnpm check --all lib/modules/platform/gitlab/index.ts lib/modules/platform/gitlab/index.spec.ts`.

Reported in [Discussion #44213](https://github.com/renovatebot/renovate/discussions/44213).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5) was used to investigate the report, inspect the relevant code, implement and review the fix and regression test, and draft this pull request body.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable.