### PR TITLE
test: add linter for `as any` in test files

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -195,6 +195,7 @@
         "renovate/codeblock-in-spec-fixtures": "error",
         "renovate/no-redundant-mock-reset": "error",
         "renovate/prefer-nullish-util": "off",
+        "renovate/prefer-partial-in-specs": "error",
         "renovate/test-root-describe": "error",
         "typescript/explicit-function-return-type": "off"
       }

--- a/lib/config/migrate-validate.spec.ts
+++ b/lib/config/migrate-validate.spec.ts
@@ -52,6 +52,7 @@ describe('config/migrate-validate', () => {
         throw new Error('test error');
       });
       await expect(
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid config for error path
         migrateAndValidate(config, { invalid: 'config' } as any),
       ).rejects.toThrow('test error');
       expect(logger.logger.debug).toHaveBeenCalledTimes(2);

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -15,6 +15,7 @@ interface TestRenovateConfig extends RenovateConfig {
 describe('config/migration', () => {
   describe('migrateConfig(config, parentConfig)', () => {
     it('migrates config', () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- legacy config with removed options for migration test
       const config: TestRenovateConfig = {
         endpoints: [{}] as never,
         enabled: true,
@@ -678,6 +679,7 @@ describe('config/migration', () => {
             '# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[^\\s]+?)(?: lookupName=(?<lookupName>[^\\s]+?))?(?: versioning=(?<versioning>[a-z-0-9]+?))?\\s(?:ENV|ARG) .+?_VERSION="?(?<currentValue>.+?)"?\\s',
           ],
         },
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- legacy lookupNameTemplate field for migration test
         {
           fileMatch: ['(^|/|\\.)Dockerfile$', '(^|/)Dockerfile[^/]*$'],
           matchStrings: [

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -661,7 +661,7 @@ describe('config/migration', () => {
     });
     const config: RenovateConfig = {
       extends: ['@org', '@org2/foo'],
-    } as any;
+    };
     const { isMigrated, migratedConfig } =
       configMigration.migrateConfig(config);
     expect(isMigrated).toBeTrue();

--- a/lib/config/migrations/custom/automerge-migration.spec.ts
+++ b/lib/config/migrations/custom/automerge-migration.spec.ts
@@ -5,7 +5,7 @@ describe('config/migrations/custom/automerge-migration', () => {
     await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'none',
-      } as any,
+      },
       {
         automerge: false,
       },
@@ -16,7 +16,7 @@ describe('config/migrations/custom/automerge-migration', () => {
     await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'patch',
-      } as any,
+      },
       {
         patch: {
           automerge: true,
@@ -35,7 +35,7 @@ describe('config/migrations/custom/automerge-migration', () => {
     await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'minor',
-      } as any,
+      },
       {
         minor: {
           automerge: true,
@@ -51,7 +51,7 @@ describe('config/migrations/custom/automerge-migration', () => {
     await expect(AutomergeMigration).toMigrate(
       {
         automerge: 'any',
-      } as any,
+      },
       {
         automerge: true,
       },

--- a/lib/config/migrations/custom/base-branch-migration.spec.ts
+++ b/lib/config/migrations/custom/base-branch-migration.spec.ts
@@ -16,7 +16,7 @@ describe('config/migrations/custom/base-branch-migration', () => {
     await expect(BaseBranchMigration).toMigrate(
       {
         baseBranch: ['test'],
-      } as any,
+      },
       {
         baseBranchPatterns: ['test'],
       },
@@ -28,7 +28,7 @@ describe('config/migrations/custom/base-branch-migration', () => {
       {
         baseBranch: ['test'],
         baseBranchPatterns: ['base'],
-      } as any,
+      },
       {
         baseBranchPatterns: ['base', 'test'],
       },

--- a/lib/config/migrations/custom/branch-name-migration.spec.ts
+++ b/lib/config/migrations/custom/branch-name-migration.spec.ts
@@ -28,10 +28,10 @@ describe('config/migrations/custom/branch-name-migration', () => {
     await expect(BranchNameMigration).toMigrate(
       {
         branchName: true,
-      } as any,
+      },
       {
         branchName: true,
-      } as any,
+      },
       false,
     );
   });

--- a/lib/config/migrations/custom/branch-prefix-migration.spec.ts
+++ b/lib/config/migrations/custom/branch-prefix-migration.spec.ts
@@ -29,10 +29,10 @@ describe('config/migrations/custom/branch-prefix-migration', () => {
     await expect(BranchPrefixMigration).toMigrate(
       {
         branchPrefix: true,
-      } as any,
+      },
       {
         branchPrefix: true,
-      } as any,
+      },
       false,
     );
   });

--- a/lib/config/migrations/custom/extends-migration.spec.ts
+++ b/lib/config/migrations/custom/extends-migration.spec.ts
@@ -6,7 +6,7 @@ describe('config/migrations/custom/extends-migration', () => {
     await expect(ExtendsMigration).toMigrate(
       {
         extends: ':js-app',
-      } as any,
+      },
       {
         extends: ['config:js-app'],
       },
@@ -15,7 +15,7 @@ describe('config/migrations/custom/extends-migration', () => {
     await expect(ExtendsMigration).toMigrate(
       {
         extends: 'foo',
-      } as any,
+      },
       {
         extends: ['foo'],
       },
@@ -37,7 +37,7 @@ describe('config/migrations/custom/extends-migration', () => {
     await expect(ExtendsMigration).toMigrate(
       {
         extends: [{}],
-      } as any,
+      },
       {
         extends: [],
       },

--- a/lib/config/migrations/custom/host-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/host-rules-migration.spec.ts
@@ -29,7 +29,7 @@ describe('config/migrations/custom/host-rules-migration', () => {
           { host: 'some.domain.com', token: '123test' },
           { matchHost: 'some.domain.com:8080', token: '123test' },
         ],
-      } as any,
+      },
       {
         hostRules: [
           {

--- a/lib/config/migrations/custom/host-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/host-rules-migration.spec.ts
@@ -68,6 +68,7 @@ describe('config/migrations/custom/host-rules-migration', () => {
   it('throws when multiple hosts are present', () => {
     expect(() =>
       new HostRulesMigration(
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- legacy baseUrl hostRule field is intentionally invalid for this migration test
         {
           hostRules: [
             {

--- a/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
+++ b/lib/config/migrations/custom/ignore-npmrc-file-migration.spec.ts
@@ -29,7 +29,7 @@ describe('config/migrations/custom/ignore-npmrc-file-migration', () => {
       {
         ignoreNpmrcFile: true,
         npmrc: true,
-      } as any,
+      },
       {
         npmrc: '',
       },

--- a/lib/config/migrations/custom/path-rules-migration.spec.ts
+++ b/lib/config/migrations/custom/path-rules-migration.spec.ts
@@ -32,7 +32,7 @@ describe('config/migrations/custom/path-rules-migration', () => {
             extends: ['foo'],
           },
         ],
-      } as any,
+      },
       {
         packageRules: [
           {

--- a/lib/config/migrations/custom/schedule-migration.spec.ts
+++ b/lib/config/migrations/custom/schedule-migration.spec.ts
@@ -5,10 +5,10 @@ describe('config/migrations/custom/schedule-migration', () => {
     await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'every friday',
-      } as any,
+      },
       {
         schedule: 'on friday',
-      } as any,
+      },
     );
   });
 
@@ -16,10 +16,10 @@ describe('config/migrations/custom/schedule-migration', () => {
     await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'every weekday',
-      } as any,
+      },
       {
         schedule: 'every weekday',
-      } as any,
+      },
       false,
     );
   });
@@ -28,10 +28,10 @@ describe('config/migrations/custom/schedule-migration', () => {
     await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'after 5:00pm on wednesday and thursday',
-      } as any,
+      },
       {
         schedule: 'after 5:00pm on wednesday and thursday',
-      } as any,
+      },
       false,
     );
   });
@@ -40,10 +40,10 @@ describe('config/migrations/custom/schedule-migration', () => {
     await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'after 1:00pm and before 5:00pm',
-      } as any,
+      },
       {
         schedule: 'after 1:00pm and before 5:00pm',
-      } as any,
+      },
       false,
     );
   });
@@ -52,10 +52,10 @@ describe('config/migrations/custom/schedule-migration', () => {
     await expect(ScheduleMigration).toMigrate(
       {
         schedule: 'after and before 5:00',
-      } as any,
+      },
       {
         schedule: 'after and before 5:00',
-      } as any,
+      },
       false,
     );
   });

--- a/lib/config/migrations/custom/semantic-commits-migration.spec.ts
+++ b/lib/config/migrations/custom/semantic-commits-migration.spec.ts
@@ -5,7 +5,7 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: true,
-      } as any,
+      },
       { semanticCommits: 'enabled' },
     );
   });
@@ -14,7 +14,7 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: false,
-      } as any,
+      },
       { semanticCommits: 'disabled' },
     );
   });
@@ -23,7 +23,7 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: null,
-      } as any,
+      },
       { semanticCommits: 'auto' },
     );
   });
@@ -32,7 +32,7 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: 'test',
-      } as any,
+      },
       { semanticCommits: 'auto' },
     );
   });
@@ -41,7 +41,7 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: 'enabled',
-      } as any,
+      },
       { semanticCommits: 'enabled' },
       false,
     );
@@ -51,7 +51,7 @@ describe('config/migrations/custom/semantic-commits-migration', () => {
     await expect(SemanticCommitsMigration).toMigrate(
       {
         semanticCommits: 'disabled',
-      } as any,
+      },
       { semanticCommits: 'disabled' },
       false,
     );

--- a/lib/config/migrations/custom/semantic-prefix-migration.spec.ts
+++ b/lib/config/migrations/custom/semantic-prefix-migration.spec.ts
@@ -5,7 +5,7 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: 'fix(deps): ',
-      } as any,
+      },
       { semanticCommitType: 'fix', semanticCommitScope: 'deps' },
     );
   });
@@ -14,7 +14,7 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: true,
-      } as any,
+      },
       {},
     );
   });
@@ -23,7 +23,7 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: 'fix: ',
-      } as any,
+      },
       { semanticCommitType: 'fix', semanticCommitScope: null },
     );
   });
@@ -32,7 +32,7 @@ describe('config/migrations/custom/semantic-prefix-migration', () => {
     await expect(SemanticPrefixMigration).toMigrate(
       {
         semanticPrefix: 'test',
-      } as any,
+      },
       { semanticCommitType: 'test', semanticCommitScope: null },
     );
   });

--- a/lib/config/migrations/custom/unpublish-safe-migration.spec.ts
+++ b/lib/config/migrations/custom/unpublish-safe-migration.spec.ts
@@ -17,7 +17,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       {
         extends: 'test',
         unpublishSafe: true,
-      } as any,
+      },
       {
         extends: ['test', 'security:minimumReleaseAgeNpm'],
       },
@@ -29,7 +29,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       {
         extends: [],
         unpublishSafe: true,
-      } as any,
+      },
       {
         extends: ['security:minimumReleaseAgeNpm'],
       },
@@ -41,7 +41,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       {
         extends: ['foo', ':unpublishSafe', 'bar'],
         unpublishSafe: true,
-      } as any,
+      },
       {
         extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       },
@@ -51,7 +51,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       {
         extends: ['foo', 'default:unpublishSafe', 'bar'],
         unpublishSafe: true,
-      } as any,
+      },
       {
         extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       },
@@ -61,7 +61,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       {
         extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
         unpublishSafe: true,
-      } as any,
+      },
       {
         extends: ['foo', 'security:minimumReleaseAgeNpm', 'bar'],
       },
@@ -73,7 +73,7 @@ describe('config/migrations/custom/unpublish-safe-migration', () => {
       {
         extends: ['foo', 'bar'],
         unpublishSafe: false,
-      } as any,
+      },
       {
         extends: ['foo', 'bar'],
       },

--- a/lib/config/secrets.spec.ts
+++ b/lib/config/secrets.spec.ts
@@ -39,6 +39,7 @@ describe('config/secrets', () => {
 
     it('throws for secrets in repositories', () => {
       expect(() =>
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid secret value type
         validateConfigSecretsAndVariables({
           repositories: [{ repository: 'x/y', secrets: { abc: 123 } }],
         } as any),
@@ -47,6 +48,7 @@ describe('config/secrets', () => {
 
     it('throws for variables in repositories', () => {
       expect(() =>
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid variable value type
         validateConfigSecretsAndVariables({
           repositories: [{ repository: 'x/y', variables: { abc: 123 } }],
         } as any),

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1,3 +1,4 @@
+import { partial } from '~test/util.ts';
 import type { HostRule } from '../types/index.ts';
 import { getConfigFileNames } from './app-strings.ts';
 import { GlobalConfig } from './global.ts';
@@ -1792,14 +1793,14 @@ describe('config/validation', () => {
     });
 
     it('errors if invalid combinations in packageRules', async () => {
-      const config = {
+      const config = partial<AllConfig>({
         packageRules: [
           {
             matchUpdateTypes: ['major'],
             registryUrls: ['https://registry.npmjs.org'],
           },
         ],
-      } as any;
+      });
       const { warnings, errors } = await configValidation.validateConfig(
         'repo',
         config,

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1817,7 +1817,7 @@ describe('config/validation', () => {
     it('warns when registryUrls is set at the top level of repo config', async () => {
       const config = {
         registryUrls: ['https://registry.npmjs.org'],
-      } as any;
+      };
       const { warnings, errors } = await configValidation.validateConfig(
         'repo',
         config,
@@ -1835,7 +1835,7 @@ describe('config/validation', () => {
     it('warns when defaultRegistryUrls is set at the top level of repo config', async () => {
       const config = {
         defaultRegistryUrls: ['https://registry.npmjs.org'],
-      } as any;
+      };
       const { warnings, errors } = await configValidation.validateConfig(
         'repo',
         config,
@@ -2876,7 +2876,7 @@ describe('config/validation', () => {
     it('warns when registryUrls is set at the top level of global config', async () => {
       const config = {
         registryUrls: ['https://registry.npmjs.org'],
-      } as any;
+      };
       const { warnings, errors } = await configValidation.validateConfig(
         'global',
         config,
@@ -2894,7 +2894,7 @@ describe('config/validation', () => {
     it('warns when defaultRegistryUrls is set at the top level of global config', async () => {
       const config = {
         defaultRegistryUrls: ['https://registry.npmjs.org'],
-      } as any;
+      };
       const { warnings, errors } = await configValidation.validateConfig(
         'global',
         config,

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -425,6 +425,7 @@ describe('config/validation', () => {
     });
 
     it('catches invalid customDatasources content', async () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid customDatasources content
       const config = {
         customDatasources: {
           foo: {
@@ -516,6 +517,7 @@ describe('config/validation', () => {
     });
 
     it('catches invalid customDatasources record type', async () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid customDatasources record type
       const config = {
         customDatasources: {
           randomKey: '',

--- a/lib/modules/manager/bundler/host-rules.spec.ts
+++ b/lib/modules/manager/bundler/host-rules.spec.ts
@@ -55,9 +55,7 @@ describe('modules/manager/bundler/host-rules', () => {
     it('returns an empty array if matchHost is missing', () => {
       delete hostRule.matchHost;
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toBeEmptyArray();
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toBeEmptyArray();
     });
 
     it('returns an empty array if username is missing and password is present', () => {
@@ -65,9 +63,7 @@ describe('modules/manager/bundler/host-rules', () => {
       delete hostRule.token;
 
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toBeEmptyArray();
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toBeEmptyArray();
     });
 
     it('returns an empty array if password and token are missing', () => {
@@ -75,45 +71,43 @@ describe('modules/manager/bundler/host-rules', () => {
       delete hostRule.token;
 
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toBeEmptyArray();
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toBeEmptyArray();
     });
 
     it('returns the hostRule if using matchHost and password', () => {
       delete hostRule.token;
 
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toMatchObject([hostRule]);
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toMatchObject([
+        hostRule,
+      ]);
     });
 
     it('returns the hostRule if using matchHost and token', () => {
       delete hostRule.password;
 
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toMatchObject([hostRule]);
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toMatchObject([
+        hostRule,
+      ]);
     });
 
     it('returns the hostRule if using baseUrl and password', () => {
       hostRule.matchHost = 'https://nuget.com';
 
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toMatchObject([hostRule]);
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toMatchObject([
+        hostRule,
+      ]);
     });
 
     it('returns the hostRule if using baseUrl and token', () => {
       hostRule.matchHost = 'https://nuget.com';
 
       add(hostRule);
-      expect(
-        findAllAuthenticatable({ hostType: 'nuget' } as any),
-      ).toMatchObject([hostRule]);
+      expect(findAllAuthenticatable({ hostType: 'nuget' })).toMatchObject([
+        hostRule,
+      ]);
     });
   });
 });

--- a/lib/modules/manager/cargo/artifacts.spec.ts
+++ b/lib/modules/manager/cargo/artifacts.spec.ts
@@ -1,7 +1,8 @@
+import type { Stats } from 'node:fs';
 import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { envMock, mockExecAll, mockExecSequence } from '~test/exec-util.ts';
-import { env, fs, git } from '~test/util.ts';
+import { env, fs, git, partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type { RepoGlobalConfig } from '../../../config/types.ts';
 import * as docker from '../../../util/exec/docker/index.ts';
@@ -71,7 +72,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('returns null if unchanged', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
     fs.readLocalFile.mockResolvedValueOnce('Current Cargo.lock');
     const execSnapshots = mockExecAll();
@@ -96,7 +97,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('returns updated Cargo.lock', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
@@ -120,7 +121,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('returns updated Cargo.lock with precise version update', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
@@ -253,7 +254,7 @@ describe('modules/manager/cargo/artifacts', () => {
       stderr: '',
       options: {},
     });
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll(execError);
@@ -432,7 +433,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('updates Cargo.lock based on the packageName, when given', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
@@ -462,7 +463,7 @@ describe('modules/manager/cargo/artifacts', () => {
     fs.statLocalFile.mockRejectedValueOnce(
       new Error('crates/Cargo.lock not found'),
     );
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
 
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
@@ -486,7 +487,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('returns updated Cargo.lock for lockfile maintenance', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
@@ -507,7 +508,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('supports docker mode', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
@@ -562,7 +563,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('supports docker mode with credentials', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
     hostRules.find.mockReturnValueOnce({
       token: 'some-token',
@@ -659,7 +660,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('supports docker mode with many credentials', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
     hostRules.find.mockReturnValueOnce({
       token: 'some-token',
@@ -747,7 +748,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('supports docker mode and ignores non git credentials', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
     hostRules.find.mockReturnValueOnce({
       token: 'some-token',
@@ -807,7 +808,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('supports docker mode with Cargo specific credential', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     GlobalConfig.set({ ...adminConfig, binarySource: 'docker' });
     hostRules.find.mockReturnValueOnce({
       token: 'some-token',
@@ -876,7 +877,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('supports install mode', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
     git.getFile.mockResolvedValueOnce('Old Cargo.lock');
     const execSnapshots = mockExecAll();
@@ -927,7 +928,7 @@ describe('modules/manager/cargo/artifacts', () => {
   });
 
   it('catches errors', async () => {
-    fs.statLocalFile.mockResolvedValueOnce({ name: 'Cargo.lock' } as any);
+    fs.statLocalFile.mockResolvedValueOnce(partial<Stats>());
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('Cargo.lock');
     fs.readLocalFile.mockResolvedValueOnce('Current Cargo.lock');
     fs.writeLocalFile.mockImplementationOnce(() => {

--- a/lib/modules/manager/index.spec.ts
+++ b/lib/modules/manager/index.spec.ts
@@ -117,11 +117,9 @@ describe('modules/manager/index', () => {
         supportedDatasources: [],
       });
       expect(
-        await manager.extractAllPackageFiles('unknown', {} as any, []),
+        await manager.extractAllPackageFiles('unknown', {}, []),
       ).toBeNull();
-      expect(
-        await manager.extractAllPackageFiles('dummy', {} as any, []),
-      ).toBeNull();
+      expect(await manager.extractAllPackageFiles('dummy', {}, [])).toBeNull();
     });
 
     it('returns non-null', async () => {
@@ -131,7 +129,7 @@ describe('modules/manager/index', () => {
         extractAllPackageFiles: () => Promise.resolve([]),
       });
       expect(
-        await manager.extractAllPackageFiles('dummy', {} as any, []),
+        await manager.extractAllPackageFiles('dummy', {}, []),
       ).not.toBeNull();
     });
 

--- a/lib/modules/manager/mise/backends.spec.ts
+++ b/lib/modules/manager/mise/backends.spec.ts
@@ -314,6 +314,7 @@ describe('modules/manager/mise/backends', () => {
 
     it('should ignore options unless tag_regex is provided', () => {
       expect(
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- deliberately passes an unrecognized option to verify it is ignored
         createUbiToolConfig('cli/cli', '2.64.0', { exe: 'gh' } as any),
       ).toStrictEqual({
         packageName: 'cli/cli',

--- a/lib/modules/platform/azure/azure-helper.spec.ts
+++ b/lib/modules/platform/azure/azure-helper.spec.ts
@@ -1,4 +1,6 @@
 import { Readable } from 'node:stream';
+import type { ICoreApi } from 'azure-devops-node-api/CoreApi.js';
+import type { IGitApi } from 'azure-devops-node-api/GitApi.js';
 import { GitPullRequestMergeStrategy } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
 import type { PolicyConfiguration } from 'azure-devops-node-api/interfaces/PolicyInterfaces.js';
 import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi.js';
@@ -21,33 +23,30 @@ describe('modules/platform/azure/azure-helper', () => {
 
   describe('getRef', () => {
     it('should get the ref with short ref name', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getRefs: vi.fn(() => [{ objectId: 132 }]),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getRefs: vi.fn().mockResolvedValue([{ objectId: 132 }]),
+        }),
       );
       const res = await azureHelper.getRefs('123', 'branch');
       expect(res).toMatchSnapshot();
     });
 
     it('should not get ref', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getRefs: vi.fn(() => []),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getRefs: vi.fn().mockResolvedValue([]),
+        }),
       );
       const res = await azureHelper.getRefs('123');
       expect(res).toHaveLength(0);
     });
 
     it('should get the ref with full ref name', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getRefs: vi.fn(() => [{ objectId: '132' }]),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getRefs: vi.fn().mockResolvedValue([{ objectId: '132' }]),
+        }),
       );
       const res = await azureHelper.getRefs('123', 'refs/head/branch1');
       expect(res).toMatchSnapshot();
@@ -56,11 +55,10 @@ describe('modules/platform/azure/azure-helper', () => {
 
   describe('getAzureBranchObj', () => {
     it('should get the branch object', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getRefs: vi.fn(() => [{ objectId: '132' }]),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getRefs: vi.fn().mockResolvedValue([{ objectId: '132' }]),
+        }),
       );
       const res = await azureHelper.getAzureBranchObj(
         '123',
@@ -71,11 +69,10 @@ describe('modules/platform/azure/azure-helper', () => {
     });
 
     it('should get the branch object when ref missing', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getRefs: vi.fn(() => []),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getRefs: vi.fn().mockResolvedValue([]),
+        }),
       );
       const res = await azureHelper.getAzureBranchObj('123', 'branchName');
       expect(res).toMatchSnapshot();
@@ -97,11 +94,10 @@ describe('modules/platform/azure/azure-helper', () => {
         },
       });
 
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItemText: vi.fn(() => mockEventStream),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItemText: vi.fn().mockResolvedValue(mockEventStream),
+        }),
       );
 
       const res = await azureHelper.getFile(
@@ -126,11 +122,10 @@ describe('modules/platform/azure/azure-helper', () => {
         },
       });
 
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItemText: vi.fn(() => mockEventStream),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItemText: vi.fn().mockResolvedValue(mockEventStream),
+        }),
       );
 
       const res = await azureHelper.getFile(
@@ -155,11 +150,10 @@ describe('modules/platform/azure/azure-helper', () => {
         },
       });
 
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItemText: vi.fn(() => mockEventStream),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItemText: vi.fn().mockResolvedValue(mockEventStream),
+        }),
       );
 
       const res = await azureHelper.getFile(
@@ -171,13 +165,12 @@ describe('modules/platform/azure/azure-helper', () => {
     });
 
     it('should return null because the file is not readable', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getItemText: vi.fn(() => ({
-              readable: false,
-            })),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getItemText: vi.fn().mockResolvedValue({
+            readable: false,
+          }),
+        }),
       );
 
       const res = await azureHelper.getFile(
@@ -191,13 +184,12 @@ describe('modules/platform/azure/azure-helper', () => {
 
   describe('getCommitDetails', () => {
     it('should get commit details', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getCommit: vi.fn(() => ({
-              parents: ['123456'],
-            })),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getCommit: vi.fn().mockResolvedValue({
+            parents: ['123456'],
+          }),
+        }),
       );
       const res = await azureHelper.getCommitDetails('123', '123456');
       expect(res).toMatchSnapshot();
@@ -206,11 +198,10 @@ describe('modules/platform/azure/azure-helper', () => {
 
   describe('getMergeMethod', () => {
     it('should default to NoFastForward', async () => {
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => []),
-          }) as any,
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([]),
+        }),
       );
       expect(await azureHelper.getMergeMethod('', '')).toEqual(
         GitPullRequestMergeStrategy.NoFastForward,
@@ -218,25 +209,24 @@ describe('modules/platform/azure/azure-helper', () => {
     });
 
     it('should return NoFastForward when policy explicitly set', async () => {
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => [
-              {
-                settings: {
-                  allowNoFastForward: true,
-                  scope: [
-                    {
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([
+            {
+              settings: {
+                allowNoFastForward: true,
+                scope: [
+                  {
+                    repositoryId: '',
+                  },
+                ],
               },
-            ]),
-          }) as any,
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+          ]),
+        }),
       );
       expect(await azureHelper.getMergeMethod('', '')).toEqual(
         GitPullRequestMergeStrategy.NoFastForward,
@@ -244,25 +234,24 @@ describe('modules/platform/azure/azure-helper', () => {
     });
 
     it('should return RebaseMerge', async () => {
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => [
-              {
-                settings: {
-                  allowRebaseMerge: true,
-                  scope: [
-                    {
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([
+            {
+              settings: {
+                allowRebaseMerge: true,
+                scope: [
+                  {
+                    repositoryId: '',
+                  },
+                ],
               },
-            ]),
-          }) as any,
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+          ]),
+        }),
       );
       expect(await azureHelper.getMergeMethod('', '')).toEqual(
         GitPullRequestMergeStrategy.RebaseMerge,
@@ -270,25 +259,24 @@ describe('modules/platform/azure/azure-helper', () => {
     });
 
     it('should return Squash', async () => {
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => [
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    repositoryId: '',
+                  },
+                ],
               },
-            ]),
-          }) as any,
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+          ]),
+        }),
       );
       expect(await azureHelper.getMergeMethod('', '')).toEqual(
         GitPullRequestMergeStrategy.Squash,
@@ -325,38 +313,37 @@ describe('modules/platform/azure/azure-helper', () => {
     });
 
     it('should return default branch policy', async () => {
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => [
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      repositoryId: 'doo-dee-doo-repository-id',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    repositoryId: 'doo-dee-doo-repository-id',
+                  },
+                ],
               },
-              {
-                settings: {
-                  allowRebase: true,
-                  scope: [
-                    {
-                      matchKind: 'DefaultBranch',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
               },
-            ]),
-          }) as any,
+            },
+            {
+              settings: {
+                allowRebase: true,
+                scope: [
+                  {
+                    matchKind: 'DefaultBranch',
+                  },
+                ],
+              },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+          ]),
+        }),
       );
       expect(await azureHelper.getMergeMethod('', '')).toEqual(
         GitPullRequestMergeStrategy.Rebase,
@@ -366,66 +353,65 @@ describe('modules/platform/azure/azure-helper', () => {
     it('should return most specific exact branch policy', async () => {
       const refMock = 'refs/heads/ding';
       const defaultBranchMock = 'dong';
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => [
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      repositoryId: 'doo-dee-doo-repository-id',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    repositoryId: 'doo-dee-doo-repository-id',
+                  },
+                ],
               },
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
               },
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      matchKind: 'DefaultBranch',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+            },
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    repositoryId: '',
+                  },
+                ],
               },
-              {
-                settings: {
-                  allowRebase: true,
-                  scope: [
-                    {
-                      matchKind: 'Exact',
-                      refName: refMock,
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
               },
-            ]),
-          }) as any,
+            },
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    matchKind: 'DefaultBranch',
+                  },
+                ],
+              },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+            {
+              settings: {
+                allowRebase: true,
+                scope: [
+                  {
+                    matchKind: 'Exact',
+                    refName: refMock,
+                    repositoryId: '',
+                  },
+                ],
+              },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+          ]),
+        }),
       );
       expect(
         await azureHelper.getMergeMethod('', '', refMock, defaultBranchMock),
@@ -435,53 +421,52 @@ describe('modules/platform/azure/azure-helper', () => {
     it('should return most specific prefix branch policy', async () => {
       const refMock = 'refs/heads/ding-wow';
       const defaultBranchMock = 'dong-wow';
-      azureApi.policyApi.mockImplementationOnce(
-        () =>
-          ({
-            getPolicyConfigurations: vi.fn(() => [
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+      azureApi.policyApi.mockResolvedValueOnce(
+        partial<IPolicyApi>({
+          getPolicyConfigurations: vi.fn().mockResolvedValue([
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    repositoryId: '',
+                  },
+                ],
               },
-              {
-                settings: {
-                  allowSquash: true,
-                  scope: [
-                    {
-                      matchKind: 'DefaultBranch',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
               },
-              {
-                settings: {
-                  allowRebase: true,
-                  scope: [
-                    {
-                      matchKind: 'Prefix',
-                      refName: 'refs/heads/ding',
-                      repositoryId: '',
-                    },
-                  ],
-                },
-                type: {
-                  id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
-                },
+            },
+            {
+              settings: {
+                allowSquash: true,
+                scope: [
+                  {
+                    matchKind: 'DefaultBranch',
+                  },
+                ],
               },
-            ]),
-          }) as any,
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+            {
+              settings: {
+                allowRebase: true,
+                scope: [
+                  {
+                    matchKind: 'Prefix',
+                    refName: 'refs/heads/ding',
+                    repositoryId: '',
+                  },
+                ],
+              },
+              type: {
+                id: 'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab',
+              },
+            },
+          ]),
+        }),
       );
       expect(
         await azureHelper.getMergeMethod('', '', refMock, defaultBranchMock),
@@ -498,14 +483,13 @@ describe('modules/platform/azure/azure-helper', () => {
         description: `team2 ${index + 1}`,
       }));
       const allTeams = team1.concat(team2);
-      azureApi.coreApi.mockImplementationOnce(
-        () =>
-          ({
-            getTeams: vi
-              .fn()
-              .mockResolvedValueOnce(team1)
-              .mockResolvedValueOnce(team2),
-          }) as any,
+      azureApi.coreApi.mockResolvedValueOnce(
+        partial<ICoreApi>({
+          getTeams: vi
+            .fn()
+            .mockResolvedValueOnce(team1)
+            .mockResolvedValueOnce(team2),
+        }),
       );
       const res = await azureHelper.getAllProjectTeams('projectId');
       expect(res).toEqual(allTeams);

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -1,5 +1,6 @@
 import { Readable } from 'node:stream';
 import { isString } from '@sindresorhus/is';
+import type { ICoreApi } from 'azure-devops-node-api/CoreApi.js';
 import type { IGitApi } from 'azure-devops-node-api/GitApi.js';
 import type {
   GitPullRequest,
@@ -69,32 +70,31 @@ describe('modules/platform/azure/index', () => {
   // do we need the args?
 
   function getRepos(_token: string, _endpoint: string) {
-    azureApi.gitApi.mockImplementationOnce(
-      () =>
-        ({
-          getRepositories: vi.fn(() => [
-            {
-              name: 'repo1',
-              project: {
-                name: 'prj1',
-              },
+    azureApi.gitApi.mockResolvedValueOnce(
+      partial<IGitApi>({
+        getRepositories: vi.fn().mockResolvedValue([
+          {
+            name: 'repo1',
+            project: {
+              name: 'prj1',
             },
-            {
-              name: 'repo2',
-              project: {
-                name: 'prj1',
-              },
-              isDisabled: false,
+          },
+          {
+            name: 'repo2',
+            project: {
+              name: 'prj1',
             },
-            {
-              name: 'repoDisabled',
-              project: {
-                name: 'prj1',
-              },
-              isDisabled: true,
+            isDisabled: false,
+          },
+          {
+            name: 'repoDisabled',
+            project: {
+              name: 'prj1',
             },
-          ]),
-        }) as any,
+            isDisabled: true,
+          },
+        ]),
+      }),
     );
     return azure.getRepos();
   }
@@ -234,24 +234,23 @@ describe('modules/platform/azure/index', () => {
 
   describe('findPr(branchName, prTitle, state, targetBranch)', () => {
     it('returns pr if found it open', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequests: vi
-              .fn()
-              .mockReturnValue([])
-              .mockReturnValueOnce([
-                {
-                  pullRequestId: 1,
-                  sourceRefName: 'refs/heads/branch-a',
-                  targetRefName: 'refs/heads/branch-b',
-                  title: 'branch a pr',
-                  status: PullRequestStatus.Active,
-                },
-              ]),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequests: vi
+            .fn()
+            .mockReturnValue([])
+            .mockReturnValueOnce([
+              {
+                pullRequestId: 1,
+                sourceRefName: 'refs/heads/branch-a',
+                targetRefName: 'refs/heads/branch-b',
+                title: 'branch a pr',
+                status: PullRequestStatus.Active,
+              },
+            ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
-          }) as any,
+          getPullRequestCommits: vi.fn().mockReturnValue([]),
+        }),
       );
       const res = await azure.findPr({
         branchName: 'branch-a',
@@ -276,24 +275,23 @@ describe('modules/platform/azure/index', () => {
     });
 
     it('returns pr if found not open', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequests: vi
-              .fn()
-              .mockReturnValue([])
-              .mockReturnValueOnce([
-                {
-                  pullRequestId: 1,
-                  sourceRefName: 'refs/heads/branch-a',
-                  targetRefName: 'refs/heads/branch-b',
-                  title: 'branch a pr',
-                  status: PullRequestStatus.Completed,
-                },
-              ]),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequests: vi
+            .fn()
+            .mockReturnValue([])
+            .mockReturnValueOnce([
+              {
+                pullRequestId: 1,
+                sourceRefName: 'refs/heads/branch-a',
+                targetRefName: 'refs/heads/branch-b',
+                title: 'branch a pr',
+                status: PullRequestStatus.Completed,
+              },
+            ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
-          }) as any,
+          getPullRequestCommits: vi.fn().mockReturnValue([]),
+        }),
       );
       const res = await azure.findPr({
         branchName: 'branch-a',
@@ -318,24 +316,23 @@ describe('modules/platform/azure/index', () => {
     });
 
     it('returns pr if found it close', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequests: vi
-              .fn()
-              .mockReturnValue([])
-              .mockReturnValueOnce([
-                {
-                  pullRequestId: 1,
-                  sourceRefName: 'refs/heads/branch-a',
-                  targetRefName: 'refs/heads/branch-b',
-                  title: 'branch a pr',
-                  status: PullRequestStatus.Abandoned,
-                },
-              ]),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequests: vi
+            .fn()
+            .mockReturnValue([])
+            .mockReturnValueOnce([
+              {
+                pullRequestId: 1,
+                sourceRefName: 'refs/heads/branch-a',
+                targetRefName: 'refs/heads/branch-b',
+                title: 'branch a pr',
+                status: PullRequestStatus.Abandoned,
+              },
+            ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
-          }) as any,
+          getPullRequestCommits: vi.fn().mockReturnValue([]),
+        }),
       );
       const res = await azure.findPr({
         branchName: 'branch-a',
@@ -360,24 +357,23 @@ describe('modules/platform/azure/index', () => {
     });
 
     it('returns pr if found it all state', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequests: vi
-              .fn()
-              .mockReturnValue([])
-              .mockReturnValueOnce([
-                {
-                  pullRequestId: 1,
-                  sourceRefName: 'refs/heads/branch-a',
-                  targetRefName: 'refs/heads/branch-b',
-                  title: 'branch a pr',
-                  status: PullRequestStatus.Abandoned,
-                },
-              ]),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequests: vi
+            .fn()
+            .mockReturnValue([])
+            .mockReturnValueOnce([
+              {
+                pullRequestId: 1,
+                sourceRefName: 'refs/heads/branch-a',
+                targetRefName: 'refs/heads/branch-b',
+                title: 'branch a pr',
+                status: PullRequestStatus.Abandoned,
+              },
+            ]),
 
-            getPullRequestCommits: vi.fn().mockReturnValue([]),
-          }) as any,
+          getPullRequestCommits: vi.fn().mockReturnValue([]),
+        }),
       );
       const res = await azure.findPr({
         branchName: 'branch-a',
@@ -512,11 +508,10 @@ describe('modules/platform/azure/index', () => {
 
   describe('getPrList()', () => {
     it('returns empty array', async () => {
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequests: vi.fn(() => []),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequests: vi.fn().mockResolvedValue([]),
+        }),
       );
       expect(await azure.getPrList()).toEqual([]);
     });
@@ -576,18 +571,19 @@ describe('modules/platform/azure/index', () => {
   describe('getBranchStatusCheck(branchName, context)', () => {
     it('should return green if status is succeeded', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Succeeded,
-                context: { genre: 'a-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Succeeded,
+              context: { genre: 'a-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -598,18 +594,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should return green if status is not applicable', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.NotApplicable,
-                context: { genre: 'a-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.NotApplicable,
+              context: { genre: 'a-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -620,18 +617,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should return red if status is failed', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Failed,
-                context: { genre: 'a-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Failed,
+              context: { genre: 'a-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -642,18 +640,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should return red if context status is error', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Error,
-                context: { genre: 'a-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Error,
+              context: { genre: 'a-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -664,18 +663,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should return yellow if status is pending', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Pending,
-                context: { genre: 'a-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Pending,
+              context: { genre: 'a-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -686,18 +686,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should return yellow if status is not set', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.NotSet,
-                context: { genre: 'a-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.NotSet,
+              context: { genre: 'a-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -730,18 +731,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should return null if status not found', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Pending,
-                context: { genre: 'another-genre', name: 'a-name' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Pending,
+              context: { genre: 'another-genre', name: 'a-name' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatusCheck(
         'somebranch',
@@ -754,18 +756,19 @@ describe('modules/platform/azure/index', () => {
   describe('getBranchStatus(branchName, ignoreTests)', () => {
     it('should pass through success', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Succeeded,
-                context: { genre: 'renovate' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Succeeded,
+              context: { genre: 'renovate' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatus('somebranch', true);
       expect(res).toBe('green');
@@ -773,18 +776,19 @@ describe('modules/platform/azure/index', () => {
 
     it('should not treat internal checks as success', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
 
-            getStatuses: vi.fn(() => [
-              {
-                state: GitStatusState.Succeeded,
-                context: { genre: 'renovate' },
-              },
-            ]),
-          }) as any,
+          getStatuses: vi.fn().mockResolvedValue([
+            {
+              state: GitStatusState.Succeeded,
+              context: { genre: 'renovate' },
+            },
+          ]),
+        }),
       );
       const res = await azure.getBranchStatus('somebranch', false);
       expect(res).toBe('yellow');
@@ -792,12 +796,15 @@ describe('modules/platform/azure/index', () => {
 
     it('should pass through failed', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: vi.fn(() => [{ state: GitStatusState.Error }]),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
+          getStatuses: vi
+            .fn()
+            .mockResolvedValue([{ state: GitStatusState.Error }]),
+        }),
       );
       const res = await azure.getBranchStatus('somebranch', true);
       expect(res).toBe('red');
@@ -805,12 +812,15 @@ describe('modules/platform/azure/index', () => {
 
     it('should pass through pending', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: vi.fn(() => [{ state: GitStatusState.Pending }]),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
+          getStatuses: vi
+            .fn()
+            .mockResolvedValue([{ state: GitStatusState.Pending }]),
+        }),
       );
       const res = await azure.getBranchStatus('somebranch', true);
       expect(res).toBe('yellow');
@@ -818,12 +828,13 @@ describe('modules/platform/azure/index', () => {
 
     it('should fall back to yellow if no statuses returned', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            getStatuses: vi.fn(() => []),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
+          getStatuses: vi.fn().mockResolvedValue([]),
+        }),
       );
       const res = await azure.getBranchStatus('somebranch', true);
       expect(res).toBe('yellow');
@@ -838,11 +849,10 @@ describe('modules/platform/azure/index', () => {
 
     it('should return null if no PR is returned from azure', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequests: vi.fn(() => []),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequests: vi.fn().mockResolvedValue([]),
+        }),
       );
       const pr = await azure.getPr(1234);
       expect(pr).toBeNull();
@@ -850,30 +860,29 @@ describe('modules/platform/azure/index', () => {
 
     it('should return a pr in the right format', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementation(
-        () =>
-          ({
-            getPullRequests: vi
-              .fn()
-              .mockReturnValue([])
-              .mockReturnValueOnce([
-                {
-                  pullRequestId: 1234,
-                },
-              ]),
-
-            getPullRequestLabels: vi
-              .fn()
-              .mockReturnValue([{ active: true, name: 'renovate' }]),
-
-            getPullRequestCommits: vi.fn().mockReturnValue([
+      azureApi.gitApi.mockResolvedValue(
+        partial<IGitApi>({
+          getPullRequests: vi
+            .fn()
+            .mockReturnValue([])
+            .mockReturnValueOnce([
               {
-                author: {
-                  name: 'renovate',
-                },
+                pullRequestId: 1234,
               },
             ]),
-          }) as any,
+
+          getPullRequestLabels: vi
+            .fn()
+            .mockReturnValue([{ active: true, name: 'renovate' }]),
+
+          getPullRequestCommits: vi.fn().mockReturnValue([
+            {
+              author: {
+                name: 'renovate',
+              },
+            },
+          ]),
+        }),
       );
       const pr = await azure.getPr(1234);
       expect(pr).toMatchSnapshot();
@@ -883,15 +892,14 @@ describe('modules/platform/azure/index', () => {
   describe('createPr()', () => {
     it('should create and return a PR object', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            createPullRequest: vi.fn(() => ({
-              pullRequestId: 456,
-            })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          createPullRequest: vi.fn().mockResolvedValue({
+            pullRequestId: 456,
+          }),
 
-            createPullRequestLabel: vi.fn(() => ({})),
-          }) as any,
+          createPullRequestLabel: vi.fn().mockResolvedValue({}),
+        }),
       );
       const pr = await azure.createPr({
         sourceBranch: 'some-branch',
@@ -905,15 +913,14 @@ describe('modules/platform/azure/index', () => {
 
     it('should create and return a PR object from base branch', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            createPullRequest: vi.fn(() => ({
-              pullRequestId: 456,
-            })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          createPullRequest: vi.fn().mockResolvedValue({
+            pullRequestId: 456,
+          }),
 
-            createPullRequestLabel: vi.fn(() => ({})),
-          }) as any,
+          createPullRequestLabel: vi.fn().mockResolvedValue({}),
+        }),
       );
       const pr = await azure.createPr({
         sourceBranch: 'some-branch',
@@ -1180,15 +1187,15 @@ describe('modules/platform/azure/index', () => {
         isRequired: false,
       };
       const updateFn = vi
-        .fn(() => prUpdateResult)
+        .fn()
+        .mockResolvedValue(prUpdateResult)
         .mockName('createPullRequestReviewer');
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            createPullRequest: vi.fn(() => prResult),
-            createPullRequestLabel: vi.fn(() => ({})),
-            createPullRequestReviewer: updateFn,
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          createPullRequest: vi.fn().mockResolvedValue(prResult),
+          createPullRequestLabel: vi.fn().mockResolvedValue({}),
+          createPullRequestReviewer: updateFn,
+        }),
       );
       const pr = await azure.createPr({
         sourceBranch: 'some-branch',
@@ -1206,12 +1213,11 @@ describe('modules/platform/azure/index', () => {
   describe('updatePr(prNo, title, body, platformPrOptions)', () => {
     it('should update the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            updatePullRequest,
-          }) as any,
+      const updatePullRequest = vi.fn().mockResolvedValue({});
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          updatePullRequest,
+        }),
       );
       await azure.updatePr({
         number: 1234,
@@ -1224,22 +1230,21 @@ describe('modules/platform/azure/index', () => {
 
     it('should update the PR including cache', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementation(
-        () =>
-          ({
-            createPullRequest: vi.fn(() => ({
-              pullRequestId: 456,
-              title: 'Title 1',
-            })),
+      azureApi.gitApi.mockResolvedValue(
+        partial<IGitApi>({
+          createPullRequest: vi.fn().mockResolvedValue({
+            pullRequestId: 456,
+            title: 'Title 1',
+          }),
 
-            createPullRequestLabel: vi.fn(() => ({})),
-            getPullRequests: vi.fn(() => []),
+          createPullRequestLabel: vi.fn().mockResolvedValue({}),
+          getPullRequests: vi.fn().mockResolvedValue([]),
 
-            updatePullRequest: vi.fn(() => ({
-              pullRequestId: 456,
-              title: 'Title 2',
-            })),
-          }) as any,
+          updatePullRequest: vi.fn().mockResolvedValue({
+            pullRequestId: 456,
+            title: 'Title 2',
+          }),
+        }),
       );
       expect(await azure.getPrList()).toEqual([]);
       const createdPr = await azure.createPr({
@@ -1262,12 +1267,11 @@ describe('modules/platform/azure/index', () => {
 
     it('should update the PR without description', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            updatePullRequest,
-          }) as any,
+      const updatePullRequest = vi.fn().mockResolvedValue({});
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          updatePullRequest,
+        }),
       );
       await azure.updatePr({
         number: 1234,
@@ -1278,12 +1282,11 @@ describe('modules/platform/azure/index', () => {
 
     it('should close the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            updatePullRequest,
-          }) as any,
+      const updatePullRequest = vi.fn().mockResolvedValue({});
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          updatePullRequest,
+        }),
       );
       await azure.updatePr({
         number: 1234,
@@ -1296,12 +1299,11 @@ describe('modules/platform/azure/index', () => {
 
     it('should reopen the PR', async () => {
       await initRepo({ repository: 'some/repo' });
-      const updatePullRequest = vi.fn(() => ({}));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            updatePullRequest,
-          }) as any,
+      const updatePullRequest = vi.fn().mockResolvedValue({});
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          updatePullRequest,
+        }),
       );
       await azure.updatePr({
         number: 1234,
@@ -1327,18 +1329,17 @@ describe('modules/platform/azure/index', () => {
         isFlagged: false,
         isRequired: false,
       };
-      const updateFn = vi.fn(() => prUpdateResult);
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            updatePullRequest: vi.fn(() => prResult),
-            createPullRequestReviewer: updateFn,
+      const updateFn = vi.fn().mockResolvedValue(prUpdateResult);
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          updatePullRequest: vi.fn().mockResolvedValue(prResult),
+          createPullRequestReviewer: updateFn,
 
-            getPullRequestById: vi.fn(() => ({
-              pullRequestId: prResult.pullRequestId,
-              createdBy: prResult.createdBy,
-            })),
-          }) as any,
+          getPullRequestById: vi.fn().mockResolvedValue({
+            pullRequestId: prResult.pullRequestId,
+            createdBy: prResult.createdBy,
+          }),
+        }),
       );
       const pr = await azure.updatePr({
         number: prResult.pullRequestId,
@@ -1563,21 +1564,23 @@ describe('modules/platform/azure/index', () => {
   describe('Assignees', () => {
     it('addAssignees', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementation(
-        () =>
-          ({
-            getRepositories: vi.fn(() => [{ id: '1', project: { id: 2 } }]),
-            createThread: vi.fn(() => [{ id: 123 }]),
-            getThreads: vi.fn(() => []),
-          }) as any,
+      azureApi.gitApi.mockResolvedValue(
+        partial<IGitApi>({
+          getRepositories: vi
+            .fn()
+            .mockResolvedValue([{ id: '1', project: { id: 2 } }]),
+          createThread: vi.fn().mockResolvedValue([{ id: 123 }]),
+          getThreads: vi.fn().mockResolvedValue([]),
+        }),
       );
-      azureApi.coreApi.mockImplementation(
-        () =>
-          ({
-            getTeamMembersWithExtendedProperties: vi.fn(() => [
+      azureApi.coreApi.mockResolvedValue(
+        partial<ICoreApi>({
+          getTeamMembersWithExtendedProperties: vi
+            .fn()
+            .mockResolvedValue([
               { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
             ]),
-          }) as any,
+        }),
       );
       azureHelper.getAllProjectTeams = vi.fn().mockReturnValue([
         { id: 3, name: 'abc' },
@@ -1591,20 +1594,22 @@ describe('modules/platform/azure/index', () => {
   describe('Reviewers', () => {
     it('addReviewers one valid', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementation(
-        () =>
-          ({
-            getRepositories: vi.fn(() => [{ id: '1', project: { id: 2 } }]),
-            createPullRequestReviewer: vi.fn(),
-          }) as any,
+      azureApi.gitApi.mockResolvedValue(
+        partial<IGitApi>({
+          getRepositories: vi
+            .fn()
+            .mockResolvedValue([{ id: '1', project: { id: 2 } }]),
+          createPullRequestReviewer: vi.fn(),
+        }),
       );
-      azureApi.coreApi.mockImplementation(
-        () =>
-          ({
-            getTeamMembersWithExtendedProperties: vi.fn(() => [
+      azureApi.coreApi.mockResolvedValue(
+        partial<ICoreApi>({
+          getTeamMembersWithExtendedProperties: vi
+            .fn()
+            .mockResolvedValue([
               { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
             ]),
-          }) as any,
+        }),
       );
       azureHelper.getAllProjectTeams = vi.fn().mockReturnValue([
         { id: 3, name: 'abc' },
@@ -1617,20 +1622,22 @@ describe('modules/platform/azure/index', () => {
 
     it('addReviewers all valid', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementation(
-        () =>
-          ({
-            getRepositories: vi.fn(() => [{ id: '1', project: { id: 2 } }]),
-            createPullRequestReviewer: vi.fn(),
-          }) as any,
+      azureApi.gitApi.mockResolvedValue(
+        partial<IGitApi>({
+          getRepositories: vi
+            .fn()
+            .mockResolvedValue([{ id: '1', project: { id: 2 } }]),
+          createPullRequestReviewer: vi.fn(),
+        }),
       );
-      azureApi.coreApi.mockImplementation(
-        () =>
-          ({
-            getTeamMembersWithExtendedProperties: vi.fn(() => [
+      azureApi.coreApi.mockResolvedValue(
+        partial<ICoreApi>({
+          getTeamMembersWithExtendedProperties: vi
+            .fn()
+            .mockResolvedValue([
               { identity: { displayName: 'jyc', uniqueName: 'jyc', id: 123 } },
             ]),
-          }) as any,
+        }),
       );
       azureHelper.getAllProjectTeams = vi.fn().mockReturnValue([
         { id: 3, name: 'abc' },
@@ -1679,12 +1686,13 @@ describe('modules/platform/azure/index', () => {
     it('should build and call the create status api properly', async () => {
       await initRepo({ repository: 'some/repo' });
       const createCommitStatusMock = vi.fn();
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            createCommitStatus: createCommitStatusMock,
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
+          createCommitStatus: createCommitStatusMock,
+        }),
       );
       await azure.setBranchStatus({
         branchName: 'test',
@@ -1711,12 +1719,13 @@ describe('modules/platform/azure/index', () => {
     it('should build and call the create status api properly with a complex context', async () => {
       await initRepo({ repository: 'some/repo' });
       const createCommitStatusMock = vi.fn();
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getBranch: vi.fn(() => ({ commit: { commitId: 'abcd1234' } })),
-            createCommitStatus: createCommitStatusMock,
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getBranch: vi
+            .fn()
+            .mockResolvedValue({ commit: { commitId: 'abcd1234' } }),
+          createCommitStatus: createCommitStatusMock,
+        }),
       );
       await azure.setBranchStatus({
         branchName: 'test',
@@ -1747,20 +1756,19 @@ describe('modules/platform/azure/index', () => {
       const pullRequestIdMock = 12345;
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-      const updatePullRequestMock = vi.fn(() => ({
+      const updatePullRequestMock = vi.fn().mockResolvedValue({
         status: 3,
-      }));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequestById: vi.fn(() => ({
-              lastMergeSourceCommit: lastMergeSourceCommitMock,
-              targetRefName: 'refs/heads/ding',
-              title: 'title',
-            })),
+      });
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: vi.fn().mockResolvedValue({
+            lastMergeSourceCommit: lastMergeSourceCommitMock,
+            targetRefName: 'refs/heads/ding',
+            title: 'title',
+          }),
 
-            updatePullRequest: updatePullRequestMock,
-          }) as any,
+          updatePullRequest: updatePullRequestMock,
+        }),
       );
 
       azureHelper.getMergeMethod = vi
@@ -1803,20 +1811,19 @@ describe('modules/platform/azure/index', () => {
         const pullRequestIdMock = 12345;
         const branchNameMock = 'test';
         const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-        const updatePullRequestMock = vi.fn(() => ({
+        const updatePullRequestMock = vi.fn().mockResolvedValue({
           status: 3,
-        }));
-        azureApi.gitApi.mockImplementationOnce(
-          () =>
-            ({
-              getPullRequestById: vi.fn(() => ({
-                lastMergeSourceCommit: lastMergeSourceCommitMock,
-                targetRefName: 'refs/heads/ding',
-                title: 'title',
-              })),
+        });
+        azureApi.gitApi.mockResolvedValueOnce(
+          partial<IGitApi>({
+            getPullRequestById: vi.fn().mockResolvedValue({
+              lastMergeSourceCommit: lastMergeSourceCommitMock,
+              targetRefName: 'refs/heads/ding',
+              title: 'title',
+            }),
 
-              updatePullRequest: updatePullRequestMock,
-            }) as any,
+            updatePullRequest: updatePullRequestMock,
+          }),
         );
 
         azureHelper.getMergeMethod = vi.fn().mockReturnValue(prMergeStrategy);
@@ -1849,17 +1856,16 @@ describe('modules/platform/azure/index', () => {
       const pullRequestIdMock = 12345;
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequestById: vi.fn(() => ({
-              lastMergeSourceCommit: lastMergeSourceCommitMock,
-            })),
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: vi.fn().mockResolvedValue({
+            lastMergeSourceCommit: lastMergeSourceCommitMock,
+          }),
 
-            updatePullRequest: vi
-              .fn()
-              .mockRejectedValue(new Error(`oh no pr couldn't be updated`)),
-          }) as any,
+          updatePullRequest: vi
+            .fn()
+            .mockRejectedValue(new Error(`oh no pr couldn't be updated`)),
+        }),
       );
 
       azureHelper.getMergeMethod = vi
@@ -1875,16 +1881,15 @@ describe('modules/platform/azure/index', () => {
 
     it('should cache the mergeMethod for subsequent merges', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementation(
-        () =>
-          ({
-            getPullRequestById: vi.fn(() => ({
-              lastMergeSourceCommit: { commitId: 'abcd1234' },
-              targetRefName: 'refs/heads/ding',
-            })),
+      azureApi.gitApi.mockResolvedValue(
+        partial<IGitApi>({
+          getPullRequestById: vi.fn().mockResolvedValue({
+            lastMergeSourceCommit: { commitId: 'abcd1234' },
+            targetRefName: 'refs/heads/ding',
+          }),
 
-            updatePullRequest: vi.fn(),
-          }) as any,
+          updatePullRequest: vi.fn(),
+        }),
       );
       azureHelper.getMergeMethod = vi
         .fn()
@@ -1909,20 +1914,19 @@ describe('modules/platform/azure/index', () => {
       const pullRequestIdMock = 12345;
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
-      const getPullRequestByIdMock = vi.fn(() => ({
+      const getPullRequestByIdMock = vi.fn().mockResolvedValue({
         lastMergeSourceCommit: lastMergeSourceCommitMock,
         targetRefName: 'refs/heads/ding',
         status: 3,
-      }));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequestById: getPullRequestByIdMock,
+      });
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: getPullRequestByIdMock,
 
-            updatePullRequest: vi.fn(() => ({
-              status: 1,
-            })),
-          }) as any,
+          updatePullRequest: vi.fn().mockResolvedValue({
+            status: 1,
+          }),
+        }),
       );
       azureHelper.getMergeMethod = vi
         .fn()
@@ -1942,20 +1946,19 @@ describe('modules/platform/azure/index', () => {
       const branchNameMock = 'test';
       const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
       const expectedNumRetries = 5;
-      const getPullRequestByIdMock = vi.fn(() => ({
+      const getPullRequestByIdMock = vi.fn().mockResolvedValue({
         lastMergeSourceCommit: lastMergeSourceCommitMock,
         targetRefName: 'refs/heads/ding',
         status: 1,
-      }));
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            getPullRequestById: getPullRequestByIdMock,
+      });
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: getPullRequestByIdMock,
 
-            updatePullRequest: vi.fn(() => ({
-              status: 1,
-            })),
-          }) as any,
+          updatePullRequest: vi.fn().mockResolvedValue({
+            status: 1,
+          }),
+        }),
       );
       azureHelper.getMergeMethod = vi
         .fn()
@@ -1975,11 +1978,10 @@ describe('modules/platform/azure/index', () => {
   describe('deleteLabel()', () => {
     it('Should delete a label', async () => {
       await initRepo({ repository: 'some/repo' });
-      azureApi.gitApi.mockImplementationOnce(
-        () =>
-          ({
-            deletePullRequestLabels: vi.fn(),
-          }) as any,
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          deletePullRequestLabels: vi.fn(),
+        }),
       );
       await azure.deleteLabel(1234, 'rebase');
       expect(azureApi.gitApi.mock.calls).toMatchSnapshot();
@@ -2127,17 +2129,16 @@ describe('modules/platform/azure/index', () => {
       },
     );
 
-    azureApi.gitApi.mockImplementationOnce(
-      () =>
-        ({
-          getItem: getItemMock,
+    azureApi.gitApi.mockResolvedValueOnce(
+      partial<IGitApi>({
+        getItem: getItemMock as IGitApi['getItem'],
 
-          getRepositories: vi
-            .fn()
-            .mockResolvedValue([
-              { id: '123456', name: 'repo', project: { name: 'some' } },
-            ]),
-        }) as any,
+        getRepositories: vi
+          .fn()
+          .mockResolvedValue([
+            { id: '123456', name: 'repo', project: { name: 'some' } },
+          ]),
+      }),
     );
     const result = await azure.getJsonFile(
       'file.json',

--- a/lib/modules/platform/azure/util.spec.ts
+++ b/lib/modules/platform/azure/util.spec.ts
@@ -1,4 +1,6 @@
 import { Readable } from 'node:stream';
+import type { GitPullRequest } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
+import { partial } from '~test/util.ts';
 import { streamToString } from '../../../util/streams.ts';
 import {
   getBranchNameWithoutRefsheadsPrefix,
@@ -90,17 +92,17 @@ describe('modules/platform/azure/util', () => {
 
   describe('getRenovatePRFormat', () => {
     it('should be formated (closed)', () => {
-      const res = getRenovatePRFormat({ status: 2 } as any);
+      const res = getRenovatePRFormat(partial<GitPullRequest>({ status: 2 }));
       expect(res).toMatchSnapshot();
     });
 
     it('should be formated (closed v2)', () => {
-      const res = getRenovatePRFormat({ status: 3 } as any);
+      const res = getRenovatePRFormat(partial<GitPullRequest>({ status: 3 }));
       expect(res).toMatchSnapshot();
     });
 
     it('should be formated (not closed)', () => {
-      const res = getRenovatePRFormat({ status: 1 } as any);
+      const res = getRenovatePRFormat(partial<GitPullRequest>({ status: 1 }));
       expect(res).toMatchSnapshot();
     });
   });

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -76,7 +76,7 @@ describe('modules/platform/gitlab/index', () => {
 
   describe('initPlatform()', () => {
     it('should throw if no token', async () => {
-      await expect(gitlab.initPlatform({} as any)).rejects.toThrow(
+      await expect(gitlab.initPlatform({})).rejects.toThrow(
         'Init: You must configure a GitLab personal access token',
       );
     });

--- a/lib/modules/platform/local/scm.spec.ts
+++ b/lib/modules/platform/local/scm.spec.ts
@@ -1,6 +1,7 @@
 import { partial } from '~test/util.ts';
 import { rawExec as _rawExec } from '../../../util/exec/common.ts';
 import type { ExecResult } from '../../../util/exec/types.ts';
+import type { CommitFilesConfig } from '../../../util/git/types.ts';
 import { LocalFs } from './scm.ts';
 
 vi.mock('glob', () => ({
@@ -46,7 +47,9 @@ describe('modules/platform/local/scm', () => {
     });
 
     it('commitAndPush', async () => {
-      expect(await localFs.commitAndPush({} as any)).toBeNull();
+      expect(
+        await localFs.commitAndPush(partial<CommitFilesConfig>()),
+      ).toBeNull();
     });
 
     it('checkoutBranch', async () => {

--- a/lib/modules/platform/types.spec.ts
+++ b/lib/modules/platform/types.spec.ts
@@ -1,3 +1,4 @@
+import { partial } from '~test/util.ts';
 import type { RepoGlobalConfig } from '../../config/types.ts';
 import type { RepoParams } from './types.ts';
 
@@ -6,12 +7,10 @@ describe('modules/platform/types', () => {
     type RequiredRepoGlobalConfig = Required<RepoGlobalConfig>;
     type RequiredRepoParams = Required<RepoParams>;
 
-    const globalConfig: Omit<
-      RequiredRepoGlobalConfig,
-      keyof RequiredRepoParams
-    > = {} as any;
-    const repoConfig: Omit<RequiredRepoParams, keyof RequiredRepoGlobalConfig> =
-      {} as any;
+    const globalConfig =
+      partial<Omit<RequiredRepoGlobalConfig, keyof RequiredRepoParams>>();
+    const repoConfig =
+      partial<Omit<RequiredRepoParams, keyof RequiredRepoGlobalConfig>>();
 
     expectTypeOf(globalConfig).toEqualTypeOf<RequiredRepoGlobalConfig>();
     expectTypeOf(repoConfig).toEqualTypeOf<RequiredRepoParams>();

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -914,7 +914,7 @@ describe('util/exec/index', () => {
       inOpts,
       outCmd: outCommand,
       outOpts,
-      adminConfig = {} as any,
+      adminConfig = {},
       hermitEnvs,
     } = testOpts;
 
@@ -929,7 +929,7 @@ describe('util/exec/index', () => {
       return Promise.resolve({ stdout: '', stderr: '' });
     });
     GlobalConfig.set({ ...globalConfig, localDir: cwd, ...adminConfig });
-    setCustomEnv(adminConfig.customEnvVariables);
+    setCustomEnv(adminConfig.customEnvVariables ?? {});
     if (hermitEnvs !== undefined) {
       getHermitEnvsMock.mockResolvedValue(hermitEnvs);
     }

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -115,6 +115,7 @@ describe('util/host-rules', () => {
     });
 
     it('warns and returns empty for bad search', () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid search input
       expect(find({ abc: 'def' } as any)).toEqual({});
     });
 
@@ -397,6 +398,7 @@ describe('util/host-rules', () => {
 
   describe('findAll()', () => {
     it('warns and returns empty for bad search', () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid search input
       expect(findAll({ abc: 'def' } as any)).toEqual([]);
     });
 

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -577,7 +577,9 @@ describe('workers/repository/update/branch/index', () => {
       scm.branchExists.mockResolvedValue(true);
       scm.isBranchModified.mockResolvedValueOnce(true);
       scm.getBranchCommit.mockResolvedValue('123test' as LongCommitSha);
-      platform.findPr.mockResolvedValueOnce({ sha: '123test' } as any);
+      platform.findPr.mockResolvedValueOnce(
+        partial<Pr>({ sha: '123test' as LongCommitSha }),
+      );
       const res = await branchWorker.processBranch(config);
       expect(res).toEqual({
         branchExists: true,
@@ -590,7 +592,9 @@ describe('workers/repository/update/branch/index', () => {
     it('skips branch if branch edited and and PR found with sha mismatch', async () => {
       scm.branchExists.mockResolvedValue(true);
       scm.isBranchModified.mockResolvedValueOnce(true);
-      platform.findPr.mockResolvedValueOnce({ sha: 'def456' } as any);
+      platform.findPr.mockResolvedValueOnce(
+        partial<Pr>({ sha: 'def456' as LongCommitSha }),
+      );
       const res = await branchWorker.processBranch(config);
       expect(res).toEqual({
         branchExists: true,
@@ -3247,7 +3251,9 @@ describe('workers/repository/update/branch/index', () => {
       scm.branchExists.mockResolvedValueOnce(true);
       scm.isBranchModified.mockResolvedValueOnce(true);
       scm.getBranchCommit.mockResolvedValueOnce('123test' as LongCommitSha);
-      platform.findPr.mockResolvedValueOnce({ sha: '123test' } as any);
+      platform.findPr.mockResolvedValueOnce(
+        partial<Pr>({ sha: '123test' as LongCommitSha }),
+      );
       const res = await branchWorker.processBranch(config);
       expect(automerge.tryBranchAutomerge).not.toHaveBeenCalled();
       expect(prAutomerge.checkAutoMerge).not.toHaveBeenCalled();

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -7,6 +7,7 @@ import noRedundantMockReset from './rules/no-redundant-mock-reset.js';
 import noStatefulGlobalRegex from './rules/no-stateful-global-regex.js';
 import noToolsImport from './rules/no-tools-import.js';
 import preferNullishUtil from './rules/prefer-nullish-util.js';
+import preferPartialInSpecs from './rules/prefer-partial-in-specs.js';
 import testRootDescribe from './rules/test-root-describe.js';
 import zodSchemaNaming from './rules/zod-schema-naming.js';
 
@@ -24,6 +25,7 @@ export default {
     'no-stateful-global-regex': noStatefulGlobalRegex,
     'no-tools-import': noToolsImport,
     'prefer-nullish-util': preferNullishUtil,
+    'prefer-partial-in-specs': preferPartialInSpecs,
     'test-root-describe': testRootDescribe,
     'zod-schema-naming': zodSchemaNaming,
   },

--- a/tools/lint/rules/prefer-partial-in-specs.js
+++ b/tools/lint/rules/prefer-partial-in-specs.js
@@ -1,0 +1,37 @@
+/**
+ * Minimal shapes of the TypeScript AST nodes inspected by this rule. oxc emits
+ * a typescript-eslint-compatible AST, but these nodes are absent from ESLint's
+ * estree typings and oxlint does not export its own node types, so the fields
+ * this rule reads are described here.
+ *
+ * @typedef {{ type: string }} TSType
+ * @typedef {{ type: string, expression: { type: string }, typeAnnotation: TSType }} TSAsExpression
+ */
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    messages: {
+      preferPartial:
+        'Casting an object literal to `any` bypasses the type system; use `partial<T>()` from `test/util` (or a properly typed value) instead.',
+    },
+  },
+  create(context) {
+    return {
+      /** @param {unknown} node */
+      TSAsExpression(node) {
+        const asExpr = /** @type {TSAsExpression} */ (node);
+        if (
+          asExpr.expression.type === 'ObjectExpression' &&
+          asExpr.typeAnnotation.type === 'TSAnyKeyword'
+        ) {
+          context.report({
+            node: /** @type {import('estree').Node} */ (node),
+            messageId: 'preferPartial',
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds a custom rule preventing `as any` for objects in test files and suggest usage of the `partial` helper. 

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: https://github.com/renovatebot/renovate/issues/44646
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
