### PR TITLE
feat(presets): add Size Limit monorepo group

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -689,6 +689,7 @@
     "shiki": "https://github.com/shikijs/shiki",
     "shopify-app-bridge": "https://github.com/Shopify/app-bridge",
     "sitecore-jss": "https://github.com/Sitecore/jss",
+    "size-limit": "https://github.com/ai/size-limit",
     "skiasharp": [
       "https://github.com/mono/SkiaSharp",
       "https://go.microsoft.com/fwlink/?linkid=868515"


### PR DESCRIPTION
## Changes

Adds the [Size Limit monorepo](https://github.com/ai/size-limit) to the preset.

## Context

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Codex did the change

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository