### PR TITLE
fix(manager/dockerfile): handle single-quoted empty ARG default value

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -957,6 +957,29 @@ describe('modules/manager/dockerfile/extract', () => {
       ]);
     });
 
+    it('handles FROM with single-quoted empty ARG default value', () => {
+      const res = extractPackageFile(
+        "ARG DOCKER_HUB_MIRROR=''\n" +
+          'ARG NODE_VERSION=21\n' +
+          'FROM ${DOCKER_HUB_MIRROR}node:${NODE_VERSION}-alpine\n',
+        '',
+        {},
+      )?.deps;
+      expect(res).toEqual([
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest: undefined,
+          currentValue: '21-alpine',
+          datasource: 'docker',
+          depName: 'node',
+          packageName: 'node',
+          depType: 'final',
+          replaceString: 'node:21-alpine',
+        },
+      ]);
+    });
+
     it('handles FROM with version in ARG value', () => {
       const res = extractPackageFile(
         'ARG\tVARIANT="1.60.0-bullseye" \nFROM\trust:${VARIANT}\n',

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -323,7 +323,10 @@ export function extractPackageFile(
       argsLines[argMatch.groups.name] = [lineNumberInstrStart, lineNumber];
       let argMatchValue = argMatch.groups?.value;
 
-      if (argMatchValue.startsWith('"') && argMatchValue.endsWith('"')) {
+      if (
+        (argMatchValue.startsWith('"') && argMatchValue.endsWith('"')) ||
+        (argMatchValue.startsWith("'") && argMatchValue.endsWith("'"))
+      ) {
         argMatchValue = argMatchValue.slice(1, -1);
       }
 


### PR DESCRIPTION
## Changes

Renovate's Dockerfile `ARG` value unquoting only stripped double quotes, so `ARG FOO=''` kept the literal `''` and `FROM ${FOO}node:...` resolved to `''node` (which fails lookup). This extends the unquoting in `lib/modules/manager/dockerfile/extract.ts` to strip single quotes the same way, so both `''` and `""` empty values yield an empty string.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44497
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small portions of code, tests, or documentation).
- [x] Yes — other (please describe): Drafted with Claude Code, using Anthropic's Claude model. AI was used for the code change, the unit test, and this description; I reviewed and verified the diff and test output myself.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Added `handles FROM with single-quoted empty ARG default value` in `extract.spec.ts` using the issue's exact repro (`ARG DOCKER_HUB_MIRROR=''`). Red before the fix (`depName: "''node"`), green after. Full dockerfile manager suite: 82 passed; the changed lines are at 100% coverage; prettier / oxlint / biome clean.
