### PR TITLE
feat(host-rules): support hostTypes for matching multiple types

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2327,6 +2327,29 @@ For example:
 You usually don't need to configure it in a host rule if you have already configured `matchHost` and only one host type is in use for those, as is usually the case.
 `hostType` can help for cases like an enterprise registry that serves multiple package types and has different authentication for each, although it's often the case that multiple `matchHost` rules could achieve the same thing.
 
+`hostType` is mutually exclusive with [`hostTypes`](#hostruleshosttypes): a host rule can use one or the other, but not both.
+
+### `hostRules.hostTypes`
+
+`hostTypes` works like [`hostType`](#hostruleshosttype), but accepts a list of host types, so a single host rule can match more than one host type.
+This helps when an enterprise registry, like Nexus, serves multiple package formats on the same host with the same credentials.
+For example, to authenticate both `npm` and `maven` requests against the same Nexus host:
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "nexus.example.com",
+      "hostTypes": ["npm", "maven"],
+      "username": "user",
+      "password": "pass"
+    }
+  ]
+}
+```
+
+`hostTypes` is mutually exclusive with `hostType`: a host rule can use one or the other, but not both.
+
 ### `hostRules.httpsCertificate`
 
 Specifies the [Certificate chains](https://en.wikipedia.org/wiki/X.509#Certificate_chains_and_cross-certification) in [PEM format](https://en.wikipedia.org/wiki/Privacy-Enhanced_Mail) for mTLS authentication.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2819,6 +2819,17 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
   },
   {
+    name: 'hostTypes',
+    description:
+      'A list of hostTypes for a host rules. Can be platform names or datasource names.',
+    type: 'array',
+    subType: 'string',
+    stage: 'repository',
+    parents: ['hostRules'],
+    cli: false,
+    env: false,
+  },
+  {
     name: 'matchHost',
     description: 'A domain name, host name or base URL to match against.',
     type: 'string',

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2022,6 +2022,33 @@ describe('config/validation', () => {
       expect(warnings).toBeEmptyArray();
     });
 
+    it('errors if both hostType and hostTypes in a host rule', async () => {
+      GlobalConfig.set({ allowedHeaders: ['X-*'] });
+
+      const config = {
+        hostRules: [
+          {
+            matchHost: 'https://nexus.example.com',
+            hostType: 'npm',
+            hostTypes: ['npm', 'maven'],
+            token: 'token',
+          },
+        ],
+      };
+      const { errors, warnings } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+      expect(errors).toMatchObject([
+        {
+          topic: 'Configuration Error',
+          message:
+            'hostRules cannot contain both `hostType` and `hostTypes` - use one or the other.',
+        },
+      ]);
+      expect(warnings).toBeEmptyArray();
+    });
+
     it('errors if forbidden header in hostRules', async () => {
       GlobalConfig.set({ allowedHeaders: ['X-*'] });
 

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -942,6 +942,14 @@ export async function validateConfig(
               });
             }
 
+            if (rule.hostType && rule.hostTypes) {
+              errors.push({
+                topic: 'Configuration Error',
+                message:
+                  'hostRules cannot contain both `hostType` and `hostTypes` - use one or the other.',
+              });
+            }
+
             if (!rule.headers) {
               continue;
             }

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -22,6 +22,7 @@ export interface HostRule {
 
   encrypted?: HostRule;
   hostType?: string;
+  hostTypes?: string[];
   matchHost?: string;
   resolvedHost?: string;
   readOnly?: boolean;
@@ -29,5 +30,10 @@ export interface HostRule {
 
 export type CombinedHostRule = Omit<
   HostRule,
-  'encrypted' | 'hostType' | 'matchHost' | 'resolvedHost' | 'readOnly'
+  | 'encrypted'
+  | 'hostType'
+  | 'hostTypes'
+  | 'matchHost'
+  | 'resolvedHost'
+  | 'readOnly'
 >;

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -51,6 +51,19 @@ describe('util/host-rules', () => {
       );
     });
 
+    it('throws if both hostType and hostTypes', () => {
+      expect(() =>
+        add({
+          hostType: 'npm',
+          hostTypes: ['npm', 'maven'],
+          matchHost: 'nexus.example.com',
+          token: 'abc',
+        }),
+      ).toThrow(
+        'hostRules cannot contain both "hostType" and "hostTypes" - use one or the other.',
+      );
+    });
+
     it('supports baseUrl-only', () => {
       add({
         matchHost: 'https://some.endpoint',
@@ -155,6 +168,76 @@ describe('util/host-rules', () => {
       expect(
         find({ hostType: NugetDatasource.id, url: 'https://nuget.local/api' }),
       ).toEqual({ token: 'abc' });
+    });
+
+    it('matches on hostTypes', () => {
+      add({
+        hostTypes: ['npm', 'maven'],
+        matchHost: 'nexus.example.com',
+        token: 'abc',
+      });
+      expect(
+        find({
+          hostType: 'npm',
+          url: 'https://nexus.example.com/repository/npm/',
+        }),
+      ).toEqual({ token: 'abc' });
+      expect(
+        find({
+          hostType: 'maven',
+          url: 'https://nexus.example.com/repository/maven/',
+        }),
+      ).toEqual({ token: 'abc' });
+      expect(
+        find({
+          hostType: 'pypi',
+          url: 'https://nexus.example.com/repository/pypi/',
+        }),
+      ).toEqual({});
+    });
+
+    it('matches on hostTypes without matchHost', () => {
+      add({
+        hostTypes: ['npm', 'maven'],
+        token: 'abc',
+      });
+      expect(
+        find({ hostType: 'maven', url: 'https://nexus.example.com' }),
+      ).toEqual({ token: 'abc' });
+      expect(
+        find({ hostType: 'pypi', url: 'https://nexus.example.com' }),
+      ).toEqual({});
+    });
+
+    it('ranks hostTypes rules like hostType rules', () => {
+      add({
+        token: 'defaultToken',
+      });
+      add({
+        hostTypes: ['npm', 'maven'],
+        token: 'hostTypesToken',
+      });
+      add({
+        matchHost: 'https://nexus.example.com',
+        token: 'hostToken',
+      });
+      add({
+        hostTypes: ['npm', 'maven'],
+        matchHost: 'https://nexus.example.com',
+        token: 'specificToken',
+      });
+      expect(
+        find({ hostType: 'npm', url: 'https://nexus.example.com' }).token,
+      ).toBe('specificToken');
+    });
+
+    it('does not match hostTypes rule when search has no hostType', () => {
+      add({
+        hostTypes: ['npm'],
+        matchHost: 'nexus.example.com',
+        token: 'abc',
+      });
+      expect(find({ url: 'https://nexus.example.com' })).toEqual({});
     });
 
     it('matches on domainName', () => {
@@ -393,6 +476,25 @@ describe('util/host-rules', () => {
         'yet.another.local.registry',
       ]);
     });
+
+    it('returns hosts matched via hostTypes', () => {
+      add({
+        hostTypes: [NugetDatasource.id, 'maven'],
+        matchHost: 'https://nexus.local/repository',
+        token: 'abc',
+      });
+      add({
+        hostType: NugetDatasource.id,
+        matchHost: 'nuget.local',
+        token: 'def',
+      });
+      expect(hosts({ hostType: NugetDatasource.id })).toEqual([
+        'nexus.local',
+        'nuget.local',
+      ]);
+      expect(hosts({ hostType: 'maven' })).toEqual(['nexus.local']);
+      expect(hosts({ hostType: 'pypi' })).toEqual([]);
+    });
   });
 
   describe('findAll()', () => {
@@ -417,6 +519,24 @@ describe('util/host-rules', () => {
           matchHost: 'nuget.org',
         },
       ]);
+    });
+
+    it('returns rules matched via hostTypes', () => {
+      add({
+        hostTypes: ['npm', 'maven'],
+        matchHost: 'nexus.example.com',
+        token: 'abc',
+      });
+      expect(findAll({ hostType: 'npm' })).toEqual([
+        {
+          hostTypes: ['npm', 'maven'],
+          matchHost: 'nexus.example.com',
+          resolvedHost: 'nexus.example.com',
+          token: 'abc',
+        },
+      ]);
+      expect(findAll({ hostType: 'maven' })).toHaveLength(1);
+      expect(findAll({ hostType: 'pypi' })).toBeEmptyArray();
     });
   });
 

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -35,6 +35,12 @@ export function migrateRule(rule: LegacyHostRule & HostRule): HostRule {
     );
   }
 
+  if (result.hostType && result.hostTypes) {
+    throw new Error(
+      `hostRules cannot contain both "hostType" and "hostTypes" - use one or the other.`,
+    );
+  }
+
   return result;
 }
 
@@ -110,8 +116,13 @@ function fromShorterToLongerMatchHost(a: HostRule, b: HostRule): number {
   return a.matchHost.length - b.matchHost.length;
 }
 
-function hostRuleRank({ hostType, matchHost, readOnly }: HostRule): number {
-  if ((hostType || readOnly) && matchHost) {
+function hostRuleRank({
+  hostType,
+  hostTypes,
+  matchHost,
+  readOnly,
+}: HostRule): number {
+  if ((hostType || hostTypes || readOnly) && matchHost) {
     return 3;
   }
 
@@ -119,7 +130,7 @@ function hostRuleRank({ hostType, matchHost, readOnly }: HostRule): number {
     return 2;
   }
 
-  if (hostType) {
+  if (hostType || hostTypes) {
     return 1;
   }
 
@@ -155,6 +166,13 @@ export function find(search: HostRuleSearch): CombinedHostRule {
       }
     }
 
+    if (rule.hostTypes) {
+      hostTypeMatch = false;
+      if (search.hostType && rule.hostTypes.includes(search.hostType)) {
+        hostTypeMatch = true;
+      }
+    }
+
     if (rule.matchHost && rule.resolvedHost) {
       hostMatch = false;
       if (search.url) {
@@ -178,15 +196,20 @@ export function find(search: HostRuleSearch): CombinedHostRule {
 
   const res: HostRule = Object.assign({}, ...matchedRules);
   delete res.hostType;
+  delete res.hostTypes;
   delete res.resolvedHost;
   delete res.matchHost;
   delete res.readOnly;
   return res;
 }
 
+function matchesHostType(rule: HostRule, hostType: string): boolean {
+  return rule.hostType === hostType || !!rule.hostTypes?.includes(hostType);
+}
+
 export function hosts({ hostType }: { hostType: string }): string[] {
   return hostRules
-    .filter((rule) => rule.hostType === hostType)
+    .filter((rule) => matchesHostType(rule, hostType))
     .map((rule) => rule.resolvedHost)
     .filter(isTruthy);
 }
@@ -203,7 +226,7 @@ export function hostType({ url }: { url: string }): string | null {
 }
 
 export function findAll({ hostType }: { hostType: string }): HostRule[] {
-  return hostRules.filter((rule) => rule.hostType === hostType);
+  return hostRules.filter((rule) => matchesHostType(rule, hostType));
 }
 
 /**


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Allow a single hostRules entry to match multiple host types via a new hostTypes array option, e.g. for enterprise registries like Nexus that serve several package formats on the same host with the same credentials. 

My use case is: "we dont want Nexus to be used for Helm charts"

hostTypes is mutually exclusive with hostType.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [X] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
