### PR TITLE
fix(config): make `platformCommit` global-only

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4033,17 +4033,6 @@ Please check platform specific docs for version requirements.
 
 To learn how to use GitHub's Merge Queue feature with Renovate, read our [GitHub Merge Queue](./key-concepts/automerge.md#github-merge-queue) docs.
 
-## `platformCommit`
-
-Only use this option if you run Renovate as a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps).
-It does not apply when you use a Personal Access Token as credential.
-
-When `platformCommit` is enabled, Renovate will create commits with GitHub's API instead of using `git` directly.
-This way Renovate can use GitHub's [Commit signing support for bots and other GitHub Apps](https://github.blog/2019-08-15-commit-signing-support-for-bots-and-other-github-apps/) feature.
-
-!!! note
-  When using platform commits, GitHub determines the git author string to use and Renovate's own gitAuthor is ignored.
-
 ## `postUpdateOptions`
 
 ### `bundlerConservative`

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1045,6 +1045,17 @@ It also may mean that ignored directories like `node_modules` can be preserved a
 
 ## `platform`
 
+## `platformCommit`
+
+Only use this option if you run Renovate as a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps).
+It does not apply when you use a Personal Access Token as credential.
+
+When `platformCommit` is enabled, Renovate will create commits with GitHub's API instead of using `git` directly.
+This way Renovate can use GitHub's [Commit signing support for bots and other GitHub Apps](https://github.blog/2019-08-15-commit-signing-support-for-bots-and-other-github-apps/) feature.
+
+!!! note
+  When using platform commits, GitHub determines the git author string to use and Renovate's own gitAuthor is ignored.
+
 ## `prCacheSyncMaxPages`
 
 Maximum number of pages to fetch when syncing the pull request cache.

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -49,6 +49,7 @@ export class GlobalConfig {
     'onboardingNoDeps',
     'onboardingPrTitle',
     'platform',
+    'platformCommit',
     'prCacheSyncMaxPages',
     'presetCachePersistence',
     'productLinks',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3395,6 +3395,7 @@ const options: Readonly<RenovateOptions>[] = [
       'Use platform API to perform commits instead of using Git directly.',
     type: 'string',
     default: 'auto',
+    globalOnly: true,
     allowedValues: ['auto', 'disabled', 'enabled'],
     supportedPlatforms: ['github'],
   },

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -128,7 +128,6 @@ export interface RenovateSharedConfig {
 
   pinDigests?: boolean;
   platformAutomerge?: boolean;
-  platformCommit?: PlatformCommitOptions;
   postUpgradeTasks?: PostUpgradeTasks;
   prBodyColumns?: string[];
   prBodyDefinitions?: Record<string, string>;
@@ -259,6 +258,7 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   localDir?: string;
   migratePresets?: Record<string, string>;
   platform?: PlatformId;
+  platformCommit?: PlatformCommitOptions;
   prCacheSyncMaxPages?: number;
   presetCachePersistence?: boolean;
   httpCacheTtlDays?: number;

--- a/lib/workers/repository/config-migration/branch/create.ts
+++ b/lib/workers/repository/config-migration/branch/create.ts
@@ -75,7 +75,7 @@ export async function createConfigMigrationBranch(
     branchName: getMigrationBranchName(config),
     files,
     message: commitMessage.toString(),
-    platformCommit: config.platformCommit,
+    platformCommit: GlobalConfig.get('platformCommit'),
     force: true,
     // Only needed by Gerrit platform
     prTitle: commitMessageFactory.getPrTitle(),

--- a/lib/workers/repository/config-migration/branch/rebase.ts
+++ b/lib/workers/repository/config-migration/branch/rebase.ts
@@ -53,7 +53,7 @@ export async function rebaseMigrationBranch(
       },
     ],
     message: commitMessage.toString(),
-    platformCommit: config.platformCommit,
+    platformCommit: GlobalConfig.get('platformCommit'),
     // Only needed by Gerrit platform
     prTitle: commitMessageFactory.getPrTitle(),
   });

--- a/lib/workers/repository/onboarding/branch/create.ts
+++ b/lib/workers/repository/onboarding/branch/create.ts
@@ -59,7 +59,7 @@ export async function createOnboardingBranch(
       },
     ],
     message: commitMessage,
-    platformCommit: config.platformCommit,
+    platformCommit: GlobalConfig.get('platformCommit'),
     force: true,
     // Only needed by Gerrit platform
     prTitle,

--- a/lib/workers/repository/onboarding/branch/rebase.ts
+++ b/lib/workers/repository/onboarding/branch/rebase.ts
@@ -67,7 +67,7 @@ export async function rebaseOnboardingBranch(
       },
     ],
     message: commitMessage.toString(),
-    platformCommit: config.platformCommit,
+    platformCommit: GlobalConfig.get('platformCommit'),
     // Only needed by Gerrit platform
     prTitle,
   });

--- a/lib/workers/repository/update/branch/commit.spec.ts
+++ b/lib/workers/repository/update/branch/commit.spec.ts
@@ -20,7 +20,6 @@ describe('workers/repository/update/branch/commit', () => {
         updatedPackageFiles: [],
         updatedArtifacts: [],
         upgrades: [],
-        platformCommit: 'auto',
       } satisfies BranchConfig;
       scm.commitAndPush.mockResolvedValueOnce('123test' as LongCommitSha);
       GlobalConfig.reset();

--- a/lib/workers/repository/update/branch/commit.ts
+++ b/lib/workers/repository/update/branch/commit.ts
@@ -54,7 +54,7 @@ export function commitFilesToBranch(
     files: updatedFiles,
     message: config.commitMessage!,
     force: !!config.forceCommit,
-    platformCommit: config.platformCommit,
+    platformCommit: GlobalConfig.get('platformCommit'),
     // Only needed by Gerrit platform
     prTitle: config.prTitle,
     // Only needed by Gerrit platform


### PR DESCRIPTION
## Changes

This PR changes `platformCommit` so that it's a global-only option rather than repository-level.

I believe this only makes sense.

/cc @zharinov

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Grok Build 4.5 for implementing this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A