### PR TITLE
feat: add `--rebase-all-open-branches`

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -430,7 +430,7 @@ This array will allow you to set the names of the branches you want to rebase/cr
 It has been designed with the intention of being run on one repository, in a one-off manner, e.g. to "force" the rebase of a known existing branch.
 It is highly unlikely that you should ever need to add this to your permanent global config.
 
-Example: `renovate --checked-branches=renovate/chalk-4.x renovate-reproductions/checked` will rebase the `renovate/chalk-4.x` branch in the `renovate-reproductions/checked` repository.`
+Example: `renovate --checked-branches=renovate/chalk-4.x renovate-reproductions/checked` will rebase the `renovate/chalk-4.x` branch in the `renovate-reproductions/checked` repository.
 
 ## `configFileNames`
 
@@ -1222,6 +1222,13 @@ Example:
 ## `productLinks`
 
 Override this object if you want to change the URLs that Renovate links to, e.g. if you have an internal forum for asking for help.
+
+## `rebaseAllOpenBranches`
+
+It has been designed with the intention of being run on one repository, in a one-off manner, e.g. to "force" the rebase of all open PRs.
+It is highly unlikely that you should ever need to add this to your permanent global config.
+
+Example: `renovate --rebase-all-open-branches=true renovate-reproductions/checked` will rebase all open PRs in the `renovate-reproductions/checked` repository.
 
 ## `redisPrefix`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3419,6 +3419,7 @@ const options: Readonly<RenovateOptions>[] = [
     description:
       'Rebase all open branches at once, as if the rebase-all-open-PRs checkbox was selected in the Dependency Dashboard issue.',
     type: 'boolean',
+    cli: true,
     experimental: true,
     globalOnly: true,
     default: false,

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3415,6 +3415,15 @@ const options: Readonly<RenovateOptions>[] = [
     default: [],
   },
   {
+    name: 'rebaseAllOpenBranches',
+    description:
+      'Rebase all open branches at once, as if the rebase-all-open-PRs checkbox was selected in the Dependency Dashboard issue.',
+    type: 'boolean',
+    experimental: true,
+    globalOnly: true,
+    default: false,
+  },
+  {
     name: 'maxRetryAfter',
     description:
       'Maximum retry-after header value to wait for before retrying a failed request.',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3410,6 +3410,7 @@ const options: Readonly<RenovateOptions>[] = [
       'A list of branch names to mark for creation or rebasing as if it was selected in the Dependency Dashboard issue.',
     type: 'array',
     subType: 'string',
+    cli: true,
     experimental: true,
     globalOnly: true,
     default: [],

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -473,6 +473,7 @@ export interface RenovateConfig
   constraintsFiltering?: ConstraintsFilter;
 
   checkedBranches?: string[];
+  rebaseAllOpenBranches?: boolean;
   customizeDashboard?: Record<string, string>;
 
   statusCheckNames?: Record<StatusCheckKey, string | null>;

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -317,6 +317,22 @@ describe('workers/repository/dependency-dashboard', () => {
       });
     });
 
+    it('applies rebaseAllOpenBranches without dashboard', async () => {
+      const conf: RenovateConfig = {};
+      conf.dependencyDashboard = false;
+      conf.rebaseAllOpenBranches = true;
+      await dependencyDashboard.readDashboardBody(conf);
+      expect(conf).toEqual({
+        dependencyDashboard: false,
+        dependencyDashboardAllAwaitingSchedule: false,
+        dependencyDashboardAllPending: false,
+        dependencyDashboardAllRateLimited: false,
+        dependencyDashboardChecks: {},
+        dependencyDashboardRebaseAllOpen: true,
+        rebaseAllOpenBranches: true,
+      });
+    });
+
     it('reads dashboard body and group size not met branches', async () => {
       const conf: RenovateConfig = {};
       conf.prCreation = 'approval';

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -207,6 +207,10 @@ export async function readDashboardBody(
     };
   }
 
+  if (config.rebaseAllOpenBranches) {
+    dashboardChecks.dependencyDashboardRebaseAllOpen = true;
+  }
+
   Object.assign(config, dashboardChecks);
 }
 


### PR DESCRIPTION
## Changes

This PR adds a `rebaseAllOpenBranches` global-only config option, which rebases all open branches at once, as if the "rebase all open PRs" checkbox was selected in the Dependency Dashboard issue.

It's the counterpart to the existing [`checkedBranches`](https://docs.renovatebot.com/self-hosted-configuration/#checkedbranches) option, but for the bulk-rebase checkbox instead of individual branches.

Like `checkedBranches`, it's meant to be run on one repository in a one-off manner, e.g. to "force" a rebase of all open PRs, not as part of a permanent global config.

**My use case:** I have a testing repository for common corner-cases where I'd like Renovate to always rebase changes when we make changes to its configuration. Some issues like poorly configured registry authentication for tools can only be found in case Renovate fully rebases the branch.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 4.8 was used to implement this.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-repro-tutorial
