### PR TITLE
feat(manager/mise): run mise lock in safe mode without allowedUnsafeExecutions

### DIFF
--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -115,9 +115,9 @@ describe('modules/manager/mise/artifacts', () => {
         },
       },
     ]);
+    // safe mode does not require trust, so `mise trust` is not run
     expect(execSnapshots).toMatchObject([
       { cmd: miseVersionCmd },
-      { cmd: trustCmd },
       {
         cmd: updateToolCmd,
         options: {

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -96,7 +96,7 @@ describe('modules/manager/mise/artifacts', () => {
       packageFileName: 'mise.toml',
       updatedDeps: [{ depName: 'node' }],
       newPackageFileContent: '',
-      config: { ...config, constraints: { mise: '2026.8.0' } },
+      config: { ...config, constraints: { mise: '2026.7.12' } },
     });
 
     expect(res).toEqual([

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -265,6 +265,25 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
+  it('runs mise lock --bump for lockFileMaintenance when mise supports it', async () => {
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce('existing content');
+    const execSnapshots = mockExecAll();
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config: { ...lockMaintenanceConfig, constraints: { mise: '2026.7.12' } },
+    });
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: trustCmd },
+      { cmd: 'mise lock --bump' },
+    ]);
+  });
+
   it('runs mise lock <tools> for targeted updates', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -85,6 +85,80 @@ describe('modules/manager/mise/artifacts', () => {
     expect(execSnapshots).toEqual([]);
   });
 
+  it('runs mise lock with MISE_SAFE when mise is pinned to a safe-mode version and not allowlisted', async () => {
+    GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce(`[[tools.node]]\nversion = "24.16.0"\n`);
+    const execSnapshots = mockExecAll();
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config: { ...config, constraints: { mise: '2026.8.0' } },
+    });
+
+    expect(res).toEqual([
+      {
+        file: {
+          contents: expect.stringContaining('version = "24.16.0"'),
+          path: 'mise.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      { cmd: trustCmd },
+      {
+        cmd: updateToolCmd,
+        options: {
+          env: expect.objectContaining({ MISE_SAFE: '1' }),
+        },
+      },
+    ]);
+  });
+
+  it('returns null when mise is not allowlisted and the constraint predates safe mode', async () => {
+    GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    const execSnapshots = mockExecAll();
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config: { ...config, constraints: { mise: '2026.7.11' } },
+    });
+
+    expect(res).toBeNull();
+    expect(execSnapshots).toEqual([]);
+  });
+
+  it('does not set MISE_SAFE on the allowlisted path', async () => {
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce(`[[tools.node]]\nversion = "24.16.0"\n`);
+    const execSnapshots = mockExecAll();
+
+    await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config,
+    });
+
+    expect(execSnapshots).toMatchObject([
+      { cmd: trustCmd },
+      {
+        cmd: updateToolCmd,
+        options: {
+          env: expect.not.objectContaining({ MISE_SAFE: '1' }),
+        },
+      },
+    ]);
+  });
+
   it('returns null if lock file unchanged after exec', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -42,6 +42,12 @@ const trustEnvLocalCmd = 'mise trust mise.test.local.toml';
 const trustSubdirCmd = 'mise trust mise.toml';
 const updateMultipleToolsCmd = 'mise lock node python';
 const lockfileMaintenanceCmd = 'mise lock';
+const miseVersionCmd = 'mise version';
+// `mise version` output for a release that supports safe mode / `mise lock --bump`
+const safeMiseVersionOutput = {
+  stdout: '2026.7.12 linux-x64 (2026-07-30)',
+  stderr: '',
+};
 
 describe('modules/manager/mise/artifacts', () => {
   beforeEach(() => {
@@ -69,9 +75,10 @@ describe('modules/manager/mise/artifacts', () => {
     expect(execSnapshots).toEqual([]);
   });
 
-  it('returns null when mise is not allowlisted', async () => {
+  it('returns null when mise is not allowlisted and version cannot be determined', async () => {
     GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
     fs.readLocalFile.mockResolvedValueOnce('existing content');
+    // default mock returns empty stdout, so the version probe cannot parse a version
     const execSnapshots = mockExecAll();
 
     const res = await updateArtifacts({
@@ -82,21 +89,21 @@ describe('modules/manager/mise/artifacts', () => {
     });
 
     expect(res).toBeNull();
-    expect(execSnapshots).toEqual([]);
+    expect(execSnapshots).toMatchObject([{ cmd: miseVersionCmd }]);
   });
 
-  it('runs mise lock with MISE_SAFE when mise is pinned to a safe-mode version and not allowlisted', async () => {
+  it('runs mise lock with MISE_SAFE when a safe-mode mise version is detected and not allowlisted', async () => {
     GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')
       .mockResolvedValueOnce(`[[tools.node]]\nversion = "24.16.0"\n`);
-    const execSnapshots = mockExecAll();
+    const execSnapshots = mockExecAll(safeMiseVersionOutput);
 
     const res = await updateArtifacts({
       packageFileName: 'mise.toml',
       updatedDeps: [{ depName: 'node' }],
       newPackageFileContent: '',
-      config: { ...config, constraints: { mise: '2026.7.12' } },
+      config,
     });
 
     expect(res).toEqual([
@@ -109,6 +116,7 @@ describe('modules/manager/mise/artifacts', () => {
       },
     ]);
     expect(execSnapshots).toMatchObject([
+      { cmd: miseVersionCmd },
       { cmd: trustCmd },
       {
         cmd: updateToolCmd,
@@ -119,23 +127,26 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
-  it('returns null when mise is not allowlisted and the constraint predates safe mode', async () => {
+  it('returns null when mise is not allowlisted and the detected version predates safe mode', async () => {
     GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
     fs.readLocalFile.mockResolvedValueOnce('existing content');
-    const execSnapshots = mockExecAll();
+    const execSnapshots = mockExecAll({
+      stdout: '2026.7.11 linux-x64 (2026-07-20)',
+      stderr: '',
+    });
 
     const res = await updateArtifacts({
       packageFileName: 'mise.toml',
       updatedDeps: [{ depName: 'node' }],
       newPackageFileContent: '',
-      config: { ...config, constraints: { mise: '2026.7.11' } },
+      config,
     });
 
     expect(res).toBeNull();
-    expect(execSnapshots).toEqual([]);
+    expect(execSnapshots).toMatchObject([{ cmd: miseVersionCmd }]);
   });
 
-  it('does not set MISE_SAFE on the allowlisted path', async () => {
+  it('does not set MISE_SAFE or probe the version on the allowlisted path', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')
       .mockResolvedValueOnce(`[[tools.node]]\nversion = "24.16.0"\n`);
@@ -259,7 +270,9 @@ describe('modules/manager/mise/artifacts', () => {
       config: lockMaintenanceConfig,
     });
 
+    // version probe returns nothing here, so no --bump
     expect(execSnapshots).toMatchObject([
+      { cmd: miseVersionCmd },
       { cmd: trustCmd },
       { cmd: lockfileMaintenanceCmd },
     ]);
@@ -269,16 +282,17 @@ describe('modules/manager/mise/artifacts', () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')
       .mockResolvedValueOnce('existing content');
-    const execSnapshots = mockExecAll();
+    const execSnapshots = mockExecAll(safeMiseVersionOutput);
 
     await updateArtifacts({
       packageFileName: 'mise.toml',
       updatedDeps: [{ depName: 'node' }],
       newPackageFileContent: '',
-      config: { ...lockMaintenanceConfig, constraints: { mise: '2026.7.12' } },
+      config: lockMaintenanceConfig,
     });
 
     expect(execSnapshots).toMatchObject([
+      { cmd: miseVersionCmd },
       { cmd: trustCmd },
       { cmd: 'mise lock --bump' },
     ]);
@@ -571,6 +585,7 @@ describe('modules/manager/mise/artifacts', () => {
     });
 
     expect(execSnapshots).toMatchObject([
+      { cmd: miseVersionCmd },
       { cmd: trustLocalCmd },
       { cmd: 'mise lock --local' },
     ]);

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -45,7 +45,7 @@ const lockfileMaintenanceCmd = 'mise lock';
 const miseVersionCmd = 'mise version';
 // `mise version` output for a release that supports safe mode / `mise lock --bump`
 const safeMiseVersionOutput = {
-  stdout: '2026.7.12 linux-x64 (2026-07-30)',
+  stdout: '2026.7.12 linux-x64 (2026-07-23)',
   stderr: '',
 };
 

--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -146,6 +146,24 @@ describe('modules/manager/mise/artifacts', () => {
     expect(execSnapshots).toMatchObject([{ cmd: miseVersionCmd }]);
   });
 
+  it('falls back to conservative behavior when the version probe throws', async () => {
+    GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
+    fs.readLocalFile.mockResolvedValueOnce('existing content');
+    const execSnapshots = mockExecSequence([new Error('mise not found')]);
+
+    const res = await updateArtifacts({
+      packageFileName: 'mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config,
+    });
+
+    // an unparseable/failed probe means safe mode cannot be guaranteed, so the
+    // allowlist is still required and locking is skipped
+    expect(res).toBeNull();
+    expect(execSnapshots).toMatchObject([{ cmd: miseVersionCmd }]);
+  });
+
   it('does not set MISE_SAFE or probe the version on the allowlisted path', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -22,14 +22,14 @@ import { getConfigType, getLockFileName } from './lockfile.ts';
  * First mise release whose `MISE_SAFE=1` safe mode is a hard boundary against
  * project configuration executing code during `mise lock`.
  *
- * TODO(mise-safe): mise added safe mode in jdx/mise#11146 and lockfile bumping
- * in jdx/mise#11145, but these have not shipped in a tagged release yet. Update
- * this constant to the first release that includes them before merging.
+ * Safe mode (jdx/mise#11146) and lockfile bumping (jdx/mise#11145) merged after
+ * v2026.7.11, so the first release to include them is expected to be 2026.7.12.
+ * TODO(mise-safe): confirm this once that release is tagged.
  *
  * @see https://github.com/jdx/mise/pull/11146
  * @see https://mise.jdx.dev/configuration/settings.html#safe
  */
-const MISE_SAFE_MODE_MIN_VERSION = '2026.8.0';
+const MISE_SAFE_MODE_MIN_VERSION = '2026.7.12';
 
 /**
  * Returns true when the configured `mise` constraint *guarantees* a version
@@ -37,8 +37,8 @@ const MISE_SAFE_MODE_MIN_VERSION = '2026.8.0';
  * without requiring `allowedUnsafeExecutions`.
  *
  * Because this gates a security bypass, the check is deliberately conservative:
- * it accepts only a single pinned version (`mise = "2026.8.1"`) at or above the
- * safe-mode release. Ranges such as `>=2026.8.0` are safe in principle but are
+ * it accepts only a single pinned version (`mise = "2026.7.12"`) at or above the
+ * safe-mode release. Ranges such as `>=2026.7.12` are safe in principle but are
  * intentionally not accepted yet — supporting them (and/or runtime detection
  * via `mise version`) is left for follow-up; see the PR discussion.
  */
@@ -113,7 +113,8 @@ export async function updateArtifacts({
   const safeMode = !miseAllowlisted && miseSupportsSafeMode(config.constraints);
   if (!miseAllowlisted && !safeMode) {
     logger.once.warn(
-      `\`mise lock\` was requested to run, but \`mise\` is not permitted in \`allowedUnsafeExecutions\` and no \`mise\` constraint guaranteeing safe-mode support (>= ${MISE_SAFE_MODE_MIN_VERSION}) is configured`,
+      { safeModeMinVersion: MISE_SAFE_MODE_MIN_VERSION },
+      '`mise lock` was requested to run, but `mise` is not permitted in `allowedUnsafeExecutions` and no `mise` constraint guaranteeing safe-mode support is configured',
     );
     return null;
   }

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -198,10 +198,16 @@ export async function updateArtifacts({
     docker: {},
   };
 
-  const trustCmd = `mise trust ${quote(upath.basename(packageFileName))}`;
+  // `mise trust` is only needed on the allowlisted path. In safe mode mise
+  // loads untrusted config without a trust prompt (the config is inert — it
+  // can neither execute code nor inject environment), so the trust step is
+  // unnecessary and is skipped.
+  const commands = safeMode
+    ? [lockCmd]
+    : [`mise trust ${quote(upath.basename(packageFileName))}`, lockCmd];
 
   try {
-    await exec([trustCmd, lockCmd], execOptions);
+    await exec(commands, execOptions);
     const newLockFileContent = await readLocalFile(lockFileName, 'utf8');
     if (!newLockFileContent || existingLockFileContent === newLockFileContent) {
       return null;

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -19,39 +19,43 @@ import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getConfigType, getLockFileName } from './lockfile.ts';
 
 /**
- * First mise release whose `MISE_SAFE=1` safe mode is a hard boundary against
- * project configuration executing code during `mise lock`.
+ * First mise release that supports the features this manager relies on:
+ * `MISE_SAFE=1` safe mode (a hard boundary against project config executing
+ * code during `mise lock`) and `mise lock --bump` (advancing fuzzy selectors).
  *
  * Safe mode (jdx/mise#11146) and lockfile bumping (jdx/mise#11145) merged after
  * v2026.7.11, so the first release to include them is expected to be 2026.7.12.
  * TODO(mise-safe): confirm this once that release is tagged.
  *
  * @see https://github.com/jdx/mise/pull/11146
+ * @see https://github.com/jdx/mise/pull/11145
  * @see https://mise.jdx.dev/configuration/settings.html#safe
  */
 const MISE_SAFE_MODE_MIN_VERSION = '2026.7.12';
 
 /**
- * Returns true when the configured `mise` constraint *guarantees* a version
- * that enforces safe mode, so `mise lock` can run against untrusted config
- * without requiring `allowedUnsafeExecutions`.
+ * Returns true when the configured `mise` constraint *guarantees* a version at
+ * or above `minVersion`. Used to gate both the safe-mode bypass of
+ * `allowedUnsafeExecutions` and the `mise lock --bump` flag, which require a
+ * new enough mise.
  *
- * Because this gates a security bypass, the check is deliberately conservative:
- * it accepts only a single pinned version (`mise = "2026.7.12"`) at or above the
- * safe-mode release. Ranges such as `>=2026.7.12` are safe in principle but are
+ * Because it gates a security bypass, the check is deliberately conservative:
+ * it accepts only a single pinned version (`mise = "2026.7.12"`) at or above
+ * `minVersion`. Ranges such as `>=2026.7.12` are safe in principle but are
  * intentionally not accepted yet — supporting them (and/or runtime detection
  * via `mise version`) is left for follow-up; see the PR discussion.
  */
-function miseSupportsSafeMode(
-  constraints?: Partial<Record<ConstraintName, string>> | null,
+function miseConstraintGuarantees(
+  constraints: Partial<Record<ConstraintName, string>> | null | undefined,
+  minVersion: string,
 ): boolean {
   const constraint = constraints?.mise;
   if (!isString(constraint) || !miseVersioning.isVersion(constraint)) {
     return false;
   }
   return (
-    miseVersioning.equals(constraint, MISE_SAFE_MODE_MIN_VERSION) ||
-    miseVersioning.isGreaterThan(constraint, MISE_SAFE_MODE_MIN_VERSION)
+    miseVersioning.equals(constraint, minVersion) ||
+    miseVersioning.isGreaterThan(constraint, minVersion)
   );
 }
 
@@ -110,7 +114,12 @@ export async function updateArtifacts({
   // the config executing code — so the allowlist is not required on that path.
   const allowlist = GlobalConfig.get('allowedUnsafeExecutions');
   const miseAllowlisted = allowlist.includes('mise');
-  const safeMode = !miseAllowlisted && miseSupportsSafeMode(config.constraints);
+  // Safe mode and `mise lock --bump` both require mise >= MISE_SAFE_MODE_MIN_VERSION.
+  const miseSupportsSafeFeatures = miseConstraintGuarantees(
+    config.constraints,
+    MISE_SAFE_MODE_MIN_VERSION,
+  );
+  const safeMode = !miseAllowlisted && miseSupportsSafeFeatures;
   if (!miseAllowlisted && !safeMode) {
     logger.once.warn(
       { safeModeMinVersion: MISE_SAFE_MODE_MIN_VERSION },
@@ -124,7 +133,13 @@ export async function updateArtifacts({
 
   let lockCmd: string;
   if (config.isLockFileMaintenance) {
-    lockCmd = `mise lock${localFlag}`;
+    // Lock file maintenance means "update to the latest versions". Plain
+    // `mise lock` only refreshes metadata for already-locked versions, so use
+    // `mise lock --bump` to also advance fuzzy selectors (e.g. `node = "22"`)
+    // to the latest matching version. `--bump` requires a new enough mise, so
+    // fall back to a plain refresh when the version cannot be guaranteed.
+    const bumpFlag = miseSupportsSafeFeatures ? ' --bump' : '';
+    lockCmd = `mise lock${localFlag}${bumpFlag}`;
   } else {
     const tools = updatedDeps
       .map(({ depName }) => depName)

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -14,13 +14,55 @@ import type {
 } from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { api as miseVersioning } from '../../versioning/semver/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getConfigType, getLockFileName } from './lockfile.ts';
+
+/**
+ * First mise release whose `MISE_SAFE=1` safe mode is a hard boundary against
+ * project configuration executing code during `mise lock`.
+ *
+ * TODO(mise-safe): mise added safe mode in jdx/mise#11146 and lockfile bumping
+ * in jdx/mise#11145, but these have not shipped in a tagged release yet. Update
+ * this constant to the first release that includes them before merging.
+ *
+ * @see https://github.com/jdx/mise/pull/11146
+ * @see https://mise.jdx.dev/configuration/settings.html#safe
+ */
+const MISE_SAFE_MODE_MIN_VERSION = '2026.8.0';
+
+/**
+ * Returns true when the configured `mise` constraint *guarantees* a version
+ * that enforces safe mode, so `mise lock` can run against untrusted config
+ * without requiring `allowedUnsafeExecutions`.
+ *
+ * Because this gates a security bypass, the check is deliberately conservative:
+ * it accepts only a single pinned version (`mise = "2026.8.1"`) at or above the
+ * safe-mode release. Ranges such as `>=2026.8.0` are safe in principle but are
+ * intentionally not accepted yet — supporting them (and/or runtime detection
+ * via `mise version`) is left for follow-up; see the PR discussion.
+ */
+function miseSupportsSafeMode(
+  constraints?: Partial<Record<ConstraintName, string>> | null,
+): boolean {
+  const constraint = constraints?.mise;
+  if (!isString(constraint) || !miseVersioning.isVersion(constraint)) {
+    return false;
+  }
+  return (
+    miseVersioning.equals(constraint, MISE_SAFE_MODE_MIN_VERSION) ||
+    miseVersioning.isGreaterThan(constraint, MISE_SAFE_MODE_MIN_VERSION)
+  );
+}
 
 /**
  * Resolver tools that mise may invoke while running `mise lock`, for instance to convert an inexact version like `1` against the npm registry.
  *
  * NOTE: this will install all relevant tools, regardless of what the given mise configuration uses.
+ *
+ * In safe mode these are unnecessary: npm version listing uses mise's built-in
+ * registry HTTP client and go runs with `GOTOOLCHAIN=local`, so `mise lock`
+ * resolves versions over HTTP without shelling out to node/npm/ruby.
  *
  * @see https://mise.jdx.dev/dev-tools/backends/npm.html
  * @see https://mise.jdx.dev/dev-tools/backends/go.html
@@ -28,9 +70,17 @@ import { getConfigType, getLockFileName } from './lockfile.ts';
  */
 function getMiseLockToolConstraints(
   constraints?: Partial<Record<ConstraintName, string>> | null,
+  safeMode = false,
 ): ToolConstraint[] {
+  const miseConstraint: ToolConstraint = {
+    toolName: 'mise',
+    constraint: constraints?.mise,
+  };
+  if (safeMode) {
+    return [miseConstraint];
+  }
   return [
-    { toolName: 'mise', constraint: constraints?.mise },
+    miseConstraint,
     { toolName: 'node', constraint: constraints?.node },
     { toolName: 'npm', constraint: constraints?.npm },
     { toolName: 'golang', constraint: constraints?.go },
@@ -54,10 +104,16 @@ export async function updateArtifacts({
     return null;
   }
 
+  // `mise lock` normally executes the project's mise config, so it requires
+  // `allowedUnsafeExecutions`. When the configured mise version guarantees safe
+  // mode, we instead run with `MISE_SAFE=1`, which is a hard boundary against
+  // the config executing code — so the allowlist is not required on that path.
   const allowlist = GlobalConfig.get('allowedUnsafeExecutions');
-  if (!allowlist.includes('mise')) {
+  const miseAllowlisted = allowlist.includes('mise');
+  const safeMode = !miseAllowlisted && miseSupportsSafeMode(config.constraints);
+  if (!miseAllowlisted && !safeMode) {
     logger.once.warn(
-      '`mise lock` was requested to run, but `mise` is not permitted in the allowedUnsafeExecutions',
+      `\`mise lock\` was requested to run, but \`mise\` is not permitted in \`allowedUnsafeExecutions\` and no \`mise\` constraint guaranteeing safe-mode support (>= ${MISE_SAFE_MODE_MIN_VERSION}) is configured`,
     );
     return null;
   }
@@ -83,6 +139,9 @@ export async function updateArtifacts({
   if (env) {
     extraEnv.MISE_ENV = env;
   }
+  if (safeMode) {
+    extraEnv.MISE_SAFE = '1';
+  }
   const token = findGithubToken(
     hostRules.find({
       hostType: 'github',
@@ -96,7 +155,7 @@ export async function updateArtifacts({
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     extraEnv,
-    toolConstraints: getMiseLockToolConstraints(config.constraints),
+    toolConstraints: getMiseLockToolConstraints(config.constraints, safeMode),
     docker: {},
   };
 

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -25,8 +25,7 @@ import { getConfigType, getLockFileName } from './lockfile.ts';
  * code during `mise lock`) and `mise lock --bump` (advancing fuzzy selectors).
  *
  * Safe mode (jdx/mise#11146) and lockfile bumping (jdx/mise#11145) merged after
- * v2026.7.11, so the first release to include them is expected to be 2026.7.12.
- * TODO(mise-safe): confirm this once that release is tagged.
+ * v2026.7.11 and first shipped in v2026.7.12.
  *
  * @see https://github.com/jdx/mise/pull/11146
  * @see https://github.com/jdx/mise/pull/11145

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -14,6 +14,7 @@ import type {
 } from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { regEx } from '../../../util/regex.ts';
 import { api as miseVersioning } from '../../versioning/semver/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getConfigType, getLockFileName } from './lockfile.ts';
@@ -34,28 +35,37 @@ import { getConfigType, getLockFileName } from './lockfile.ts';
 const MISE_SAFE_MODE_MIN_VERSION = '2026.7.12';
 
 /**
- * Returns true when the configured `mise` constraint *guarantees* a version at
- * or above `minVersion`. Used to gate both the safe-mode bypass of
- * `allowedUnsafeExecutions` and the `mise lock --bump` flag, which require a
- * new enough mise.
+ * Detects the mise version that will actually run, by executing `mise version`.
+ * `mise version` only prints the binary's version — it does not load or execute
+ * project configuration — so it is safe to run even without allowlisting.
  *
- * Because it gates a security bypass, the check is deliberately conservative:
- * it accepts only a single pinned version (`mise = "2026.7.12"`) at or above
- * `minVersion`. Ranges such as `>=2026.7.12` are safe in principle but are
- * intentionally not accepted yet — supporting them (and/or runtime detection
- * via `mise version`) is left for follow-up; see the PR discussion.
+ * Output looks like `2026.7.12 macos-arm64 (2026-07-21)`; we take the leading
+ * `major.minor.patch`. Returns `null` if the probe fails or cannot be parsed,
+ * in which case callers fall back to the conservative (pre-safe-mode) behavior.
  */
-function miseConstraintGuarantees(
-  constraints: Partial<Record<ConstraintName, string>> | null | undefined,
-  minVersion: string,
-): boolean {
-  const constraint = constraints?.mise;
-  if (!isString(constraint) || !miseVersioning.isVersion(constraint)) {
-    return false;
+async function detectMiseVersion(
+  execOptions: ExecOptions,
+): Promise<string | null> {
+  try {
+    const { stdout } = await exec('mise version', execOptions);
+    const version = regEx(/\d+\.\d+\.\d+/).exec(stdout)?.[0];
+    if (version && miseVersioning.isVersion(version)) {
+      return version;
+    }
+    logger.debug({ stdout }, 'Could not parse mise version output');
+    return null;
+  } catch (err) {
+    logger.debug({ err }, 'Failed to determine mise version');
+    return null;
   }
+}
+
+/** True when `version` is at or above the safe-mode / `--bump` release. */
+function versionSupportsSafeFeatures(version: string | null): boolean {
   return (
-    miseVersioning.equals(constraint, minVersion) ||
-    miseVersioning.isGreaterThan(constraint, minVersion)
+    !!version &&
+    (miseVersioning.equals(version, MISE_SAFE_MODE_MIN_VERSION) ||
+      miseVersioning.isGreaterThan(version, MISE_SAFE_MODE_MIN_VERSION))
   );
 }
 
@@ -109,21 +119,34 @@ export async function updateArtifacts({
   }
 
   // `mise lock` normally executes the project's mise config, so it requires
-  // `allowedUnsafeExecutions`. When the configured mise version guarantees safe
-  // mode, we instead run with `MISE_SAFE=1`, which is a hard boundary against
-  // the config executing code — so the allowlist is not required on that path.
+  // `allowedUnsafeExecutions`. When the mise that will run supports safe mode,
+  // we instead run with `MISE_SAFE=1`, which is a hard boundary against the
+  // config executing code — so the allowlist is not required on that path.
   const allowlist = GlobalConfig.get('allowedUnsafeExecutions');
   const miseAllowlisted = allowlist.includes('mise');
-  // Safe mode and `mise lock --bump` both require mise >= MISE_SAFE_MODE_MIN_VERSION.
-  const miseSupportsSafeFeatures = miseConstraintGuarantees(
-    config.constraints,
-    MISE_SAFE_MODE_MIN_VERSION,
-  );
+
+  // The mise version is needed to decide safe mode (untrusted path) and
+  // `mise lock --bump` (lock file maintenance). Detect it at runtime rather
+  // than requiring a pinned `constraints.mise`. Skip the probe when it cannot
+  // change the outcome: an allowlisted, non-maintenance run behaves the same
+  // regardless of version.
+  let miseSupportsSafeFeatures = false;
+  if (!miseAllowlisted || config.isLockFileMaintenance) {
+    const miseVersion = await detectMiseVersion({
+      cwdFile: packageFileName,
+      toolConstraints: [
+        { toolName: 'mise', constraint: config.constraints?.mise },
+      ],
+      docker: {},
+    });
+    miseSupportsSafeFeatures = versionSupportsSafeFeatures(miseVersion);
+  }
+
   const safeMode = !miseAllowlisted && miseSupportsSafeFeatures;
   if (!miseAllowlisted && !safeMode) {
     logger.once.warn(
       { safeModeMinVersion: MISE_SAFE_MODE_MIN_VERSION },
-      '`mise lock` was requested to run, but `mise` is not permitted in `allowedUnsafeExecutions` and no `mise` constraint guaranteeing safe-mode support is configured',
+      '`mise lock` requires either `mise` in `allowedUnsafeExecutions`, or a mise version that supports safe mode',
     );
     return null;
   }

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -48,11 +48,11 @@ In particular:
 
 #### Safe mode (no allowlist required)
 
-mise's [safe mode](https://mise.jdx.dev/configuration/settings.html#safe) (`MISE_SAFE=1`) is a hard boundary against project configuration executing code: templates that call `exec()`/`read_file()`, `_.source` scripts, hooks, tasks, asdf plugin scripts, and plugin installs are all refused, while version resolution over HTTP-based backends still works.
+mise's [safe mode](https://mise.jdx.dev/configuration/settings.html#safe) (`MISE_SAFE=1`) makes an untrusted project config inert: code execution is refused (`exec()`/`read_file()`, `_.source`, hooks, tasks, asdf plugin scripts, plugin installs) and project `[env]`, `_.path`, `[shell_alias]`, and `[settings]` are ignored, while version resolution over HTTP-based backends still works.
 
-When the `mise` binary that Renovate runs is new enough to support safe mode, Renovate runs `mise lock` with `MISE_SAFE=1` and no longer requires `mise` in `allowedUnsafeExecutions` — the safe-mode boundary, not the allowlist, is what protects the host. Renovate determines this at runtime by running `mise version` (which does not load or execute project configuration), so no extra configuration is needed; installing or pinning a recent enough `mise` is enough.
+When the `mise` binary that Renovate runs is new enough to support safe mode, Renovate runs `mise lock` with `MISE_SAFE=1`. Because the config is inert, this needs neither `mise` in `allowedUnsafeExecutions` **nor** a preceding `mise trust` — the safe-mode boundary, not the allowlist or trust store, is what protects the host. Renovate determines support at runtime by running `mise version` (which does not load or execute project configuration), so no extra configuration is needed; installing or pinning a recent enough `mise` is enough.
 
-The `allowedUnsafeExecutions` path is unchanged: if `mise` is allowlisted, Renovate runs `mise lock` exactly as before (without forcing safe mode), so configs that legitimately rely on code execution during locking keep working.
+The `allowedUnsafeExecutions` path is unchanged: if `mise` is allowlisted, Renovate runs `mise trust` and `mise lock` exactly as before (without forcing safe mode), so configs that legitimately rely on code execution during locking keep working.
 
 ### Renovate only updates primary versions
 

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -46,6 +46,22 @@ In particular:
 - an existing `mise.lock` is required
 - self-hosted administrators decide whether this unsafe execution is acceptable for their environment
 
+#### Safe mode (no allowlist required)
+
+mise's [safe mode](https://mise.jdx.dev/configuration/settings.html#safe) (`MISE_SAFE=1`) is a hard boundary against project configuration executing code: templates that call `exec()`/`read_file()`, `_.source` scripts, hooks, tasks, asdf plugin scripts, and plugin installs are all refused, while version resolution over HTTP-based backends still works.
+
+When your `constraints.mise` pins a mise version that supports safe mode, Renovate runs `mise lock` with `MISE_SAFE=1` and no longer requires `mise` in `allowedUnsafeExecutions` — the safe-mode boundary, not the allowlist, is what protects the host:
+
+```json
+{
+  "constraints": {
+    "mise": "2026.8.0"
+  }
+}
+```
+
+The `allowedUnsafeExecutions` path is unchanged: if `mise` is allowlisted, Renovate runs `mise lock` exactly as before (without forcing safe mode), so configs that legitimately rely on code execution during locking keep working.
+
 ### Renovate only updates primary versions
 
 Renovate's `mise` manager is designed to automatically update the _first_ (primary) version listed for each tool in the `mise.toml` file.

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -55,7 +55,7 @@ When your `constraints.mise` pins a mise version that supports safe mode, Renova
 ```json
 {
   "constraints": {
-    "mise": "2026.8.0"
+    "mise": "2026.7.12"
   }
 }
 ```

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -22,7 +22,7 @@ When a lock file is present:
 
 - Dependencies will have their `lockedVersion` extracted from the lock file
 - Renovate can update lock files when dependencies change
-- Lock file maintenance is supported via the `lockFileMaintenance` option
+- Lock file maintenance is supported via the `lockFileMaintenance` option. When the configured mise version supports it (see [safe mode](#safe-mode-no-allowlist-required) for how the version is determined), maintenance runs `mise lock --bump`, which advances fuzzy selectors (e.g. `node = "22"`) to the latest matching version rather than only refreshing existing locked versions.
 
 Renovate recognizes environment-specific lock files:
 

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -22,7 +22,7 @@ When a lock file is present:
 
 - Dependencies will have their `lockedVersion` extracted from the lock file
 - Renovate can update lock files when dependencies change
-- Lock file maintenance is supported via the `lockFileMaintenance` option. When the configured mise version supports it (see [safe mode](#safe-mode-no-allowlist-required) for how the version is determined), maintenance runs `mise lock --bump`, which advances fuzzy selectors (e.g. `node = "22"`) to the latest matching version rather than only refreshing existing locked versions.
+- Lock file maintenance is supported via the `lockFileMaintenance` option. When the `mise` version Renovate runs supports it (see [safe mode](#safe-mode-no-allowlist-required) for how the version is detected), maintenance runs `mise lock --bump`, which advances fuzzy selectors (e.g. `node = "22"`) to the latest matching version rather than only refreshing existing locked versions.
 
 Renovate recognizes environment-specific lock files:
 
@@ -50,15 +50,7 @@ In particular:
 
 mise's [safe mode](https://mise.jdx.dev/configuration/settings.html#safe) (`MISE_SAFE=1`) is a hard boundary against project configuration executing code: templates that call `exec()`/`read_file()`, `_.source` scripts, hooks, tasks, asdf plugin scripts, and plugin installs are all refused, while version resolution over HTTP-based backends still works.
 
-When your `constraints.mise` pins a mise version that supports safe mode, Renovate runs `mise lock` with `MISE_SAFE=1` and no longer requires `mise` in `allowedUnsafeExecutions` — the safe-mode boundary, not the allowlist, is what protects the host:
-
-```json
-{
-  "constraints": {
-    "mise": "2026.7.12"
-  }
-}
-```
+When the `mise` binary that Renovate runs is new enough to support safe mode, Renovate runs `mise lock` with `MISE_SAFE=1` and no longer requires `mise` in `allowedUnsafeExecutions` — the safe-mode boundary, not the allowlist, is what protects the host. Renovate determines this at runtime by running `mise version` (which does not load or execute project configuration), so no extra configuration is needed; installing or pinning a recent enough `mise` is enough.
 
 The `allowedUnsafeExecutions` path is unchanged: if `mise` is allowlisted, Renovate runs `mise lock` exactly as before (without forcing safe mode), so configs that legitimately rely on code execution during locking keep working.
 

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -22,7 +22,7 @@ When a lock file is present:
 
 - Dependencies will have their `lockedVersion` extracted from the lock file
 - Renovate can update lock files when dependencies change
-- Lock file maintenance is supported via the `lockFileMaintenance` option. When the `mise` version Renovate runs supports it (see [safe mode](#safe-mode-no-allowlist-required) for how the version is detected), maintenance runs `mise lock --bump`, which advances fuzzy selectors (e.g. `node = "22"`) to the latest matching version rather than only refreshing existing locked versions.
+- Lock file maintenance is supported via the `lockFileMaintenance` option. When the `mise` version Renovate runs supports it (see [safe mode](#trust-model-for-lock-file-updates) for how the version is detected), maintenance runs `mise lock --bump`, which advances fuzzy selectors (e.g. `node = "22"`) to the latest matching version rather than only refreshing existing locked versions.
 
 Renovate recognizes environment-specific lock files:
 

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -46,14 +46,6 @@ In particular:
 - an existing `mise.lock` is required
 - self-hosted administrators decide whether this unsafe execution is acceptable for their environment
 
-#### Safe mode (no allowlist required)
-
-mise's [safe mode](https://mise.jdx.dev/configuration/settings.html#safe) (`MISE_SAFE=1`) makes an untrusted project config inert: code execution is refused (`exec()`/`read_file()`, `_.source`, hooks, tasks, asdf plugin scripts, plugin installs) and project `[env]`, `_.path`, `[shell_alias]`, and `[settings]` are ignored, while version resolution over HTTP-based backends still works.
-
-When the `mise` binary that Renovate runs is new enough to support safe mode, Renovate runs `mise lock` with `MISE_SAFE=1`. Because the config is inert, this needs neither `mise` in `allowedUnsafeExecutions` **nor** a preceding `mise trust` — the safe-mode boundary, not the allowlist or trust store, is what protects the host. Renovate determines support at runtime by running `mise version` (which does not load or execute project configuration), so no extra configuration is needed; installing or pinning a recent enough `mise` is enough.
-
-The `allowedUnsafeExecutions` path is unchanged: if `mise` is allowlisted, Renovate runs `mise trust` and `mise lock` exactly as before (without forcing safe mode), so configs that legitimately rely on code execution during locking keep working.
-
 ### Renovate only updates primary versions
 
 Renovate's `mise` manager is designed to automatically update the _first_ (primary) version listed for each tool in the `mise.toml` file.

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -39,7 +39,15 @@ Running `mise lock` can execute repository-defined behavior, so Renovate treats 
 
 Self-hosted administrators must explicitly allow this path by including `mise` in the global [`allowedUnsafeExecutions`](../../../self-hosted-configuration.md#allowedunsafeexecutions) setting.
 
-When `mise` is allowed and an existing `mise.lock` is present, Renovate explicitly runs `mise trust` before `mise lock` from the repository checkout. This makes the trust step visible in logs and lets mise own any future trust behavior changes.
+Because mise lock can execute repository-defined scripts, Renovate treats lockfile refreshes as an unsafe execution and attempts to run mise in [safe mode](https://mise.jdx.dev/configuration/settings.html#safe).
+
+If mise does not support safe mode or version detection fails, Renovate blocks all mise operations.
+
+#### Allowing Unsafe Executions
+
+Self-hosted administrators can permit these operations by adding "mise" to the global [`allowedUnsafeExecutions`](../../../self-hosted-configuration.md#allowedunsafeexecutions) configuration.
+
+Once allowed, Renovate runs mise trust before mise lock when a mise.lock file is present. This exposes the trust step in execution logs and defers trust rules to mise.
 
 In particular:
 


### PR DESCRIPTION
## Changes

Lets the `mise` manager refresh `mise.lock` on **untrusted** configuration (e.g. PR branches) without requiring self-hosted admins to allowlist `mise` in [`allowedUnsafeExecutions`](https://docs.renovatebot.com/self-hosted-configuration/#allowedunsafeexecutions).

#43606 added that allowlist requirement because `mise lock` can execute repo-defined behavior. mise now provides a code-execution boundary for exactly this use case — safe mode (`MISE_SAFE=1`) — so on the opt-in path the allowlist is no longer needed.

All changes are in `lib/modules/manager/mise/artifacts.ts`:

- **Run `mise lock` under `MISE_SAFE=1` when the mise binary supports it, and skip the `allowedUnsafeExecutions` requirement on that path.** Safe mode makes an untrusted config inert (no code execution, no env injection), so it — not the allowlist — is what protects the host here.
- **Detect support at runtime via `mise version`** rather than requiring a pinned `constraints.mise`. It's a cheap extra exec that doesn't read project config, and it's skipped on the allowlisted, non-maintenance path where it can't change the outcome.
- **Skip the `mise trust` step on the safe-mode path.** An inert config needs no trust; `mise lock` runs with `MISE_SAFE=1` alone.
- **Drop the `node`/`npm`/`golang`/`ruby` resolver tool constraints on the safe-mode path.** mise resolves versions over HTTP in safe mode, so these installs aren't needed — also addressing the container-provisioning pain in #44174.
- **Use `mise lock --bump` for `lockFileMaintenance`** (when supported). `lockFileMaintenance` means "update to the latest versions", but plain `mise lock` only refreshes already-locked versions; `--bump` advances fuzzy selectors like `node = "22"` to the latest match. Related to the selector-resolution work in #44615.

**Backwards compatible / opt-in:** the allowlisted path is unchanged — if `mise` is allowlisted, `mise lock` runs exactly as before (with `mise trust`, no forced safe mode), so configs that legitimately execute code during locking keep working. Older mise binaries that lack safe mode transparently fall back to the existing allowlist-required behavior.

<details>
<summary>What "safe mode" guarantees (mise side)</summary>

`MISE_SAFE=1` makes an untrusted project config inert: code execution is refused (template `exec()`/`read_file()`, `_.source`, hooks, tasks, asdf plugin scripts, plugin installs) and project `[env]`, `_.path`, `_.file`, `[shell_alias]`, and `[settings]` are ignored, so an untrusted config can't inject `PATH`/`LD_PRELOAD`/`NODE_OPTIONS` or change mise's resolution behavior. HTTP-based version resolution still works, and because the config is inert, no trust is required. Shipped in mise [v2026.7.12](https://github.com/jdx/mise/releases/tag/v2026.7.12); `MISE_SAFE_MODE_MIN_VERSION` is set accordingly.

</details>

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Tooling: Claude Code (Claude, Anthropic). Implemented with substantial AI assistance and reviewed by the author (a mise maintainer).

## Documentation

- [x] I have updated the documentation (`lib/modules/manager/mise/readme.md`)

## How I've tested my work

- [x] Newly added/modified unit tests (`artifacts.spec.ts`) — 33/33 pass.
- [x] Validated the mise-side behavior end-to-end against the real `v2026.7.12` binary: on an untrusted config with hooks/tasks/`[env]`, plain `mise lock` errors on trust while `MISE_SAFE=1 mise lock` refreshes the lockfile with no trust and no allowlist; `mise lock --bump` advances a `node = "22"` selector; and the untrusted `[env]` is ignored.
