### PR TITLE
docs(manager): make sure that Supported Datasources are de-duped and sorted

### DIFF
--- a/lib/modules/manager/renovate-config/index.ts
+++ b/lib/modules/manager/renovate-config/index.ts
@@ -12,10 +12,12 @@ export const defaultConfig = {
   ),
 };
 
-export const supportedDatasources = [
-  GithubTagsDatasource.id,
-  GitlabTagsDatasource.id,
-  GiteaTagsDatasource.id,
+export const supportedDatasources = Array.from(
+  new Set([
+    GithubTagsDatasource.id,
+    GitlabTagsDatasource.id,
+    GiteaTagsDatasource.id,
 
-  ...Object.values(allToolConfig).map((conf) => conf.datasource),
-];
+    ...Object.values(allToolConfig).map((conf) => conf.datasource),
+  ]),
+);

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -138,7 +138,8 @@ export async function generateManagers(
       }
       md += `For details on how to extend a manager's \`managerFilePatterns\` value, please follow [this link](../index.md#file-matching).\n\n`;
       md += '## Supported datasources\n\n';
-      const escapedDatasources = (supportedDatasources || [])
+      const escapedDatasources = Array.from(new Set(supportedDatasources || []))
+        .sort()
         .map(
           (datasource) =>
             `[\`${datasource}\`](../../datasource/${datasource}/index.md)`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #44764, we otherwise end up with a lot of duplicated
entries for `renovate-config`.

We can also sort them to make ti a slightly more readable list.


After: 

<img width="802" height="181" alt="Screenshot 2026-07-21 at 19 05 27" src="https://github.com/user-attachments/assets/7e419db6-9f1f-40c4-a24f-ac31b0aa7193" />


## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
