### PR TITLE
refactor(oxlint): enable unicorn/prefer-at

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -163,6 +163,7 @@
     "typescript/no-require-imports": "error",
     "typescript/no-unnecessary-type-constraint": "error",
     "typescript/no-unsafe-function-type": "error",
+    "unicorn/prefer-at": "error",
     "unicorn/prefer-node-protocol": "error",
 
     "typescript/no-useless-default-assignment": "error",

--- a/lib/modules/datasource/aws-machine-image/index.ts
+++ b/lib/modules/datasource/aws-machine-image/index.ts
@@ -151,7 +151,7 @@ export class AwsMachineImageDatasource extends Datasource {
     packageName: serializedAmiFilter,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const images = await this.getSortedAwsMachineImages(serializedAmiFilter);
-    const latestImage = images[images.length - 1];
+    const latestImage = images.at(-1);
     if (!latestImage?.ImageId) {
       return null;
     }

--- a/lib/modules/datasource/dart-version/index.ts
+++ b/lib/modules/datasource/dart-version/index.ts
@@ -88,6 +88,6 @@ export class DartVersionDatasource extends Datasource {
   // Prefix should have a format of "channels/stable/release/2.9.3/"
   private getVersionFromPrefix(prefix: string): string | undefined {
     const parts = prefix.split('/');
-    return parts[parts.length - 2];
+    return parts.at(-2);
   }
 }

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -1184,7 +1184,7 @@ export class DockerDatasource extends Datasource {
     const tags = releases.map((release) => release.version);
     const latestTag = tags.includes('latest')
       ? 'latest'
-      : (findLatestStable(tags) ?? tags[tags.length - 1]);
+      : (findLatestStable(tags) ?? tags.at(-1));
 
     /* v8 ignore next 3 -- TODO: add test */
     if (!latestTag) {

--- a/lib/modules/manager/bazel/parser.ts
+++ b/lib/modules/manager/bazel/parser.ts
@@ -24,7 +24,7 @@ function emptyCtx(source: string): Ctx {
 }
 
 function currentFragment(ctx: Ctx): NestedFragment {
-  const deepestFragment = ctx.stack[ctx.stack.length - 1];
+  const deepestFragment = ctx.stack.at(-1)!;
   return deepestFragment;
 }
 

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -76,8 +76,7 @@ function processDepForAutoReplace(
   });
 
   const minLine = lineNumberRangesToReplace[0]?.[0];
-  const maxLine =
-    lineNumberRangesToReplace[lineNumberRangesToReplace.length - 1]?.[1];
+  const maxLine = lineNumberRangesToReplace.at(-1)?.[1];
   if (
     lineNumberRanges.length === 1 ||
     minLine === undefined ||
@@ -129,10 +128,7 @@ export function splitImageParts(currentFrom: string): PackageDependency {
   const depTagSplit = currentDepTag.split(':');
   let depName: string;
   let currentValue: string | undefined;
-  if (
-    depTagSplit.length === 1 ||
-    depTagSplit[depTagSplit.length - 1].includes('/')
-  ) {
+  if (depTagSplit.length === 1 || depTagSplit.at(-1)!.includes('/')) {
     depName = currentDepTag;
   } else {
     currentValue = depTagSplit.pop();
@@ -455,6 +451,6 @@ export function extractPackageFile(
   for (const d of deps) {
     d.depType ??= 'stage';
   }
-  deps[deps.length - 1].depType = 'final';
+  deps.at(-1)!.depType = 'final';
   return { deps };
 }

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -25,7 +25,7 @@ interface QuotedValue {
 export function parseQuote(input: string): QuotedValue {
   const trimmed = input.trim();
   const first = trimmed[0];
-  const last = trimmed[trimmed.length - 1];
+  const last = trimmed.at(-1);
 
   if (
     trimmed.length >= 2 &&

--- a/lib/modules/manager/gradle/parser/common.ts
+++ b/lib/modules/manager/gradle/parser/common.ts
@@ -129,7 +129,7 @@ export function findVariableInKotlinImport(
 ): VariableData | undefined {
   if (ctx.tmpKotlinImportStore.length && name.includes('.')) {
     for (const tokens of ctx.tmpKotlinImportStore) {
-      const lastToken = tokens[tokens.length - 1];
+      const lastToken = tokens.at(-1);
       if (lastToken && name.startsWith(`${lastToken.value}.`)) {
         const prefix = tokens
           .slice(0, -1)

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -94,7 +94,7 @@ export function handleDepString(ctx: Ctx): Ctx {
   }
 
   if (!dep.managerData) {
-    const lastToken = stringTokens[stringTokens.length - 1];
+    const lastToken = stringTokens.at(-1);
     if (
       lastToken?.type === 'string-value' &&
       dep.currentValue &&

--- a/lib/modules/manager/npm/extract/common/overrides.ts
+++ b/lib/modules/manager/npm/extract/common/overrides.ts
@@ -22,8 +22,7 @@ export function extractOverrideDepsRec(
     if (isString(versionValue)) {
       // special handling for "." override dependency name
       // "." means the constraint is applied to the parent dep
-      const currDepName =
-        overrideName === '.' ? parents[parents.length - 1] : overrideName;
+      const currDepName = overrideName === '.' ? parents.at(-1)! : overrideName;
       const dep: PackageDependency<NpmManagerData> = {
         depName: currDepName,
         depType: 'overrides',

--- a/lib/modules/manager/npm/update/dependency/index.ts
+++ b/lib/modules/manager/npm/update/dependency/index.ts
@@ -304,7 +304,7 @@ function overrideDepPosition(
   overrideDepName: string;
 } {
   // get override dep position when its nested in an object
-  const lastParent = parents[parents.length - 1];
+  const lastParent = parents.at(-1);
   let overrideDep: OverrideDependency = overrideBlock;
   for (const parent of parents) {
     // v8 ignore else -- TODO: add test #40625

--- a/lib/modules/manager/osgi/extract.ts
+++ b/lib/modules/manager/osgi/extract.ts
@@ -83,7 +83,7 @@ export function extractPackageFile(
       continue;
     }
     // parsing should use the last entry for the version
-    const currentValue = parts[parts.length - 1];
+    const currentValue = parts.at(-1)!;
     const result: PackageDependency = {
       datasource: MavenDatasource.id,
       depName: `${parts[0]}:${parts[1]}`,

--- a/lib/modules/manager/pip_setup/extract.ts
+++ b/lib/modules/manager/pip_setup/extract.ts
@@ -65,7 +65,7 @@ function depStringHandler(
 // Add `skip-reason` for dependencies annotated
 // with "# renovate: ignore" comment
 function depSkipHandler(ctx: Context): Context {
-  const dep = ctx.deps[ctx.deps.length - 1];
+  const dep = ctx.deps.at(-1);
   const deps = ctx.deps.slice(0, -1);
   deps.push({ ...dep, skipReason: 'ignored' });
   return { ...ctx, deps };

--- a/lib/modules/manager/terraform/lockfile/util.ts
+++ b/lib/modules/manager/terraform/lockfile/util.ts
@@ -212,7 +212,7 @@ export function writeLockUpdates(
   });
 
   const trailingNotUpdatedLines = lines.slice(
-    updates[updates.length - 1].lineNumbers.block?.end,
+    updates.at(-1)!.lineNumbers.block?.end,
   );
   sections.push(trailingNotUpdatedLines);
 

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -852,7 +852,7 @@ const platform: Platform = {
           }
 
           // Pick the last issue in the list as the active one
-          activeIssue = issues[issues.length - 1];
+          activeIssue = issues.at(-1)!;
         }
 
         // Close any duplicate issues

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -860,7 +860,7 @@ const platform: Platform = {
           }
 
           // Pick the last issue in the list as the active one
-          activeIssue = issues[issues.length - 1];
+          activeIssue = issues.at(-1)!;
         }
 
         // Close any duplicate issues

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1459,7 +1459,7 @@ export async function ensureIssue({
         if (shouldReOpen) {
           logger.debug('Reopening previously closed issue');
         }
-        issue = issues[issues.length - 1];
+        issue = issues.at(-1)!;
       }
       for (const i of issues) {
         if (i.state === 'open' && i.number !== issue.number) {

--- a/lib/modules/platform/github/pr.ts
+++ b/lib/modules/platform/github/pr.ts
@@ -126,9 +126,7 @@ export async function getPrCache(
           // even if no Renovate PRs are found.
           prApiCache.updateLastModified(page[0].updated_at);
 
-          const oldestOnPage = DateTime.fromISO(
-            page[page.length - 1].updated_at,
-          );
+          const oldestOnPage = DateTime.fromISO(page.at(-1)!.updated_at);
           if (oldestOnPage < cutoffTime) {
             needNextPageSync = false;
           }

--- a/lib/modules/versioning/composer/index.ts
+++ b/lib/modules/versioning/composer/index.ts
@@ -315,7 +315,7 @@ function getNewValue({
     const hasOr = currentValue.includes(' || ');
     if (hasOr || rangeStrategy === 'widen') {
       const splitValues = currentValue.split('||');
-      const lastValue = splitValues[splitValues.length - 1];
+      const lastValue = splitValues.at(-1)!;
       const replacementValue = getNewValue({
         currentValue: lastValue.trim(),
         rangeStrategy: 'replace',
@@ -326,7 +326,7 @@ function getNewValue({
         newValue = replacementValue;
       } else if (replacementValue) {
         const parsedRange = parseRange(replacementValue);
-        const element = parsedRange[parsedRange.length - 1];
+        const element = parsedRange.at(-1)!;
         if (element.operator?.startsWith('<')) {
           const splitCurrent = currentValue.split(element.operator);
           splitCurrent.pop();

--- a/lib/modules/versioning/conan/range.ts
+++ b/lib/modules/versioning/conan/range.ts
@@ -124,7 +124,7 @@ export function replaceRange({
   newVersion,
 }: NewValueConfig): string {
   const parsedRange = parseRange(currentValue);
-  const element = parsedRange[parsedRange.length - 1];
+  const element = parsedRange.at(-1)!;
   const toVersionMajor = getMajor(newVersion);
   const toVersionMinor = getMinor(newVersion);
   const toVersionPatch = getPatch(newVersion);
@@ -218,7 +218,7 @@ export function widenRange(
   options: semver.Options,
 ): string | null {
   const parsedRange = parseRange(currentValue);
-  const element = parsedRange[parsedRange.length - 1];
+  const element = parsedRange.at(-1)!;
 
   if (matchesWithOptions(newVersion, currentValue, options)) {
     return currentValue;
@@ -235,7 +235,7 @@ export function widenRange(
     return splitCurrent.join(element.operator) + newValue;
   }
   if (parsedRange.length > 1) {
-    const previousElement = parsedRange[parsedRange.length - 2];
+    const previousElement = parsedRange.at(-2)!;
     if (previousElement.operator === '-') {
       const splitCurrent = currentValue.split('-');
       splitCurrent.pop();
@@ -265,7 +265,7 @@ export function bumpRange(
     );
   }
   const parsedRange = parseRange(currentValue);
-  const element = parsedRange[parsedRange.length - 1];
+  const element = parsedRange.at(-1)!;
 
   const toVersionMajor = getMajor(newVersion);
   const toVersionMinor = getMinor(newVersion);

--- a/lib/modules/versioning/conda/index.ts
+++ b/lib/modules/versioning/conda/index.ts
@@ -165,7 +165,7 @@ function getSatisfyingVersion(
     return null;
   }
 
-  return satisfiedVersions[satisfiedVersions.length - 1][1];
+  return satisfiedVersions.at(-1)![1];
 }
 
 function minSatisfyingVersion(

--- a/lib/modules/versioning/ivy/index.ts
+++ b/lib/modules/versioning/ivy/index.ts
@@ -81,7 +81,7 @@ function matches(a: string, b: string): boolean {
     }
     const tokens = tokenize(a);
     if (tokens.length) {
-      const token = tokens[tokens.length - 1];
+      const token = tokens.at(-1)!;
       if (token.type === TYPE_QUALIFIER) {
         return token.val.toLowerCase() === value;
       }

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -489,7 +489,7 @@ function coerceRangeValue(prev: string, next: string): string {
 
 function incrementRangeValue(value: string): string {
   const tokens = tokenize(value);
-  const lastToken = tokens[tokens.length - 1];
+  const lastToken = tokens.at(-1)!;
   if (typeof lastToken.val === 'number') {
     lastToken.val += 1;
     return coerceRangeValue(value, tokensToStr(tokens));
@@ -568,7 +568,7 @@ function autoExtendMavenRange(
   } else if (rightValue !== null) {
     if (interval.rightType === INCLUDING_POINT) {
       const tokens = tokenize(rightValue);
-      const lastToken = tokens[tokens.length - 1];
+      const lastToken = tokens.at(-1)!;
       if (typeof lastToken.val === 'number') {
         interval.rightValue = coerceRangeValue(rightValue, newValue);
       } else {

--- a/lib/modules/versioning/npm/range.ts
+++ b/lib/modules/versioning/npm/range.ts
@@ -90,7 +90,7 @@ export function getNewValue({
     });
   }
   const parsedRange = semverUtils.parseRange(currentValue);
-  const element = parsedRange[parsedRange.length - 1];
+  const element = parsedRange.at(-1)!;
   if (rangeStrategy === 'widen') {
     if (satisfiesRange(newVersion, currentValue)) {
       return currentValue;
@@ -109,7 +109,7 @@ export function getNewValue({
       return `${splitCurrent.join(element.operator)}${newValue!}`;
     }
     if (parsedRange.length > 1) {
-      const previousElement = parsedRange[parsedRange.length - 2];
+      const previousElement = parsedRange.at(-2)!;
       if (previousElement.operator === '-') {
         const splitCurrent = currentValue.split('-');
         splitCurrent.pop();

--- a/lib/modules/versioning/pep440/index.ts
+++ b/lib/modules/versioning/pep440/index.ts
@@ -52,7 +52,7 @@ function getSatisfyingVersion(
   range: string,
 ): string | null {
   const found = pep440.filter(versions, range).sort(sortVersions);
-  return found.length === 0 ? null : found[found.length - 1];
+  return found.length === 0 ? null : found.at(-1)!;
 }
 
 function minSatisfyingVersion(

--- a/lib/modules/versioning/poetry/index.ts
+++ b/lib/modules/versioning/poetry/index.ts
@@ -182,7 +182,7 @@ function getNewValue({
       );
     }
     const parsedRange = parseRange(npmCurrentValue);
-    const element = parsedRange[parsedRange.length - 1];
+    const element = parsedRange.at(-1)!;
     if (parsedRange.length === 1 && element.operator) {
       if (element.operator === '^') {
         const version = handleShort('^', npmCurrentValue, newVersion);

--- a/lib/modules/versioning/ruby/version.ts
+++ b/lib/modules/versioning/ruby/version.ts
@@ -40,7 +40,7 @@ const adapt = (left: string, right: string): string =>
 
 const trimZeroes = (version: string): string => {
   const segments = version.split('.');
-  while (segments.length > 0 && segments[segments.length - 1] === '0') {
+  while (segments.length > 0 && segments.at(-1) === '0') {
     segments.pop();
   }
   return segments.join('.');

--- a/lib/modules/versioning/rust-release-channel/index.ts
+++ b/lib/modules/versioning/rust-release-channel/index.ts
@@ -193,7 +193,7 @@ class RustReleaseChannelVersioning implements VersioningApi {
 
     // Sort and return the highest (last in sorted array)
     matching.sort((a, b) => this.sortVersions(a, b));
-    return matching.slice(-1)[0];
+    return matching.at(-1)!;
   }
 
   minSatisfyingVersion(versions: string[], range: string): string | null {

--- a/lib/util/github/graphql/datasource-fetcher.spec.ts
+++ b/lib/util/github/graphql/datasource-fetcher.spec.ts
@@ -326,7 +326,7 @@ describe('util/github/graphql/datasource-fetcher', () => {
         const pages = partitions.map((nodes, idx) =>
           resp(false, nodes, `page-${idx + 2}`),
         );
-        delete pages[pages.length - 1].data?.repository.payload.pageInfo;
+        delete pages.at(-1)!.data?.repository.payload.pageInfo;
         return pages;
       }
 

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -341,7 +341,7 @@ function parseFileChanges(
     return { state: 'unmodified' };
   }
 
-  const lastChange = changes[changes.length - 1];
+  const lastChange = changes.at(-1)!;
   if (lastChange.type === 'deletion') {
     return { state: 'deleted' };
   }

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -98,7 +98,7 @@ export async function flattenUpdates(
         packagePath.splice(-1, 1);
       }
       if (packagePath.length > 0) {
-        packageFileConfig.parentDir = packagePath[packagePath.length - 1];
+        packageFileConfig.parentDir = packagePath.at(-1);
         packageFileConfig.packageFileDir = packagePath.join('/');
       } else {
         packageFileConfig.parentDir = '';

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -301,9 +301,7 @@ export function generateBranchConfig(
 
     const pendingVersionsLength = upgrade.pendingVersions?.length;
     if (pendingVersionsLength) {
-      upgrade.displayPending = `\`${upgrade
-        .pendingVersions!.slice(-1)
-        .pop()!}\``;
+      upgrade.displayPending = `\`${upgrade.pendingVersions!.at(-1)!}\``;
       if (pendingVersionsLength > 1) {
         upgrade.displayPending += ` (+${pendingVersionsLength - 1})`;
       }

--- a/test/http-mock.ts
+++ b/test/http-mock.ts
@@ -149,7 +149,7 @@ function massageHttpMockStacktrace(err: Error): void {
 
   const lines = content.slice(0, idx).split('\n');
   const lineNum = lines.length;
-  const linePos = lines[lines.length - 1].length + 1;
+  const linePos = lines.at(-1)!.length + 1;
 
   const stackLine = `    at <test> (${state.testPath}:${lineNum}:${linePos})`;
   err.stack = err.stack.replace(/\+\+\+.*$/s, stackLine);

--- a/tools/prettier/plugins/mkdocs-admonitions/index.mjs
+++ b/tools/prettier/plugins/mkdocs-admonitions/index.mjs
@@ -100,7 +100,7 @@ function maskAdmonitions(text) {
           bodyLines.push(lines[i]);
           i++;
         }
-        while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') {
+        while (bodyLines.length > 0 && bodyLines.at(-1) === '') {
           bodyLines.pop();
           i--;
         }
@@ -124,7 +124,7 @@ function maskAdmonitions(text) {
 
       // Strip trailing blank lines to avoid double-blank in prettier output;
       // they will be re-emitted to the masked stream as normal blank lines.
-      while (bodyLines.length > 0 && bodyLines[bodyLines.length - 1] === '') {
+      while (bodyLines.length > 0 && bodyLines.at(-1) === '') {
         bodyLines.pop();
         i--;
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This rule only triggers by default for potential negative indexes. https://oxc.rs/docs/guide/usage/linter/rules/unicorn/prefer-at.html#unicorn-prefer-at-oxlint

Enable the unicorn/prefer-at rule as error in .oxlintrc.json and fix all 43 pre-existing violations (arr[arr.length - 1] -> arr.at(-1)) via oxlint autofix. Where .at() widened the type to T | undefined, non-null assertions were added at sites where surrounding logic guarantees the element exists (length guards, split results), preserving the original runtime behavior and typing.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
