### PR TITLE
fix(presets/monorepo): group ckeditor5-premium-features with ckeditor5

### DIFF
--- a/lib/config/presets/internal/monorepos.preset.ts
+++ b/lib/config/presets/internal/monorepos.preset.ts
@@ -24,3 +24,11 @@ for (const [name, value] of Object.entries(monorepoGroups.patternGroups)) {
     matchPackageNames: toArray(value),
   };
 }
+
+presets.ckeditor = {
+  description: 'ckeditor monorepo',
+  packageRules: [
+    { matchSourceUrls: ['https://github.com/ckeditor/ckeditor5'] },
+    { matchPackageNames: ['ckeditor5-premium-features'] },
+  ],
+};

--- a/lib/config/presets/internal/monorepos.preset.ts
+++ b/lib/config/presets/internal/monorepos.preset.ts
@@ -28,7 +28,14 @@ for (const [name, value] of Object.entries(monorepoGroups.patternGroups)) {
 presets.ckeditor = {
   description: 'ckeditor monorepo',
   packageRules: [
-    { matchSourceUrls: ['https://github.com/ckeditor/ckeditor5'] },
-    { matchPackageNames: ['ckeditor5-premium-features'] },
+    {
+      description: 'Group ckeditor5 monorepo packages by source URL.',
+      matchSourceUrls: ['https://github.com/ckeditor/ckeditor5'],
+    },
+    {
+      description:
+        'Group ckeditor5-premium-features by name; it ships no repository field.',
+      matchPackageNames: ['ckeditor5-premium-features'],
+    },
   ],
 };

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -146,10 +146,6 @@
     "chakra-ui": "https://github.com/chakra-ui/chakra-ui",
     "chromely": "https://github.com/chromelyapps/Chromely",
     "citation-js": "https://github.com/citation-js/citation-js",
-    "ckeditor": [
-      "https://github.com/ckeditor/ckeditor5",
-      "https://github.com/ckeditor/ckeditor5-premium-features"
-    ],
     "clarity": "https://github.com/vmware/clarity",
     "clearscript": [
       "https://github.com/microsoft/ClearScript",


### PR DESCRIPTION
## Changes

Replace the broken `repoGroups.ckeditor` URL entry with a hand-crafted preset in `lib/config/presets/internal/monorepos.preset.ts` that uses two OR'd `packageRules`:

1. `matchSourceUrls: ['https://github.com/ckeditor/ckeditor5']` — covers scoped `@ckeditor/ckeditor5-*` packages whose `sourceUrl` is normalized to this canonical form by `addMetaData`.
2. `matchPackageNames: ['ckeditor5-premium-features']` — covers the premium package by name, since it ships no `repository` field.

Each sub-rule carries a `description` so it survives `massageConfig` (which strips match-only rules) and satisfies the validator's non-match-field requirement. Follows the precedent in `replacements.preset.ts` of layering hand-crafted presets on top of the data-driven ones.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

The URL entry added in #39194 has never matched. The `ckeditor5-premium-features` npm package has never shipped a `repository` field in its `package.json` (verified across `0.0.1`, `41.4.0`, and `48.3.1`), so the npm datasource cannot derive a `sourceUrl` for it.

A name-pattern fix (`/^@ckeditor/ckeditor5-/`) was considered and rejected: wrapper packages such as `@ckeditor/ckeditor5-angular` (v11.2.0) and `@ckeditor/ckeditor5-react` (v11.2.0) carry the prefix but live in separate repos with independent versioning and must not be grouped with the main release train (currently v48.3.1).

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Authored with the assistance of opencode (glm-5.2). Investigation, edit, and PR body generated by the AI agent under user direction.

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Code inspection only

Two-rule OR semantics work via the existing migration flattening at `lib/config/migration.ts:163-185`. `pnpm vitest run lib/config/presets/internal/index.spec.ts lib/data/index.spec.ts lib/config/presets/internal/monorepos.spec.ts lib/config/presets/internal/group.spec.ts` — 1869/1869 pass.
