### PR TITLE
feat(datasource/docker): Identify private ECR registries across AWS partitions

### DIFF
--- a/lib/modules/datasource/docker/ecr.ts
+++ b/lib/modules/datasource/docker/ecr.ts
@@ -8,7 +8,7 @@ import { regEx } from '../../../util/regex.ts';
 import { addSecretForSanitizing } from '../../../util/sanitize.ts';
 
 export const ecrRegex = regEx(
-  /\d+\.(?:dkr\.ecr|dkr-ecr)(?:-fips)?\.([-a-z0-9]+)\.(?:amazonaws\.com|on\.aws)/,
+  /\d+\.(?:dkr\.ecr|dkr-ecr)(?:-fips)?\.([-a-z0-9]+)\.(?:amazonaws\.com|on\.aws|amazonaws\.com\.cn|on\.amazonwebservices\.com\.cn|amazonaws\.eu|on\.amazonwebservices\.eu|c2s\.ic\.gov|on\.aws\.ic\.gov|sc2s\.sgov\.gov|on\.aws\.scloud|scloud\.adc-e\.uk|on\.cloud-aws\.adc-e\.uk|csp\.hci\.ic\.gov|on\.aws\.hci\.ic\.gov|)/,
 );
 export const ecrPublicRegex = regEx(/public\.ecr\.aws|ecr-public\.aws\.com/);
 

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -28,10 +28,130 @@ const gcrUrl = 'https://eu.gcr.io/v2';
 const garUrl = 'https://europe-docker.pkg.dev/v2';
 const dockerHubUrl = 'https://hub.docker.com/v2/repositories';
 const amazonHosts = [
-  { host: '123456789.dkr.ecr.us-east-1.amazonaws.com' },
-  { host: '123456789.dkr.ecr-fips.us-east-1.amazonaws.com' },
-  { host: '123456789.dkr-ecr.us-east-1.on.aws' },
-  { host: '123456789.dkr-ecr-fips.us-east-1.on.aws' },
+  // partition: aws
+  { host: '123456789.dkr.ecr.us-east-1.amazonaws.com', region: 'us-east-1' },
+  {
+    host: '123456789.dkr.ecr-fips.us-east-1.amazonaws.com',
+    region: 'us-east-1',
+  },
+  { host: '123456789.dkr-ecr.us-east-1.on.aws', region: 'us-east-1' },
+  { host: '123456789.dkr-ecr-fips.us-east-1.on.aws', region: 'us-east-1' },
+  // partition: aws-cn
+  {
+    host: '123456789.dkr.ecr.cn-north-1.amazonaws.com.cn',
+    region: 'cn-north-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.cn-north-1.amazonaws.com.cn',
+    region: 'cn-north-1',
+  },
+  {
+    host: '123456789.dkr-ecr.cn-north-1.on.amazonwebservices.com.cn',
+    region: 'cn-north-1',
+  },
+  {
+    host: '123456789.dkr-ecr-fips.cn-north-1.on.amazonwebservices.com.cn',
+    region: 'cn-north-1',
+  },
+  // partition: aws-eusc
+  {
+    host: '123456789.dkr.ecr.eusc-de-east-1.amazonaws.eu',
+    region: 'eusc-de-east-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.eusc-de-east-1.amazonaws.eu',
+    region: 'eusc-de-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr.eusc-de-east-1.on.amazonwebservices.eu',
+    region: 'eusc-de-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr-fips.eusc-de-east-1.on.amazonwebservices.eu',
+    region: 'eusc-de-east-1',
+  },
+  // partition: aws-iso
+  {
+    host: '123456789.dkr.ecr.us-iso-east-1.c2s.ic.gov',
+    region: 'us-iso-east-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.us-iso-east-1.c2s.ic.gov',
+    region: 'us-iso-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr.us-iso-east-1.on.aws.ic.gov',
+    region: 'us-iso-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr-fips.us-iso-east-1.on.aws.ic.gov',
+    region: 'us-iso-east-1',
+  },
+  // partition: aws-iso-b
+  {
+    host: '123456789.dkr.ecr.us-isob-east-1.sc2s.sgov.gov',
+    region: 'us-isob-east-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.us-isob-east-1.sc2s.sgov.gov',
+    region: 'us-isob-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr.us-isob-east-1.on.aws.scloud',
+    region: 'us-isob-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr-fips.us-isob-east-1.on.aws.scloud',
+    region: 'us-isob-east-1',
+  },
+  // partition: aws-iso-e
+  {
+    host: '123456789.dkr.ecr.eu-isoe-west-1.scloud.adc-e.uk',
+    region: 'eu-isoe-west-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.eu-isoe-west-1.cloud.adc-e.uk',
+    region: 'eu-isoe-west-1',
+  },
+  {
+    host: '123456789.dkr-ecr.eu-isoe-west-1.on.cloud-aws.adc-e.uk',
+    region: 'eu-isoe-west-1',
+  },
+  {
+    host: '123456789.dkr-ecr-fips.eu-isoe-west-1.on.cloud-aws.adc-e.uk',
+    region: 'eu-isoe-west-1',
+  },
+  // partition: aws-iso-f
+  {
+    host: '123456789.dkr.ecr.us-isof-east-1.csp.hci.ic.gov',
+    region: 'us-isof-east-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.us-isof-east-1.csp.hci.ic.gov',
+    region: 'us-isof-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr.us-isof-east-1.on.aws.hci.ic.gov',
+    region: 'us-isof-east-1',
+  },
+  {
+    host: '123456789.dkr-ecr-fips.us-isof-east-1.on.aws.hci.ic.gov',
+    region: 'us-isof-east-1',
+  },
+  // partition: aws-us-gov
+  {
+    host: '123456789.dkr.ecr.us-gov-east-1.amazonaws.com',
+    region: 'us-gov-east-1',
+  },
+  {
+    host: '123456789.dkr.ecr-fips.us-gov-east-1.amazonaws.com',
+    region: 'us-gov-east-1',
+  },
+  { host: '123456789.dkr-ecr.us-gov-east-1.on.aws', region: 'us-gov-east-1' },
+  {
+    host: '123456789.dkr-ecr-fips.us-gov-east-1.on.aws',
+    region: 'us-gov-east-1',
+  },
 ];
 
 function mockEcrAuthResolve(
@@ -252,7 +372,7 @@ describe('modules/datasource/docker/index', () => {
 
     it.each(amazonHosts)(
       'passes credentials to ECR client for host $host',
-      async ({ host }) => {
+      async ({ host, region }) => {
         httpMock
           .scope(`https://${host}/v2`)
           .get('/')
@@ -279,7 +399,7 @@ describe('modules/datasource/docker/index', () => {
         ).toBe('some-digest');
 
         const ecr = ecrMock.call(0).thisValue as ECRClient;
-        expect(await ecr.config.region()).toBe('us-east-1');
+        expect(await ecr.config.region()).toBe(region);
         expect(await ecr.config.credentials()).toEqual({
           $source: {
             CREDENTIALS_CODE: 'e',
@@ -292,7 +412,7 @@ describe('modules/datasource/docker/index', () => {
 
     it.each(amazonHosts)(
       'passes session token to ECR client for host $host',
-      async ({ host }) => {
+      async ({ host, region }) => {
         httpMock
           .scope(`https://${host}/v2`)
           .get('/')
@@ -325,7 +445,7 @@ describe('modules/datasource/docker/index', () => {
         ).toBe('some-digest');
 
         const ecr = ecrMock.call(0).thisValue as ECRClient;
-        expect(await ecr.config.region()).toBe('us-east-1');
+        expect(await ecr.config.region()).toBe(region);
         expect(await ecr.config.credentials()).toEqual({
           $source: {
             CREDENTIALS_CODE: 'e',


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR expands the regular expression for identifying a private ECR registry to include hosts [in all AWS partitions](https://github.com/boto/botocore/blob/develop/botocore/data/partitions.json).

I'm willing to do a larger refactor if this new regular expression it too large to maintain. I also considered maintaining individual regular expressions for identifying ECR hosts in each partition, and then OR'ing the expressions together into the current `ecrRegex` constant.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
