### PR TITLE
fix(terraform): normalize lock file constraint order after provider update

### DIFF
--- a/lib/modules/manager/terraform/lockfile/index.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/index.spec.ts
@@ -1263,7 +1263,8 @@ describe('modules/manager/terraform/lockfile/index', () => {
           },
           '>= 2.41.0, <= 2.41.0, >= 2.0.0',
         ),
-      ).toBe('>= 2.41.0, <= 2.46.0, >= 2.0.0');
+        // normalized: boundary version ascending
+      ).toBe('>= 2.0.0, >= 2.41.0, <= 2.46.0');
     });
 
     it('create constraint with full version', () => {
@@ -1277,6 +1278,48 @@ describe('modules/manager/terraform/lockfile/index', () => {
           '>= 4.0.0, < 4.12.0',
         ),
       ).toBe('< 4.21.0');
+    });
+
+    it('normalizes constraint order when a bumped exact pin overtakes a range', () => {
+      // A root module pins an exact version while a child module keeps a `~>`
+      // range; after the bump the exact pin must sort after the range.
+      // https://github.com/renovatebot/renovate/issues/37273
+      expect(
+        getNewConstraint(
+          {
+            currentValue: '5.0.0',
+            newValue: '5.9.0',
+            newVersion: '5.9.0',
+          },
+          '5.0.0, ~> 5.0',
+        ),
+      ).toBe('~> 5.0, 5.9.0');
+    });
+
+    it('normalizes constraint order for three-part pessimistic ranges', () => {
+      expect(
+        getNewConstraint(
+          {
+            currentValue: '0.0.176',
+            newValue: '0.0.186',
+            newVersion: '0.0.186',
+          },
+          '0.0.176, ~> 0.0.176',
+        ),
+      ).toBe('~> 0.0.176, 0.0.186');
+    });
+
+    it('normalizes constraint order when a range is widened past a lower bound', () => {
+      expect(
+        getNewConstraint(
+          {
+            currentValue: '~> 5.0',
+            newValue: '~> 6.0',
+            newVersion: '6.6.0',
+          },
+          '~> 5.0, >= 5.81.0',
+        ),
+      ).toBe('>= 5.81.0, ~> 6.0');
     });
   });
 });

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -20,6 +20,7 @@ import {
   isPinnedVersion,
   massageNewValue,
   readLockFile,
+  sortConstraints,
   writeLockUpdates,
 } from './util.ts';
 
@@ -101,9 +102,11 @@ export function getNewConstraint(
       `Updating constraint "${oldConstraint}" to replace "${currentValue}" with "${newValue}" for "${packageName}"`,
     );
     //remove surplus .0 version
-    return oldConstraint.replace(
-      regEx(`(,\\s|^)${escapeRegExp(currentValue)}(\\.0)*`),
-      `$1${newValue}`,
+    return sortConstraints(
+      oldConstraint.replace(
+        regEx(`(,\\s|^)${escapeRegExp(currentValue)}(\\.0)*`),
+        `$1${newValue}`,
+      ),
     );
   }
 
@@ -116,7 +119,7 @@ export function getNewConstraint(
     logger.debug(
       `Updating constraint "${oldConstraint}" to replace "${currentVersion}" with "${newVersion}" for "${packageName}"`,
     );
-    return oldConstraint.replace(currentVersion, newVersion);
+    return sortConstraints(oldConstraint.replace(currentVersion, newVersion));
   }
 
   if (isPinnedVersion(newValue)) {

--- a/lib/modules/manager/terraform/lockfile/util.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/util.spec.ts
@@ -1,7 +1,37 @@
 import { codeBlock } from 'common-tags';
-import { extractLocks } from './util.ts';
+import { extractLocks, sortConstraints } from './util.ts';
 
 describe('modules/manager/terraform/lockfile/util', () => {
+  describe('sortConstraints()', () => {
+    it.each`
+      input                               | expected
+      ${undefined}                        | ${undefined}
+      ${'5.9.0'}                          | ${'5.9.0'}
+      ${'~> 5.0'}                         | ${'~> 5.0'}
+      ${'~> 5.0, 5.9.0'}                  | ${'~> 5.0, 5.9.0'}
+      ${'5.9.0, ~> 5.0'}                  | ${'~> 5.0, 5.9.0'}
+      ${'0.0.186, ~> 0.0.176'}            | ${'~> 0.0.176, 0.0.186'}
+      ${'~> 6.0, >= 5.81.0'}              | ${'>= 5.81.0, ~> 6.0'}
+      ${'0.0.176, ~> 0.0.176'}            | ${'0.0.176, ~> 0.0.176'}
+      ${'>= 2.41.0, <= 2.46.0, >= 2.0.0'} | ${'>= 2.0.0, >= 2.41.0, <= 2.46.0'}
+      ${'< 2.0.0, > 1.0.0'}               | ${'> 1.0.0, < 2.0.0'}
+      ${'!= 1.5.0, >= 1.0.0'}             | ${'>= 1.0.0, != 1.5.0'}
+      ${'= 2.0.0, ~> 1.0'}                | ${'~> 1.0, = 2.0.0'}
+      ${'~> 2.0, ~> 2.0.0'}               | ${'~> 2.0.0, ~> 2.0'}
+      ${'>= 1.0.0, > 1.0.0'}              | ${'> 1.0.0, >= 1.0.0'}
+      ${'< 1.0.0, <= 1.0.0'}              | ${'<= 1.0.0, < 1.0.0'}
+      ${'!= 1.0.0, 1.0.0'}                | ${'1.0.0, != 1.0.0'}
+    `('normalizes "$input" to "$expected"', ({ input, expected }) => {
+      expect(sortConstraints(input)).toBe(expected);
+    });
+
+    it('leaves unparseable constraints untouched', () => {
+      expect(sortConstraints('not-a-version, also-bad')).toBe(
+        'not-a-version, also-bad',
+      );
+    });
+  });
+
   describe('extractLocks()', () => {
     it('returns null for empty', () => {
       const result = extractLocks('nothing here');

--- a/lib/modules/manager/terraform/lockfile/util.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/util.spec.ts
@@ -21,6 +21,7 @@ describe('modules/manager/terraform/lockfile/util', () => {
       ${'>= 1.0.0, > 1.0.0'}              | ${'> 1.0.0, >= 1.0.0'}
       ${'< 1.0.0, <= 1.0.0'}              | ${'<= 1.0.0, < 1.0.0'}
       ${'!= 1.0.0, 1.0.0'}                | ${'1.0.0, != 1.0.0'}
+      ${'1.0.0-rc1, ~> 1.0'}              | ${'1.0.0-rc1, ~> 1.0'}
     `('normalizes "$input" to "$expected"', ({ input, expected }) => {
       expect(sortConstraints(input)).toBe(expected);
     });

--- a/lib/modules/manager/terraform/lockfile/util.ts
+++ b/lib/modules/manager/terraform/lockfile/util.ts
@@ -230,6 +230,114 @@ export function writeLockUpdates(
   };
 }
 
+// Operators Terraform allows in a version constraint, matched longest-first so
+// ">=" wins over ">" and "<=" over "<".
+const constraintOperators = ['>=', '<=', '!=', '~>', '=', '>', '<'];
+
+interface ParsedConstraint {
+  raw: string;
+  operator: string;
+  rawVersion: string;
+  cmpVersion: string;
+}
+
+// Mirrors Terraform's getproviders.versionSelectionsBoundaryPriority: when two
+// constraints share the same boundary version, this decides their relative
+// order in the normalized string.
+function operatorPriority(operator: string, rawVersion: string): number {
+  switch (operator) {
+    case '>':
+      return 1;
+    case '>=':
+      return 2;
+    case '': // exact pin, serialized without an operator
+      return 3;
+    case '~>':
+      // patch-only (~> x.y.z) sorts before minor-only (~> x.y)
+      return rawVersion.split('.').length > 2 ? 4 : 5;
+    case '<=':
+      return 6;
+    case '<':
+      return 7;
+    case '!=':
+      return 8;
+    /* v8 ignore next 2 -- unreachable for constraints that parsed successfully */
+    default:
+      return 0;
+  }
+}
+
+// Pad the numeric core to three components, matching Terraform's
+// VersionSpec.ConstrainToZero so "5.0" and "5.0.0" compare (and dedupe) equal.
+function constrainToZero(version: string): string {
+  const [core, ...extra] = version.split(/(?=[-+])/);
+  const segments = core.split('.');
+  while (segments.length < 3) {
+    segments.push('0');
+  }
+  return segments.join('.') + extra.join('');
+}
+
+function parseConstraint(token: string): ParsedConstraint {
+  const raw = token.trim();
+  for (const operator of constraintOperators) {
+    if (raw.startsWith(operator)) {
+      const rawVersion = raw.slice(operator.length).trim();
+      return {
+        raw,
+        // Terraform serializes an exact pin without an operator, so treat "="
+        // the same as a bare version.
+        operator: operator === '=' ? '' : operator,
+        rawVersion,
+        cmpVersion: constrainToZero(rawVersion),
+      };
+    }
+  }
+  return {
+    raw,
+    operator: '',
+    rawVersion: raw,
+    cmpVersion: constrainToZero(raw),
+  };
+}
+
+/**
+ * Reorder the sub-constraints of a Terraform lock `constraints` string into the
+ * normalized form Terraform/OpenTofu require: boundary version ascending, ties
+ * broken by operator priority. Renovate updates a version in place without
+ * re-sorting, which produces strings Terraform rejects with "must be written in
+ * normalized form" once a bumped exact pin overtakes an inherited `~>` range.
+ * See https://github.com/renovatebot/renovate/issues/37273.
+ */
+export function sortConstraints(
+  constraint: string | undefined,
+): string | undefined {
+  if (!constraint?.includes(',')) {
+    return constraint;
+  }
+  const versioning = getVersioning('hashicorp');
+  const parsed: ParsedConstraint[] = [];
+  for (const token of constraint.split(',')) {
+    const entry = parseConstraint(token);
+    // Leave the constraint untouched if any token is unrecognizable, rather
+    // than risk corrupting it.
+    if (!versioning.isValid(entry.cmpVersion)) {
+      return constraint;
+    }
+    parsed.push(entry);
+  }
+  parsed.sort((a, b) => {
+    if (!versioning.equals(a.cmpVersion, b.cmpVersion)) {
+      return versioning.isGreaterThan(a.cmpVersion, b.cmpVersion) ? 1 : -1;
+    }
+    return (
+      operatorPriority(a.operator, a.rawVersion) -
+      operatorPriority(b.operator, b.rawVersion)
+    );
+  });
+  return parsed.map((entry) => entry.raw).join(', ');
+}
+
 export function massageNewValue(value: string | undefined): string | undefined {
   if (isNullOrUndefined(value)) {
     return value;

--- a/lib/modules/manager/terraform/lockfile/util.ts
+++ b/lib/modules/manager/terraform/lockfile/util.ts
@@ -266,7 +266,7 @@ function operatorPriority(operator: string, rawVersion: string): number {
       return 7;
     case '!=':
       return 8;
-    /* v8 ignore next 2 -- unreachable for constraints that parsed successfully */
+    /* v8 ignore next -- unreachable for constraints that parsed successfully */
     default:
       return 0;
   }

--- a/lib/modules/manager/terraform/lockfile/util.ts
+++ b/lib/modules/manager/terraform/lockfile/util.ts
@@ -230,8 +230,13 @@ export function writeLockUpdates(
   };
 }
 
+const hashicorpVersioning = getVersioning('hashicorp');
+
 // Operators Terraform allows in a version constraint, matched longest-first so
-// ">=" wins over ">" and "<=" over "<".
+// ">=" wins over ">" and "<=" over "<". The normalization implemented below
+// (operator set, boundary-version sort, priority tie-break) mirrors Terraform's
+// getproviders.VersionConstraintsString and versionSelectionsBoundaryPriority:
+// https://github.com/hashicorp/terraform/blob/main/internal/getproviders/providerreqs/version.go
 const constraintOperators = ['>=', '<=', '!=', '~>', '=', '>', '<'];
 
 interface ParsedConstraint {
@@ -270,12 +275,14 @@ function operatorPriority(operator: string, rawVersion: string): number {
 // Pad the numeric core to three components, matching Terraform's
 // VersionSpec.ConstrainToZero so "5.0" and "5.0.0" compare (and dedupe) equal.
 function constrainToZero(version: string): string {
-  const [core, ...extra] = version.split(/(?=[-+])/);
+  const sep = version.search(regEx(/[-+]/)); // start of prerelease/build metadata, -1 if none
+  const core = sep === -1 ? version : version.slice(0, sep);
+  const extra = sep === -1 ? '' : version.slice(sep);
   const segments = core.split('.');
   while (segments.length < 3) {
     segments.push('0');
   }
-  return segments.join('.') + extra.join('');
+  return segments.join('.') + extra;
 }
 
 function parseConstraint(token: string): ParsedConstraint {
@@ -315,20 +322,21 @@ export function sortConstraints(
   if (!constraint?.includes(',')) {
     return constraint;
   }
-  const versioning = getVersioning('hashicorp');
   const parsed: ParsedConstraint[] = [];
   for (const token of constraint.split(',')) {
     const entry = parseConstraint(token);
     // Leave the constraint untouched if any token is unrecognizable, rather
     // than risk corrupting it.
-    if (!versioning.isValid(entry.cmpVersion)) {
+    if (!hashicorpVersioning.isValid(entry.cmpVersion)) {
       return constraint;
     }
     parsed.push(entry);
   }
   parsed.sort((a, b) => {
-    if (!versioning.equals(a.cmpVersion, b.cmpVersion)) {
-      return versioning.isGreaterThan(a.cmpVersion, b.cmpVersion) ? 1 : -1;
+    if (!hashicorpVersioning.equals(a.cmpVersion, b.cmpVersion)) {
+      return hashicorpVersioning.isGreaterThan(a.cmpVersion, b.cmpVersion)
+        ? 1
+        : -1;
     }
     return (
       operatorPriority(a.operator, a.rawVersion) -


### PR DESCRIPTION
## Changes

Terraform and OpenTofu require the `constraints` field in `.terraform.lock.hcl` to be written in normalized form. When Renovate updates a provider version, `getNewConstraint` replaces the version in place but does not re-sort the sub-constraints.

When a provider's constraint combines an exact pin (from `required_providers`) with a `~>` range inherited from a module, bumping the pin can push it past the range boundary — e.g. `5.0.0, ~> 5.0` becomes `5.9.0, ~> 5.0`. That is no longer normalized, so `terraform`/`tofu init` fails:

> The recorded version constraints for provider registry.terraform.io/hashicorp/vault must be written in normalized form: "~> 5.0, 5.9.0".

This PR adds `sortConstraints`, which reorders the sub-constraints into Terraform's canonical order — boundary version ascending, ties broken by operator priority — mirroring `getproviders.VersionConstraintsString` in Terraform. It only reorders existing tokens (it never rewrites operators or version precision) and returns the string untouched if any token cannot be parsed, so it cannot corrupt a valid constraint. It is applied at the two in-place replacement branches of `getNewConstraint`.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #37273
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was written primarily by Claude Code (model: Claude Opus 4.8) — the code, tests, and this description. The approach was directed and reviewed by me, including cross-checking the sort order against Terraform's `getproviders.VersionConstraintsString`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (unit tests only; not yet run against a live repository)
