### PR TITLE
fix(presets/monorepos): add Effect-TS/effect URL to effect group

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -359,7 +359,10 @@
     "dotnetcore-cap": "https://github.com/dotnetcore/CAP",
     "dropwizard": "https://github.com/dropwizard/dropwizard",
     "duende-identityserver": "https://github.com/DuendeSoftware/IdentityServer",
-    "effect": "https://github.com/Effect-TS/effect-smol",
+    "effect": [
+      "https://github.com/Effect-TS/effect",
+      "https://github.com/Effect-TS/effect-smol"
+    ],
     "elastic-apm-agent-rum-js": "https://github.com/elastic/apm-agent-rum-js",
     "elastic-ecs-dotnet": "https://github.com/elastic/ecs-dotnet",
     "electron-forge": [


### PR DESCRIPTION
## Changes

The `effect` monorepo group only matched https://github.com/Effect-TS/effect-smol, the development repository for the upcoming Effect v4 (added in #41939). However, the currently published npm packages (`effect`, `@effect/platform`, `@effect/cli`, etc.) are released in lockstep from https://github.com/Effect-TS/effect and their `sourceUrl` points there, so they were not grouped and Renovate raised separate PRs for each package.

This PR adds the main `Effect-TS/effect` repository URL to the group, so both the current packages and the future v4 packages are grouped together.

For reference, the npm metadata of the published packages points to the main repository:

- `effect`: `"repository": "git+https://github.com/Effect-TS/effect.git"`
- `@effect/platform`: `"repository": "https://github.com/Effect-TS/effect.git"` (with `directory: packages/platform`)

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR (the investigation, the one-line data change, and this description) was written by Claude Code (Claude Fable 5), reviewed by me.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`pnpm check` and `pnpm test-schema` pass locally.

https://claude.ai/code/session_01Xn7ZbERnKd6ERegDAgt7Zi