### PR TITLE
docs: fix outdated statement that Docker major updates are disabled by default

### DIFF
--- a/docs/usage/docker.md
+++ b/docs/usage/docker.md
@@ -110,8 +110,8 @@ We recommend you use the `major.minor.patch` tagging scheme, so change `myimage:
 This way you can see the changes in Renovate PRs.
 You can see the difference between a PR that upgrades `myimage` from `1.1.1` to `1.1.2` and a PR that changes the contents of the version you already use (`1.1.1`).
 
-By default, Renovate will upgrade `minor` and `patch` versions, so from `1.2.0` to `1.2.1`, but _not_ upgrade `major` versions.
-If you wish to enable `major` versions: add the preset `docker:enableMajor` to the `extends` array in your `renovate.json` file.
+By default, Renovate will upgrade `major`, `minor` and `patch` versions.
+If you do _not_ want `major` updates: add the preset `docker:disableMajor` to the `extends` array in your `renovate.json` file.
 
 Renovate has some Docker-specific intelligence when it comes to versions.
 For example:
@@ -189,9 +189,9 @@ Add all paths to ignore into the `ignorePaths` configuration field. e.g.
 }
 ```
 
-### Enable Docker major updates
+### Disable Docker major updates
 
-Add `"docker:enableMajor"` to your `extends` array.
+Add `"docker:disableMajor"` to your `extends` array.
 
 ### Disable digest pinning
 


### PR DESCRIPTION
## Changes

`docs/usage/docker.md` still says that Renovate will _not_ upgrade `major` versions of Docker images by default, and recommends adding `docker:enableMajor` to enable them.

This has been outdated since #9470 (April 2021, Renovate v25), which removed `major: { enabled: false }` from the docker datasource's `defaultConfig`. Since then, `major` updates for the `docker` datasource are enabled by default, and neither `config:recommended` nor any preset it extends disables them (`docker:disableMajor` / `docker:enableMajor` are both opt-in).

This PR updates the two affected spots:

- The "Version Upgrading" paragraph now states that `major`, `minor` and `patch` are upgraded by default, and points to `docker:disableMajor` for opting out.
- The "Enable Docker major updates" config section is replaced with "Disable Docker major updates" (`docker:disableMajor`), since enabling is already the default.

The stale wording actively misleads users: we saw an automated code reviewer cite this page to (incorrectly) flag a `packageRules` entry matching `matchUpdateTypes: ["major"]` on a docker datasource as dead code.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR (research, wording, and commit) was prepared with Claude Code (model: Claude Fable 5), operated and reviewed by me. The root cause was verified against the source: the docker datasource `defaultConfig` on `main` and v43, the `config:recommended` preset chain, and the #9470 diff.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository