### PR TITLE
fix(presets/workarounds): keep major-only Java Docker tags rolling

### DIFF
--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -210,6 +210,42 @@ export const presets: Record<string, Preset> = {
           'regex:^(?<major>\\d+)?(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?([\\._+](?<build>(\\d\\.?)+)(LTS)?)?(-(?<compatibility>.*))?$',
       },
       {
+        description:
+          'Use docker versioning for major-only Java image tags so rolling tags (e.g. 21-jre) are not upgraded to full-precision tags (e.g. 21.0.11_10-jre).',
+        matchCurrentValue: '/^\\d+(-|$)/',
+        matchDatasources: ['docker'],
+        matchPackageNames: [
+          'eclipse-temurin',
+          'amazoncorretto',
+          'adoptopenjdk',
+          'openjdk',
+          'java',
+          'java-jdk',
+          'java-jre',
+          'sapmachine',
+          '/^azul/zulu-openjdk/',
+          '/^bellsoft/liberica-openj(dk|re)-/',
+          '/^cimg/openjdk/',
+        ],
+        versioning: 'docker',
+      },
+      {
+        description:
+          'Use docker versioning for major-only Java image tags so rolling tags (e.g. 21-jre) are not upgraded to full-precision tags (e.g. 21.0.11_10-jre).',
+        matchCurrentValue: '/^\\d+(-|$)/',
+        matchDatasources: ['docker'],
+        matchDepNames: [
+          'eclipse-temurin',
+          'amazoncorretto',
+          'adoptopenjdk',
+          'openjdk',
+          'java',
+          'java-jre',
+          'sapmachine',
+        ],
+        versioning: 'docker',
+      },
+      {
         allowedVersions: '/^(?:jdk|jdk-all|jre)-(?:8|11|17|21|25)(?:\\.|-|$)/',
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -1,5 +1,7 @@
 import * as versionings from '../../../modules/versioning/index.ts';
+import { applyPackageRules } from '../../../util/package-rules/index.ts';
 import { matchRegexOrGlob } from '../../../util/string-match.ts';
+import type { PackageRule, PackageRuleInputConfig } from '../../types.ts';
 import { presets } from './workarounds.preset.ts';
 
 describe('config/presets/internal/workarounds', () => {
@@ -237,11 +239,82 @@ describe('config/presets/internal/workarounds', () => {
 
   describe('javaLTSVersions', () => {
     const preset = presets.javaLTSVersions;
+    const packageRules = preset.packageRules!;
+    // Indices: 0 regex+names, 1 regex+deps, 2 docker major-only+names, 3 docker major-only+deps, 4 liberica
+    const regexPackageRule = packageRules[0];
+    const majorOnlyPackageRule = packageRules[2];
+    const majorOnlyDepRule = packageRules[3];
+    const libericaRule = packageRules[4];
+    const javaRegexVersioning = regexPackageRule.versioning;
+
+    describe('major-only docker tag override', () => {
+      const matchCurrentValue = majorOnlyPackageRule.matchCurrentValue!;
+
+      it.each`
+        input                      | expected
+        ${'21'}                    | ${true}
+        ${'21-jre'}                | ${true}
+        ${'21-jre-jammy'}          | ${true}
+        ${'25-jre'}                | ${true}
+        ${'8-jdk'}                 | ${true}
+        ${'8-jdk-alpine'}          | ${true}
+        ${'21.0'}                  | ${false}
+        ${'21.0-jre'}              | ${false}
+        ${'21.0.11_10-jre'}        | ${false}
+        ${'21.0.11_10-jre-alpine'} | ${false}
+        ${'jdk-21-slim-musl'}      | ${false}
+        ${'latest'}                | ${false}
+      `('matchCurrentValue("$input") == "$expected"', ({ input, expected }) => {
+        expect(matchRegexOrGlob(input, matchCurrentValue)).toEqual(expected);
+      });
+
+      it('uses docker versioning for major-only package and dep rules', () => {
+        expect(majorOnlyPackageRule.versioning).toEqual('docker');
+        expect(majorOnlyDepRule.versioning).toEqual('docker');
+        expect(majorOnlyDepRule.matchCurrentValue).toEqual(matchCurrentValue);
+      });
+
+      it('applies docker versioning for major-only current values', async () => {
+        const res = await applyPackageRules({
+          datasource: 'docker',
+          depName: 'eclipse-temurin',
+          packageName: 'eclipse-temurin',
+          currentValue: '21-jre',
+          packageRules,
+        } as PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>);
+
+        expect(res.versioning).toEqual('docker');
+        expect(res.allowedVersions).toEqual('/^(?:8|11|17|21|25)(?:\\.|-|$)/');
+      });
+
+      it('keeps regex versioning for full-precision current values', async () => {
+        const res = await applyPackageRules({
+          datasource: 'docker',
+          depName: 'eclipse-temurin',
+          packageName: 'eclipse-temurin',
+          currentValue: '21.0.9_10-jre',
+          packageRules,
+        } as PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>);
+
+        expect(res.versioning).toEqual(javaRegexVersioning);
+        expect(res.allowedVersions).toEqual('/^(?:8|11|17|21|25)(?:\\.|-|$)/');
+      });
+
+      it('keeps regex versioning for java-version major-only values', async () => {
+        const res = await applyPackageRules({
+          datasource: 'java-version',
+          depName: 'java',
+          packageName: 'java-jdk',
+          currentValue: '21',
+          packageRules,
+        } as PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>);
+
+        expect(res.versioning).toEqual(javaRegexVersioning);
+      });
+    });
 
     describe('bellsoft/liberica-runtime-container', () => {
-      const packageRule = preset.packageRules![2];
-
-      const allowedVersions = packageRule.allowedVersions!;
+      const allowedVersions = libericaRule.allowedVersions!;
 
       it.each`
         input                           | expected


### PR DESCRIPTION
## Changes

Major-only Java Docker tags (e.g. `21-jre`, `8-jdk-alpine`) are rolling tags that should track the latest patch under a major. The `javaLTSVersions` workaround applies a `regex:` versioning that parses full-precision tags, so `21-jre` gets upgraded to `21.0.11_10-jre`, breaking the rolling tag.

This adds package rules that switch to `docker` versioning when the current value is a major-only tag (`matchCurrentValue: /^\d+(-|$)/`) on the `docker` datasource, so rolling tags stay rolling. Full-precision tags and the `java-version` datasource keep the existing `regex:` versioning.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related:

- https://github.com/renovatebot/renovate/discussions/43634

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Code (Opus 4.8) for code, tests, and review.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-repro-java-lts-major-only/pulls
