### PR TITLE
test(git): disable git maintenance to prevent test flakiness

### DIFF
--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -46,6 +46,15 @@ const SimpleGit = simpleGit().constructor as {
   prototype: ReturnType<typeof simpleGit>;
 };
 
+// Avoids flakiness when cleaning up temp directories
+async function disableGitAutoMaintenance(
+  repo: ReturnType<typeof simpleGit>,
+): Promise<void> {
+  await repo.addConfig('gc.auto', '0');
+  await repo.addConfig('maintenance.auto', 'false');
+  await repo.addConfig('receive.autogc', 'false');
+}
+
 describe('util/git/index', { timeout: 30000 }, () => {
   const masterCommitDate = new Date();
   masterCommitDate.setMilliseconds(0);
@@ -57,6 +66,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     base = await tmp.dir({ unsafeCleanup: true });
     const repo = simpleGit(base.path);
     await repo.init();
+    await disableGitAutoMaintenance(repo);
     defaultBranch = (await repo.raw('branch', '--show-current')).trim();
     await repo.addConfig('user.email', 'Jest@example.com');
     await repo.addConfig('user.name', 'Jest');
@@ -140,6 +150,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     origin = await tmp.dir({ unsafeCleanup: true });
     const repo = simpleGit(origin.path);
     await repo.clone(base.path, '.', ['--bare']);
+    await disableGitAutoMaintenance(repo);
     await repo.addConfig('commit.gpgsign', 'false');
     tmpDir = await tmp.dir({ unsafeCleanup: true });
     GlobalConfig.set({ localDir: tmpDir.path });
@@ -247,6 +258,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
         await fs.mkdir(submoduleBasePath);
         const submodule = simpleGit(submoduleBasePath);
         await submodule.init();
+        await disableGitAutoMaintenance(submodule);
         await submodule.addConfig('user.email', 'Jest@example.com');
         await submodule.addConfig('user.name', 'Jest');
         await submodule.addConfig('commit.gpgsign', 'false');
@@ -1897,6 +1909,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       upstreamBase = await tmp.dir({ unsafeCleanup: true });
       const upstream = simpleGit(upstreamBase.path);
       await upstream.init();
+      await disableGitAutoMaintenance(upstream);
       const defaultUpsBranch = (
         await upstream.raw('branch', '--show-current')
       ).trim();
@@ -1913,6 +1926,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       upstreamOrigin = await tmp.dir({ unsafeCleanup: true });
       const upstreamRepo = simpleGit(upstreamOrigin.path);
       await upstreamRepo.clone(upstreamBase.path, '.', ['--bare']);
+      await disableGitAutoMaintenance(upstreamRepo);
       await upstreamRepo.addConfig('commit.gpgsign', 'false');
     });
 


### PR DESCRIPTION
## Changes

Disables `gc.auto`, `maintenance.auto`, and `receive.autogc` on the git repos created in `lib/util/git/index.spec.ts`. Background gc/maintenance can still be writing objects/pack in a test's tmp dir when `tmp`'s `unsafeCleanup` removes it, causing an intermittent `ENOTEMPTY` failure when Vitest tears down (as seen at https://github.com/renovatebot/renovate/pull/44589#issuecomment-5003423929).

Set via `addConfig` (persisted in the repo config) rather than simple-git's global `-c`, since `-c` doesn't reach the `receive-pack` process spawned for a push.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Claude Sonnet 5 to draft and iterate on the fix.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
