### PR TITLE
fix(platform/azure): don't create Dependency Dashboard for projects without an `Issue` type

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -2210,6 +2210,7 @@ describe('modules/platform/azure/index', () => {
       partial<IWorkItemTrackingApi>({
         queryByWiql: vi.fn().mockResolvedValue({ workItems: [] }),
         createWorkItem: createWorkItemMock,
+        getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
       }),
     );
     const result = await azure.ensureIssue({

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -309,6 +309,7 @@ describe('modules/platform/azure/issue', () => {
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           createWorkItem: createWorkItemMock,
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
         }),
       );
 
@@ -328,6 +329,7 @@ describe('modules/platform/azure/issue', () => {
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           createWorkItem: createWorkItemMock,
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
         }),
       );
 
@@ -340,6 +342,29 @@ describe('modules/platform/azure/issue', () => {
       expect(result).toBeNull();
       expect(logger.warn).toHaveBeenCalledWith(
         'Azure: work item creation returned no result; skipping issue',
+      );
+    });
+
+    it('should skip issue when the Issue work item type does not exist', async () => {
+      vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
+
+      const createWorkItemMock = vi.fn();
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          createWorkItem: createWorkItemMock,
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Bug' }]),
+        }),
+      );
+
+      const result = await issueService.ensureIssue({
+        title: 'Test Issue',
+        body: 'Test body content',
+      });
+
+      expect(createWorkItemMock).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("work item type 'Issue' does not exist"),
       );
     });
 
@@ -650,6 +675,7 @@ describe('modules/platform/azure/issue', () => {
       azureApi.workItemTrackingApi.mockResolvedValue(
         partial<IWorkItemTrackingApi>({
           createWorkItem: createWorkItemMock,
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
         }),
       );
 
@@ -699,6 +725,7 @@ describe('modules/platform/azure/issue', () => {
         partial<IWorkItemTrackingApi>({
           createWorkItem: createWorkItemMock,
           getWorkItemTypeStates: vi.fn().mockResolvedValue(noProposedStates),
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
         }),
       );
 

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -321,6 +321,28 @@ describe('modules/platform/azure/issue', () => {
       expect(result).toEqual('created');
     });
 
+    it('should return null when work item creation returns no result', async () => {
+      vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
+
+      const createWorkItemMock = vi.fn().mockResolvedValue(null);
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          createWorkItem: createWorkItemMock,
+        }),
+      );
+
+      const result = await issueService.ensureIssue({
+        title: 'Test Issue',
+        body: 'Test body content',
+      });
+
+      expect(createWorkItemMock).toHaveBeenCalled();
+      expect(result).toBeNull();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Azure: work item creation returned no result; skipping issue',
+      );
+    });
+
     it('should reopen closed issue when shouldReOpen is true', async () => {
       const mockClosedIssue = {
         number: 1,

--- a/lib/modules/platform/azure/issue.ts
+++ b/lib/modules/platform/azure/issue.ts
@@ -341,6 +341,19 @@ export class IssueService {
         workItemType,
       );
 
+      // Azure DevOps normally returns the created work item, but the
+      // underlying REST client resolves to `null` instead of throwing for
+      // some responses: a 404, or any 2xx with an empty/non-JSON body (e.g. a
+      // 203 sign-in page from an expired token or an SSO/proxy in front of the
+      // instance). Guard the result so such a response does not crash the whole
+      // run with `Cannot read properties of null (reading 'id')`.
+      if (!newWorkItem?.id) {
+        logger.warn(
+          'Azure: work item creation returned no result; skipping issue',
+        );
+        return null;
+      }
+
       logger.debug(`Created new issue #${newWorkItem.id}`);
       return 'created';
     } catch (err) {

--- a/lib/modules/platform/azure/issue.ts
+++ b/lib/modules/platform/azure/issue.ts
@@ -2,6 +2,7 @@ import type {
   WorkItem,
   WorkItemStateColor,
 } from 'azure-devops-node-api/interfaces/WorkItemTrackingInterfaces.js';
+import type { IWorkItemTrackingApi } from 'azure-devops-node-api/WorkItemTrackingApi.js';
 import { logger } from '../../../logger/index.ts';
 import { Lazy } from '../../../util/lazy.ts';
 import { sanitize } from '../../../util/sanitize.ts';
@@ -124,6 +125,18 @@ export class IssueService {
       logger.error({ err }, 'Error finding issue');
       return null;
     }
+  }
+
+  /**
+   * Whether the project's process defines the `Issue` work item type. Some
+   * processes (e.g. Scrum) do not, in which case creating one fails; checking
+   * up front lets us log an actionable message instead of a cryptic error.
+   */
+  private async hasWorkItemType(
+    azureApiWit: IWorkItemTrackingApi,
+  ): Promise<boolean> {
+    const types = await azureApiWit.getWorkItemTypes(this.config.project);
+    return types.some((t) => t.name === workItemType);
   }
 
   async getIssueList(titleFilter?: string): Promise<Issue[]> {
@@ -317,6 +330,18 @@ export class IssueService {
       // omitted so Azure DevOps applies the work item type's default initial
       // state for the project's process (e.g. `To Do` on Basic, `New`/`Active`
       // on Agile). Passing a hardcoded state fails on processes that lack it.
+
+      // The `Issue` work item type only exists in some processes (Basic, Agile,
+      // CMMI) but not others (e.g. Scrum). Creating one on a process without it
+      // returns a 404 that the REST client surfaces as `null`, so check first
+      // and log an actionable message instead of failing cryptically.
+      if (!(await this.hasWorkItemType(azureApiWit))) {
+        logger.warn(
+          `Azure: work item type '${workItemType}' does not exist in project '${this.config.project}' (or the token lacks permission to it); skipping issue. The Dependency Dashboard needs a process that defines the '${workItemType}' work item type.`,
+        );
+        return null;
+      }
+
       const newWorkItem = await azureApiWit.createWorkItem(
         undefined,
         [


### PR DESCRIPTION
## Changes

`IssueService.ensureIssue` dereferences `newWorkItem.id` immediately after `createWorkItem`, assuming a work item is always returned. The underlying `azure-devops-node-api` / `typed-rest-client` layer, however, resolves `createWorkItem` to `null` **without throwing** for:

- HTTP `404 Not Found` (returned as `{ result: null }`), and
- any `2xx` response with an empty or non-JSON body — e.g. a `203` sign-in page from an expired/invalid token, or an HTML page injected by an SSO/proxy in front of the instance (JSON parsing fails silently and `result` stays `null`).

In those cases the run crashed with:

```
WARN: Error ensuring issue (repository=...)
TypeError: Cannot read properties of null (reading 'id')
    at IssueService.ensureIssue (.../azure/issue.ts:344:54)
```

This guards the result: if no work item (with an `id`) is returned, we log a warning and skip the issue instead of crashing the Dependency Dashboard for the whole repository. Reported in discussion #43785 as a regression-adjacent edge case after the Azure Dependency Dashboard state autodetection (#44412) fixed the original `System.State` `400` errors.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation): investigation, the null guard, and the unit test were drafted with GitHub Copilot CLI (Claude Opus 4.8) and reviewed by me.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests

Added a unit test asserting that `ensureIssue` returns `null` and logs a warning when `createWorkItem` resolves to `null`. `pnpm vitest run lib/modules/platform/azure/issue.spec.ts` passes (93 tests).
