### PR TITLE
feat(manager/mise): support dotnet tool upgrades

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -430,6 +430,93 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
+    it('extracts the dotnet core tool', async () => {
+      const content = codeBlock`
+      [tools]
+      dotnet = "10.0.301"
+    `;
+      const result = await extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'dotnet',
+            currentValue: '10.0.301',
+            datasource: 'dotnet-version',
+            packageName: 'dotnet-sdk',
+          },
+        ],
+      });
+    });
+
+    it('extracts only the primary entry from a dotnet mixed sdk/runtime array', async () => {
+      const content = codeBlock`
+      [tools]
+      dotnet = [{ version = "8.0.14", runtime = "dotnet" }, { version = "10.0.301" }]
+    `;
+      const result = await extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'dotnet',
+            currentValue: '8.0.14',
+            datasource: 'dotnet-version',
+            packageName: 'dotnet-runtime',
+          },
+        ],
+      });
+      expect(result?.deps).toHaveLength(1);
+    });
+
+    it('extracts dotnet with a runtime option', async () => {
+      const content = codeBlock`
+      [tools]
+      dotnet = { version = "8.0.14", runtime = "dotnet" }
+    `;
+      const result = await extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'dotnet',
+            currentValue: '8.0.14',
+            datasource: 'dotnet-version',
+            packageName: 'dotnet-runtime',
+          },
+        ],
+      });
+    });
+
+    it('skips dotnet with an unsupported runtime', async () => {
+      const content = codeBlock`
+      [tools]
+      dotnet = [{ version = "9.0.0", runtime = "aspnetcore" }]
+    `;
+      const result = await extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'dotnet',
+            skipReason: 'unsupported-datasource',
+          },
+        ],
+      });
+    });
+
+    it('skips array entries without a version', async () => {
+      const content = codeBlock`
+      [tools]
+      dotnet = [{ runtime = "dotnet" }]
+    `;
+      const result = await extractPackageFile(content, miseFilename);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            depName: 'dotnet',
+            skipReason: 'unspecified-version',
+          },
+        ],
+      });
+    });
+
     it('extracts tools with plugin options', async () => {
       const content = codeBlock`
       [tools]
@@ -1291,6 +1378,25 @@ describe('modules/manager/mise/extract', () => {
         depName: 'python',
         currentValue: '3.10',
         lockedVersion: '3.10.17',
+      });
+    });
+
+    it('extracts lockedVersion for the dotnet core tool', async () => {
+      const dotnetLockFileContent = codeBlock`
+        [[tools.dotnet]]
+        version = "10.0.301"
+        backend = "core:dotnet"
+      `;
+      fs.readLocalFile.mockResolvedValueOnce(dotnetLockFileContent);
+      const content = codeBlock`
+        [tools]
+        dotnet = "10.0.301"
+      `;
+      const result = await extractPackageFile(content, 'mise.toml');
+      expect(result?.deps[0]).toMatchObject({
+        depName: 'dotnet',
+        currentValue: '10.0.301',
+        lockedVersion: '10.0.301',
       });
     });
 

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -1,10 +1,8 @@
 import {
   isArray,
   isFunction,
-  isNonEmptyObject,
   isNonEmptyString,
   isObject,
-  isString,
 } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
@@ -100,21 +98,34 @@ export async function extractPackageFile(
   return result;
 }
 
-function parseVersion(toolData: MiseTool): string | null {
+interface ToolVersionSpec {
+  version: string;
+  options: MiseToolOptions;
+}
+
+function parseVersion(toolData: MiseTool): ToolVersionSpec | null {
   if (isNonEmptyString(toolData)) {
     // Handle the string case
     // e.g. 'erlang = "23.3"'
-    return toolData;
+    return { version: toolData, options: {} };
   }
-  if (isArray(toolData, isString)) {
-    // Handle the array case
-    // e.g. 'erlang = ["23.3", "24.0"]'
-    return toolData.length ? toolData[0] : null; // Get the first version in the array
+  if (isArray(toolData)) {
+    // Handle the array case, only the first (primary) version is used
+    // e.g. 'erlang = ["23.3", "24.0"]' -> "23.3"
+    // or 'dotnet = [{ version = "8.0.14", runtime = "dotnet" }, { version = "10.0.301" }]' -> "8.0.14"
+    const first = toolData.length ? toolData[0] : undefined;
+    if (isNonEmptyString(first)) {
+      return { version: first, options: {} };
+    }
+    if (isObject(first) && isNonEmptyString(first.version)) {
+      return { version: first.version, options: first };
+    }
+    return null;
   }
   if (isObject(toolData) && isNonEmptyString(toolData.version)) {
     // Handle the object case with a string version
     // e.g. 'python = { version = "3.11.2" }'
-    return toolData.version;
+    return { version: toolData.version, options: toolData };
   }
   return null; // Return null if no version is found
 }
@@ -144,7 +155,11 @@ function getToolConfig(
   switch (backend) {
     case '': {
       // If the tool name does not specify a backend, it should be a short name or an alias defined by users
-      const staticResult = getRegistryToolConfig(toolName, version);
+      const staticResult = getRegistryToolConfig(
+        toolName,
+        version,
+        toolOptions,
+      );
       if (staticResult) {
         return staticResult;
       }
@@ -183,14 +198,14 @@ function getToolConfig(
     // We can specify core, asdf, vfox, aqua backends for tools in the default registry
     // e.g. 'core:rust', 'asdf:rust', 'vfox:clang', 'aqua:act'
     case 'core':
-      return getConfigFromTooling(miseTooling, toolName, version);
+      return getConfigFromTooling(miseTooling, toolName, version, toolOptions);
     case 'asdf':
-      return getConfigFromTooling(asdfTooling, toolName, version);
+      return getConfigFromTooling(asdfTooling, toolName, version, toolOptions);
     case 'vfox':
-      return getRegistryToolConfig(toolName, version);
+      return getRegistryToolConfig(toolName, version, toolOptions);
     case 'aqua':
       return (
-        getRegistryToolConfig(toolName, version) ??
+        getRegistryToolConfig(toolName, version, toolOptions) ??
         createAquaToolConfig(toolName, version)
       );
     case 'cargo':
@@ -224,11 +239,12 @@ function getToolConfig(
 function getRegistryToolConfig(
   short: string,
   version: string,
+  toolOptions: MiseToolOptions,
 ): StaticTooling | null {
   // Try to get the config from miseTooling first, then asdfTooling
   return (
-    getConfigFromTooling(miseTooling, short, version) ??
-    getConfigFromTooling(asdfTooling, short, version)
+    getConfigFromTooling(miseTooling, short, version, toolOptions) ??
+    getConfigFromTooling(asdfTooling, short, version, toolOptions)
   );
 }
 
@@ -236,6 +252,7 @@ function getConfigFromTooling(
   toolingSource: Record<string, ToolingDefinition>,
   name: string,
   version: string,
+  toolOptions: MiseToolOptions,
 ): StaticTooling | null {
   const toolDefinition = toolingSource[name];
   if (!toolDefinition) {
@@ -244,28 +261,25 @@ function getConfigFromTooling(
 
   return (
     (isFunction(toolDefinition.config)
-      ? toolDefinition.config(version)
+      ? toolDefinition.config(version, toolOptions)
       : toolDefinition.config) ?? null
   ); // Ensure null is returned instead of undefined
 }
 
 function extractToolEntry(name: string, toolData: MiseTool): PackageDependency {
-  const version = parseVersion(toolData);
   const { name: depName, options: optionsInName } = optionInToolNameRegex.exec(
     name.trim(),
   )!.groups!;
   const delimiterIndex = depName.indexOf(':');
   const backend = depName.substring(0, delimiterIndex);
   const toolName = depName.substring(delimiterIndex + 1);
-  const options = parseOptions(
-    optionsInName,
-    isNonEmptyObject(toolData) ? toolData : {},
-  );
-  const toolConfig =
-    version === null
-      ? null
-      : getToolConfig(backend, toolName, version, options);
-  return createDependency(depName, version, toolConfig);
+  const spec = parseVersion(toolData);
+  if (!spec) {
+    return createDependency(depName, null, null);
+  }
+  const options = parseOptions(optionsInName, spec.options);
+  const toolConfig = getToolConfig(backend, toolName, spec.version, options);
+  return createDependency(depName, spec.version, toolConfig);
 }
 
 function createDependency(

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -99,6 +99,7 @@ Renovate's `mise` manager supports the following [backends](https://mise.jdx.dev
 - [`asdf`](https://mise.jdx.dev/dev-tools/backends/asdf.html)
 - [`aqua`](https://mise.jdx.dev/dev-tools/backends/aqua.html)
 - [`cargo`](https://mise.jdx.dev/dev-tools/backends/cargo.html)
+- [`dotnet`](https://mise.jdx.dev/dev-tools/backends/dotnet.html)
 - [`gem`](https://mise.jdx.dev/dev-tools/backends/gem.html)
 - [`github`](https://mise.jdx.dev/dev-tools/backends/github.html)
 - [`go`](https://mise.jdx.dev/dev-tools/backends/go.html)

--- a/lib/modules/manager/mise/schema.ts
+++ b/lib/modules/manager/mise/schema.ts
@@ -13,15 +13,19 @@ const MiseToolOptions = z.object({
   tag_regex: z.string().optional(),
   // github backend only
   version_prefix: z.string().optional(),
+  // dotnet core tool only
+  runtime: z.string().optional(),
 });
 export type MiseToolOptions = z.infer<typeof MiseToolOptions>;
 
+const MiseToolEntry = MiseToolOptions.extend({
+  version: z.string().optional(),
+});
+
 const MiseTool = z.union([
   z.string(),
-  MiseToolOptions.extend({
-    version: z.string().optional(),
-  }),
-  z.array(z.string()),
+  MiseToolEntry,
+  z.array(z.union([z.string(), MiseToolEntry])),
 ]);
 export type MiseTool = z.infer<typeof MiseTool>;
 

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -1,5 +1,6 @@
 import miseRegistry from '../../../data/mise-registry.json' with { type: 'json' };
 import { regEx } from '../../../util/regex.ts';
+import { DotnetVersionDatasource } from '../../datasource/dotnet-version/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { HexpmBobDatasource } from '../../datasource/hexpm-bob/index.ts';
@@ -10,13 +11,19 @@ import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 import * as regexVersioning from '../../versioning/regex/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
 import * as semverPartialVersioning from '../../versioning/semver-partial/index.ts';
-import type { ToolingConfig } from '../asdf/upgradeable-tooling.ts';
+import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
 import { upgradeableTooling } from '../asdf/upgradeable-tooling.ts';
+import type { MiseToolOptions } from './schema.ts';
 import { MiseRegistryJson } from './schema.ts';
 import type { MiseRegistryData } from './types.ts';
 
 export interface ToolingDefinition {
-  config: ToolingConfig;
+  config:
+    | StaticTooling
+    | ((
+        version: string,
+        options: MiseToolOptions,
+      ) => StaticTooling | undefined);
   misePluginUrl?: string;
 }
 
@@ -44,6 +51,28 @@ const miseCoreTooling: Record<string, ToolingDefinition> = {
       packageName: 'denoland/deno',
       datasource: GithubReleasesDatasource.id,
       extractVersion: '^v(?<version>\\S+)',
+    },
+  },
+  dotnet: {
+    misePluginUrl: 'https://mise.jdx.dev/lang/dotnet.html',
+    config: (_version, options) => {
+      // A plain version installs the .NET SDK.
+      // `runtime = "dotnet"` installs the .NET runtime for that version instead.
+      // https://mise.jdx.dev/lang/dotnet.html#example-mix-sdk-and-runtime
+      if (!options.runtime) {
+        return {
+          packageName: 'dotnet-sdk',
+          datasource: DotnetVersionDatasource.id,
+        };
+      }
+      if (options.runtime === 'dotnet') {
+        return {
+          packageName: 'dotnet-runtime',
+          datasource: DotnetVersionDatasource.id,
+        };
+      }
+      // Other runtimes (e.g. "aspnetcore") have no matching datasource
+      return undefined;
     },
   },
   elixir: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

The mise manager previously skipped the `dotnet` core tool entirely, and would not create pull requests for new versions.
it was missing from the tooling registry (unsupported-datasource), and mise's documented mixed SDK/runtime syntax `dotnet = [{ version = "8.0.14", runtime = "dotnet" }, { version = "10.0.301" }]` could not be parsed at all (unspecified-version).

- add `dotnet` to miseCoreTooling, mapping to the dotnet-version datasource (`dotnet-sdk` by default, `dotnet-runtime` when the entry sets `runtime = "dotnet"`)
- pass tool options through to tooling config functions

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Yes, Claude Fable.  

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/RocketSurgeonsGuild/MSBuildSdk

https://github.com/JamieTanna-Mend-testing/renovate-pr-44650

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->

