### PR TITLE
test(config/global): ensure that `GlobalConfig.OPTIONS` is updated for new global options

### DIFF
--- a/lib/config/global.spec.ts
+++ b/lib/config/global.spec.ts
@@ -1,4 +1,5 @@
 import { GlobalConfig } from './global.ts';
+import { getOptions } from './options/index.ts';
 
 describe('config/global', () => {
   it('all values in OPTIONS are sorted', () => {
@@ -9,5 +10,81 @@ describe('config/global', () => {
     expect(defined, 'OPTIONS should be sorted alphabetically').toStrictEqual(
       sorted,
     );
+  });
+
+  it('all globalOnly configuration options should be defined in OPTIONS', () => {
+    // TODO #39685 we need to migrate these over
+    const optionsThatStillNeedMigrating = new Set([
+      'autodiscover',
+      'autodiscoverFilter',
+      'autodiscoverNamespaces',
+      'autodiscoverProjects',
+      'autodiscoverTopics',
+      'baseDir',
+      'configValidationError',
+      'deleteAdditionalConfigFile',
+      'deleteConfigFile',
+      'detectGlobalManagerConfig',
+      'detectHostRulesFromEnv',
+      'force',
+      'forceCli',
+      'forkCreation',
+      'forkOrg',
+      'forkToken',
+      'gitNoVerify',
+      'gitPrivateKey',
+      'gitPrivateKeyPassphrase',
+      'gitUrl',
+      'globalExtends',
+      'inheritConfig',
+      'inheritConfigFileName',
+      'inheritConfigRepoName',
+      'inheritConfigStrict',
+      'logContext',
+      'mergeConfidenceDatasources',
+      'mergeConfidenceEndpoint',
+      'onboardingRebaseCheckbox',
+      'optimizeForDisabled',
+      'password',
+      'persistRepoData',
+      'prCommitsPerRunLimit',
+      'privateKey',
+      'privateKeyOld',
+      'privateKeyPath',
+      'privateKeyPathOld',
+      'processEnv',
+      'redisPrefix',
+      'redisUrl',
+      'reportFormatting',
+      'reportPath',
+      'reportType',
+      'repositories',
+      'repositoryCache',
+      'repositoryCacheType',
+      'secrets',
+      'token',
+      'unicodeEmoji',
+      'useCloudMetadataServices',
+      'username',
+      'variables',
+      'writeDiscoveredRepos',
+    ]);
+
+    const globalOnlyOptions = getOptions()
+      .filter((o) => o.globalOnly)
+      .map((o) => o.name)
+      // TODO #39685 there are still some options that need migrating
+      .filter((o) => !optionsThatStillNeedMigrating.has(o))
+      .sort();
+
+    const defined = Array.from(GlobalConfig.OPTIONS)
+      // not actually a config option
+      .filter((o) => o !== 'localDir')
+      // toolSettings at an admin level can be used to specify a maximum for the setting, but is also possible to set at a repo level, so can't be marked as `globalOnly`
+      .filter((o) => o !== 'toolSettings');
+    expect(
+      globalOnlyOptions,
+      'All globalOnly options should be defined in OPTIONS',
+    ).toEqual(defined);
   });
 });

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -39,6 +39,7 @@ export class GlobalConfig {
     'httpCacheTtlDays',
     'ignorePrAuthor',
     'includeMirrors',
+    /** NOTE that this is not a config option, but an internal variable **/
     'localDir',
     'migratePresets',
     'onboarding',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -257,6 +257,7 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   gitTimeout?: number;
   githubTokenWarn?: boolean;
   includeMirrors?: boolean;
+  /** NOTE that this is not a config option, but an internal variable **/
   localDir?: string;
   migratePresets?: Record<string, string>;
   platform?: PlatformId;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes




As I'd forgotten to check this as part of reviewing https://github.com/renovatebot/renovate/pull/44607, so let's finally finish #9603.

Until we've finished the migration, we can opt out a few options until
completion in #39685.

Also document `localDir` isn't a `globalOnly` option


Will fail until https://github.com/renovatebot/renovate/pull/44607 follow-up


Takes the basis of the test from https://github.com/renovatebot/renovate/pull/44613 and will be completed in https://github.com/renovatebot/renovate/pull/44100

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #9603
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
