### PR TITLE
feat(github-actions): support `jdx/mise-action` version input

### DIFF
--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -167,6 +167,10 @@ export const communityActions: Record<string, CommunityActionConfig> = {
     packageName: '', // determined from `repo` input
     withSchema: InstallBinaryWith,
   },
+  'jdx/mise-action': {
+    datasource: GithubReleasesDatasource.id,
+    packageName: 'jdx/mise',
+  },
   'oven-sh/setup-bun': {
     datasource: NpmDatasource.id,
     packageName: 'bun',

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1170,6 +1170,36 @@ describe('modules/manager/github-actions/extract', () => {
       ]);
     });
 
+    it('extracts the mise version from jdx/mise-action', () => {
+      const yamlContent = codeBlock`
+        jobs:
+          build:
+            steps:
+              - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+                with:
+                  version: 2026.7.10
+                  install_args: cargo:cargo-deny
+        `;
+
+      const res = extractPackageFile(yamlContent, 'workflow.yml');
+      expect(res?.deps).toMatchObject([
+        {
+          currentDigest: 'e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d',
+          currentValue: 'v4.2.0',
+          datasource: 'github-tags',
+          depName: 'jdx/mise-action',
+          depType: 'action',
+        },
+        {
+          currentValue: '2026.7.10',
+          datasource: 'github-releases',
+          depName: 'jdx/mise',
+          depType: 'uses-with',
+          packageName: 'jdx/mise',
+        },
+      ]);
+    });
+
     it('extracts steps nested in nested parallel blocks', () => {
       const yamlContent = codeBlock`
         jobs:


### PR DESCRIPTION
## Changes

This adds native extraction of the `version` input from [`jdx/mise-action`](https://github.com/jdx/mise-action) as a `github-releases` dependency on [`jdx/mise`](https://github.com/jdx/mise).

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
