### PR TITLE
fix(github): respect automergeStrategy with platform automerge

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -303,6 +303,8 @@ If possible, Renovate follows the merge strategy set on the platform itself for 
 If you've set `automerge=true` and `automergeType=pr` for any of your dependencies, then you may choose what automerge strategy Renovate uses by setting the `automergeStrategy` config option.
 If you're happy with the default behavior, you don't need to do anything.
 
+On GitHub, Renovate applies `automergeStrategy` both when Renovate merges the PR directly and when `platformAutomerge=true` enables GitHub-native automerge.
+
 You may choose from these values:
 
 - `auto`, Renovate decides how to merge

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -303,7 +303,7 @@ If possible, Renovate follows the merge strategy set on the platform itself for 
 If you've set `automerge=true` and `automergeType=pr` for any of your dependencies, then you may choose what automerge strategy Renovate uses by setting the `automergeStrategy` config option.
 If you're happy with the default behavior, you don't need to do anything.
 
-On GitHub, Renovate applies `automergeStrategy` both when Renovate merges the PR directly and when `platformAutomerge=true` enables GitHub-native automerge.
+On supported platforms, `automergeStrategy` also applies when using platform-native automerge.
 
 You may choose from these values:
 
@@ -4017,6 +4017,8 @@ If enabled Renovate will pin Docker images or GitHub Actions by means of their S
   The default `"failed"` only sets the check when artifact updates fail, so a required check rule would block every PR that has no artifact errors (the check would never appear). Setting it to `"always"` makes Renovate report green when there are no errors and red when there are, which is what branch protection requires.
 
 If you have enabled `automerge` and set `automergeType=pr` in the Renovate config, then leaving `platformAutomerge` as `true` speeds up merging via the platform's native automerge functionality.
+
+Where supported, platform-native automerge uses [`automergeStrategy`](#automergestrategy) to select the merge method.
 
 On Bitbucket Server, GitHub and GitLab, Renovate re-enables the PR for platform-native automerge whenever it's rebased.
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -4170,6 +4170,36 @@ describe('modules/platform/github/index', () => {
         ]);
       });
 
+      it('should use the configured automerge strategy', async () => {
+        const scope = await mockScope();
+        scope.post('/graphql').reply(200, graphqlAutomergeResp);
+
+        const pr = await github.createPr({
+          ...prConfig,
+          platformPrOptions: {
+            usePlatformAutomerge: true,
+            automergeStrategy: 'rebase',
+          },
+        });
+
+        expect(pr).toMatchObject({ number: 123 });
+        expect(httpMock.getTrace()).toMatchObject([
+          graphqlGetRepo,
+          restCreatePr,
+          restAddLabels,
+          {
+            ...graphqlAutomerge,
+            graphql: {
+              ...graphqlAutomerge.graphql,
+              variables: {
+                pullRequestId: 'abcd',
+                mergeMethod: 'REBASE',
+              },
+            },
+          },
+        ]);
+      });
+
       it('should handle GraphQL errors', async () => {
         const scope = await mockScope();
         scope.post('/graphql').reply(200, graphqlAutomergeErrorResp);

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1856,7 +1856,11 @@ async function tryPrAutomerge(
   }
 
   try {
-    const mergeMethod = config.mergeMethod?.toUpperCase() || 'MERGE';
+    const mergeMethod =
+      (
+        mapMergeStartegy(platformPrOptions.automergeStrategy) ??
+        config.mergeMethod
+      )?.toUpperCase() || 'MERGE';
 
     let commitHeadline: string | undefined;
     let commitBody: string | undefined;


### PR DESCRIPTION
## Changes

Use the configured `automergeStrategy` when enabling GitHub platform-native automerge, falling back to the repository-detected merge method when the strategy is `auto` or unsupported.

Add a regression test proving that an explicit `rebase` strategy overrides the detected `squash` method in the `enablePullRequestAutoMerge` GraphQL mutation.

Document that supported platforms apply `automergeStrategy` to platform-native automerge, with cross-references from both related option sections.

## Context

Related discussion: https://github.com/renovatebot/renovate/discussions/41177

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn’t close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Codex, based on GPT-5, was used to inspect the codebase, implement the change, add the regression test and documentation, and prepare this pull request description.

## Documentation

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I’ve tested my work

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Full `pnpm test` using the repository-pinned Node 24.18.0 toolchain:

- 942 test files passed
- 24,195 tests passed; 1 expected failure
- 100% statements, functions, and lines coverage

The documentation updates also pass `pnpm check --all docs/usage/configuration-options.md`.