### PR TITLE
refactor(oxlint): enable no-else-return and unicorn/no-lonely-if

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -66,6 +66,8 @@
     "prefer-template": "error",
     "prefer-arrow-callback": ["error", { "allowUnboundThis": false }],
     "no-nested-ternary": "error",
+    "no-else-return": ["error", { "allowElseIf": false }],
+    "unicorn/no-lonely-if": "error",
 
     "renovate/enforce-ts-extension": "error",
     "renovate/no-hardcoded-docs-url": "error",

--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -289,14 +289,12 @@ If you have specified global self-hosted configuration (https://docs.renovatebot
 
   await program.parseAsync();
 })().catch((e) => {
-  if (e instanceof CommanderError) {
-    // Commander throws an error at the end of Action execution i.e. as part of the `help` and `version` commands, and so we don't want to return an error code in this case
-    if (
-      e.code === 'commander.helpDisplayed' ||
-      e.code === 'commander.version'
-    ) {
-      return;
-    }
+  // Commander throws an error at the end of Action execution i.e. as part of the `help` and `version` commands, and so we don't want to return an error code in this case
+  if (
+    e instanceof CommanderError &&
+    (e.code === 'commander.helpDisplayed' || e.code === 'commander.version')
+  ) {
+    return;
   }
 
   // oxlint-disable-next-line no-console -- intentional: display critical error on CLI

--- a/lib/config/app-strings.ts
+++ b/lib/config/app-strings.ts
@@ -29,7 +29,8 @@ export function getConfigFileNames(platform?: PlatformId): string[] {
       const matchResult = platfromRe.exec(filename);
       if (!matchResult) {
         return true;
-      } else if (matchResult?.groups?.platform === platform) {
+      }
+      if (matchResult?.groups?.platform === platform) {
         return true;
       }
 

--- a/lib/config/decrypt/bcpgp.ts
+++ b/lib/config/decrypt/bcpgp.ts
@@ -57,9 +57,8 @@ function runtime(): RuntimeType {
     if (isSupportedRuntime(runtime)) {
       logger.trace({ runtime }, 'Using configured PGP runtime');
       return runtime;
-    } else {
-      logger.once.warn({ runtime }, 'Unknown PGP runtime, using wasm-java');
     }
+    logger.once.warn({ runtime }, 'Unknown PGP runtime, using wasm-java');
   }
   logger.trace('Using default PGP runtime: wasm-java');
   return 'wasm-java';

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -205,22 +205,23 @@ export function migrateConfig(
         return pattern.replace(/\.in\$\/$/, '.txt$/');
       });
     }
-    // @ts-expect-error -- TODO: fix me
-    if (isNonEmptyArray(migratedConfig.matchManagers)) {
+    if (
       // @ts-expect-error -- TODO: fix me
-      if (migratedConfig.matchManagers.includes('gradle-lite')) {
+      isNonEmptyArray(migratedConfig.matchManagers) &&
+      // @ts-expect-error -- TODO: fix me
+      migratedConfig.matchManagers.includes('gradle-lite')
+    ) {
+      // @ts-expect-error -- TODO: fix me
+      // v8 ignore else -- TODO: add test #40625
+      if (!migratedConfig.matchManagers.includes('gradle')) {
         // @ts-expect-error -- TODO: fix me
-        // v8 ignore else -- TODO: add test #40625
-        if (!migratedConfig.matchManagers.includes('gradle')) {
-          // @ts-expect-error -- TODO: fix me
-          migratedConfig.matchManagers.push('gradle');
-        }
-        // @ts-expect-error -- TODO: fix me
-        migratedConfig.matchManagers = migratedConfig.matchManagers.filter(
-          // @ts-expect-error -- TODO: fix me
-          (manager) => manager !== 'gradle-lite',
-        );
+        migratedConfig.matchManagers.push('gradle');
       }
+      // @ts-expect-error -- TODO: fix me
+      migratedConfig.matchManagers = migratedConfig.matchManagers.filter(
+        // @ts-expect-error -- TODO: fix me
+        (manager) => manager !== 'gradle-lite',
+      );
     }
     // @ts-expect-error -- TODO: fix me
     if (isNonEmptyObject(migratedConfig['gradle-lite'])) {

--- a/lib/config/validation-helpers/match-base-branches.ts
+++ b/lib/config/validation-helpers/match-base-branches.ts
@@ -11,13 +11,14 @@ export function check({
   baseBranchPatterns,
 }: CheckBaseBranchesArgs): ValidationMessage[] {
   const warnings: ValidationMessage[] = [];
-  if (Array.isArray(resolvedRule.matchBaseBranches)) {
-    if (!isNonEmptyArray(baseBranchPatterns)) {
-      warnings.push({
-        topic: 'Configuration Error',
-        message: `${currentPath}: You must configure baseBranchPatterns in order to use them inside matchBaseBranches.`,
-      });
-    }
+  if (
+    Array.isArray(resolvedRule.matchBaseBranches) &&
+    !isNonEmptyArray(baseBranchPatterns)
+  ) {
+    warnings.push({
+      topic: 'Configuration Error',
+      message: `${currentPath}: You must configure baseBranchPatterns in order to use them inside matchBaseBranches.`,
+    });
   }
 
   return warnings;

--- a/lib/config/validation-helpers/regex-glob-matchers.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.ts
@@ -26,13 +26,11 @@ export function check({
       // Validate regex pattern
       // No need to validate if the string is a glob
       // minimatch allows any string as glob
-      if (isRegexMatch(matcher)) {
-        if (!getRegexPredicate(matcher)) {
-          res.push({
-            topic: 'Configuration Error',
-            message: `Failed to parse regex pattern for ${currentPath}: ${matcher}`,
-          });
-        }
+      if (isRegexMatch(matcher) && !getRegexPredicate(matcher)) {
+        res.push({
+          topic: 'Configuration Error',
+          message: `Failed to parse regex pattern for ${currentPath}: ${matcher}`,
+        });
       }
     }
   } else {

--- a/lib/config/validation-helpers/utils.ts
+++ b/lib/config/validation-helpers/utils.ts
@@ -69,15 +69,14 @@ export function isFalseGlobal(
   optionName: string,
   parentPath?: string,
 ): boolean {
-  if (parentPath?.includes('hostRules')) {
-    // v8 ignore else -- TODO: add test #40625
-    if (
-      optionName === 'token' ||
+  // v8 ignore else -- TODO: add test #40625
+  if (
+    parentPath?.includes('hostRules') &&
+    (optionName === 'token' ||
       optionName === 'username' ||
-      optionName === 'password'
-    ) {
-      return true;
-    }
+      optionName === 'password')
+  ) {
+    return true;
   }
 
   return false;

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -925,13 +925,14 @@ export async function validateConfig(
               : GlobalConfig.get('allowedHeaders');
           for (const rule of val as HostRule[]) {
             if (isNonEmptyString(rule.matchHost)) {
-              if (rule.matchHost.includes('://')) {
-                if (parseUrl(rule.matchHost) === null) {
-                  errors.push({
-                    topic: 'Configuration Error',
-                    message: `hostRules matchHost \`${rule.matchHost}\` is not a valid URL.`,
-                  });
-                }
+              if (
+                rule.matchHost.includes('://') &&
+                parseUrl(rule.matchHost) === null
+              ) {
+                errors.push({
+                  topic: 'Configuration Error',
+                  message: `hostRules matchHost \`${rule.matchHost}\` is not a valid URL.`,
+                });
               }
             } else if (isEmptyString(rule.matchHost)) {
               errors.push({

--- a/lib/modules/datasource/artifactory/index.ts
+++ b/lib/modules/datasource/artifactory/index.ts
@@ -91,14 +91,12 @@ export class ArtifactoryDatasource extends Datasource {
         );
       }
     } catch (err) {
-      if (err instanceof HttpError) {
-        if (err.response?.statusCode === 404) {
-          logger.warn(
-            { registryUrl, packageName },
-            'artifactory: `Not Found` error',
-          );
-          return null;
-        }
+      if (err instanceof HttpError && err.response?.statusCode === 404) {
+        logger.warn(
+          { registryUrl, packageName },
+          'artifactory: `Not Found` error',
+        );
+        return null;
       }
       this.handleGenericErrors(err);
     }

--- a/lib/modules/datasource/azure-pipelines-tasks/index.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.ts
@@ -81,27 +81,22 @@ export class AzurePipelinesTasksDatasource extends Datasource {
         });
 
       return result;
-    } else {
-      const versions =
-        (
-          await this.getTasks(
-            BUILT_IN_TASKS_URL,
-            {},
-            AzurePipelinesFallbackTasks,
-          )
-        )[packageName.toLowerCase()] ??
-        (
-          await this.getTasks(
-            MARKETPLACE_TASKS_URL,
-            {},
-            AzurePipelinesFallbackTasks,
-          )
-        )[packageName.toLowerCase()];
+    }
+    const versions =
+      (
+        await this.getTasks(BUILT_IN_TASKS_URL, {}, AzurePipelinesFallbackTasks)
+      )[packageName.toLowerCase()] ??
+      (
+        await this.getTasks(
+          MARKETPLACE_TASKS_URL,
+          {},
+          AzurePipelinesFallbackTasks,
+        )
+      )[packageName.toLowerCase()];
 
-      if (versions) {
-        const releases = versions.map((version) => ({ version }));
-        return { releases };
-      }
+    if (versions) {
+      const releases = versions.map((version) => ({ version }));
+      return { releases };
     }
 
     return null;

--- a/lib/modules/datasource/conda/index.ts
+++ b/lib/modules/datasource/conda/index.ts
@@ -79,10 +79,8 @@ export class CondaDatasource extends Datasource {
         result.releases.push(thisRelease);
       });
     } catch (err) {
-      if (err instanceof HttpError) {
-        if (err.response?.statusCode !== 404) {
-          throw new ExternalHostError(err);
-        }
+      if (err instanceof HttpError && err.response?.statusCode !== 404) {
+        throw new ExternalHostError(err);
       }
       this.handleGenericErrors(err);
     }

--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -510,11 +510,10 @@ describe('modules/datasource/crate/index', () => {
                 'fatal: dumb http transport does not support shallow capabilities',
               ),
             );
-          } else {
-            const path = `${clonePath}/my/pk/mypkg`;
-            fs.mkdirSync(upath.dirname(path), { recursive: true });
-            fs.writeFileSync(path, Fixtures.get('mypkg'), { encoding: 'utf8' });
           }
+          const path = `${clonePath}/my/pk/mypkg`;
+          fs.mkdirSync(upath.dirname(path), { recursive: true });
+          fs.writeFileSync(path, Fixtures.get('mypkg'), { encoding: 'utf8' });
         });
 
       const gitMock = partial<SimpleGit>({
@@ -556,9 +555,8 @@ describe('modules/datasource/crate/index', () => {
                 'fatal: dumb http transport does not support shallow capabilities',
               ),
             );
-          } else {
-            return Promise.reject(new Error('mocked error'));
           }
+          return Promise.reject(new Error('mocked error'));
         });
 
       const gitMock = partial<SimpleGit>({

--- a/lib/modules/datasource/datasource.ts
+++ b/lib/modules/datasource/datasource.ts
@@ -59,10 +59,11 @@ export abstract class Datasource implements DatasourceApi {
       this.handleHttpErrors(err);
 
       const statusCode = err.response?.statusCode;
-      if (statusCode) {
-        if (statusCode === 429 || (statusCode >= 500 && statusCode < 600)) {
-          throw new ExternalHostError(err);
-        }
+      if (
+        statusCode &&
+        (statusCode === 429 || (statusCode >= 500 && statusCode < 600))
+      ) {
+        throw new ExternalHostError(err);
       }
     }
 

--- a/lib/modules/datasource/devbox/index.ts
+++ b/lib/modules/datasource/devbox/index.ts
@@ -44,10 +44,8 @@ export class DevboxDatasource extends Datasource {
       res.releases = response.body.releases;
       res.homepage = response.body.homepage;
     } catch (err) {
-      if (err instanceof HttpError) {
-        if (err.response?.statusCode !== 404) {
-          throw new ExternalHostError(err);
-        }
+      if (err instanceof HttpError && err.response?.statusCode !== 404) {
+        throw new ExternalHostError(err);
       }
       this.handleGenericErrors(err);
     }

--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -22,7 +22,8 @@ export async function getECRAuthToken(
       `AWS user specified, encoding basic auth credentials for ECR registry`,
     );
     return Buffer.from(`AWS:${opts.password}`).toString('base64');
-  } else if (opts.username && opts.password) {
+  }
+  if (opts.username && opts.password) {
     logger.trace(
       `Using AWS accessKey to get Authorization token for ECR registry`,
     );

--- a/lib/modules/datasource/galaxy-collection/index.ts
+++ b/lib/modules/datasource/galaxy-collection/index.ts
@@ -125,20 +125,19 @@ export class GalaxyCollectionDatasource extends Datasource {
       return ensureTrailingSlash(
         joinUrlParts(registryUrl, 'api/v3/collections', namespace, projectName),
       );
-    } else {
-      const repository =
-        repositoryRegex.exec(registryUrl)?.groups?.repository ?? 'published';
-      return ensureTrailingSlash(
-        joinUrlParts(
-          registryUrl,
-          'v3/plugin/ansible/content',
-          repository,
-          'collections/index',
-          namespace,
-          projectName,
-        ),
-      );
     }
+    const repository =
+      repositoryRegex.exec(registryUrl)?.groups?.repository ?? 'published';
+    return ensureTrailingSlash(
+      joinUrlParts(
+        registryUrl,
+        'v3/plugin/ansible/content',
+        repository,
+        'collections/index',
+        namespace,
+        projectName,
+      ),
+    );
   }
 
   private async _getVersionDetails(

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -247,11 +247,11 @@ export class GoProxyDatasource extends Datasource {
     const parts = goDirective.split('.');
     if (parts.length === 1) {
       return `${parts[0]}.0.0`;
-    } else if (parts.length === 2) {
-      return `${parts[0]}.${parts[1]}.0`;
-    } else {
-      return `${parts[0]}.${parts[1]}.${parts[2]}`;
     }
+    if (parts.length === 2) {
+      return `${parts[0]}.${parts[1]}.0`;
+    }
+    return `${parts[0]}.${parts[1]}.${parts[2]}`;
   }
 
   async getLatestVersion(

--- a/lib/modules/datasource/java-version/index.ts
+++ b/lib/modules/datasource/java-version/index.ts
@@ -85,10 +85,8 @@ export class JavaVersionDatasource extends Datasource {
         releases = await this.getPageReleases(url, page);
       }
     } catch (err) {
-      if (err instanceof HttpError) {
-        if (err.response?.statusCode !== 404) {
-          throw new ExternalHostError(err);
-        }
+      if (err instanceof HttpError && err.response?.statusCode !== 404) {
+        throw new ExternalHostError(err);
       }
       this.handleGenericErrors(err);
     }

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -195,9 +195,8 @@ export async function downloadHttpProtocol(
             }
           }
           return Result.err({ type: 'maven-central-temporary-error', err });
-        } else {
-          return Result.err({ type: 'temporary-error' });
         }
+        return Result.err({ type: 'temporary-error' });
       }
 
       if (isConnectionError(err)) {

--- a/lib/modules/datasource/nuget/common.ts
+++ b/lib/modules/datasource/nuget/common.ts
@@ -63,12 +63,11 @@ export function sortNugetVersions(a: string, b: string): number {
   if (versioning.isValid(a)) {
     if (versioning.isValid(b)) {
       return versioning.sortVersions(a, b);
-    } else {
-      return 1;
     }
-  } else if (versioning.isValid(b)) {
-    return -1;
-  } else {
-    return 0;
+    return 1;
   }
+  if (versioning.isValid(b)) {
+    return -1;
+  }
+  return 0;
 }

--- a/lib/modules/datasource/util.ts
+++ b/lib/modules/datasource/util.ts
@@ -26,17 +26,15 @@ export async function getGoogleAuthHostRule(): Promise<HostRule | null> {
         username: 'oauth2accesstoken',
         password: accessToken,
       };
-    } else {
-      logger.warn(
-        'Could not retrieve access token using google-auth-library getAccessToken',
-      );
     }
+    logger.warn(
+      'Could not retrieve access token using google-auth-library getAccessToken',
+    );
   } catch (err) {
     if (err.message?.includes('Could not load the default credentials')) {
       return null;
-    } else {
-      throw err;
     }
+    throw err;
   }
   return null;
 }

--- a/lib/modules/manager/azure-pipelines/extract.ts
+++ b/lib/modules/manager/azure-pipelines/extract.ts
@@ -125,12 +125,12 @@ export function parseAzurePipelines(
   const res = AzurePipelinesYaml.safeParse(content);
   if (res.success) {
     return res.data;
-  } else {
-    logger.debug(
-      { err: res.error, packageFile },
-      'Error parsing pubspec lockfile.',
-    );
   }
+  logger.debug(
+    { err: res.error, packageFile },
+    'Error parsing pubspec lockfile.',
+  );
+
   return null;
 }
 

--- a/lib/modules/manager/bazel/extract.ts
+++ b/lib/modules/manager/bazel/extract.ts
@@ -27,10 +27,12 @@ export function extractPackageFile(
       // functionality work correctly.
       const rules = [...dockerRules, ...ociRules, ...gitRules, ...goRules];
       const replaceString = fragment.value;
-      if (rules.some((rule) => replaceString.startsWith(rule))) {
-        if (dep.currentValue && dep.currentDigest) {
-          dep.replaceString = replaceString;
-        }
+      if (
+        rules.some((rule) => replaceString.startsWith(rule)) &&
+        dep.currentValue &&
+        dep.currentDigest
+      ) {
+        dep.replaceString = replaceString;
       }
 
       deps.push(dep);

--- a/lib/modules/manager/buildpacks/extract.ts
+++ b/lib/modules/manager/buildpacks/extract.ts
@@ -36,7 +36,8 @@ function isBuildpackRegistryId(ref: string): boolean {
   const bpRegistryMatch = buildpackRegistryId.exec(ref);
   if (!bpRegistryMatch) {
     return false;
-  } else if (!bpRegistryMatch.groups?.version) {
+  }
+  if (!bpRegistryMatch.groups?.version) {
     return true;
   }
   return isVersion(bpRegistryMatch.groups.version);

--- a/lib/modules/manager/bundler/common.ts
+++ b/lib/modules/manager/bundler/common.ts
@@ -28,32 +28,32 @@ export async function getRubyConstraint(
   if (ruby) {
     logger.debug('Using ruby constraint from config');
     return ruby;
-  } else {
-    const rubyMatch = extractRubyVersion(newPackageFileContent);
-    if (rubyMatch) {
-      logger.debug('Using ruby version from gemfile');
-      return rubyMatch;
-    }
-    for (const file of ['.ruby-version', '.tool-versions']) {
-      const rubyVersion = (
-        await readLocalFile(getSiblingFileName(packageFileName, file), 'utf8')
-      )?.match(regEx(/^(?:ruby(?:-|\s+))?(\d[\d.]*)/m))?.[1];
-      if (rubyVersion) {
-        logger.debug(`Using ruby version specified in ${file}`);
-        return rubyVersion;
-      }
-    }
-    const lockFile = await getLockFilePath(packageFileName);
-    if (lockFile) {
-      const rubyVersion = (await readLocalFile(lockFile, 'utf8'))?.match(
-        regEx(/^ {3}ruby (\d[\d.]*)(?:[a-z]|\s|$)/m),
-      )?.[1];
-      if (rubyVersion) {
-        logger.debug(`Using ruby version specified in lock file`);
-        return rubyVersion;
-      }
+  }
+  const rubyMatch = extractRubyVersion(newPackageFileContent);
+  if (rubyMatch) {
+    logger.debug('Using ruby version from gemfile');
+    return rubyMatch;
+  }
+  for (const file of ['.ruby-version', '.tool-versions']) {
+    const rubyVersion = (
+      await readLocalFile(getSiblingFileName(packageFileName, file), 'utf8')
+    )?.match(regEx(/^(?:ruby(?:-|\s+))?(\d[\d.]*)/m))?.[1];
+    if (rubyVersion) {
+      logger.debug(`Using ruby version specified in ${file}`);
+      return rubyVersion;
     }
   }
+  const lockFile = await getLockFilePath(packageFileName);
+  if (lockFile) {
+    const rubyVersion = (await readLocalFile(lockFile, 'utf8'))?.match(
+      regEx(/^ {3}ruby (\d[\d.]*)(?:[a-z]|\s|$)/m),
+    )?.[1];
+    if (rubyVersion) {
+      logger.debug(`Using ruby version specified in lock file`);
+      return rubyVersion;
+    }
+  }
+
   return null;
 }
 
@@ -68,15 +68,15 @@ export function getBundlerConstraint(
   if (bundler) {
     logger.debug('Using bundler constraint from config');
     return bundler;
-  } else {
-    const bundledWith = regEx(/\nBUNDLED WITH\n\s+(.*?)(\n|$)/).exec(
-      existingLockFileContent,
-    );
-    if (bundledWith) {
-      logger.debug('Using bundler version specified in lockfile');
-      return bundledWith[1];
-    }
   }
+  const bundledWith = regEx(/\nBUNDLED WITH\n\s+(.*?)(\n|$)/).exec(
+    existingLockFileContent,
+  );
+  if (bundledWith) {
+    logger.debug('Using bundler version specified in lockfile');
+    return bundledWith[1];
+  }
+
   return null;
 }
 

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -131,10 +131,8 @@ export async function extractPackageFile(
     }
 
     const variableMatch = variableMatchRegex.exec(line);
-    if (variableMatch) {
-      if (variableMatch.groups?.key) {
-        variables[variableMatch.groups?.key] = variableMatch.groups?.value;
-      }
+    if (variableMatch?.groups?.key) {
+      variables[variableMatch.groups?.key] = variableMatch.groups?.value;
     }
 
     const gemMatch = gemMatchRegex.exec(line)?.groups;
@@ -201,10 +199,11 @@ export async function extractPackageFile(
         if (sourceBlockMatch.groups?.registryUrl) {
           repositoryUrl = sourceBlockMatch.groups.registryUrl;
         }
-        if (sourceBlockMatch.groups?.sourceName) {
-          if (variables[sourceBlockMatch.groups.sourceName]) {
-            repositoryUrl = variables[sourceBlockMatch.groups.sourceName];
-          }
+        if (
+          sourceBlockMatch.groups?.sourceName &&
+          variables[sourceBlockMatch.groups.sourceName]
+        ) {
+          repositoryUrl = variables[sourceBlockMatch.groups.sourceName];
         }
         const sourceLineNumber = lineNumber;
         let sourceContent = '';

--- a/lib/modules/manager/cargo/extract.ts
+++ b/lib/modules/manager/cargo/extract.ts
@@ -88,12 +88,11 @@ async function readCargoConfig(): Promise<CargoConfig | null> {
       const parsedCargoConfig = CargoConfig.safeParse(payload);
       if (parsedCargoConfig.success) {
         return parsedCargoConfig.data;
-      } else {
-        logger.debug(
-          { err: parsedCargoConfig.error, path },
-          `Error parsing cargo config`,
-        );
       }
+      logger.debug(
+        { err: parsedCargoConfig.error, path },
+        `Error parsing cargo config`,
+      );
     }
   }
 
@@ -155,15 +154,13 @@ function resolveRegistryIndex(
   const registryIndex = config.registries?.[registryName]?.index;
   if (registryIndex) {
     return registryIndex;
-  } else {
-    // we don't need an explicit index if we're using the default registry
-    if (registryName === DEFAULT_REGISTRY_ID) {
-      return DEFAULT_REGISTRY_URL;
-    } else {
-      logger.debug(`${registryName} cargo registry is missing index`);
-      return null;
-    }
   }
+  // we don't need an explicit index if we're using the default registry
+  if (registryName === DEFAULT_REGISTRY_ID) {
+    return DEFAULT_REGISTRY_URL;
+  }
+  logger.debug(`${registryName} cargo registry is missing index`);
+  return null;
 }
 
 export async function extractPackageFile(

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -138,9 +138,8 @@ function resolveHelmRepository(
             registryAliases,
           ).packageName;
           return null;
-        } else {
-          return repo.spec.url;
         }
+        return repo.spec.url;
       })
       .filter(isString);
 

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -130,10 +130,12 @@ export function matchesContentDescriptor(
   if (hasIncludes && hasExcludes) {
     // if both includes and excludes exist, dep must match include and not match exclude
     return matchesInclude && !matchesExclude;
-  } else if (hasIncludes) {
+  }
+  if (hasIncludes) {
     // if only includes exist, dep must match at least one include
     return matchesInclude;
-  } else if (hasExcludes) {
+  }
+  if (hasExcludes) {
     // if only excludes exist, dep must not match any exclude
     return !matchesExclude;
   }

--- a/lib/modules/manager/gradle/extract/catalog.ts
+++ b/lib/modules/manager/gradle/extract/catalog.ts
@@ -106,14 +106,13 @@ function extractVersion({
       depSubContent: versionSubContent,
       sectionKey: originalAlias,
     });
-  } else {
-    return extractLiteralVersion({
-      version,
-      depStartIndex,
-      depSubContent,
-      sectionKey: depName,
-    });
   }
+  return extractLiteralVersion({
+    version,
+    depStartIndex,
+    depSubContent,
+    sectionKey: depName,
+  });
 }
 
 function extractLiteralVersion({
@@ -129,11 +128,13 @@ function extractLiteralVersion({
 }): VersionExtract {
   if (!version) {
     return { skipReason: 'unspecified-version' };
-  } else if (isString(version)) {
+  }
+  if (isString(version)) {
     const fileReplacePosition =
       depStartIndex + findVersionIndex(depSubContent, sectionKey, version);
     return { currentValue: version, fileReplacePosition };
-  } else if (isPlainObject(version)) {
+  }
+  if (isPlainObject(version)) {
     // https://github.com/gradle/gradle/blob/d9adf33a57925582988fc512002dcc0e8ce4db95/subprojects/core/src/main/java/org/gradle/api/internal/catalog/parser/TomlCatalogFileParser.java#L368
     // https://docs.gradle.org/current/userguide/rich_versions.html
     // https://docs.gradle.org/current/userguide/platforms.html#sub::toml-dependencies-format

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -22,9 +22,8 @@ import {
 function isValidChartName(name: string | undefined, oci: boolean): boolean {
   if (oci) {
     return !!name && !regEx(/[!@#$%^&*(),.?":{}|<>A-Z]/).test(name);
-  } else {
-    return !!name && !regEx(/[!@#$%^&*(),.?":{}/|<>A-Z]/).test(name);
   }
+  return !!name && !regEx(/[!@#$%^&*(),.?":{}/|<>A-Z]/).test(name);
 }
 
 function isLocalPath(possiblePath: string): boolean {

--- a/lib/modules/manager/maven/update.ts
+++ b/lib/modules/manager/maven/update.ts
@@ -69,7 +69,8 @@ export function updateAtPosition(
     // TODO: validate newValue (#22198)
     const replacedPart = versionPart.replace(version, newValue!);
     return leftPart + replacedPart + restPart;
-  } else if (
+  }
+  if (
     upgrade.datasource === 'docker' ||
     upgrade.datasource === 'buildpacks-registry'
   ) {

--- a/lib/modules/manager/mise/utils.ts
+++ b/lib/modules/manager/mise/utils.ts
@@ -8,8 +8,7 @@ export function parseTomlFile(
   const res = MiseFile.safeParse(content);
   if (res.success) {
     return res.data;
-  } else {
-    logger.debug({ err: res.error, packageFile }, 'Error parsing Mise file.');
-    return null;
   }
+  logger.debug({ err: res.error, packageFile }, 'Error parsing Mise file.');
+  return null;
 }

--- a/lib/modules/manager/npm/extract/yarn.ts
+++ b/lib/modules/manager/npm/extract/yarn.ts
@@ -120,7 +120,8 @@ export function getYarnVersionFromLock(lockfile: LockFile): string {
   if (lockfileVersion && lockfileVersion >= 8) {
     // https://github.com/yarnpkg/berry/commit/9bcd27ae34aee77a567dd104947407532fa179b3
     return '^3.0.0';
-  } else if (lockfileVersion && lockfileVersion >= 6) {
+  }
+  if (lockfileVersion && lockfileVersion >= 6) {
     // https://github.com/yarnpkg/berry/commit/f753790380cbda5b55d028ea84b199445129f9ba
     return '^2.2.0';
   }

--- a/lib/modules/manager/npm/npmrc.ts
+++ b/lib/modules/manager/npm/npmrc.ts
@@ -30,10 +30,8 @@ export async function resolveNpmrc(
         npmrc = config.npmrc;
       } else {
         npmrc = config.npmrc ?? '';
-        if (npmrc.length) {
-          if (!npmrc.endsWith('\n')) {
-            npmrc += '\n';
-          }
+        if (npmrc.length && !npmrc.endsWith('\n')) {
+          npmrc += '\n';
         }
         if (repoNpmrc?.includes('package-lock')) {
           logger.debug('Stripping package-lock setting from .npmrc');

--- a/lib/modules/manager/npm/update/dependency/common.ts
+++ b/lib/modules/manager/npm/update/dependency/common.ts
@@ -12,13 +12,12 @@ export function getNewGitValue(upgrade: Upgrade): string | null {
       // TODO #22198
       upgrade.newDigest!.substring(0, upgrade.currentDigest.length),
     );
-  } else {
-    logger.debug('Updating git version tag');
-    return upgrade.currentRawValue.replace(
-      upgrade.currentValue,
-      upgrade.newValue,
-    );
   }
+  logger.debug('Updating git version tag');
+  return upgrade.currentRawValue.replace(
+    upgrade.currentValue,
+    upgrade.newValue,
+  );
 }
 
 export function getNewNpmAliasValue(

--- a/lib/modules/manager/npm/update/dependency/pnpm.ts
+++ b/lib/modules/manager/npm/update/dependency/pnpm.ts
@@ -162,7 +162,6 @@ function getDepPath({
 }): string[] {
   if (catalogName === 'default' && usesImplicitDefaultCatalog) {
     return ['catalog', depName];
-  } else {
-    return ['catalogs', catalogName, depName];
   }
+  return ['catalogs', catalogName, depName];
 }

--- a/lib/modules/manager/npm/update/dependency/yarn.ts
+++ b/lib/modules/manager/npm/update/dependency/yarn.ts
@@ -139,7 +139,6 @@ function getDepPath({
 }): string[] {
   if (catalogName === 'default') {
     return ['catalog', depName];
-  } else {
-    return ['catalogs', catalogName, depName];
   }
+  return ['catalogs', catalogName, depName];
 }

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -293,9 +293,8 @@ async function getUsernamePassword(
     const hostRule = await getGoogleAuthHostRule();
     if (hostRule) {
       return hostRule;
-    } else {
-      logger.once.debug({ url }, 'Could not get Google access token');
     }
+    logger.once.debug({ url }, 'Could not get Google access token');
   }
 
   return {};

--- a/lib/modules/manager/pip-compile/extract.spec.ts
+++ b/lib/modules/manager/pip-compile/extract.spec.ts
@@ -299,14 +299,17 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
-      } else if (name === '2.txt') {
+      }
+      if (name === '2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === '3.in') {
+      }
+      if (name === '3.in') {
         return '-r 2.txt\nfoo';
-      } else if (name === '4.txt') {
+      }
+      if (name === '4.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=4.txt 3.in',
           ['foo==1.0.1'],
@@ -445,14 +448,17 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
-      } else if (name === '2.txt') {
+      }
+      if (name === '2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === '3.in') {
+      }
+      if (name === '3.in') {
         return '-r 1.in\nfoo';
-      } else if (name === '4.txt') {
+      }
+      if (name === '4.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=4.txt 3.in',
           ['foo==1.0.1'],
@@ -473,21 +479,26 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
-      } else if (name === '2.txt') {
+      }
+      if (name === '2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === '3.in') {
+      }
+      if (name === '3.in') {
         return '-r 1.in\nfoo';
-      } else if (name === '4.txt') {
+      }
+      if (name === '4.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=4.txt 3.in',
           ['foo==1.0.1'],
         );
-      } else if (name === '5.in') {
+      }
+      if (name === '5.in') {
         return '-r 4.txt\nfoo';
-      } else if (name === '6.txt') {
+      }
+      if (name === '6.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=6.txt 5.in',
           ['foo==1.0.1'],
@@ -509,9 +520,11 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === 'reqs-no-headers.txt') {
         return Fixtures.get('requirementsNoHeaders.txt');
-      } else if (name === '1.in') {
+      }
+      if (name === '1.in') {
         return '-r reqs-no-headers.txt\nfoo';
-      } else if (name === '2.txt') {
+      }
+      if (name === '2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 1.in',
           ['foo==1.0.1'],
@@ -534,7 +547,8 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return '-r unmanaged-file.txt\nfoo';
-      } else if (name === '2.txt') {
+      }
+      if (name === '2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 1.in',
           ['foo==1.0.1'],
@@ -557,28 +571,35 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
-      } else if (name === '1.txt') {
+      }
+      if (name === '1.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=1.txt 1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === '2.in') {
+      }
+      if (name === '2.in') {
         return '-r 1.txt\nbar';
-      } else if (name === '2.txt') {
+      }
+      if (name === '2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 2.in',
           ['foo==1.0.1', 'bar==2.0.0'],
         );
-      } else if (name === '3.in') {
+      }
+      if (name === '3.in') {
         return '-r 1.txt\nbaz';
-      } else if (name === '3.txt') {
+      }
+      if (name === '3.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=3.txt 3.in',
           ['foo==1.0.1', 'baz==2.0.0'],
         );
-      } else if (name === '4.in') {
+      }
+      if (name === '4.in') {
         return '-r 2.txt\n-r 3.txt\nqux';
-      } else if (name === '4.txt') {
+      }
+      if (name === '4.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=4.txt 4.in',
           ['foo==1.0.1', 'bar==2.0.0', 'baz==2.0.0', 'qux==1.2.3'],
@@ -601,16 +622,20 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
-      } else if (name === '2.in') {
+      }
+      if (name === '2.in') {
         return 'bar';
-      } else if (name === 'multi_input.txt') {
+      }
+      if (name === 'multi_input.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=multi_input.txt 1.in 2.in',
           ['foo==1.0.1', 'bar==2.0.0'],
         );
-      } else if (name === '3.in') {
+      }
+      if (name === '3.in') {
         return '-r multi_input.txt\nbaz';
-      } else if (name === 'dash_r.txt') {
+      }
+      if (name === 'dash_r.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=dash_r.txt 3.in',
           ['foo==1.0.1', 'bar==2.0.0', 'baz==2.0.0'],
@@ -632,16 +657,20 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === '1.in') {
         return 'foo';
-      } else if (name === '2.in') {
+      }
+      if (name === '2.in') {
         return 'bar';
-      } else if (name === 'multi_input.txt') {
+      }
+      if (name === 'multi_input.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=multi_input.txt 1.in 2.in',
           ['foo==1.0.1', 'bar==2.0.0'],
         );
-      } else if (name === '3.in') {
+      }
+      if (name === '3.in') {
         return '-r 1.in\nbaz';
-      } else if (name === 'dash_r.txt') {
+      }
+      if (name === 'dash_r.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=dash_r.txt 3.in',
           ['foo==1.0.1', 'baz==2.0.0'],
@@ -663,14 +692,17 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === 'dir/1.in') {
         return 'foo';
-      } else if (name === 'dir/2.in') {
+      }
+      if (name === 'dir/2.in') {
         return '-r 1.in\nbar';
-      } else if (name === 'dir/1.txt') {
+      }
+      if (name === 'dir/1.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=1.txt 1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === 'dir/2.txt') {
+      }
+      if (name === 'dir/2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 2.in',
           ['foo==1.0.1', 'bar==2.0.0'],
@@ -691,14 +723,17 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === 'common/1.in') {
         return 'foo';
-      } else if (name === 'dir/2.in') {
+      }
+      if (name === 'dir/2.in') {
         return '-r ../common/1.in\nbar';
-      } else if (name === 'common/1.txt') {
+      }
+      if (name === 'common/1.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=1.txt 1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === 'dir/2.txt') {
+      }
+      if (name === 'dir/2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=2.txt 2.in',
           ['foo==1.0.1', 'bar==2.0.0'],
@@ -719,14 +754,17 @@ describe('modules/manager/pip-compile/extract', () => {
     fs.readLocalFile.mockImplementation((name): any => {
       if (name === 'common/1.in') {
         return 'foo';
-      } else if (name === 'dir/2.in') {
+      }
+      if (name === 'dir/2.in') {
         return '-r ../common/1.in\nbar';
-      } else if (name === 'common/1.txt') {
+      }
+      if (name === 'common/1.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=common/1.txt common/1.in',
           ['foo==1.0.1'],
         );
-      } else if (name === 'dir/2.txt') {
+      }
+      if (name === 'dir/2.txt') {
         return getSimpleRequirementsFile(
           'pip-compile --output-file=dir/2.txt dir/2.in',
           ['foo==1.0.1', 'bar==2.0.0'],

--- a/lib/modules/manager/poetry/schema.ts
+++ b/lib/modules/manager/poetry/schema.ts
@@ -70,19 +70,19 @@ const PoetryGitDependency = z
           currentValue: tag,
           packageName: repo,
         };
-      } else if (source === 'gitlab.com') {
+      }
+      if (source === 'gitlab.com') {
         return {
           datasource: GitlabTagsDatasource.id,
           currentValue: tag,
           packageName: repo,
         };
-      } else {
-        return {
-          datasource: GitTagsDatasource.id,
-          currentValue: tag,
-          packageName: git,
-        };
       }
+      return {
+        datasource: GitTagsDatasource.id,
+        currentValue: tag,
+        packageName: git,
+      };
     }
 
     if (rev) {

--- a/lib/modules/manager/pub/artifacts.ts
+++ b/lib/modules/manager/pub/artifacts.ts
@@ -108,24 +108,22 @@ function getExecCommand(
 ): string {
   if (isLockFileMaintenance) {
     return `${toolName} pub upgrade`;
-  } else {
-    const depNames = updatedDeps.map((dep) => dep.depName).filter(isString);
-    if (depNames.length === 1 && SDK_NAMES.includes(depNames[0])) {
-      return `${toolName} ${PUB_GET_COMMAND}`;
-    }
-    // If there are two updated dependencies and both of them are SDK updates (Dart and Flutter),
-    // we use Flutter over Dart to run `pub get` as it is a Flutter project.
-    else if (
-      depNames.length === 2 &&
-      depNames.filter((depName) => SDK_NAMES.includes(depName)).length === 2
-    ) {
-      return `flutter ${PUB_GET_COMMAND}`;
-    } else {
-      const depNamesCmd = depNames
-        .filter((depName) => !SDK_NAMES.includes(depName))
-        .map(quote)
-        .join(' ');
-      return `${toolName} pub upgrade ${depNamesCmd}`;
-    }
   }
+  const depNames = updatedDeps.map((dep) => dep.depName).filter(isString);
+  if (depNames.length === 1 && SDK_NAMES.includes(depNames[0])) {
+    return `${toolName} ${PUB_GET_COMMAND}`;
+  }
+  // If there are two updated dependencies and both of them are SDK updates (Dart and Flutter),
+  // we use Flutter over Dart to run `pub get` as it is a Flutter project.
+  if (
+    depNames.length === 2 &&
+    depNames.filter((depName) => SDK_NAMES.includes(depName)).length === 2
+  ) {
+    return `flutter ${PUB_GET_COMMAND}`;
+  }
+  const depNamesCmd = depNames
+    .filter((depName) => !SDK_NAMES.includes(depName))
+    .map(quote)
+    .join(' ');
+  return `${toolName} pub upgrade ${depNamesCmd}`;
 }

--- a/lib/modules/manager/pub/utils.ts
+++ b/lib/modules/manager/pub/utils.ts
@@ -8,9 +8,9 @@ export function parsePubspec(
   const res = Pubspec.safeParse(fileContent);
   if (res.success) {
     return res.data;
-  } else {
-    logger.debug({ err: res.error, fileName }, 'Error parsing pubspec.');
   }
+  logger.debug({ err: res.error, fileName }, 'Error parsing pubspec.');
+
   return null;
 }
 
@@ -21,11 +21,8 @@ export function parsePubspecLock(
   const res = PubspecLock.safeParse(fileContent);
   if (res.success) {
     return res.data;
-  } else {
-    logger.debug(
-      { err: res.error, fileName },
-      'Error parsing pubspec lockfile.',
-    );
   }
+  logger.debug({ err: res.error, fileName }, 'Error parsing pubspec lockfile.');
+
   return null;
 }

--- a/lib/modules/manager/puppet/common.ts
+++ b/lib/modules/manager/puppet/common.ts
@@ -13,23 +13,22 @@ export function parseGitOwnerRepo(
 
   if (genericGitSsh?.groups) {
     return genericGitSsh.groups.repository.replace(regEx(/\.git$/), '');
-  } else {
-    if (githubUrl) {
-      return git
-        .replace(regEx(/^github:/), '')
-        .replace(regEx(/^git\+/), '')
-        .replace(regEx(/^https:\/\/github\.com\//), '')
-        .replace(regEx(/\.git$/), '');
-    }
-
-    const url = parseUrl(git);
-
-    if (!url) {
-      return null;
-    }
-
-    return url.pathname.replace(regEx(/\.git$/), '').replace(regEx(/^\//), '');
   }
+  if (githubUrl) {
+    return git
+      .replace(regEx(/^github:/), '')
+      .replace(regEx(/^git\+/), '')
+      .replace(regEx(/^https:\/\/github\.com\//), '')
+      .replace(regEx(/\.git$/), '');
+  }
+
+  const url = parseUrl(git);
+
+  if (!url) {
+    return null;
+  }
+
+  return url.pathname.replace(regEx(/\.git$/), '').replace(regEx(/^\//), '');
 }
 
 export function isGithubUrl(gitUrl: string, parsedUrl: URL | null): boolean {

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -427,9 +427,8 @@ function extractPackageFileInternal(
       return {
         deps: [sbtDependency],
       };
-    } else {
-      return null;
     }
+    return null;
   }
 
   let parsedResult: Ctx | null = null;

--- a/lib/modules/manager/sbt/util.ts
+++ b/lib/modules/manager/sbt/util.ts
@@ -25,9 +25,8 @@ export function normalizeScalaVersion(str: string): string {
   if (regEx(/^\d+\.\d+\.\d+$/).test(str)) {
     if (isScala3) {
       return str.replace(regEx(/^(\d+)\.(\d+)\.\d+$/), '$1');
-    } else {
-      return str.replace(regEx(/^(\d+)\.(\d+)\.\d+$/), '$1.$2');
     }
+    return str.replace(regEx(/^(\d+)\.(\d+)\.\d+$/), '$1.$2');
   }
   // istanbul ignore next
   return str;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -954,19 +954,18 @@ async function getUserIds(users: string[]): Promise<User[]> {
           isRequired = true;
         }
         if (
-          reviewer.toLowerCase() === m.identity?.displayName?.toLowerCase() ||
-          reviewer.toLowerCase() === m.identity?.uniqueName?.toLowerCase()
+          (reviewer.toLowerCase() === m.identity?.displayName?.toLowerCase() ||
+            reviewer.toLowerCase() === m.identity?.uniqueName?.toLowerCase()) &&
+          ids.filter((c) => c.id === m.identity?.id).length === 0
         ) {
-          if (ids.filter((c) => c.id === m.identity?.id).length === 0) {
-            // TODO #22198
-            ids.push({
-              id: m.identity.id!,
-              name: reviewer,
-              isRequired,
-            });
+          // TODO #22198
+          ids.push({
+            id: m.identity.id!,
+            name: reviewer,
+            isRequired,
+          });
 
-            validReviewers.add(reviewer);
-          }
+          validReviewers.add(reviewer);
         }
       });
     });
@@ -980,14 +979,15 @@ async function getUserIds(users: string[]): Promise<User[]> {
         reviewer = reviewer.replace(requiredReviewerPrefix, '');
         isRequired = true;
       }
-      if (reviewer.toLowerCase() === t.name?.toLowerCase()) {
-        // v8 ignore else -- TODO: add test #40625
-        if (ids.filter((c) => c.id === t.id).length === 0) {
-          // TODO #22198
-          ids.push({ id: t.id!, name: reviewer, isRequired });
+      // v8 ignore else -- TODO: add test #40625
+      if (
+        reviewer.toLowerCase() === t.name?.toLowerCase() &&
+        ids.filter((c) => c.id === t.id).length === 0
+      ) {
+        // TODO #22198
+        ids.push({ id: t.id!, name: reviewer, isRequired });
 
-          validReviewers.add(reviewer);
-        }
+        validReviewers.add(reviewer);
       }
     });
   });

--- a/lib/modules/platform/azure/issue.ts
+++ b/lib/modules/platform/azure/issue.ts
@@ -135,7 +135,8 @@ export class IssueService {
         if (existingIssue.state === 'closed' && once) {
           logger.debug('Issue already closed - skipping update');
           return null;
-        } else if (existingIssue.state === 'closed' && shouldReOpen) {
+        }
+        if (existingIssue.state === 'closed' && shouldReOpen) {
           // Reopen and update work item
           if (!existingIssue.number) {
             logger.warn('Cannot reopen issue without number');
@@ -166,7 +167,8 @@ export class IssueService {
           );
           logger.debug(`Reopened issue #${existingIssue.number}`);
           return 'updated';
-        } else if (existingIssue.state === 'open') {
+        }
+        if (existingIssue.state === 'open') {
           // Update work item if needed
           if (
             existingIssue.title !== finalTitle ||

--- a/lib/modules/platform/bitbucket-server/utils.spec.ts
+++ b/lib/modules/platform/bitbucket-server/utils.spec.ts
@@ -70,17 +70,16 @@ function infoMock(
       origin: { name: repositorySlug, slug: repositorySlug },
       links,
     };
-  } else {
-    // This mimics the behavior of bb-server which does not include the clone property at all
-    // if ssh and https are both turned off
-    return {
-      id: 1,
-      slug: repositorySlug,
-      project: { key: projectKey },
-      origin: { name: repositorySlug, slug: repositorySlug },
-      links: { clone: undefined },
-    };
   }
+  // This mimics the behavior of bb-server which does not include the clone property at all
+  // if ssh and https are both turned off
+  return {
+    id: 1,
+    slug: repositorySlug,
+    project: { key: projectKey },
+    origin: { name: repositorySlug, slug: repositorySlug },
+    links: { clone: undefined },
+  };
 }
 
 describe('modules/platform/bitbucket-server/utils', () => {

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -969,11 +969,12 @@ async function sanitizeReviewers(
             )
           ).body;
 
-          if (reviewerUser.account_status === 'active') {
-            // There are cases where an active user may still not be a member of a workspace
-            if (await isAccountMemberOfWorkspace(reviewer, config.repository)) {
-              sanitizedReviewers.push(reviewer);
-            }
+          // There are cases where an active user may still not be a member of a workspace
+          if (
+            reviewerUser.account_status === 'active' &&
+            (await isAccountMemberOfWorkspace(reviewer, config.repository))
+          ) {
+            sanitizedReviewers.push(reviewer);
           }
         }
         // Bitbucket returns a 400 if any of the PR reviewer accounts are no longer members of this workspace

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -389,7 +389,8 @@ const platform: Platform = {
         );
         const repos = await map(fetchRepoArgs, fetchRepositories);
         return deduplicateArray(repos.flat());
-      } else if (config?.namespaces) {
+      }
+      if (config?.namespaces) {
         logger.debug(
           { namespaces: config.namespaces },
           'Auto-discovering by organization',
@@ -404,12 +405,11 @@ const platform: Platform = {
           },
         );
         return deduplicateArray(repos.flat());
-      } else {
-        return await fetchRepositories({
-          sort: config?.sort,
-          order: config?.order,
-        });
       }
+      return await fetchRepositories({
+        sort: config?.sort,
+        order: config?.order,
+      });
     } catch (err) {
       logger.error({ err }, 'Forgejo getRepos() error');
       throw err;

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -134,13 +134,12 @@ export class GerritScm extends DefaultGitScm {
     if (change) {
       const mergeInfo = await client.getMergeableInfo(change);
       return !mergeInfo.mergeable;
-    } else {
-      logger.warn(
-        { branch, baseBranch },
-        'There is no open change with this branch',
-      );
-      return true;
     }
+    logger.warn(
+      { branch, baseBranch },
+      'There is no open change with this branch',
+    );
+    return true;
   }
 
   override async isBranchModified(

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -387,7 +387,8 @@ const platform: Platform = {
         );
         const repos = await map(fetchRepoArgs, fetchRepositories);
         return deduplicateArray(repos.flat());
-      } else if (config?.namespaces) {
+      }
+      if (config?.namespaces) {
         logger.debug(
           { namespaces: config.namespaces },
           'Auto-discovering by organization',
@@ -402,12 +403,11 @@ const platform: Platform = {
           },
         );
         return deduplicateArray(repos.flat());
-      } else {
-        return await fetchRepositories({
-          sort: config?.sort,
-          order: config?.order,
-        });
       }
+      return await fetchRepositories({
+        sort: config?.sort,
+        order: config?.order,
+      });
     } catch (err) {
       logger.error({ err }, 'Gitea getRepos() error');
       throw err;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -291,13 +291,12 @@ async function fetchRepositories(): Promise<GhRestRepo[]> {
         paginate: 'all',
       });
       return res.body.repositories;
-    } else {
-      const res = await githubApi.getJsonUnchecked<GhRestRepo[]>(
-        `user/repos?per_page=100`,
-        { paginate: 'all' },
-      );
-      return res.body;
     }
+    const res = await githubApi.getJsonUnchecked<GhRestRepo[]>(
+      `user/repos?per_page=100`,
+      { paginate: 'all' },
+    );
+    return res.body;
   } catch (err) /* v8 ignore next */ {
     logger.error({ err }, `GitHub getRepos error`);
     throw err;
@@ -1836,15 +1835,16 @@ async function tryPrAutomerge(
 
   // If GitHub Enterprise Server <3.3.0 it doesn't support automerge
   // TODO #22198
-  if (platformConfig.isGhe) {
-    // semver not null safe, accepts null and undefined
-    if (semver.satisfies(platformConfig.gheVersion!, '<3.3.0')) {
-      logger.debug(
-        { prNumber },
-        'GitHub-native automerge: not supported on this version of GHE. Use 3.3.0 or newer.',
-      );
-      return;
-    }
+  // semver not null safe, accepts null and undefined
+  if (
+    platformConfig.isGhe &&
+    semver.satisfies(platformConfig.gheVersion!, '<3.3.0')
+  ) {
+    logger.debug(
+      { prNumber },
+      'GitHub-native automerge: not supported on this version of GHE. Use 3.3.0 or newer.',
+    );
+    return;
   }
 
   if (!config.autoMergeAllowed) {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -887,9 +887,8 @@ export function maxBodyLength(): number {
       'GitLab versions earlier than 13.4 have issues with long descriptions, truncating to 25K characters',
     );
     return 25000;
-  } else {
-    return 1000000;
   }
+  return 1000000;
 }
 
 /* v8 ignore next: no need to test */

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -54,13 +54,12 @@ export function smartTruncate(input: string, len: number): string {
       truncatedInput.substring(0, len - truncationNotice.length) +
       truncationNotice
     );
-  } else {
-    return (
-      preNotes +
-      releaseNotes.slice(0, availableLength) +
-      truncationNotice +
-      divider +
-      postNotes
-    );
   }
+  return (
+    preNotes +
+    releaseNotes.slice(0, availableLength) +
+    truncationNotice +
+    divider +
+    postNotes
+  );
 }

--- a/lib/modules/versioning/apk/index.ts
+++ b/lib/modules/versioning/apk/index.ts
@@ -195,13 +195,14 @@ class ApkVersioningApi extends GenericVersioningApi {
 
         if (matchv1 && /^\d+$/.test(matchv1)) {
           return 1;
-        } else if (matchv2 && /^\d+$/.test(matchv2)) {
-          return -1;
-        } else if (matchv1) {
-          return -1;
-        } else {
-          return 1;
         }
+        if (matchv2 && /^\d+$/.test(matchv2)) {
+          return -1;
+        }
+        if (matchv1) {
+          return -1;
+        }
+        return 1;
       }
     }
 

--- a/lib/modules/versioning/composer/index.ts
+++ b/lib/modules/versioning/composer/index.ts
@@ -364,15 +364,13 @@ function sortVersions(a: string, b: string): number {
   if (aContainsPatch === bContainsPatch) {
     // If both [a and b] contain patch version or both [a and b] do not contain patch version, then npm comparison deliveres correct results
     return npm.sortVersions(composer2npm(a), composer2npm(b));
-  } else if (
-    npm.equals(composer2npm(aWithoutPatch), composer2npm(bWithoutPatch))
-  ) {
+  }
+  if (npm.equals(composer2npm(aWithoutPatch), composer2npm(bWithoutPatch))) {
     // If only one [a or b] contains patch version and the parts without patch versions are equal, then the version with patch is greater (this is the case where npm comparison fails)
     return aContainsPatch ? 1 : -1;
-  } else {
-    // All other cases can be compared correctly by npm
-    return npm.sortVersions(composer2npm(a), composer2npm(b));
   }
+  // All other cases can be compared correctly by npm
+  return npm.sortVersions(composer2npm(a), composer2npm(b));
 }
 
 function isCompatible(version: string): boolean {

--- a/lib/modules/versioning/conan/common.ts
+++ b/lib/modules/versioning/conan/common.ts
@@ -94,15 +94,13 @@ export function findSatisfyingVersion(
       const cleanedVersion = cleanVersion(versionFromList);
       const options = getOptions(range);
       const cleanRange = cleanVersion(range);
-      if (matchesWithOptions(cleanedVersion, cleanRange, options)) {
-        if (
-          !cur ||
-          semver.compare(curSV, versionFromList, options) === compareRt
-        ) {
-          cur = versionFromList;
-          curIndex = index;
-          curSV = new semver.SemVer(cur, options);
-        }
+      if (
+        matchesWithOptions(cleanedVersion, cleanRange, options) &&
+        (!cur || semver.compare(curSV, versionFromList, options) === compareRt)
+      ) {
+        cur = versionFromList;
+        curIndex = index;
+        curSV = new semver.SemVer(cur, options);
       }
     }
     index += 1;

--- a/lib/modules/versioning/conan/index.ts
+++ b/lib/modules/versioning/conan/index.ts
@@ -41,10 +41,8 @@ function isVersion(input: string): boolean {
   if (input && !input.includes('[')) {
     const qualifiers = getOptions(input);
     const version = cleanVersion(input);
-    if (qualifiers.loose) {
-      if (looseAPI.isVersion(version)) {
-        return true;
-      }
+    if (qualifiers.loose && looseAPI.isVersion(version)) {
+      return true;
     }
     return makeVersion(version, qualifiers) !== null;
   }

--- a/lib/modules/versioning/gradle/index.ts
+++ b/lib/modules/versioning/gradle/index.ts
@@ -210,14 +210,12 @@ function getNewValue({
           .join('.');
 
         return `${newPrefixed}.+`;
-      } else {
-        // our new version is shorter than our prefix range so drop our prefix range
-        return newVersion;
       }
-    } else {
-      // our version is already "+" which includes ever version
-      return null;
+      // our new version is shorter than our prefix range so drop our prefix range
+      return newVersion;
     }
+    // our version is already "+" which includes ever version
+    return null;
   }
 
   const mavenRange = parseMavenBasedRange(currentValue);

--- a/lib/modules/versioning/hermit/index.ts
+++ b/lib/modules/versioning/hermit/index.ts
@@ -164,9 +164,11 @@ export class HermitVersioning extends RegExpVersioningApi {
         verVal !== otherVal
       ) {
         return verVal - otherVal;
-      } else if (verVal === undefined) {
+      }
+      if (verVal === undefined) {
         return 1;
-      } else if (otherVal === undefined) {
+      }
+      if (otherVal === undefined) {
         return -1;
       }
     }

--- a/lib/modules/versioning/npm/range.ts
+++ b/lib/modules/versioning/npm/range.ts
@@ -36,11 +36,9 @@ function replaceCaretValue(oldValue: string, newValue: string): string {
     const newVal = newTuple[idx];
 
     let leadingDigit = false;
-    if (oldVal !== 0 || newVal !== 0) {
-      if (leadingZero) {
-        leadingZero = false;
-        leadingDigit = true;
-      }
+    if ((oldVal !== 0 || newVal !== 0) && leadingZero) {
+      leadingZero = false;
+      leadingDigit = true;
     }
 
     if (leadingDigit && newVal > oldVal) {

--- a/lib/modules/versioning/nuget/version.ts
+++ b/lib/modules/versioning/nuget/version.ts
@@ -50,17 +50,23 @@ export function compare(x: NugetVersion, y: NugetVersion): number {
 
   if (xMajor !== yMajor) {
     return Math.sign(xMajor - yMajor);
-  } else if (xMinor !== yMinor) {
+  }
+  if (xMinor !== yMinor) {
     return Math.sign(xMinor - yMinor);
-  } else if (xPatch !== yPatch) {
+  }
+  if (xPatch !== yPatch) {
     return Math.sign(xPatch - yPatch);
-  } else if (xRevision !== yRevision) {
+  }
+  if (xRevision !== yRevision) {
     return Math.sign(xRevision - yRevision);
-  } else if (x.prerelease && !y.prerelease) {
+  }
+  if (x.prerelease && !y.prerelease) {
     return -1;
-  } else if (!x.prerelease && y.prerelease) {
+  }
+  if (!x.prerelease && y.prerelease) {
     return 1;
-  } else if (x.prerelease && y.prerelease) {
+  }
+  if (x.prerelease && y.prerelease) {
     return comparePrereleases(x.prerelease, y.prerelease);
   }
 

--- a/lib/modules/versioning/pep440/range.ts
+++ b/lib/modules/versioning/pep440/range.ts
@@ -509,10 +509,12 @@ function handleReplaceStrategy(
       // trim last element of the newBase when new accepted version is out of range.
       // example: let new bound be >8.2.5 & newVersion be 8.2.5
       // return value will be: >8.2
-      if (range.operator === '>') {
-        if (newVersion === newBase.join('.') && newBase.length > 1) {
-          newBase.pop();
-        }
+      if (
+        range.operator === '>' &&
+        newVersion === newBase.join('.') &&
+        newBase.length > 1
+      ) {
+        newBase.pop();
       }
       return range.operator + newBase.join('.');
     }
@@ -560,11 +562,10 @@ export function checkRangeAndRemoveUnnecessaryRangeLimit(
     if (
       newRes[0].includes('.*') &&
       newRes[0].includes('==') &&
-      newRes[1].includes('>=')
+      newRes[1].includes('>=') &&
+      satisfies(newVersion, newRes[0])
     ) {
-      if (satisfies(newVersion, newRes[0])) {
-        newRange = newRes[0];
-      }
+      newRange = newRes[0];
     }
   } else {
     return rangeInput;

--- a/lib/modules/versioning/pvp/index.ts
+++ b/lib/modules/versioning/pvp/index.ts
@@ -165,11 +165,11 @@ function isSame(
   }
   if (type === 'major') {
     return 'eq' === compareIntArray(aParts.major, bParts.major);
-  } else if (type === 'minor') {
-    return 'eq' === compareIntArray(aParts.minor, bParts.minor);
-  } else {
-    return 'eq' === compareIntArray(aParts.patch, bParts.patch);
   }
+  if (type === 'minor') {
+    return 'eq' === compareIntArray(aParts.minor, bParts.minor);
+  }
+  return 'eq' === compareIntArray(aParts.patch, bParts.patch);
 }
 
 function subset(subRange: string, superRange: string): boolean | undefined {

--- a/lib/modules/versioning/rpm/index.ts
+++ b/lib/modules/versioning/rpm/index.ts
@@ -141,7 +141,8 @@ class RpmVersioningApi extends GenericVersioningApi {
 
       if (c1 > c2) {
         return 1;
-      } else if (c1 < c2) {
+      }
+      if (c1 < c2) {
         return -1;
       }
     }
@@ -193,7 +194,8 @@ class RpmVersioningApi extends GenericVersioningApi {
         }
 
         return Math.sign(result);
-      } else if (isNumericString(matchv2?.[0])) {
+      }
+      if (isNumericString(matchv2?.[0])) {
         return -1;
       }
 
@@ -258,7 +260,8 @@ class RpmVersioningApi extends GenericVersioningApi {
     // No Prerelease wins
     if (parsed1.rpmPreRelease === '' && parsed2.rpmPreRelease !== '') {
       return 1;
-    } else if (parsed1.rpmPreRelease !== '' && parsed2.rpmPreRelease === '') {
+    }
+    if (parsed1.rpmPreRelease !== '' && parsed2.rpmPreRelease === '') {
       return -1;
     }
 

--- a/lib/modules/versioning/ruby/range.ts
+++ b/lib/modules/versioning/ruby/range.ts
@@ -47,9 +47,8 @@ export function satisfiesRange(ver: string, range: Range): boolean {
       satisfies(ver, `${range.operator}${range.version}`) &&
       satisfiesRange(ver, range.companion)
     );
-  } else {
-    return satisfies(ver, `${range.operator}${range.version}`);
   }
+  return satisfies(ver, `${range.operator}${range.version}`);
 }
 
 /**
@@ -87,9 +86,8 @@ export function stringifyRanges(ranges: Range[]): string {
     .map((r) => {
       if (r.companion) {
         return `${r.operator}${r.delimiter}${r.version}, ${r.companion.operator}${r.companion.delimiter}${r.companion.version}`;
-      } else {
-        return `${r.operator}${r.delimiter}${r.version}`;
       }
+      return `${r.operator}${r.delimiter}${r.version}`;
     })
     .join(', ');
 }

--- a/lib/modules/versioning/ruby/strategies/bump.ts
+++ b/lib/modules/versioning/ruby/strategies/bump.ts
@@ -21,14 +21,13 @@ export default ({ range, to }: { range: string; to: string }): string => {
         if (trimZeroes(trimmed) === trimZeroes(to)) {
           // E.g. `'~> 5.2', '>= 5.2.0'`. In this case the latter is redundant.
           return { ...part, version: trimmed, companion: undefined };
-        } else {
-          // E.g. `'~> 5.2', '>= 5.2.1'`.
-          return {
-            ...part,
-            version: trimmed,
-            companion: { operator: GTE, delimiter: ' ', version: to },
-          };
         }
+        // E.g. `'~> 5.2', '>= 5.2.1'`.
+        return {
+          ...part,
+          version: trimmed,
+          companion: { operator: GTE, delimiter: ' ', version: to },
+        };
       }
       case NOT_EQUAL:
         if (lt(ver, to)) {

--- a/lib/modules/versioning/ruby/strategies/replace.ts
+++ b/lib/modules/versioning/ruby/strategies/replace.ts
@@ -20,9 +20,9 @@ export function replacePart(part: Range, to: string): Range {
           version: floor(adapt(to, ver)),
           companion: { ...companion, version: to },
         };
-      } else {
-        return { ...part, version: floor(adapt(to, ver)) };
       }
+      return { ...part, version: floor(adapt(to, ver)) };
+
     case GT:
       return { ...part, version: decrement(to) };
     case GTE:

--- a/lib/modules/versioning/rust-release-channel/util.ts
+++ b/lib/modules/versioning/rust-release-channel/util.ts
@@ -19,7 +19,8 @@ export function sortParsed(
 
   if (isANightly && !isBNightly) {
     return 1;
-  } else if (!isANightly && isBNightly) {
+  }
+  if (!isANightly && isBNightly) {
     return -1;
   }
 
@@ -30,9 +31,11 @@ export function sortParsed(
 
     if (dateA.year !== dateB.year) {
       return dateA.year - dateB.year;
-    } else if (dateA.month !== dateB.month) {
+    }
+    if (dateA.month !== dateB.month) {
       return dateA.month - dateB.month;
-    } else if (dateA.day !== dateB.day) {
+    }
+    if (dateA.day !== dateB.day) {
       return dateA.day - dateB.day;
     }
 
@@ -61,7 +64,8 @@ export function sortParsed(
     // Version with prerelease is less than version without
     if (hasPreA && !hasPreB) {
       return -1;
-    } else if (!hasPreA && hasPreB) {
+    }
+    if (!hasPreA && hasPreB) {
       return 1;
     }
 

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -158,11 +158,10 @@ export function getInheritedOrGlobal<Key extends keyof GlobalInheritableConfig>(
     if (
       key === 'onboardingAutoCloseAge' &&
       isNumber(inheritedValue) &&
-      isNumber(globalValue)
+      isNumber(globalValue) &&
+      globalValue < inheritedValue
     ) {
-      if (globalValue < inheritedValue) {
-        return globalValue;
-      }
+      return globalValue;
     }
 
     return inheritedValue;

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -221,15 +221,14 @@ function kill(cp: ChildProcess, signal: NodeJS.Signals): boolean {
        * and for which the process has permission to send a signal.
        */
       return process.kill(-cp.pid, signal);
-    } else {
-      // destroying stdio is needed for unref to work
-      // https://nodejs.org/api/child_process.html#subprocessunref
-      // https://github.com/nodejs/node/blob/4d5ff25a813fd18939c9f76b17e36291e3ea15c3/lib/child_process.js#L412-L426
-      cp.stderr?.destroy();
-      cp.stdout?.destroy();
-      cp.unref();
-      return cp.kill(signal);
     }
+    // destroying stdio is needed for unref to work
+    // https://nodejs.org/api/child_process.html#subprocessunref
+    // https://github.com/nodejs/node/blob/4d5ff25a813fd18939c9f76b17e36291e3ea15c3/lib/child_process.js#L412-L426
+    cp.stderr?.destroy();
+    cp.stdout?.destroy();
+    cp.unref();
+    return cp.kill(signal);
   } catch {
     // cp is a single node tree, therefore -pid is invalid as there is no such pgid,
     return false;

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -289,10 +289,8 @@ function isStable(
   if (!versioningApi.isStable(version)) {
     return false;
   }
-  if (isString(latest)) {
-    if (versioningApi.isGreaterThan(version, latest)) {
-      return false;
-    }
+  if (isString(latest) && versioningApi.isGreaterThan(version, latest)) {
+    return false;
   }
   return true;
 }

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -172,9 +172,8 @@ describe('util/git/index', { timeout: 30000 }, () => {
       const gitFunc = vi.fn().mockImplementation((args) => {
         if (args === undefined) {
           return 'some result';
-        } else {
-          return 'different result';
         }
+        return 'different result';
       });
       expect(await git.gitRetry(() => gitFunc())).toBe('some result');
       expect(await git.gitRetry(() => gitFunc('arg'))).toBe('different result');

--- a/lib/util/git/instrument.ts
+++ b/lib/util/git/instrument.ts
@@ -115,9 +115,8 @@ export class InstrumentedSimpleGit {
       async () => {
         if (typeof whatOrOptions === 'string') {
           return await this.git.checkout(whatOrOptions);
-        } else {
-          return await this.git.checkout(whatOrOptions);
         }
+        return await this.git.checkout(whatOrOptions);
       },
       options,
     );
@@ -224,9 +223,8 @@ export class InstrumentedSimpleGit {
       async () => {
         if (typeof optionOrOptions === 'string') {
           return await this.git.revparse(optionOrOptions);
-        } else {
-          return await this.git.revparse(optionOrOptions);
         }
+        return await this.git.revparse(optionOrOptions);
       },
       options,
     );
@@ -261,9 +259,8 @@ export class InstrumentedSimpleGit {
       async () => {
         if (verbose === true) {
           return await instrument('other', () => this.git.getRemotes(true));
-        } else {
-          return await instrument('other', () => this.git.getRemotes());
         }
+        return await instrument('other', () => this.git.getRemotes());
       },
       options,
     );

--- a/lib/util/github/graphql/datasource-fetcher.ts
+++ b/lib/util/github/graphql/datasource-fetcher.ts
@@ -139,11 +139,10 @@ export class GithubGraphqlDatasourceFetcher<
         const { message } = errors[0];
         const err = new Error(message);
         return [null, err];
-      } else {
-        const errorInstances = errors.map(({ message }) => new Error(message));
-        const err = new AggregateError(errorInstances);
-        return [null, err];
       }
+      const errorInstances = errors.map(({ message }) => new Error(message));
+      const err = new AggregateError(errorInstances);
+      return [null, err];
     }
 
     if (!data) {

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -201,10 +201,12 @@ function handleGotError(
     const errors = GithubErrors.parse(err.body?.errors);
     if (errors.some((e) => e.field === 'milestone')) {
       return err;
-    } else if (errors.some((e) => e.code === 'invalid')) {
+    }
+    if (errors.some((e) => e.code === 'invalid')) {
       logger.debug({ err }, 'Received invalid response - aborting');
       return new Error(REPOSITORY_CHANGED);
-    } else if (
+    }
+    if (
       errors.some((e) => e.message?.startsWith('A pull request already exists'))
     ) {
       return err;

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -47,9 +47,8 @@ function isZodResult<Output extends Val>(
       typeof input.data !== 'undefined' &&
       input.data !== null
     );
-  } else {
-    return 'error' in input;
   }
+  return 'error' in input;
 }
 
 function fromZodResult<ZodOutput extends Val>(

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -144,9 +144,9 @@ export function parseLinkHeader(
 export function massageHostUrl(url: string): string {
   if (!url.includes('://') && url.includes('/')) {
     return `https://${url}`;
-  } else if (!url.includes('://') && url.includes(':')) {
-    return `https://${url}`;
-  } else {
-    return url;
   }
+  if (!url.includes('://') && url.includes(':')) {
+    return `https://${url}`;
+  }
+  return url;
 }

--- a/lib/workers/global/config/parse/cli.ts
+++ b/lib/workers/global/config/parse/cli.ts
@@ -109,36 +109,34 @@ export function getConfig(input: string[]): AllConfig {
       }
 
       for (const option of options) {
-        if (option.cli !== false) {
-          if (opts[option.name] !== undefined) {
-            config[option.name] = opts[option.name];
-            if (option.name === 'dryRun') {
-              if (config[option.name] === 'true') {
-                logger.warn(
-                  'cli config dryRun property has been changed to full',
-                );
-                config[option.name] = 'full';
-              } else if (config[option.name] === 'false') {
-                logger.warn(
-                  'cli config dryRun property has been changed to null',
-                );
-                config[option.name] = null;
-              } else if (config[option.name] === 'null') {
-                config[option.name] = null;
-              }
+        if (option.cli !== false && opts[option.name] !== undefined) {
+          config[option.name] = opts[option.name];
+          if (option.name === 'dryRun') {
+            if (config[option.name] === 'true') {
+              logger.warn(
+                'cli config dryRun property has been changed to full',
+              );
+              config[option.name] = 'full';
+            } else if (config[option.name] === 'false') {
+              logger.warn(
+                'cli config dryRun property has been changed to null',
+              );
+              config[option.name] = null;
+            } else if (config[option.name] === 'null') {
+              config[option.name] = null;
             }
-            if (option.name === 'requireConfig') {
-              if (config[option.name] === 'true') {
-                logger.warn(
-                  'cli config requireConfig property has been changed to required',
-                );
-                config[option.name] = 'required';
-              } else if (config[option.name] === 'false') {
-                logger.warn(
-                  'cli config requireConfig property has been changed to optional',
-                );
-                config[option.name] = 'optional';
-              }
+          }
+          if (option.name === 'requireConfig') {
+            if (config[option.name] === 'true') {
+              logger.warn(
+                'cli config requireConfig property has been changed to required',
+              );
+              config[option.name] = 'required';
+            } else if (config[option.name] === 'false') {
+              logger.warn(
+                'cli config requireConfig property has been changed to optional',
+              );
+              config[option.name] = 'optional';
             }
           }
         }

--- a/lib/workers/global/config/parse/env.ts
+++ b/lib/workers/global/config/parse/env.ts
@@ -67,11 +67,9 @@ function massageEnvKeyValues(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const result = { ...env };
   for (const { oldName, newName, from, to } of migratedKeysWithValues) {
     const key = getEnvName({ name: oldName });
-    if (env[key] !== undefined) {
-      if (result[key] === from) {
-        delete result[key];
-        result[getEnvName({ name: newName })] = to;
-      }
+    if (env[key] !== undefined && result[key] === from) {
+      delete result[key];
+      result[getEnvName({ name: newName })] = to;
     }
   }
   return result;

--- a/lib/workers/repository/config-migration/branch/index.ts
+++ b/lib/workers/repository/config-migration/branch/index.ts
@@ -26,17 +26,16 @@ export async function checkConfigMigrationBranch(
   const configMigrationCheckboxState =
     config.dependencyDashboardChecks?.configMigrationCheckboxState;
 
-  if (!config.configMigration) {
-    if (
-      isUndefined(configMigrationCheckboxState) ||
+  if (
+    !config.configMigration &&
+    (isUndefined(configMigrationCheckboxState) ||
       configMigrationCheckboxState === 'no-checkbox' ||
-      configMigrationCheckboxState === 'unchecked'
-    ) {
-      logger.debug(
-        'Config migration needed but config migration is disabled and checkbox not checked or not present.',
-      );
-      return { result: 'no-migration-branch' };
-    }
+      configMigrationCheckboxState === 'unchecked')
+  ) {
+    logger.debug(
+      'Config migration needed but config migration is disabled and checkbox not checked or not present.',
+    );
+    return { result: 'no-migration-branch' };
   }
 
   const configMigrationBranch = getMigrationBranchName(config);

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -99,10 +99,9 @@ export async function detectRepoFileConfig(
         configFileParsed = configFileParsed.renovate;
       }
       return { configFileName, configFileParsed };
-    } else {
-      logger.debug('Existing config file no longer exists');
-      delete cache.configFileName;
     }
+    logger.debug('Existing config file no longer exists');
+    delete cache.configFileName;
   }
 
   if (OnboardingState.onboardingCacheValid) {

--- a/lib/workers/repository/onboarding/branch/check.ts
+++ b/lib/workers/repository/onboarding/branch/check.ts
@@ -115,18 +115,16 @@ export async function isOnboarded(config: RenovateConfig): Promise<boolean> {
       const configFileContent = await platform.getJsonFile(
         cache.configFileName,
       );
-      if (configFileContent) {
-        if (
-          cache.configFileName !== 'package.json' ||
-          configFileContent.renovate
-        ) {
-          logger.debug('Existing config file confirmed');
-          logger.debug(
-            { fileName: cache.configFileName, config: configFileContent },
-            'Repository config',
-          );
-          return true;
-        }
+      if (
+        configFileContent &&
+        (cache.configFileName !== 'package.json' || configFileContent.renovate)
+      ) {
+        logger.debug('Existing config file confirmed');
+        logger.debug(
+          { fileName: cache.configFileName, config: configFileContent },
+          'Repository config',
+        );
+        return true;
       }
     } catch {
       // probably file doesn't exist

--- a/lib/workers/repository/onboarding/branch/index.ts
+++ b/lib/workers/repository/onboarding/branch/index.ts
@@ -107,11 +107,10 @@ export async function checkOnboardingBranch(
 
     if (
       Object.entries((await extractAllDependencies(mergedConfig)).packageFiles)
-        .length === 0
+        .length === 0 &&
+      getInheritedOrGlobal('onboardingNoDeps') !== 'enabled'
     ) {
-      if (getInheritedOrGlobal('onboardingNoDeps') !== 'enabled') {
-        throw new Error(REPOSITORY_NO_PACKAGE_FILES);
-      }
+      throw new Error(REPOSITORY_NO_PACKAGE_FILES);
     }
     logger.debug('Need to create onboarding PR');
     if (config.onboardingRebaseCheckbox) {
@@ -126,12 +125,10 @@ export async function checkOnboardingBranch(
       );
     }
   }
-  if (!GlobalConfig.get('dryRun')) {
-    // TODO #22198
-    if (!isConflicted) {
-      logger.debug('Merge onboarding branch in default branch');
-      await scm.mergeToLocal(onboardingBranch!);
-    }
+  // TODO #22198
+  if (!GlobalConfig.get('dryRun') && !isConflicted) {
+    logger.debug('Merge onboarding branch in default branch');
+    await scm.mergeToLocal(onboardingBranch!);
   }
   setOnboardingCache(
     getBranchCommit(config.defaultBranch!)!,

--- a/lib/workers/repository/onboarding/branch/onboarding-branch-cache.ts
+++ b/lib/workers/repository/onboarding/branch/onboarding-branch-cache.ts
@@ -78,9 +78,8 @@ export async function isOnboardingBranchModified(
     !isUndefined(onboardingCache.isModified)
   ) {
     return onboardingCache.isModified;
-  } else {
-    isModified = await scm.isBranchModified(onboardingBranch, defaultBranch);
   }
+  isModified = await scm.isBranchModified(onboardingBranch, defaultBranch);
 
   return isModified;
 }
@@ -123,12 +122,8 @@ export async function isOnboardingBranchConflicted(
     !isUndefined(onboardingCache.isConflicted)
   ) {
     return onboardingCache.isConflicted;
-  } else {
-    isConflicted = await scm.isBranchConflicted(
-      defaultBranch,
-      onboardingBranch,
-    );
   }
+  isConflicted = await scm.isBranchConflicted(defaultBranch, onboardingBranch);
 
   return isConflicted;
 }

--- a/lib/workers/repository/process/libyear.ts
+++ b/lib/workers/repository/process/libyear.ts
@@ -108,10 +108,8 @@ function getManagerLibYears(deps: DepInfo[]): Record<string, number> {
     const depKey = `${dep.depName}@${dep.version}@${dep.datasource}`;
     const manager = dep.manager;
     managerLibYears[manager] ??= {};
-    if (dep.libYear) {
-      if (!managerLibYears[manager][depKey]) {
-        managerLibYears[manager][depKey] = dep.libYear;
-      }
+    if (dep.libYear && !managerLibYears[manager][depKey]) {
+      managerLibYears[manager][depKey] = dep.libYear;
     }
   }
 

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -181,20 +181,18 @@ export async function filterInternalChecks(
       );
     }
 
-    if (!release) {
-      // v8 ignore else -- TODO: add test #40625
-      if (pendingReleases.length) {
-        // If all releases were pending then just take the highest
-        logger.trace(
-          { depName, bucket },
-          'All releases are pending - using latest',
-        );
-        release = pendingReleases.pop();
-        // None are pending anymore because we took the latest, so empty the array
-        pendingReleases = [];
-        if (internalChecksFilter === 'strict') {
-          pendingChecks = true;
-        }
+    // v8 ignore else -- TODO: add test #40625
+    if (!release && pendingReleases.length) {
+      // If all releases were pending then just take the highest
+      logger.trace(
+        { depName, bucket },
+        'All releases are pending - using latest',
+      );
+      release = pendingReleases.pop();
+      // None are pending anymore because we took the latest, so empty the array
+      pendingReleases = [];
+      if (internalChecksFilter === 'strict') {
+        pendingChecks = true;
       }
     }
   }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -652,17 +652,18 @@ export async function lookupUpdates(
             newValue: config.currentValue,
           });
         }
-      } else if (config.pinDigests) {
+      } else if (
+        config.pinDigests &&
         // Create a pin only if one doesn't already exists
         // v8 ignore else -- TODO: add test #40625
-        if (!res.updates.some((update) => update.updateType === 'pin')) {
-          // pin digest
-          res.updates.push({
-            isPinDigest: true,
-            updateType: 'pinDigest',
-            newValue: config.currentValue,
-          });
-        }
+        !res.updates.some((update) => update.updateType === 'pin')
+      ) {
+        // pin digest
+        res.updates.push({
+          isPinDigest: true,
+          updateType: 'pinDigest',
+          newValue: config.currentValue,
+        });
       }
       if (versioningApi.valueToVersion) {
         // TODO #22198

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -635,11 +635,14 @@ export class Vulnerabilities {
     aliases = aliases.map((id) => {
       if (id.startsWith('CVE-')) {
         return `[${id}](https://nvd.nist.gov/vuln/detail/${id})`;
-      } else if (id.startsWith('GHSA-')) {
+      }
+      if (id.startsWith('GHSA-')) {
         return `[${id}](https://github.com/advisories/${id})`;
-      } else if (id.startsWith('GO-')) {
+      }
+      if (id.startsWith('GO-')) {
         return `[${id}](https://pkg.go.dev/vuln/${id})`;
-      } else if (id.startsWith('RUSTSEC-')) {
+      }
+      if (id.startsWith('RUSTSEC-')) {
         return `[${id}](https://rustsec.org/advisories/${id}.html)`;
       }
 

--- a/lib/workers/repository/reconfigure/index.ts
+++ b/lib/workers/repository/reconfigure/index.ts
@@ -56,11 +56,12 @@ export async function checkReconfigureBranch(
   const reconfigureCache = cache.reconfigureBranchCache;
 
   // only use valid cached information
-  if (reconfigureCache?.reconfigureBranchSha === branchSha) {
-    if (!existingPr || reconfigureCache.extractResult) {
-      logger.debug('Skipping validation check as branch sha is unchanged');
-      return;
-    }
+  if (
+    reconfigureCache?.reconfigureBranchSha === branchSha &&
+    (!existingPr || reconfigureCache.extractResult)
+  ) {
+    logger.debug('Skipping validation check as branch sha is unchanged');
+    return;
   }
 
   const result = await getReconfigureConfig(reconfigureBranch);

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -300,11 +300,12 @@ export async function getUpdatedPackageFiles(
         updatedFileContents[packageFile] = newContent;
         delete nonUpdatedFileContents[packageFile];
       }
-      if (newContent === packageFileContent) {
-        if (upgrade.manager === 'git-submodules') {
-          updatedFileContents[packageFile] = newContent;
-          delete nonUpdatedFileContents[packageFile];
-        }
+      if (
+        newContent === packageFileContent &&
+        upgrade.manager === 'git-submodules'
+      ) {
+        updatedFileContents[packageFile] = newContent;
+        delete nonUpdatedFileContents[packageFile];
       }
     }
   }

--- a/lib/workers/repository/update/pr/body/updates-table.ts
+++ b/lib/workers/repository/update/pr/body/updates-table.ts
@@ -29,10 +29,8 @@ function getNonEmptyColumns(
   const res: string[] = [];
   for (const header of prBodyColumns) {
     for (const row of rows) {
-      if (row[header]?.length) {
-        if (!res.includes(header)) {
-          res.push(header);
-        }
+      if (row[header]?.length && !res.includes(header)) {
+        res.push(header);
       }
     }
   }

--- a/lib/workers/repository/update/pr/changelog/common.ts
+++ b/lib/workers/repository/update/pr/changelog/common.ts
@@ -44,7 +44,8 @@ export function compareChangelogFilePath(a: string, b: string): number {
   const bPreferedIndex = preferedChangelogRegexList.findIndex((f) => f.test(b));
   if (aPreferedIndex === bPreferedIndex) {
     return a.localeCompare(b);
-  } else if (aPreferedIndex >= 0 && bPreferedIndex >= 0) {
+  }
+  if (aPreferedIndex >= 0 && bPreferedIndex >= 0) {
     return aPreferedIndex - bPreferedIndex;
   }
   return aPreferedIndex >= 0 ? -1 : 1;

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -497,11 +497,11 @@ export async function ensurePr(
       if (GlobalConfig.get('dryRun')) {
         logger.info(`DRY-RUN: Would update PR #${existingPr.number}`);
         return { type: 'with-pr', pr: existingPr };
-      } else {
-        await platform.updatePr(updatePrConfig);
-        logger.info({ pr: existingPr.number, prTitle }, `PR updated`);
-        setPrCache(branchName, prBodyFingerprint, true);
       }
+      await platform.updatePr(updatePrConfig);
+      logger.info({ pr: existingPr.number, prTitle }, `PR updated`);
+      setPrCache(branchName, prBodyFingerprint, true);
+
       return {
         type: 'with-pr',
         pr: {

--- a/tools/docs/github-query-items.ts
+++ b/tools/docs/github-query-items.ts
@@ -93,21 +93,20 @@ export async function getOpenGitHubItems(): Promise<RenovateOpenItems> {
     return result;
   }
 
-  if (process.env.CI) {
-    if (
-      process.env.GITHUB_REF === 'main' &&
-      process.env.GITHUB_REPOSITORY !== 'renovatebot/renovatebot.github.io' &&
-      process.env.GITHUB_REPOSITORY !== 'renovatebot/renovate'
-    ) {
-      logger.warn(
-        {
-          repository: process.env.GITHUB_REPOSITORY,
-          ref: process.env.GITHUB_REF,
-        },
-        "Skipping collection of open GitHub Issues, as we're running CI on a non-HEAD branch of Renovate or its docs site",
-      );
-      return result;
-    }
+  if (
+    process.env.CI &&
+    process.env.GITHUB_REF === 'main' &&
+    process.env.GITHUB_REPOSITORY !== 'renovatebot/renovatebot.github.io' &&
+    process.env.GITHUB_REPOSITORY !== 'renovatebot/renovate'
+  ) {
+    logger.warn(
+      {
+        repository: process.env.GITHUB_REPOSITORY,
+        ref: process.env.GITHUB_REF,
+      },
+      "Skipping collection of open GitHub Issues, as we're running CI on a non-HEAD branch of Renovate or its docs site",
+    );
+    return result;
   }
 
   try {

--- a/tools/docs/presets.ts
+++ b/tools/docs/presets.ts
@@ -197,11 +197,9 @@ export async function generatePresets(dist: string): Promise<void> {
       let header = `\n### ${name === 'default' ? '' : name}:${preset}`;
       let presetDescription = value.description as string;
       delete value.description;
-      if (!presetDescription) {
-        if (value.packageRules?.[0].description) {
-          presetDescription = value.packageRules[0].description as string;
-          delete value.packageRules[0].description;
-        }
+      if (!presetDescription && value.packageRules?.[0].description) {
+        presetDescription = value.packageRules[0].description as string;
+        delete value.packageRules[0].description;
       }
       let body = '';
       if (presetDescription) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Enable no-else-return (with allowElseIf: false) and unicorn/no-lonely-if as errors in .oxlintrc.json and fix all 131 pre-existing violations (91 no-else-return, 40 unicorn/no-lonely-if) across 98 files.

The no-else-return violations were fixed with the oxlint autofix (iterated to a fixpoint, plus two else-if chains that required --fix-dangerously) followed by Prettier formatting. One comment dropped by the autofix in lib/modules/manager/pub/artifacts.ts was restored manually. The unicorn/no-lonely-if violations were merged by hand, preserving comments and coverage-ignore hints.
## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
