### PR TITLE
fix(platform/azure): evaluate policies before attempting to merge PR

### DIFF
--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -474,6 +474,29 @@ describe('modules/platform/azure/azure-helper', () => {
     });
   });
 
+  describe('getPolicyEvaluations', () => {
+    it('should get the policy evaluations for a pull request', async () => {
+      const policyEvaluations = [{ status: 2 }];
+      const getPolicyEvaluationsMock = vi
+        .fn()
+        .mockResolvedValue(policyEvaluations);
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyEvaluations: getPolicyEvaluationsMock,
+        }),
+      );
+      const res = await azureHelper.getPolicyEvaluations(
+        'projectId',
+        'artifactId',
+      );
+      expect(getPolicyEvaluationsMock).toHaveBeenCalledWith(
+        'projectId',
+        'artifactId',
+      );
+      expect(res).toEqual(policyEvaluations);
+    });
+  });
+
   describe('getAllProjectTeams', () => {
     it('should get all teams', async () => {
       const team1 = Array.from({ length: 100 }, (_, index) => ({

--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -4,7 +4,10 @@ import type {
   GitRef,
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
 import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
-import type { PolicyConfiguration } from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
+import type {
+  PolicyConfiguration,
+  PolicyEvaluationRecord,
+} from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
 import { logger } from '../../../logger/index.ts';
 import { streamToString } from '../../../util/streams.ts';
 import { getNewBranchName } from '../util.ts';
@@ -200,6 +203,17 @@ export async function getMergeMethod(
     `getMergeMethod(branchRef=${branchRef!})=${GitPullRequestMergeStrategy[GitPullRequestMergeStrategy.NoFastForward]}`,
   );
   return GitPullRequestMergeStrategy.NoFastForward;
+}
+
+export async function getPolicyEvaluations(
+  project: string,
+  artifactId: string,
+): Promise<PolicyEvaluationRecord[]> {
+  logger.debug(`getPolicyEvaluations(${project}, ${artifactId})`);
+  const policyEvaluations = await (
+    await azureApi.policyApi()
+  ).getPolicyEvaluations(project, artifactId);
+  return policyEvaluations;
 }
 
 export async function getAllProjectTeams(

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -12,6 +12,12 @@ import {
   GitVersionType,
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
+import type {
+  PolicyConfiguration,
+  PolicyEvaluationRecord,
+  PolicyTypeRef,
+} from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
+import { PolicyEvaluationStatus } from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
 import type { IWorkItemTrackingApi } from 'azure-devops-node-api/WorkItemTrackingApi.js';
 import type { Mocked, MockedObject } from 'vitest';
 import { vi } from 'vitest';
@@ -59,6 +65,7 @@ describe('modules/platform/azure/index', () => {
     git.isBranchBehindBase.mockResolvedValue(false);
     hostRules.clear();
     hostRules.add({ token: 'token' });
+    azureHelper.getPolicyEvaluations.mockResolvedValue([]);
     await azure.initPlatform({
       endpoint: 'https://dev.azure.com/renovate12345',
       token: 'token',
@@ -1749,6 +1756,103 @@ describe('modules/platform/azure/index', () => {
   });
 
   describe('mergePr', () => {
+    it('should not complete the PR if there are pending blocking policy evaluations', async () => {
+      await initRepo({ repository: 'some/repo' });
+      const pullRequestIdMock = 12345;
+      const branchNameMock = 'test';
+      const updatePullRequestMock = vi.fn();
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: vi.fn(),
+          updatePullRequest: updatePullRequestMock,
+        }),
+      );
+      const pendingEvaluationMock = partial<PolicyEvaluationRecord>({
+        configuration: partial<PolicyConfiguration>({
+          isBlocking: true,
+          type: partial<PolicyTypeRef>({
+            displayName: 'Minimum number of reviewers',
+          }),
+        }),
+        status: PolicyEvaluationStatus.Running,
+      });
+      azureHelper.getPolicyEvaluations.mockResolvedValueOnce([
+        pendingEvaluationMock,
+      ]);
+
+      const res = await azure.mergePr({
+        branchName: branchNameMock,
+        id: pullRequestIdMock,
+        strategy: 'auto',
+      });
+
+      expect(logger.debug).toHaveBeenCalledWith(
+        {
+          pullRequestId: pullRequestIdMock,
+          artifactId: `vstfs:///CodeReview/CodeReviewId/undefined/${pullRequestIdMock}`,
+          policyEvaluations: [pendingEvaluationMock],
+        },
+        'Retrieved policy evaluations for PR',
+      );
+      expect(logger.debug).toHaveBeenCalledWith(
+        {
+          pullRequestId: pullRequestIdMock,
+          pendingPolicies: [
+            { name: 'Minimum number of reviewers', status: 'Running' },
+          ],
+        },
+        'Not completing PR because branch policies have not been satisfied yet',
+      );
+      expect(updatePullRequestMock).not.toHaveBeenCalled();
+      expect(res).toBeFalse();
+    });
+
+    it('should complete the PR if blocking policies have been approved or are not applicable', async () => {
+      await initRepo({ repository: 'some/repo' });
+      const pullRequestIdMock = 12345;
+      const branchNameMock = 'test';
+      const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
+      const updatePullRequestMock = vi.fn().mockResolvedValue({
+        status: 3,
+      });
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: vi.fn().mockResolvedValue({
+            lastMergeSourceCommit: lastMergeSourceCommitMock,
+            targetRefName: 'refs/heads/ding',
+            title: 'title',
+          }),
+          updatePullRequest: updatePullRequestMock,
+        }),
+      );
+      azureHelper.getMergeMethod = vi
+        .fn()
+        .mockReturnValue(GitPullRequestMergeStrategy.Squash);
+      azureHelper.getPolicyEvaluations.mockResolvedValueOnce([
+        partial<PolicyEvaluationRecord>({
+          configuration: partial<PolicyConfiguration>({ isBlocking: true }),
+          status: PolicyEvaluationStatus.Approved,
+        }),
+        partial<PolicyEvaluationRecord>({
+          configuration: partial<PolicyConfiguration>({ isBlocking: true }),
+          status: PolicyEvaluationStatus.NotApplicable,
+        }),
+        partial<PolicyEvaluationRecord>({
+          configuration: partial<PolicyConfiguration>({ isBlocking: false }),
+          status: PolicyEvaluationStatus.Running,
+        }),
+      ]);
+
+      const res = await azure.mergePr({
+        branchName: branchNameMock,
+        id: pullRequestIdMock,
+        strategy: 'auto',
+      });
+
+      expect(updatePullRequestMock).toHaveBeenCalledOnce();
+      expect(res).toBeTrue();
+    });
+
     it('should complete the PR', async () => {
       await initRepo({ repository: 'some/repo' });
       const pullRequestIdMock = 12345;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -13,6 +13,8 @@ import {
   GitVersionType,
   PullRequestStatus,
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
+import type { PolicyEvaluationRecord } from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
+import { PolicyEvaluationStatus } from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
 import {
   REPOSITORY_ARCHIVED,
   REPOSITORY_EMPTY,
@@ -223,6 +225,7 @@ export async function initRepo({
   config.repoId = repo.id!;
 
   config.project = repo.project!.name!;
+  config.projectId = repo.project!.id!;
   issueService = new IssueService(config);
   config.owner = '?owner?';
   logger.debug(`${repository} owner = ${config.owner}`);
@@ -470,6 +473,26 @@ async function getMergeStrategy(
       targetRefName,
       config.defaultBranch,
     ))
+  );
+}
+
+async function getPendingBlockingPolicyEvaluations(
+  pullRequestId: number,
+): Promise<PolicyEvaluationRecord[]> {
+  const artifactId = `vstfs:///CodeReview/CodeReviewId/${config.projectId}/${pullRequestId}`;
+  const policyEvaluations = await azureHelper.getPolicyEvaluations(
+    config.project,
+    artifactId,
+  );
+  logger.debug(
+    { pullRequestId, artifactId, policyEvaluations },
+    'Retrieved policy evaluations for PR',
+  );
+  return policyEvaluations.filter(
+    (evaluation) =>
+      evaluation.configuration?.isBlocking &&
+      evaluation.status !== PolicyEvaluationStatus.Approved &&
+      evaluation.status !== PolicyEvaluationStatus.NotApplicable,
   );
 }
 
@@ -808,6 +831,23 @@ export async function mergePr({
   strategy,
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${pullRequestId}, ${branchName!})`);
+
+  const pendingPolicyEvaluations =
+    await getPendingBlockingPolicyEvaluations(pullRequestId);
+  if (pendingPolicyEvaluations.length) {
+    logger.debug(
+      {
+        pullRequestId,
+        pendingPolicies: pendingPolicyEvaluations.map((evaluation) => ({
+          name: evaluation.configuration?.type?.displayName,
+          status: PolicyEvaluationStatus[evaluation.status!],
+        })),
+      },
+      'Not completing PR because branch policies have not been satisfied yet',
+    );
+    return false;
+  }
+
   const azureApiGit = await azureApi.gitApi();
 
   let pr = await azureApiGit.getPullRequestById(pullRequestId, config.project);

--- a/lib/modules/platform/azure/types.ts
+++ b/lib/modules/platform/azure/types.ts
@@ -19,6 +19,7 @@ export interface Config {
   owner: string;
   repoId: string;
   project: string;
+  projectId: string;
   prList: AzurePr[];
   fileList: null;
   repository: string;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When a PR created on Azure is inside a project or repository that has
additional policy evaluations that need to be fulfilled for a given PR,
we should not attempt to perform a manual `mergePr` unless the policies
allow us to.

Previously, we would attempt to `mergePr` and would result in

    DEBUG: Failed to set the PR as completed.

Platform-native auto-merge functionality would still work as expected,
as once the evaluations had succeeded (for instance, a PR is approved by
a human) Azure will auto-merge it.

However, the failure in attempting to merge it is noisy, and should be
avoided by evaluating the policies before attempting to merge.

<!-- Describe what behavior is changed by this PR. -->
## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
