### PR TITLE
feat(manager/nuget): pass defaultRegistryUrls to NuGet artifact updates to support private feeds

### DIFF
--- a/lib/modules/manager/nuget/artifacts.spec.ts
+++ b/lib/modules/manager/nuget/artifacts.spec.ts
@@ -515,4 +515,33 @@ describe('modules/manager/nuget/artifacts', () => {
     ]);
     expect(execSnapshots).toBeEmptyArray();
   });
+
+  it('respects defaultRegistryUrls', async () => {
+    const execSnapshots = mockExecAll();
+    fs.getSiblingFileName.mockReturnValueOnce('packages.lock.json');
+    git.getFiles.mockResolvedValueOnce({
+      'packages.lock.json': 'Current packages.lock.json',
+    });
+    fs.getLocalFiles.mockResolvedValueOnce({
+      'packages.lock.json': 'New packages.lock.json',
+    });
+    const defaultRegistryUrls = [
+      'https://my-private-nuget-feed.com/v3/index.json',
+    ];
+
+    await nuget.updateArtifacts({
+      packageFileName: 'project.csproj',
+      updatedDeps: [{ depName: 'dep', defaultRegistryUrls }],
+      newPackageFileContent: '{}',
+      config: { ...config, defaultRegistryUrls },
+    });
+
+    expect(fs.outputCacheFile).toHaveBeenCalledWith(
+      expect.stringContaining('nuget.config'),
+      expect.stringContaining(
+        'https://my-private-nuget-feed.com/v3/index.json',
+      ),
+    );
+    expect(execSnapshots).toHaveLength(1);
+  });
 });

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -40,9 +40,14 @@ async function createCachedNuGetConfigFile(
   nugetCacheDir: string,
   packageFileName: string,
   updatedDeps: Upgrade[],
+  config: UpdateArtifactsConfig,
 ): Promise<string> {
+  const fallbackRegistries = config.defaultRegistryUrls
+    ? config.defaultRegistryUrls.map((url) => ({ url }))
+    : getDefaultRegistries();
+
   const registries =
-    (await getConfiguredRegistries(packageFileName)) ?? getDefaultRegistries();
+    (await getConfiguredRegistries(packageFileName)) ?? fallbackRegistries;
 
   const updatedDepsRegistries: Registry[] = Array.from(
     new Set(
@@ -76,6 +81,7 @@ async function runDotnetRestore(
     nugetCacheDir,
     packageFileName,
     updatedDeps,
+    config,
   );
 
   const dotnetVersion =

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -52,6 +52,7 @@ export interface UpdateArtifactsConfig {
   newVersion?: string;
   newMajor?: number;
   registryAliases?: Record<string, string>;
+  defaultRegistryUrls?: string[];
   skipArtifactsUpdate?: boolean;
   lockFiles?: string[];
   toolSettings?: ToolSettingsOptions;
@@ -242,6 +243,7 @@ export interface Upgrade<
   isVulnerabilityAlert?: boolean;
   vulnerabilitySeverity?: string;
   registryUrls?: string[] | null;
+  defaultRegistryUrls?: string[];
   currentVersion?: string;
   replaceString?: string;
   replacementApproach?: 'replace' | 'alias';

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -505,6 +505,9 @@ async function managerUpdateArtifacts(
     return null;
   }
 
+  updateArtifact.config.defaultRegistryUrls =
+    updateArtifact.updatedDeps?.[0]?.defaultRegistryUrls;
+
   return await updateArtifacts(updateArtifact);
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This PR modifies the NuGet manager's artifact/lockfile update process to respect the existing `defaultRegistryUrls` configuration option instead of falling back to the hardcoded `api.nuget.org` registry feed.
Specifically:

- Exposes `defaultRegistryUrls` to manager-level artifact updaters in `UpdateArtifactsConfig` (`lib/modules/manager/types.ts`).
- Passes down the resolved `defaultRegistryUrls` from the first updated dependency when invoking manager-level restores in `get-updated.ts`.
- Updates `createCachedNuGetConfigFile` in `lib/modules/manager/nuget/artifacts.ts` to check for `config.defaultRegistryUrls`. If configured, it will map these to NuGet package sources, completely bypassing the default fallback to the public `api.nuget.org` registry.
This allows self-hosted Renovate deployments to run cleanly in airgapped environments (using internal mirrors like Artifactory) without encountering slow network connection timeouts on `api.nuget.org` during `dotnet restore` execution, and without requiring any new configuration options to be added.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

**Details**:
This pull request was co-authored with **Antigravity**, a coding assistant developed by Google DeepMind running the **Gemini 3.5 Flash (Medium)** model. The AI was used to research the codebase structure, design the non-breaking implementation flow, draft the type/worker changes, write the new unit tests, and format documentation.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
