### PR TITLE
feat(datasource/docker): check OCI referrers for attestation on GCR/AR images

### DIFF
--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -23,6 +23,12 @@ For more information see [the OpenTelemetry docs](opentelemetry.md).
 
 If set to any value, Renovate will always paginate requests to GitHub fully, instead of stopping after 10 pages.
 
+## `RENOVATE_X_DOCKER_CHECK_REFERRERS`
+
+If set to any value, Renovate will check the [OCI Distribution Spec Referrers API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md#listing-referrers) for the latest tag of Google Container/Artifact Registry (`*gcr.io`, `*-docker.pkg.dev`) images, and populate `attestation: true` on the corresponding release if any referrers (attestations, signatures, SBOMs, etc.) are found.
+
+This is presence-based only (any referrer counts, regardless of `artifactType`), and only checks the latest tag rather than every tag, to keep the added request overhead bounded. See [this discussion](https://github.com/renovatebot/renovate/discussions) for context and to give feedback on wider registry support.
+
 ## `RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP`
 
 If set to any value, Renovate will skip attempting to get release labels (e.g. gitRef, sourceUrl) from manifest annotations for `https://index.docker.io`.

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -3093,6 +3093,203 @@ describe('modules/datasource/docker/index', () => {
     });
   });
 
+  describe('getReleases > OCI referrers / attestation', () => {
+    beforeEach(() => {
+      delete process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS;
+    });
+
+    it('sets attestation=true when the latest tag has referrers', async () => {
+      process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS = 'true';
+      httpMock
+        .scope(gcrUrl)
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {})
+        .get('/')
+        .reply(200, '', {})
+        .head('/some-package/manifests/1.0.0')
+        .reply(200, '', { 'docker-content-digest': 'sha256:abc' })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/referrers/sha256:abc')
+        .reply(200, {
+          schemaVersion: 2,
+          mediaType: 'application/vnd.oci.image.index.v1+json',
+          manifests: [
+            {
+              mediaType: 'application/vnd.oci.image.manifest.v1+json',
+              size: 123,
+              digest: 'sha256:def',
+              artifactType: 'application/json',
+            },
+          ],
+        });
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'eu.gcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0', attestation: true }]);
+    });
+
+    it('sets attestation=false when referrers is empty (404)', async () => {
+      process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS = 'true';
+      httpMock
+        .scope(gcrUrl)
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {})
+        .get('/')
+        .reply(200, '', {})
+        .head('/some-package/manifests/1.0.0')
+        .reply(200, '', { 'docker-content-digest': 'sha256:abc' })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/referrers/sha256:abc')
+        .reply(404);
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'eu.gcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0', attestation: false }]);
+    });
+
+    it('does not check referrers when the flag is not set', async () => {
+      httpMock
+        .scope(gcrUrl)
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {});
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'eu.gcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+
+    it('returns null attestation when no auth headers can be resolved', async () => {
+      process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS = 'true';
+      httpMock
+        .scope(gcrUrl)
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {})
+        .get('/')
+        .reply(200, '', {})
+        .head('/some-package/manifests/1.0.0')
+        .reply(200, '', { 'docker-content-digest': 'sha256:abc' })
+        .get('/')
+        .reply(401); // no www-authenticate header -> getAuthHeaders() resolves null
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'eu.gcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+
+    it('returns null attestation when the referrers response cannot be parsed', async () => {
+      process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS = 'true';
+      httpMock
+        .scope(gcrUrl)
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {})
+        .get('/')
+        .reply(200, '', {})
+        .head('/some-package/manifests/1.0.0')
+        .reply(200, '', { 'docker-content-digest': 'sha256:abc' })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/referrers/sha256:abc')
+        .reply(200, 'not-valid-json-{');
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'eu.gcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+
+    it('skips the referrers check when the digest cannot be resolved', async () => {
+      process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS = 'true';
+      httpMock
+        .scope(gcrUrl)
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {})
+        .get('/')
+        .reply(200, '', {})
+        .head('/some-package/manifests/1.0.0')
+        .reply(404);
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'eu.gcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+
+    it('does not check referrers for non-Google registries', async () => {
+      process.env.RENOVATE_X_DOCKER_CHECK_REFERRERS = 'true';
+      httpMock
+        .scope('https://ghcr.io/v2')
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/some-package/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] })
+        .get('/')
+        .reply(200, '', {})
+        .get('/some-package/manifests/1.0.0')
+        .reply(200, '', {});
+
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'ghcr.io/some-package',
+      });
+
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+    });
+  });
+
   describe('getLabels', () => {
     const ds = new DockerDatasource();
 

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -43,6 +43,7 @@ import {
 } from './common.ts';
 import { DockerHubCache } from './dockerhub-cache.ts';
 import { ecrPublicRegex, ecrRegex, isECRMaxResultsError } from './ecr.ts';
+import { googleRegex } from './google.ts';
 import type { DistributionManifest, OciImageManifest } from './schema.ts';
 import {
   DockerHubTagsPage,
@@ -176,6 +177,69 @@ export class DockerDatasource extends Datasource {
           tag,
         },
         'Unknown Error looking up docker manifest',
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Checks the OCI Distribution Spec Referrers API
+   * (`GET /v2/<name>/referrers/<digest>`) for any artifacts (attestations,
+   * signatures, SBOMs, etc.) attached to the given digest.
+   *
+   * This is intentionally presence-based (any referrer counts) rather than
+   * filtering by a specific `artifactType`, since attestation conventions
+   * vary widely between registries/tools (cosign, in-toto, custom CI
+   * pipelines producing their own attestation artifacts, etc.).
+   *
+   * The caller currently only invokes this for registries matched by
+   * `googleRegex` (Google Container/Artifact Registry), as a starting
+   * point, since referrers support elsewhere in the ecosystem is less
+   * consistent — see the linked discussion for context on widening this.
+   */
+  private async hasReferrers(
+    registryHost: string,
+    dockerRepository: string,
+    digest: string,
+  ): Promise<boolean | null> {
+    logger.debug(
+      `hasReferrers(${registryHost}, ${dockerRepository}, ${digest})`,
+    );
+    try {
+      const headers = await getAuthHeaders(
+        this.http,
+        registryHost,
+        dockerRepository,
+      );
+      if (!headers) {
+        return null;
+      }
+      headers.accept = 'application/vnd.oci.image.index.v1+json';
+      const url = `${registryHost}/v2/${dockerRepository}/referrers/${digest}`;
+      const referrersResponse = await this.http.getText(url, {
+        headers,
+        noAuth: true,
+        cacheProvider: memCacheProvider,
+      });
+      const parsed = ManifestJson.safeParse(referrersResponse.body);
+      if (!parsed.success) {
+        return null;
+      }
+      const referrersIndex = parsed.data;
+      return (
+        'manifests' in referrersIndex && referrersIndex.manifests.length > 0
+      );
+    } catch (err) /* istanbul ignore next */ {
+      if (err instanceof ExternalHostError) {
+        throw err;
+      }
+      if (err.statusCode === 404) {
+        // No referrers, or registry doesn't support the Referrers API
+        return false;
+      }
+      logger.debug(
+        { err, registryHost, dockerRepository, digest },
+        'Unknown error checking OCI referrers',
       );
       return null;
     }
@@ -1209,6 +1273,44 @@ export class DockerDatasource extends Datasource {
         ret.homepage = labels[imageUrlLabel];
       }
     }
+
+    // Experimental / opt-in: checking OCI referrers adds an extra request
+    // per lookup, so this is gated behind an explicit flag rather than
+    // enabled unconditionally for every Google-hosted registry. See the
+    // linked discussion for the plan to graduate this out of RENOVATE_X_.
+    if (
+      getEnv().RENOVATE_X_DOCKER_CHECK_REFERRERS &&
+      googleRegex.test(registryHost)
+    ) {
+      const manifestResponse = await this.getManifestResponse(
+        registryHost,
+        dockerRepository,
+        latestTag,
+        'head',
+      );
+      const latestDigest =
+        manifestResponse &&
+        hasKey('docker-content-digest', manifestResponse.headers)
+          ? (manifestResponse.headers['docker-content-digest'] as string)
+          : null;
+      if (latestDigest) {
+        const attested = await this.hasReferrers(
+          registryHost,
+          dockerRepository,
+          latestDigest,
+        );
+        if (attested !== null) {
+          const latestRelease = releases.find(
+            (release) => release.version === latestTag,
+          );
+          /* v8 ignore next 3 -- latestTag is always derived from releases, so this is always found */
+          if (latestRelease) {
+            latestRelease.attestation = attested;
+          }
+        }
+      }
+    }
+
     return ret;
   }
 


### PR DESCRIPTION
## Context

Discussion: https://github.com/renovatebot/renovate/discussions/44637

We run an attestation pipeline on Google Artifact Registry (Binary
Authorization) and hit a real gap: Renovate proposes bumps to whatever
digest exists in AR, regardless of whether it's actually attested
(concretely: a build on an *open, unmerged* PR pushed a real digest before
attestation ran; a downstream Renovate instance picked it up and opened a PR
for that unattested digest).

## What

Populates the existing `Release.attestation` field (added for npm in #37268
/ #37258) for Docker images on Google Container/Artifact Registry, by
checking the OCI Distribution Spec Referrers API
(`GET /v2/<name>/referrers/<digest>`) for the **latest tag only** — mirroring
the existing sourceUrl/gitRef label lookup, which already does one extra
request scoped to the latest tag.

No changes needed to `Release`'s type or the PR-worker warning logic — both
are already datasource-agnostic since #37268.

Presence-based (any referrer counts) rather than filtering by
`artifactType`, and scoped to `googleRegex` hosts for now. Gated behind
`RENOVATE_X_DOCKER_CHECK_REFERRERS` (opt-in, default off) since it adds
request overhead.

Opened as **draft** — there are open design questions in the linked
discussion (scope to current-version too? artifactType filtering? broader
registry support? RENOVATE_X_ vs unconditional?) that I'd like input on
before finalizing.

## AI assistance disclosure

This PR was written primarily by Claude Code, based on a design I reviewed
and iterated on. I ran the full local test/lint/type-check suite myself
before opening this PR.

## Tests

- `pnpm check lib/modules/datasource/docker/index.ts lib/modules/datasource/docker/index.spec.ts docs/usage/self-hosted-experimental.md` — clean (oxlint, biome, prettier, tsc)
- New tests cover: referrers found, referrers empty/404, flag off (no-op),
  non-Google registry (no-op), auth-resolution failure, unparseable
  referrers response
- 100% statement/line/function coverage on the changed lines in
  `lib/modules/datasource/docker/index.ts` (verified locally; remaining
  uncovered branches in that file pre-date this change)