### PR TITLE
fix(schedule): match cron schedules on the edge of an hour

### DIFF
--- a/lib/workers/repository/update/branch/schedule.spec.ts
+++ b/lib/workers/repository/update/branch/schedule.spec.ts
@@ -215,15 +215,6 @@ describe('workers/repository/update/branch/schedule', () => {
       expect(res).toBeFalse();
     });
 
-    it('matches cron schedules in the last minute of an hour window', () => {
-      config.schedule = ['* 3-7 * * *'];
-      vi.setSystemTime(new Date('2026-06-30T07:59:01.000'));
-      expect(schedule.isScheduledNow(config)).toBeTrue();
-
-      vi.setSystemTime(new Date('2026-06-30T08:00:00.000'));
-      expect(schedule.isScheduledNow(config)).toBeFalse();
-    });
-
     it('supports cron syntax with days', () => {
       config.schedule = ['* * 30 * *'];
       let res = schedule.isScheduledNow(config);
@@ -252,6 +243,30 @@ describe('workers/repository/update/branch/schedule', () => {
       config.schedule = ['* * * * 6'];
       res = schedule.isScheduledNow(config);
       expect(res).toBeFalse();
+    });
+
+    describe('matches cron schedules in the last minute of an hour', () => {
+      beforeEach(() => {
+        config.schedule = ['* 3-7 * * *'];
+      });
+
+      it('does not allow the previous hour', () => {
+        vi.setSystemTime(new Date('2026-06-30T02:59:01.000'));
+        expect(schedule.isScheduledNow(config)).toBeFalse();
+      });
+
+      it.each(['00.000', '01.000', '59.000', '59.999'])(
+        'allows %s seconds after the last minute',
+        (secondsAndMillis) => {
+          vi.setSystemTime(new Date(`2026-06-30T07:59:${secondsAndMillis}`));
+          expect(schedule.isScheduledNow(config)).toBeTrue();
+        },
+      );
+
+      it('does not allow the next hour', () => {
+        vi.setSystemTime(new Date('2026-06-30T08:00:00.000'));
+        expect(schedule.isScheduledNow(config)).toBeFalse();
+      });
     });
 
     describe('supports cron syntax on Sundays', () => {

--- a/lib/workers/repository/update/branch/schedule.spec.ts
+++ b/lib/workers/repository/update/branch/schedule.spec.ts
@@ -215,6 +215,15 @@ describe('workers/repository/update/branch/schedule', () => {
       expect(res).toBeFalse();
     });
 
+    it('matches cron schedules in the last minute of an hour window', () => {
+      config.schedule = ['* 3-7 * * *'];
+      vi.setSystemTime(new Date('2026-06-30T07:59:01.000'));
+      expect(schedule.isScheduledNow(config)).toBeTrue();
+
+      vi.setSystemTime(new Date('2026-06-30T08:00:00.000'));
+      expect(schedule.isScheduledNow(config)).toBeFalse();
+    });
+
     it('supports cron syntax with days', () => {
       config.schedule = ['* * 30 * *'];
       let res = schedule.isScheduledNow(config);

--- a/lib/workers/repository/update/branch/schedule.ts
+++ b/lib/workers/repository/update/branch/schedule.ts
@@ -104,8 +104,11 @@ export function cronMatches(
     return false;
   }
 
-  // return the next date which matches the cron schedule
-  const nextRun = parsedCron.nextRun();
+  // check next viable cron run after right before the current minute
+  // if now is 09:59:xx, look for next run after 09:58:59, which is 09:59:00
+  const nowMinute = now.startOf('minute');
+  const probe = nowMinute.minus({ milliseconds: 1 });
+  const nextRun = parsedCron.nextRun(probe.toJSDate());
   // istanbul ignore if: should not happen
   if (!nextRun) {
     logger.warn(
@@ -115,16 +118,10 @@ export function cronMatches(
     return false;
   }
 
-  let nextDate = DateTime.fromJSDate(nextRun);
-  if (timezone) {
-    nextDate = nextDate.setZone(timezone);
-  }
-
-  return (
-    nextDate.hour === now.hour &&
-    nextDate.day === now.day &&
-    nextDate.month === now.month
-  );
+  // compare the next run minute to current minute
+  // if they match, then the current minute is within the cron schedule
+  const nextMinute = DateTime.fromJSDate(nextRun).startOf('minute');
+  return nextMinute.toMillis() === nowMinute.toMillis();
 }
 
 export function isScheduledNow(


### PR DESCRIPTION
## Changes

This PR fixes this issue:

> With schedule * 3-7 * * * at 05:59:54Z (Etc/UTC), this minute is inside the configured window (03:00-07:59), but Renovate logs `Skipping branch creation as not within schedule` and does not perform any update.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44752 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): Used Cursor to understand the codebase and the problem in depth, generate test case and do a code review before submitting the PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
