### PR TITLE
feat(report): surface additional repository metadata in report

### DIFF
--- a/lib/instrumentation/reporting.spec.ts
+++ b/lib/instrumentation/reporting.spec.ts
@@ -142,6 +142,20 @@ describe('instrumentation/reporting', () => {
     ).toBeNull();
   });
 
+  it('omits configFileName when the repo has no in-repo config file', () => {
+    const config: RenovateConfig = {
+      repository: 'myOrg/myRepo',
+      reportType: 'logging',
+      defaultBranch: 'main',
+    };
+
+    addRepositoryMetadata(config, '');
+
+    expect(getReport().repositories['myOrg/myRepo']).not.toHaveProperty(
+      'configFileName',
+    );
+  });
+
   it('adds onboarding status with an open onboarding PR', () => {
     GlobalConfig.set({ onboardingBranch: 'renovate/configure' });
     const config: RenovateConfig = {

--- a/lib/instrumentation/reporting.spec.ts
+++ b/lib/instrumentation/reporting.spec.ts
@@ -1,14 +1,18 @@
 import type { S3Client } from '@aws-sdk/client-s3';
 import { mock, mockDeep } from 'vitest-mock-extended';
 import { s3 } from '~test/s3.ts';
-import { fs, logger } from '~test/util.ts';
+import { fs, logger, partial } from '~test/util.ts';
+import { GlobalConfig } from '../config/global.ts';
 import type { RenovateConfig } from '../config/types.ts';
 import type { PackageFile } from '../modules/manager/types.ts';
+import type { Pr } from '../modules/platform/index.ts';
 import type { BranchCache } from '../util/cache/repository/types.ts';
 import {
   addBranchStats,
   addExtractionStats,
   addLibYears,
+  addOnboardingStatus,
+  addRepositoryMetadata,
   exportStats,
   finalizeReport,
   getReport,
@@ -23,6 +27,7 @@ vi.mock('../logger/index.ts', () => mockDeep());
 describe('instrumentation/reporting', () => {
   beforeEach(() => {
     resetReport();
+    GlobalConfig.reset();
   });
 
   const branchInformation: Partial<BranchCache>[] = [
@@ -83,11 +88,110 @@ describe('instrumentation/reporting', () => {
       libYears: { managers: {}, total: 0 },
       dependencyStatus: { outdated: 0, total: 0 },
     });
+    addRepositoryMetadata(config, 'renovate.json');
+    addOnboardingStatus(config, []);
 
     expect(getReport()).toEqual({
       problems: [],
       repositories: {},
     });
+  });
+
+  it('adds repository metadata to the report', () => {
+    GlobalConfig.set({
+      platform: 'github',
+      endpoint: 'https://api.github.com/',
+    });
+    const config: RenovateConfig = {
+      repository: 'myOrg/myRepo',
+      reportType: 'logging',
+      defaultBranch: 'main',
+      dependencyDashboardIssue: 42,
+    };
+
+    addRepositoryMetadata(config, '.github/renovate.json5');
+
+    expect(getReport()).toEqual({
+      problems: [],
+      repositories: {
+        'myOrg/myRepo': {
+          problems: [],
+          branches: [],
+          packageFiles: {},
+          platform: 'github',
+          endpoint: 'https://api.github.com/',
+          defaultBranch: 'main',
+          dependencyDashboardIssue: 42,
+          configFileName: '.github/renovate.json5',
+        },
+      },
+    });
+  });
+
+  it('sets dependencyDashboardIssue to null when there is no dashboard', () => {
+    const config: RenovateConfig = {
+      repository: 'myOrg/myRepo',
+      reportType: 'logging',
+      defaultBranch: 'main',
+    };
+
+    addRepositoryMetadata(config);
+
+    expect(
+      getReport().repositories['myOrg/myRepo'].dependencyDashboardIssue,
+    ).toBeNull();
+  });
+
+  it('adds onboarding status with an open onboarding PR', () => {
+    GlobalConfig.set({ onboardingBranch: 'renovate/configure' });
+    const config: RenovateConfig = {
+      repository: 'myOrg/myRepo',
+      reportType: 'logging',
+      repoIsOnboarded: false,
+    };
+    const prList: Pr[] = [
+      partial<Pr>({
+        number: 7,
+        sourceBranch: 'renovate/configure',
+        state: 'open',
+        title: 'Configure Renovate',
+      }),
+      partial<Pr>({
+        number: 8,
+        sourceBranch: 'renovate/some-dep',
+        state: 'open',
+        title: 'Update dep',
+      }),
+    ];
+
+    addOnboardingStatus(config, prList);
+
+    const repoReport = getReport().repositories['myOrg/myRepo'];
+    expect(repoReport.repoIsOnboarded).toBe(false);
+    expect(repoReport.onboardingPrNumber).toBe(7);
+  });
+
+  it('sets onboardingPrNumber to null when the onboarding PR is not open', () => {
+    GlobalConfig.set({ onboardingBranch: 'renovate/configure' });
+    const config: RenovateConfig = {
+      repository: 'myOrg/myRepo',
+      reportType: 'logging',
+      repoIsOnboarded: true,
+    };
+    const prList: Pr[] = [
+      partial<Pr>({
+        number: 7,
+        sourceBranch: 'renovate/configure',
+        state: 'merged',
+        title: 'Configure Renovate',
+      }),
+    ];
+
+    addOnboardingStatus(config, prList);
+
+    const repoReport = getReport().repositories['myOrg/myRepo'];
+    expect(repoReport.repoIsOnboarded).toBe(true);
+    expect(repoReport.onboardingPrNumber).toBeNull();
   });
 
   it('return report if reportType is set to logging', () => {

--- a/lib/instrumentation/reporting.ts
+++ b/lib/instrumentation/reporting.ts
@@ -1,10 +1,13 @@
 import type { PutObjectCommandInput } from '@aws-sdk/client-s3';
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { isNullOrUndefined, isUndefined } from '@sindresorhus/is';
+import { GlobalConfig } from '../config/global.ts';
 import type { RenovateConfig } from '../config/types.ts';
 import { prettier } from '../expose.ts';
 import { getProblems, logger } from '../logger/index.ts';
+import type { Pr } from '../modules/platform/index.ts';
 import type { BranchCache } from '../util/cache/repository/types.ts';
+import { getInheritedOrGlobal } from '../util/common.ts';
 import { writeSystemFile } from '../util/fs/index.ts';
 import { getS3Client, parseS3Url } from '../util/s3.ts';
 import type { ExtractResult } from '../workers/repository/process/extract-update.ts';
@@ -34,6 +37,42 @@ export function addBranchStats(
 
   coerceRepo(config.repository!);
   report.repositories[config.repository!].branches = branchesInformation;
+}
+
+export function addRepositoryMetadata(
+  config: RenovateConfig,
+  configFileName?: string,
+): void {
+  if (isNullOrUndefined(config.reportType)) {
+    return;
+  }
+
+  coerceRepo(config.repository!);
+  const repoReport = report.repositories[config.repository!];
+  repoReport.platform = GlobalConfig.get('platform');
+  repoReport.endpoint = GlobalConfig.get('endpoint');
+  repoReport.defaultBranch = config.defaultBranch;
+  repoReport.dependencyDashboardIssue = config.dependencyDashboardIssue ?? null;
+  repoReport.configFileName = configFileName;
+}
+
+export function addOnboardingStatus(
+  config: RenovateConfig,
+  prList: Pr[],
+): void {
+  if (isNullOrUndefined(config.reportType)) {
+    return;
+  }
+
+  coerceRepo(config.repository!);
+  const repoReport = report.repositories[config.repository!];
+  repoReport.repoIsOnboarded = config.repoIsOnboarded;
+
+  const onboardingBranch = getInheritedOrGlobal('onboardingBranch');
+  const onboardingPr = prList.find(
+    (pr) => pr.sourceBranch === onboardingBranch && pr.state === 'open',
+  );
+  repoReport.onboardingPrNumber = onboardingPr?.number ?? null;
 }
 
 export function addExtractionStats(

--- a/lib/instrumentation/reporting.ts
+++ b/lib/instrumentation/reporting.ts
@@ -53,7 +53,10 @@ export function addRepositoryMetadata(
   repoReport.endpoint = GlobalConfig.get('endpoint');
   repoReport.defaultBranch = config.defaultBranch;
   repoReport.dependencyDashboardIssue = config.dependencyDashboardIssue ?? null;
-  repoReport.configFileName = configFileName;
+  // Omit when there is no in-repo config file (cache stores an empty string).
+  if (configFileName) {
+    repoReport.configFileName = configFileName;
+  }
 }
 
 export function addOnboardingStatus(

--- a/lib/instrumentation/types.ts
+++ b/lib/instrumentation/types.ts
@@ -1,6 +1,7 @@
 import type { Attributes, SpanKind, SpanOptions } from '@opentelemetry/api';
 import type { ATTR_CODE_FUNCTION_NAME } from '@opentelemetry/semantic-conventions';
 import type { RenovateSplit } from '../config/types.ts';
+import type { PlatformId } from '../constants/index.ts';
 import type { BunyanRecord } from '../logger/types.ts';
 import type { PackageFile } from '../modules/manager/types.ts';
 import type { BranchCache } from '../util/cache/repository/types.ts';
@@ -54,6 +55,35 @@ interface RepoReport {
   branches: Partial<BranchCache>[];
   packageFiles: Record<string, PackageFile[]>;
   libYearsWithStatus?: LibYearsWithStatus;
+  /**
+   * The platform type of the repository (ex: `github`, `gitlab`).
+   */
+  platform?: PlatformId;
+  /**
+   * The platform API endpoint used for the repository.
+   */
+  endpoint?: string;
+  /**
+   * The default branch name of the repository.
+   */
+  defaultBranch?: string;
+  /**
+   * The issue number of the Dependency Dashboard, or `null` if none exists.
+   */
+  dependencyDashboardIssue?: number | null;
+  /**
+   * Path to the repository's Renovate config file (ex: `.github/renovate.json5`).
+   * Empty when the repository has no in-repo config file.
+   */
+  configFileName?: string;
+  /**
+   * Whether the repository has already been onboarded (has a merged Renovate config).
+   */
+  repoIsOnboarded?: boolean;
+  /**
+   * The number of the open (unmerged) onboarding PR, or `null` if none exists.
+   */
+  onboardingPrNumber?: number | null;
 }
 
 export interface LibYearsWithStatus {

--- a/lib/instrumentation/types.ts
+++ b/lib/instrumentation/types.ts
@@ -73,7 +73,7 @@ interface RepoReport {
   dependencyDashboardIssue?: number | null;
   /**
    * Path to the repository's Renovate config file (ex: `.github/renovate.json5`).
-   * Empty when the repository has no in-repo config file.
+   * Omitted when the repository has no in-repo config file.
    */
   configFileName?: string;
   /**

--- a/lib/workers/repository/finalize/index.ts
+++ b/lib/workers/repository/finalize/index.ts
@@ -1,4 +1,5 @@
 import type { AllConfig, RenovateConfig } from '../../../config/types.ts';
+import { addOnboardingStatus } from '../../../instrumentation/reporting.ts';
 import { logger } from '../../../logger/index.ts';
 import { platform } from '../../../modules/platform/index.ts';
 import * as repositoryCache from '../../../util/cache/repository/index.ts';
@@ -39,6 +40,7 @@ export async function finalizeRepo(
   }
   runBranchSummary(config);
   runRenovateRepoStats(config, prList);
+  addOnboardingStatus(config, prList);
 }
 
 // istanbul ignore next

--- a/lib/workers/repository/finalize/repository-statistics.ts
+++ b/lib/workers/repository/finalize/repository-statistics.ts
@@ -1,5 +1,8 @@
 import type { RenovateConfig } from '../../../config/types.ts';
-import { addBranchStats } from '../../../instrumentation/reporting.ts';
+import {
+  addBranchStats,
+  addRepositoryMetadata,
+} from '../../../instrumentation/reporting.ts';
 import { logger } from '../../../logger/index.ts';
 import type { Pr } from '../../../modules/platform/index.ts';
 import {
@@ -77,7 +80,15 @@ function filterDependencyDashboardData(
   const branchesFiltered: Partial<BranchCache>[] = [];
   for (const branch of branches) {
     const upgradesFiltered: Partial<BranchUpgradeCache>[] = [];
-    const { branchName, prNo, prTitle, result, upgrades, prBlockedBy } = branch;
+    const {
+      baseBranch,
+      branchName,
+      prNo,
+      prTitle,
+      result,
+      upgrades,
+      prBlockedBy,
+    } = branch;
 
     for (const upgrade of upgrades ?? []) {
       const {
@@ -115,6 +126,7 @@ function filterDependencyDashboardData(
     }
 
     const filteredBranch: Partial<BranchCache> = {
+      baseBranch,
       branchName,
       prNo,
       prTitle,
@@ -129,8 +141,11 @@ function filterDependencyDashboardData(
 }
 
 export function runBranchSummary(config: RenovateConfig): void {
+  const { scan, branches, configFileName } = getCache();
+
+  addRepositoryMetadata(config, configFileName);
+
   const defaultBranch = config.defaultBranch;
-  const { scan, branches } = getCache();
 
   const baseMetadata: BaseBranchMetadata[] = [];
   for (const [branchName, cached] of Object.entries(scan ?? {})) {


### PR DESCRIPTION
## Changes

Surfaces additional repository metadata in the report generated via `reportType`
(`logging`/`file`/`s3`), to make reports more self-describing without needing to
cross-reference the run that produced them.

Per repository, the report now includes `platform`, `endpoint`, `defaultBranch`,
`dependencyDashboardIssue` (or `null`), `configFileName`, `repoIsOnboarded`, and
`onboardingPrNumber` (or `null`). Each branch entry now also carries its
`baseBranch`.

Rough shape of the additions (marked with `// +`):

```jsonc
{
  "repositories": {
    "some-org/some-repo": {          // the key is already the repository identifier
      "problems": [],
      "branches": [
        {
          "baseBranch": "main",                       // +
          "branchName": "renovate/actions-checkout-6.x",
          "prNo": 105,
          "prTitle": "Update actions/checkout action to v6.0.3",
          "result": "pr-created",
          "upgrades": [ /* unchanged */ ]
        }
      ],
      "packageFiles": { /* unchanged */ },
      "libYearsWithStatus": { /* unchanged */ },
      "platform": "github",                            // +
      "endpoint": "https://api.github.com/",           // +
      "defaultBranch": "main",                         // +
      "dependencyDashboardIssue": 6,                   // + (null when none exists)
      "configFileName": ".github/renovate.json5",      // +
      "repoIsOnboarded": true,                         // +
      "onboardingPrNumber": null                       // + (PR number when an unmerged onboarding PR exists)
    }
  }
}
```

Onboarding status is derived in `finalizeRepo` from the already-fetched PR list,
so no additional platform API calls are made. `platform`/`endpoint` are read from
`GlobalConfig`; the remaining values come from the repo config, cache, and PR list.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI (Claude Code, model Claude Opus 4.8) was used to author the implementation,
unit tests, and this PR description, under human direction and review.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/justfalter/renovate-test-repo

Verified in this run (report visible in the job logs under `Printing report`):
https://github.com/justfalter/renovate-test-repo/actions/runs/29619043257
