### PR TITLE
refactor(oxlint): enable typescript/no-unnecessary-type-arguments

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -86,6 +86,7 @@
     "typescript/no-base-to-string": "error",
     "typescript/no-for-in-array": "error",
     "typescript/no-implied-eval": "error",
+    "typescript/no-unnecessary-type-arguments": "error",
     "typescript/no-unnecessary-type-assertion": "error",
     "typescript/only-throw-error": "error",
     "typescript/restrict-plus-operands": "error",

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -366,7 +366,7 @@ export class DockerDatasource extends Datasource {
     currentDigest: string,
   ): Promise<string | null | undefined> {
     try {
-      let manifestResponse: HttpResponse<string> | null;
+      let manifestResponse: HttpResponse | null;
 
       try {
         manifestResponse = await this.getManifestResponse(

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -122,7 +122,7 @@ export async function downloadHttpProtocol(
     }
   }
 
-  const fetchResult = await Result.wrap<HttpResponse, Error>(
+  const fetchResult = await Result.wrap<HttpResponse>(
     http.getText(url, { ...opts, cacheProvider: selectCacheProvider(url) }),
   )
     .transform((res): MavenFetchSuccess => {

--- a/lib/modules/datasource/utils.spec.ts
+++ b/lib/modules/datasource/utils.spec.ts
@@ -8,7 +8,7 @@ const googleAuth = vi.mocked(_googleAuth);
 
 describe('modules/datasource/utils', () => {
   it('is artifactory server invalid', () => {
-    const response: HttpResponse<string> = {
+    const response: HttpResponse = {
       statusCode: 200,
       body: 'test',
       headers: { 'invalid-header': 'version' },
@@ -17,7 +17,7 @@ describe('modules/datasource/utils', () => {
   });
 
   it('is artifactory server valid', () => {
-    const response: HttpResponse<string> = {
+    const response: HttpResponse = {
       statusCode: 200,
       body: 'test',
       headers: { 'x-jfrog-version': 'version' },

--- a/lib/modules/manager/azure-pipelines/extract.ts
+++ b/lib/modules/manager/azure-pipelines/extract.ts
@@ -134,9 +134,7 @@ export function parseAzurePipelines(
   return null;
 }
 
-function extractSteps(
-  steps: Step[] | undefined,
-): PackageDependency<Record<string, any>>[] {
+function extractSteps(steps: Step[] | undefined): PackageDependency[] {
   const deps = [];
   for (const step of coerceArray(steps)) {
     const task = extractAzurePipelinesTasks(step.task);

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -87,7 +87,7 @@ export function extractPackageFile(
     return null;
   }
   try {
-    const deps: PackageDependency<Record<string, any>>[] = [];
+    const deps: PackageDependency[] = [];
 
     for (const con of parsedContent) {
       deps.push(...findDependencies(con, config.registryAliases));

--- a/lib/modules/manager/maven/extract.ts
+++ b/lib/modules/manager/maven/extract.ts
@@ -248,10 +248,10 @@ function deepExtract(
 }
 
 function applyProps(
-  dep: PackageDependency<Record<string, any>>,
+  dep: PackageDependency,
   depPackageFile: string,
   props: MavenProp,
-): PackageDependency<Record<string, any>> {
+): PackageDependency {
   let result = dep;
   let anyChange = false;
   const alreadySeenProps = new Set<string>();
@@ -281,11 +281,11 @@ function applyProps(
 }
 
 function applyPropsInternal(
-  dep: PackageDependency<Record<string, any>>,
+  dep: PackageDependency,
   depPackageFile: string,
   props: MavenProp,
   previouslySeenProps: Set<string>,
-): [PackageDependency<Record<string, any>>, boolean, boolean] {
+): [PackageDependency, boolean, boolean] {
   let anyChange = false;
   let fatal = false;
 

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -9,7 +9,7 @@ import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import type { PackageDependency } from '../types.ts';
 import { depTypes, pep508ToPackageDependency } from './utils.ts';
 
-type Pep508Dependency = z.ZodType<PackageDependency<Record<string, any>>>;
+type Pep508Dependency = z.ZodType<PackageDependency>;
 
 function Pep508Dependency(depType: string): Pep508Dependency {
   return z.string().transform((x, ctx) => {
@@ -29,7 +29,7 @@ function Pep508Dependency(depType: string): Pep508Dependency {
   }) as Pep508Dependency;
 }
 
-type DependencyGroup = z.ZodType<PackageDependency<Record<string, any>>[]>;
+type DependencyGroup = z.ZodType<PackageDependency[]>;
 
 export function DependencyGroup(depType: string): DependencyGroup {
   return LooseRecord(LooseArray(Pep508Dependency(depType))).transform(

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -63,7 +63,7 @@ export function extractEnvironmentVariableName(
 }
 
 export function addExtraEnvVariable(
-  extraEnv: ExtraEnv<unknown>,
+  extraEnv: ExtraEnv,
   environmentVariableName: string,
   environmentValue: string,
 ): void {
@@ -91,7 +91,7 @@ export function addExtraEnvVariable(
 async function addCredentialsForSourceUrls(
   newPipfileContent: string,
   pipfileName: string,
-  extraEnv: ExtraEnv<unknown>,
+  extraEnv: ExtraEnv,
 ): Promise<void> {
   const sourceUrls = await findPipfileSourceUrlsWithCredentials(
     newPipfileContent,

--- a/lib/util/http/cache/package-http-cache-provider.ts
+++ b/lib/util/http/cache/package-http-cache-provider.ts
@@ -18,13 +18,13 @@ export interface PackageHttpCacheProviderOptions {
   softTtlMinutes?: number;
   checkCacheControlHeader: boolean;
   checkAuthorizationHeader: boolean;
-  writeSchema?: ZodType<unknown>;
+  writeSchema?: ZodType;
 }
 
 export class PackageHttpCacheProvider extends AbstractHttpCacheProvider {
   private namespace: PackageCacheNamespace;
   private defaultTtlMinutes: number;
-  private writeSchema?: ZodType<unknown>;
+  private writeSchema?: ZodType;
 
   checkCacheControlHeader: boolean;
   checkAuthorizationHeader: boolean;

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -107,11 +107,11 @@ export abstract class HttpBase<
   private async request(
     requestUrl: string | URL,
     httpOptions: InternalHttpOptions,
-  ): Promise<HttpResponse<string>>;
+  ): Promise<HttpResponse>;
   private async request(
     requestUrl: string | URL,
     httpOptions: InternalHttpOptions & { responseType: 'text' },
-  ): Promise<HttpResponse<string>>;
+  ): Promise<HttpResponse>;
   private async request(
     requestUrl: string | URL,
     httpOptions: InternalHttpOptions & { responseType: 'buffer' },
@@ -341,10 +341,7 @@ export abstract class HttpBase<
     }) as Promise<HttpResponse<never>>;
   }
 
-  getText(
-    url: string | URL,
-    options: HttpOptions = {},
-  ): Promise<HttpResponse<string>> {
+  getText(url: string | URL, options: HttpOptions = {}): Promise<HttpResponse> {
     return this.request(url, { ...options, responseType: 'text' });
   }
 

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -657,7 +657,7 @@ describe('util/http/index', () => {
           .get('/')
           .reply(200, JSON.stringify({ x: 2, y: 2 }));
 
-        const { body }: HttpResponse<string> = await http.getJson(
+        const { body }: HttpResponse = await http.getJson(
           'http://renovate.com',
           { headers: { accept: 'application/json' } },
           Some,
@@ -731,7 +731,7 @@ describe('util/http/index', () => {
           .post('/')
           .reply(200, JSON.stringify({ x: 2, y: 2 }));
 
-        const { body }: HttpResponse<string> = await http.postJson(
+        const { body }: HttpResponse = await http.postJson(
           'http://renovate.com',
           Some,
         );

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -54,7 +54,7 @@ function isZodResult<Output extends Val>(
 
 function fromZodResult<ZodOutput extends Val>(
   input: ZodSafeParseResult<ZodOutput>,
-): Result<ZodOutput, ZodError<unknown>> {
+): Result<ZodOutput, ZodError> {
   return input.success ? Result.ok(input.data) : Result.err(input.error);
 }
 
@@ -145,7 +145,7 @@ export class Result<T extends Val, E extends Val = Error> {
    */
   static wrap<T extends Val>(
     zodResult: ZodSafeParseResult<T>,
-  ): Result<T, ZodError<unknown>>;
+  ): Result<T, ZodError>;
   static wrap<T extends Val, E extends Val = Error>(
     callback: () => RawValue<T>,
   ): Result<T, E>;
@@ -165,7 +165,7 @@ export class Result<T extends Val, E extends Val = Error> {
       | (() => Promise<RawValue<T>>)
       | Promise<Result<T, EE>>
       | Promise<RawValue<T>>,
-  ): Result<T, ZodError<unknown>> | Result<T, E | EE> | AsyncResult<T, E | EE> {
+  ): Result<T, ZodError> | Result<T, E | EE> | AsyncResult<T, E | EE> {
     if (isZodResult<T>(input)) {
       return fromZodResult<T>(input);
     }
@@ -432,10 +432,10 @@ export class Result<T extends Val, E extends Val = Error> {
   ): AsyncResult<U, E | EE>;
   transform<U extends Val>(
     fn: (value: T) => ZodSafeParseResult<NonNullable<U>>,
-  ): Result<U, E | ZodError<unknown>>;
+  ): Result<U, E | ZodError>;
   transform<U extends Val>(
     fn: (value: T) => Promise<ZodSafeParseResult<NonNullable<U>>>,
-  ): AsyncResult<U, E | ZodError<unknown>>;
+  ): AsyncResult<U, E | ZodError>;
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => Promise<Result<U, E | EE>>,
   ): AsyncResult<U, E | EE>;
@@ -454,9 +454,7 @@ export class Result<T extends Val, E extends Val = Error> {
       | Promise<Result<U, E | EE>>
       | Promise<RawValue<U>>
       | RawValue<U>,
-  ):
-    | Result<U, E | EE | ZodError<unknown>>
-    | AsyncResult<U, E | EE | ZodError<unknown>> {
+  ): Result<U, E | EE | ZodError> | AsyncResult<U, E | EE | ZodError> {
     if (!this.res.ok) {
       return Result.err(this.res.err);
     }
@@ -537,7 +535,7 @@ export class Result<T extends Val, E extends Val = Error> {
   static parse<Schema extends ZodType<any, any, any>>(
     input: unknown,
     schema: Schema,
-  ): Result<NonNullable<ZodOutput<Schema>>, ZodError<unknown>> {
+  ): Result<NonNullable<ZodOutput<Schema>>, ZodError> {
     const parseResult = schema
       .transform((result, ctx): NonNullable<ZodOutput<Schema>> => {
         if (result === undefined) {
@@ -569,7 +567,7 @@ export class Result<T extends Val, E extends Val = Error> {
    */
   parse<Schema extends ZodType<any, any, any>>(
     schema: Schema,
-  ): Result<NonNullable<ZodOutput<Schema>>, E | ZodError<unknown>> {
+  ): Result<NonNullable<ZodOutput<Schema>>, E | ZodError> {
     if (this.res.ok) {
       return Result.parse(this.res.val, schema);
     }
@@ -764,10 +762,10 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
   ): AsyncResult<U, E | EE>;
   transform<U extends Val>(
     fn: (value: T) => ZodSafeParseResult<NonNullable<U>>,
-  ): AsyncResult<U, E | ZodError<unknown>>;
+  ): AsyncResult<U, E | ZodError>;
   transform<U extends Val>(
     fn: (value: T) => Promise<ZodSafeParseResult<NonNullable<U>>>,
-  ): AsyncResult<U, E | ZodError<unknown>>;
+  ): AsyncResult<U, E | ZodError>;
   transform<U extends Val, EE extends Val>(
     fn: (value: T) => Promise<Result<U, E | EE>>,
   ): AsyncResult<U, E | EE>;
@@ -786,7 +784,7 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
       | Promise<Result<U, E | EE>>
       | Promise<RawValue<U>>
       | RawValue<U>,
-  ): AsyncResult<U, E | EE | ZodError<unknown>> {
+  ): AsyncResult<U, E | EE | ZodError> {
     return new AsyncResult(
       this.asyncResult
         .then((oldResult) => {
@@ -859,7 +857,7 @@ export class AsyncResult<T extends Val, E extends Val> implements PromiseLike<
    */
   parse<Schema extends ZodType<any, any, any>>(
     schema: Schema,
-  ): AsyncResult<NonNullable<ZodOutput<Schema>>, E | ZodError<unknown>> {
+  ): AsyncResult<NonNullable<ZodOutput<Schema>>, E | ZodError> {
     return new AsyncResult(
       this.asyncResult
         .then((oldResult) => oldResult.parse(schema))

--- a/lib/workers/repository/extract/index.spec.ts
+++ b/lib/workers/repository/extract/index.spec.ts
@@ -22,7 +22,7 @@ describe('workers/repository/extract/index', () => {
 
     it('runs', async () => {
       managerFiles.getManagerPackageFiles.mockResolvedValue([
-        partial<PackageFile<Record<string, any>>>({}),
+        partial<PackageFile>({}),
       ]);
       delete config.customManagers; // for coverage
       const res = await extractAllDependencies(config);
@@ -32,7 +32,7 @@ describe('workers/repository/extract/index', () => {
     it('skips non-enabled managers', async () => {
       config.enabledManagers = ['npm'];
       managerFiles.getManagerPackageFiles.mockResolvedValue([
-        partial<PackageFile<Record<string, any>>>({}),
+        partial<PackageFile>({}),
       ]);
       const res = await extractAllDependencies(config);
       expect(res).toMatchObject({
@@ -59,7 +59,7 @@ describe('workers/repository/extract/index', () => {
 
     it('checks custom managers', async () => {
       managerFiles.getManagerPackageFiles.mockResolvedValue([
-        partial<PackageFile<Record<string, any>>>({}),
+        partial<PackageFile>({}),
       ]);
       config.customManagers = [
         {

--- a/lib/workers/repository/process/extract-update.ts
+++ b/lib/workers/repository/process/extract-update.ts
@@ -250,7 +250,7 @@ export async function lookup(
 }
 
 export function reportMaliciousSkippedDependencies(
-  allPackageFiles: Record<string, PackageFile<Record<string, any>>[]>,
+  allPackageFiles: Record<string, PackageFile[]>,
 ): void {
   if (allPackageFiles === undefined) {
     return;

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -20,7 +20,7 @@ import { PackageFiles } from '../package-files.ts';
 import { lookupUpdates } from './lookup/index.ts';
 import type { LookupUpdateConfig, UpdateResult } from './lookup/types.ts';
 
-type LookupResult = Result<PackageDependency, Error>;
+type LookupResult = Result<PackageDependency>;
 
 async function lookup(
   packageFileConfig: RenovateConfig & PackageFile,
@@ -91,7 +91,7 @@ async function lookup(
           'Dependency lookup error',
         );
       })
-      .catch((err): Result<UpdateResult, Error> => {
+      .catch((err): Result<UpdateResult> => {
         if (
           packageFileConfig.repoIsOnboarded === true ||
           !(err instanceof ExternalHostError)

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -70,7 +70,7 @@ async function getTimestamp(
 
 export async function lookupUpdates(
   inconfig: LookupUpdateConfig,
-): Promise<Result<UpdateResult, Error>> {
+): Promise<Result<UpdateResult>> {
   let config: LookupUpdateConfig = { ...inconfig };
   config.versioning ??= getDefaultVersioning(config.datasource);
 

--- a/tools/mkdocs.ts
+++ b/tools/mkdocs.ts
@@ -58,7 +58,7 @@ program
     if (opts.strict) {
       mkdocsArgs.push('--strict');
     }
-    const spawnServe = (): ExecaChildProcess<string> =>
+    const spawnServe = (): ExecaChildProcess =>
       execa('uv', mkdocsArgs, {
         cwd: 'tools/mkdocs',
         stdio: 'inherit',
@@ -73,7 +73,7 @@ program
       return;
     }
 
-    let activeChild: ExecaChildProcess<string> | null = null;
+    let activeChild: ExecaChildProcess | null = null;
     let shouldRestart = false;
     let debounceTimer: ReturnType<typeof setTimeout> | undefined;
 
@@ -110,7 +110,7 @@ async function prepareDocs(opts: any): Promise<void> {
   }
 }
 
-function checkResult(res: ExecaReturnValue<string>): void {
+function checkResult(res: ExecaReturnValue): void {
   if (res.signal) {
     logger.error(`Signal received: ${res.signal}`);
     process.exit(-1);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Enable the type-aware typescript/no-unnecessary-type-arguments rule as error and remove all 44 pre-existing redundant type arguments (type arguments identical to the type parameter default), e.g. HttpResponse<string>, ZodError<unknown>,
PackageDependency<Record<string, any>>.
## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
