### PR TITLE
fix(docker): include `global` and `inherited` JSON schemas

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,4 +6,6 @@
 !pnpm-workspace.yaml
 !patches/
 !renovate-schema.json
+!renovate-inherited-schema.json
+!renovate-global-schema.json
 !license

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,6 @@
 !pnpm-workspace.yaml
 !patches/
 !renovate-schema.json
-!renovate-inherited-schema.json
 !renovate-global-schema.json
+!renovate-inherited-schema.json
 !license


### PR DESCRIPTION
## Changes

The `renovate-schema.json` is already part of the Docker image, but `renovate-inherited-schema.json` and `renovate-global-schema.json` are not.

I'm not sure why (probably a miss), but this adds them to the Docker image as well.

I use such schemas to validate my global config, and normally fetch them through the docker image like:

```console
docker run --rm my.company.com/my/renovate:43.240.0 cat /usr/local/renovate/renovate-global-schema.json
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Grok Build to prepare the branch, edit, and draft this PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository