### PR TITLE
feat(gitlab): add gitlab codeowners role support

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1758,6 +1758,8 @@ The above would mean Renovate would not include files matching the above glob pa
 If configured, Renovate will expand any matching `CODEOWNERS` groups into a full list of group members and assign them individually instead of the group.
 This is particularly useful when combined with `assigneesSampleSize` and `assigneesFromCodeOwners`, so that only a subset of the Codeowners are assigned instead of the whole group.
 
+On GitLab, this also expands [role handles](https://docs.gitlab.com/user/project/codeowners/reference/#add-a-role-as-a-code-owner) (`@@developer`, `@@maintainer`, `@@owner`) into the project members who hold that exact role.
+
 ## `extends`
 
 See [shareable config presets](./config-presets.md) for details.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2654,7 +2654,7 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'expandCodeOwnersGroups',
     description:
-      'Expand the configured code owner groups into a full list of group members. On GitLab, also expands role handles (`@@developer`, `@@maintainer`, `@@owner`) into the project members holding that role.',
+      'Expand the configured code owner groups into a full list of group members.',
     type: 'boolean',
     default: false,
     supportedPlatforms: ['gitlab'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2654,7 +2654,7 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'expandCodeOwnersGroups',
     description:
-      'Expand the configured code owner groups into a full list of group members.',
+      'Expand the configured code owner groups into a full list of group members. On GitLab, also expands role handles (`@@developer`, `@@maintainer`, `@@owner`) into the project members holding that role.',
     type: 'boolean',
     default: false,
     supportedPlatforms: ['gitlab'],

--- a/lib/modules/platform/gitlab/http.ts
+++ b/lib/modules/platform/gitlab/http.ts
@@ -21,7 +21,7 @@ export async function getUserID(username: string): Promise<number> {
   return userInfo[0].id;
 }
 
-async function getMembers(group: string): Promise<GitLabUser[]> {
+async function getGroupMembers(group: string): Promise<GitLabUser[]> {
   const groupEncoded = encodeURIComponent(group);
   return (
     await gitlabApi.getJsonUnchecked<GitLabUser[]>(
@@ -32,7 +32,7 @@ async function getMembers(group: string): Promise<GitLabUser[]> {
 
 export async function getMemberUserIDs(group: string): Promise<number[]> {
   try {
-    const members = await getMembers(group);
+    const members = await getGroupMembers(group);
     return members.map((u) => u.id);
   } catch (err) {
     logger.once.warn(
@@ -44,7 +44,7 @@ export async function getMemberUserIDs(group: string): Promise<number[]> {
 }
 
 export async function getMemberUsernames(group: string): Promise<string[]> {
-  const members = await getMembers(group);
+  const members = await getGroupMembers(group);
   return members.map((u) => u.username);
 }
 

--- a/lib/modules/platform/gitlab/http.ts
+++ b/lib/modules/platform/gitlab/http.ts
@@ -48,25 +48,22 @@ export async function getMemberUsernames(group: string): Promise<string[]> {
   return members.map((u) => u.username);
 }
 
-async function getProjectMembersByRole(
-  repo: string,
-  accessLevel: number,
-): Promise<GitLabUser[]> {
-  const members = (
+async function getProjectMembers(repo: string): Promise<GitLabUser[]> {
+  const repoEncoded = encodeURIComponent(repo);
+  return (
     await gitlabApi.getJsonUnchecked<GitLabUser[]>(
-      `projects/${encodeURIComponent(repo)}/members`,
+      `projects/${repoEncoded}/members`,
       { paginate: true },
     )
   ).body;
-  return members.filter((m) => m.access_level === accessLevel);
 }
 
-export async function getRoleMemberUsernames(
+export async function getProjectMembersByRole(
   repo: string,
   accessLevel: number,
-): Promise<string[]> {
-  const members = await getProjectMembersByRole(repo, accessLevel);
-  return members.map((u) => u.username);
+): Promise<GitLabUser[]> {
+  const members = await getProjectMembers(repo);
+  return members.filter((m) => m.access_level === accessLevel);
 }
 
 export async function isUserBusy(user: string): Promise<boolean> {

--- a/lib/modules/platform/gitlab/http.ts
+++ b/lib/modules/platform/gitlab/http.ts
@@ -48,6 +48,27 @@ export async function getMemberUsernames(group: string): Promise<string[]> {
   return members.map((u) => u.username);
 }
 
+async function getProjectMembersByRole(
+  repo: string,
+  accessLevel: number,
+): Promise<GitLabUser[]> {
+  const members = (
+    await gitlabApi.getJsonUnchecked<GitLabUser[]>(
+      `projects/${encodeURIComponent(repo)}/members`,
+      { paginate: true },
+    )
+  ).body;
+  return members.filter((m) => m.access_level === accessLevel);
+}
+
+export async function getRoleMemberUsernames(
+  repo: string,
+  accessLevel: number,
+): Promise<string[]> {
+  const members = await getProjectMembersByRole(repo, accessLevel);
+  return members.map((u) => u.username);
+}
+
 export async function isUserBusy(user: string): Promise<boolean> {
   try {
     const url = `/users/${user}/status`;

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -4199,17 +4199,9 @@ These updates have all been created already. To force a retry/rebase of any, cli
         .reply(200, [{ username: 'maria' }, { username: 'jimmy' }])
         .get('/api/v4/groups/group-b/members')
         .reply(200, [{ username: 'john' }]);
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        'u@email.com',
-        '@group-a',
-        '@group-b',
-      ]);
-      expect(expandedGroupMembers).toEqual([
-        'u@email.com',
-        'maria',
-        'jimmy',
-        'john',
-      ]);
+      await expect(
+        gitlab.expandGroupMembers?.(['u@email.com', '@group-a', '@group-b']),
+      ).resolves.toEqual(['u@email.com', 'maria', 'jimmy', 'john']);
     });
 
     it('users are not expanded when 404', async () => {
@@ -4217,8 +4209,9 @@ These updates have all been created already. To force a retry/rebase of any, cli
         .scope(gitlabApiHost)
         .get('/api/v4/groups/john/members')
         .reply(404, { message: '404 Group Not Found' });
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.(['john']);
-      expect(expandedGroupMembers).toEqual(['john']);
+      await expect(gitlab.expandGroupMembers?.(['john'])).resolves.toEqual([
+        'john',
+      ]);
     });
 
     it('users are not expanded when non 404', async () => {
@@ -4226,10 +4219,9 @@ These updates have all been created already. To force a retry/rebase of any, cli
         .scope(gitlabApiHost)
         .get('/api/v4/groups/group/members')
         .reply(403, { message: '403 Authorization' });
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        '@group',
+      await expect(gitlab.expandGroupMembers?.(['@group'])).resolves.toEqual([
+        'group',
       ]);
-      expect(expandedGroupMembers).toEqual(['group']);
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
         expect.any(Object),
@@ -4242,17 +4234,15 @@ These updates have all been created already. To force a retry/rebase of any, cli
         .scope(gitlabApiHost)
         .get('/api/v4/groups/group-c/members')
         .reply(200, []);
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        '@group-c',
-      ]);
-      expect(expandedGroupMembers).toEqual([]);
+      await expect(gitlab.expandGroupMembers?.(['@group-c'])).resolves.toEqual(
+        [],
+      );
     });
 
     it('includes email in final result', async () => {
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        'u@email.com',
-      ]);
-      expect(expandedGroupMembers).toEqual(['u@email.com']);
+      await expect(
+        gitlab.expandGroupMembers?.(['u@email.com']),
+      ).resolves.toEqual(['u@email.com']);
     });
 
     it('expands a role handle into members holding exactly that role', async () => {
@@ -4265,10 +4255,9 @@ These updates have all been created already. To force a retry/rebase of any, cli
           { username: 'dev-two', access_level: 30 },
           { username: 'owner', access_level: 50 },
         ]);
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        '@@developer',
-      ]);
-      expect(expandedGroupMembers).toEqual(['dev-one', 'dev-two']);
+      await expect(
+        gitlab.expandGroupMembers?.(['@@developer']),
+      ).resolves.toEqual(['dev-one', 'dev-two']);
     });
 
     it('resolves roles, groups, emails and users together', async () => {
@@ -4283,18 +4272,14 @@ These updates have all been created already. To force a retry/rebase of any, cli
         .reply(200, [{ username: 'maria' }])
         .get('/api/v4/groups/john/members')
         .reply(404, { message: '404 Group Not Found' });
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        '@@maintainer',
-        '@group-a',
-        'u@email.com',
-        'john',
-      ]);
-      expect(expandedGroupMembers).toEqual([
-        'alice',
-        'u@email.com',
-        'maria',
-        'john',
-      ]);
+      await expect(
+        gitlab.expandGroupMembers?.([
+          '@@maintainer',
+          '@group-a',
+          'u@email.com',
+          'john',
+        ]),
+      ).resolves.toEqual(['alice', 'u@email.com', 'maria', 'john']);
     });
 
     it('swallows role member fetch errors', async () => {
@@ -4302,10 +4287,9 @@ These updates have all been created already. To force a retry/rebase of any, cli
         .scope(gitlabApiHost)
         .get('/api/v4/projects/undefined/members')
         .reply(403, { message: '403 Authorization' });
-      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
-        '@@developer',
-      ]);
-      expect(expandedGroupMembers).toEqual([]);
+      await expect(
+        gitlab.expandGroupMembers?.(['@@developer']),
+      ).resolves.toEqual([]);
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
         expect.any(Object),

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -4254,5 +4254,63 @@ These updates have all been created already. To force a retry/rebase of any, cli
       ]);
       expect(expandedGroupMembers).toEqual(['u@email.com']);
     });
+
+    it('expands a role handle into members holding exactly that role', async () => {
+      httpMock
+        .scope(gitlabApiHost)
+        .get('/api/v4/projects/undefined/members')
+        .reply(200, [
+          { username: 'dev-one', access_level: 30 },
+          { username: 'maintainer', access_level: 40 },
+          { username: 'dev-two', access_level: 30 },
+          { username: 'owner', access_level: 50 },
+        ]);
+      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
+        '@@developer',
+      ]);
+      expect(expandedGroupMembers).toEqual(['dev-one', 'dev-two']);
+    });
+
+    it('resolves roles, groups, emails and users together', async () => {
+      httpMock
+        .scope(gitlabApiHost)
+        .get('/api/v4/projects/undefined/members')
+        .reply(200, [
+          { username: 'alice', access_level: 40 },
+          { username: 'bob', access_level: 30 },
+        ])
+        .get('/api/v4/groups/group-a/members')
+        .reply(200, [{ username: 'maria' }])
+        .get('/api/v4/groups/john/members')
+        .reply(404, { message: '404 Group Not Found' });
+      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
+        '@@maintainer',
+        '@group-a',
+        'u@email.com',
+        'john',
+      ]);
+      expect(expandedGroupMembers).toEqual([
+        'alice',
+        'u@email.com',
+        'maria',
+        'john',
+      ]);
+    });
+
+    it('swallows role member fetch errors', async () => {
+      httpMock
+        .scope(gitlabApiHost)
+        .get('/api/v4/projects/undefined/members')
+        .reply(403, { message: '403 Authorization' });
+      const expandedGroupMembers = await gitlab.expandGroupMembers?.([
+        '@@developer',
+      ]);
+      expect(expandedGroupMembers).toEqual([]);
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        expect.any(Object),
+        'Unable to fetch role members',
+      );
+    });
   });
 });

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -57,12 +57,14 @@ import { smartTruncate } from '../utils/pr-body.ts';
 import {
   getMemberUserIDs,
   getMemberUsernames,
+  getRoleMemberUsernames,
   getUserID,
   gitlabApi,
   isUserBusy,
 } from './http.ts';
 import { getMR, updateMR } from './merge-request.ts';
 import { GitlabPrCache } from './pr-cache.ts';
+import { getRoleAccessLevel } from './roles.ts';
 import type { GitLabMergeRequest } from './schema.ts';
 import { LastPipelineId } from './schema.ts';
 import type {
@@ -1475,6 +1477,25 @@ export async function expandGroupMembers(
 
   // Skip passing user emails to Gitlab API, but include them in the final result
   for (const reviewerOrAssignee of reviewersOrAssignees) {
+    // Resolve GitLab CODEOWNERS role handles (@@developer, @@maintainer,
+    // @@owner) to project members instead of treating them as groups
+    const roleAccessLevel = getRoleAccessLevel(reviewerOrAssignee);
+    if (roleAccessLevel !== null) {
+      try {
+        const members = await getRoleMemberUsernames(
+          config.repository,
+          roleAccessLevel,
+        );
+        expandedReviewersOrAssignees.push(...members);
+      } catch (err) {
+        logger.debug(
+          { err, reviewerOrAssignee },
+          'Unable to fetch role members',
+        );
+      }
+      continue;
+    }
+
     if (reviewerOrAssignee.indexOf('@') > 0) {
       expandedReviewersOrAssignees.push(reviewerOrAssignee);
       continue;

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -57,7 +57,7 @@ import { smartTruncate } from '../utils/pr-body.ts';
 import {
   getMemberUserIDs,
   getMemberUsernames,
-  getRoleMemberUsernames,
+  getProjectMembersByRole,
   getUserID,
   gitlabApi,
   isUserBusy,
@@ -1482,11 +1482,11 @@ export async function expandGroupMembers(
     const roleAccessLevel = getRoleAccessLevel(reviewerOrAssignee);
     if (roleAccessLevel !== null) {
       try {
-        const members = await getRoleMemberUsernames(
+        const members = await getProjectMembersByRole(
           config.repository,
           roleAccessLevel,
         );
-        expandedReviewersOrAssignees.push(...members);
+        expandedReviewersOrAssignees.push(...members.map((u) => u.username));
       } catch (err) {
         logger.debug(
           { err, reviewerOrAssignee },

--- a/lib/modules/platform/gitlab/roles.spec.ts
+++ b/lib/modules/platform/gitlab/roles.spec.ts
@@ -1,0 +1,36 @@
+import { getRoleAccessLevel } from './roles.ts';
+
+describe('modules/platform/gitlab/roles', () => {
+  describe('getRoleAccessLevel', () => {
+    it.each`
+      handle                | expected
+      ${'@@no_access'}      | ${0}
+      ${'@@minimal_access'} | ${5}
+      ${'@@guest'}          | ${10}
+      ${'@@planner'}        | ${15}
+      ${'@@reporter'}       | ${20}
+      ${'@@developer'}      | ${30}
+      ${'@@maintainer'}     | ${40}
+      ${'@@owner'}          | ${50}
+    `('resolves $handle to $expected', ({ handle, expected }) => {
+      expect(getRoleAccessLevel(handle)).toBe(expected);
+    });
+
+    it('is case-insensitive', () => {
+      expect(getRoleAccessLevel('@@Maintainer')).toBe(40);
+      expect(getRoleAccessLevel('@@OWNER')).toBe(50);
+    });
+
+    it.each`
+      handle
+      ${'@developer'}
+      ${'@@unknown'}
+      ${'developer'}
+      ${'@@'}
+      ${'@group'}
+      ${'u@email.com'}
+    `('returns null for $handle', ({ handle }) => {
+      expect(getRoleAccessLevel(handle)).toBeNull();
+    });
+  });
+});

--- a/lib/modules/platform/gitlab/roles.ts
+++ b/lib/modules/platform/gitlab/roles.ts
@@ -1,0 +1,26 @@
+import { regEx } from '../../../util/regex.ts';
+
+// See: https://docs.gitlab.com/api/users/#list-projects-and-groups-that-a-user-is-a-member-of
+const roleAccessLevels: Record<string, number> = {
+  no_access: 0,
+  minimal_access: 5,
+  guest: 10,
+  planner: 15,
+  reporter: 20,
+  developer: 30,
+  maintainer: 40,
+  owner: 50,
+};
+
+const roleRegex = regEx(/^@@(\w+)$/);
+
+/**
+ * Parse a GitLab CODEOWNERS role handle (`@@developer`, `@@maintainer`,
+ * `@@owner`, etc) into its access level. Returns `null` when the handle is not a
+ * recognized role, so `getRoleAccessLevel(x) !== null` doubles as a role check.
+ */
+export function getRoleAccessLevel(handle: string): number | null {
+  const match = roleRegex.exec(handle);
+  const level = match ? roleAccessLevels[match[1].toLowerCase()] : undefined;
+  return level ?? null;
+}

--- a/lib/modules/platform/gitlab/roles.ts
+++ b/lib/modules/platform/gitlab/roles.ts
@@ -10,7 +10,7 @@ const roleAccessLevels: Record<string, number> = {
   developer: 30,
   maintainer: 40,
   owner: 50,
-};
+} as const;
 
 const roleRegex = regEx(/^@@(?<role>\w+)$/);
 

--- a/lib/modules/platform/gitlab/roles.ts
+++ b/lib/modules/platform/gitlab/roles.ts
@@ -12,7 +12,7 @@ const roleAccessLevels: Record<string, number> = {
   owner: 50,
 };
 
-const roleRegex = regEx(/^@@(\w+)$/);
+const roleRegex = regEx(/^@@(?<role>\w+)$/);
 
 /**
  * Parse a GitLab CODEOWNERS role handle (`@@developer`, `@@maintainer`,
@@ -20,7 +20,7 @@ const roleRegex = regEx(/^@@(\w+)$/);
  * recognized role, so `getRoleAccessLevel(x) !== null` doubles as a role check.
  */
 export function getRoleAccessLevel(handle: string): number | null {
-  const match = roleRegex.exec(handle);
-  const level = match ? roleAccessLevels[match[1].toLowerCase()] : undefined;
+  const role = roleRegex.exec(handle)?.groups?.role;
+  const level = role ? roleAccessLevels[role.toLowerCase()] : undefined;
   return level ?? null;
 }

--- a/lib/modules/platform/gitlab/types.ts
+++ b/lib/modules/platform/gitlab/types.ts
@@ -16,6 +16,7 @@ export interface GitlabComment {
 export interface GitLabUser {
   id: number;
   username: string;
+  access_level?: number; // present on project/group member responses
 }
 
 export interface GitlabPr extends Pr {


### PR DESCRIPTION
Discussion: https://github.com/renovatebot/renovate/discussions/44620

## Changes

GitLab supports the `@@role` syntax in its CODEOWNERS specification (for example `@@developer`, `@@maintainer`, `@@owner`), which assigns a code owner by project role rather than by a specific user or group. See the [GitLab docs](https://docs.gitlab.com/user/project/codeowners/reference/#add-a-role-as-a-code-owner).

Previously, when resolving reviewers/assignees, `expandGroupMembers` did not recognise the `@@role` syntax. It stripped the leading `@` and passed the remainder (for example `@developer`) to the GitLab groups API as if it were a group name. No such group exists, so the request returned a `404`, the role handle was pushed through unchanged as a fallback, and the intended reviewers were never assigned.

This PR detects `@@role` handles in `expandGroupMembers` before the group-expansion path. When a handle maps to a known GitLab role, it resolves to the project's members at the matching access level (via the project members API, filtered by `access_level`) and expands to their usernames, mirroring how group handles are expanded today. Handles that are not recognised roles continue through the existing group/user logic unchanged.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Opus 4.8) was used to help implement the role-resolution logic, write unit tests, and draft documentation. All changes were reviewed by me.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
