### PR TITLE
fix(manager/quadlet): enable digest replacement metadata

### DIFF
--- a/lib/modules/manager/quadlet/digest-replacement.spec.ts
+++ b/lib/modules/manager/quadlet/digest-replacement.spec.ts
@@ -1,0 +1,32 @@
+import { codeBlock } from 'common-tags';
+import { extractPackageFile } from './extract.ts';
+
+describe('modules/manager/quadlet/digest-replacement', () => {
+  it('supports digest replacement metadata for Quadlet images', () => {
+    const image =
+      'docker.io/library/alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375';
+    const content = codeBlock`
+      [Container]
+      Image=${image}
+    `;
+
+    const result = extractPackageFile(content, 'alpine.container', {});
+
+    expect(result).toEqual({
+      deps: [
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest:
+            'sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375',
+          currentValue: '3.23.0',
+          datasource: 'docker',
+          depName: 'docker.io/library/alpine',
+          depType: 'image',
+          packageName: 'docker.io/library/alpine',
+          replaceString: image,
+        },
+      ],
+    });
+  });
+});

--- a/lib/modules/manager/quadlet/extract.ts
+++ b/lib/modules/manager/quadlet/extract.ts
@@ -40,7 +40,7 @@ function getQuadletImage(
     const cleanedImage = image
       .replace(regEx(/^docker:\/\//), '')
       .replace(regEx(/^docker-daemon:/), '');
-    const dep = getDep(cleanedImage, false, config.registryAliases);
+    const dep = getDep(cleanedImage, true, config.registryAliases);
     if (dep) {
       dep.depType = 'image';
 


### PR DESCRIPTION
## Changes

Enable Quadlet Docker image replacement metadata for tag-and-digest updates and add a focused regression test.

## Context

- [x] This closes an existing Issue, Closes: #44500
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Codex (OpenAI) was used to generate the code and focused regression test under human review.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

- `node_modules/.bin/vitest lib/modules/manager/quadlet/digest-replacement.spec.ts` — passed in a network-isolated container.

---
AI assistance was used; I reviewed and own this change.

Northset self-run record for commit `77ba52c5b588`: [M-016 receipt](https://northset-oss.github.io/verification-pilot/#M-016).
It records the declared checks and published bundle provenance.
Contributor self-run; not maintainer verification.
