### PR TITLE
fix(platform/azure): use issue body limit for dependency dashboard markdown

### DIFF
--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1673,6 +1673,12 @@ describe('modules/platform/azure/index', () => {
         '[`v4.78.0`](https://github.com/org/repo/blob/HEAD/CHANGELOG.md#4780-june-18-2026)';
       expect(azure.massageMarkdown(input)).toBe(input);
     });
+
+    it('uses a higher limit for issue markdown than PR markdown', () => {
+      const input = 'a'.repeat(4100);
+      expect(azure.massageIssueMarkdown(input)).toBe(input);
+      expect(azure.massageMarkdown(input).length).toBeLessThan(input.length);
+    });
   });
 
   describe('setBranchStatus', () => {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1676,7 +1676,7 @@ describe('modules/platform/azure/index', () => {
 
     it('uses a higher limit for issue markdown than PR markdown', () => {
       const input = 'a'.repeat(4100);
-      expect(azure.massageIssueMarkdown(input)).toBe(input);
+      expect(azure.massageIssueMarkdown?.(input)).toBe(input);
       expect(azure.massageMarkdown(input).length).toBeLessThan(input.length);
     });
   });

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -878,9 +878,17 @@ export async function mergePr({
 }
 
 export function massageMarkdown(input: string): string {
+  return massageMarkdownWithLimit(input, maxBodyLength());
+}
+
+export function massageIssueMarkdown(input: string): string {
+  return massageMarkdownWithLimit(input, maxIssueBodyLength());
+}
+
+function massageMarkdownWithLimit(input: string, maxLength: number): string {
   // Remove any HTML we use
   return (
-    smartTruncate(readOnlyIssueBody(input), maxBodyLength())
+    smartTruncate(readOnlyIssueBody(input), maxLength)
       .replace(
         'you tick the rebase/retry checkbox',
         'PR is renamed to start with "rebase!"',
@@ -902,6 +910,10 @@ export function massageMarkdown(input: string): string {
 
 export function maxBodyLength(): number {
   return 4000;
+}
+
+export function maxIssueBodyLength(): number {
+  return 1048576;
 }
 
 export async function findIssue(title: string): Promise<Issue | null> {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -255,22 +255,16 @@ export interface Platform {
   ensureIssue(
     issueConfig: EnsureIssueConfig,
   ): Promise<EnsureIssueResult | null>;
-  massageMarkdown(
-    prBody: string,
-    /**
-     * Useful for suggesting the use of rebase label when there is no better
-     * way, e.g. for Gerrit.
-     */
-    rebaseLabel?: string,
-  ): string;
-  massageIssueMarkdown?(
-    issueBody: string,
-    /**
-     * Useful for suggesting the use of rebase label when there is no better
-     * way, e.g. for Gerrit.
-     */
-    rebaseLabel?: string,
-  ): string;
+  /**
+   * @param rebaseLabel Useful for suggesting the use of rebase label when there is no better
+   *   way, e.g. for Gerrit.
+   */
+  massageMarkdown(prBody: string, rebaseLabel?: string): string;
+  /**
+   * @param rebaseLabel Useful for suggesting the use of rebase label when there is no better
+   *   way, e.g. for Gerrit.
+   */
+  massageIssueMarkdown?(issueBody: string, rebaseLabel?: string): string;
   updatePr(prConfig: UpdatePrConfig): Promise<void>;
   mergePr(config: MergePRConfig): Promise<boolean>;
   addReviewers(number: number, reviewers: string[]): Promise<void>;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -263,6 +263,14 @@ export interface Platform {
      */
     rebaseLabel?: string,
   ): string;
+  massageIssueMarkdown?(
+    issueBody: string,
+    /**
+     * Useful for suggesting the use of rebase label when there is no better
+     * way, e.g. for Gerrit.
+     */
+    rebaseLabel?: string,
+  ): string;
   updatePr(prConfig: UpdatePrConfig): Promise<void>;
   mergePr(config: MergePRConfig): Promise<boolean>;
   addReviewers(number: number, reviewers: string[]): Promise<void>;
@@ -318,6 +326,7 @@ export interface Platform {
   extractRulesFromCodeOwnersLines?(cleanedLines: string[]): FileOwnerRule[];
 
   maxBodyLength(): number;
+  maxIssueBodyLength?(): number;
   labelCharLimit?(): number;
 }
 

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -1720,6 +1720,36 @@ None detected
           // same with dry run
           await dryRun(branches, platform, 0, 1);
         });
+
+        it('uses issue-specific body limits and formatter when available', async () => {
+          const branches: BranchConfig[] = [];
+          const packageFilesBigRepo = genRandPackageFile(100, 700);
+          PackageFiles.clear();
+          PackageFiles.add('main', packageFilesBigRepo);
+
+          platform.maxBodyLength.mockReturnValue(1000);
+          platform.maxIssueBodyLength.mockReturnValue(60_000);
+          platform.massageIssueMarkdown.mockImplementation((body) => body);
+
+          await dependencyDashboard.ensureDependencyDashboard(
+            config,
+            branches,
+            {},
+            { result: 'no-migration' },
+          );
+
+          expect(platform.maxIssueBodyLength).toHaveBeenCalledTimes(1);
+          expect(platform.massageIssueMarkdown).toHaveBeenCalledTimes(1);
+          expect(platform.massageMarkdown).toHaveBeenCalledTimes(0);
+          expect(platform.ensureIssue).toHaveBeenCalledTimes(1);
+          expect(
+            platform.ensureIssue.mock.calls[0][0].body.length >
+              platform.maxBodyLength(),
+          ).toBeTrue();
+
+          // same with dry run
+          await dryRun(branches, platform, 0, 1);
+        });
       });
 
       describe('dependency dashboard lookup warnings', () => {

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -616,8 +616,10 @@ export async function ensureDependencyDashboard(
 
   // fit the detected dependencies section
   const footer = getFooter(config);
+  const issueBodyLimit =
+    platform.maxIssueBodyLength?.() ?? platform.maxBodyLength();
   issueBody += PackageFiles.getDashboardMarkdown(
-    platform.maxBodyLength() - issueBody.length - footer.length,
+    issueBodyLimit - issueBody.length - footer.length,
   );
 
   issueBody += footer;
@@ -667,7 +669,9 @@ export async function ensureDependencyDashboard(
     await platform.ensureIssue({
       title: config.dependencyDashboardTitle!,
       reuseTitle,
-      body: platform.massageMarkdown(issueBody, config.rebaseLabel),
+      body:
+        platform.massageIssueMarkdown?.(issueBody, config.rebaseLabel) ??
+        platform.massageMarkdown(issueBody, config.rebaseLabel),
       labels: config.dependencyDashboardLabels,
       confidential: config.confidential,
     });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR fixes Azure DevOps Dependency Dashboard body truncation by separating markdown size limits for pull requests vs issues/work items.

- Keep PR description handling at the Azure PR limit.
- Use the Azure work item description limit for Dependency Dashboard issue content.
- Add and update tests to verify the larger issue-body flow and guard against regressions.

This aligns behavior with Azure DevOps field constraints and avoids unnecessary truncation of dashboard content.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44606
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI usage details: I used GitHub Copilot Chat for support with implementation and test updates. Model used: GPT-5.3-Codex.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Tested on a private Azure DevOps project and repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
