### PR TITLE
fix(manager/npm): don't include versions in extracted Yarn `resolutions`' `depName`#

### DIFF
--- a/lib/modules/manager/npm/extract/common/dependency.spec.ts
+++ b/lib/modules/manager/npm/extract/common/dependency.spec.ts
@@ -1,0 +1,58 @@
+import { parseDepName } from './dependency.ts';
+
+describe('modules/manager/npm/extract/common/dependency', () => {
+  describe('parseDepName', () => {
+    it('returns key unchanged for non-resolutions depTypes', () => {
+      expect(parseDepName('dependencies', '@cypress/request/qs@~6.14.1')).toBe(
+        '@cypress/request/qs@~6.14.1',
+      );
+    });
+
+    it('returns simple package name unchanged', () => {
+      expect(parseDepName('resolutions', 'left-pad')).toBe('left-pad');
+    });
+
+    it('returns scoped package name unchanged', () => {
+      expect(parseDepName('resolutions', '@angular/cli')).toBe('@angular/cli');
+    });
+
+    it('extracts child package name from nested path', () => {
+      expect(parseDepName('resolutions', 'config/glob')).toBe('glob');
+    });
+
+    it('extracts child package name from wildcard nested path', () => {
+      expect(parseDepName('resolutions', '**/config')).toBe('config');
+    });
+
+    it('extracts scoped child package name from wildcard nested path', () => {
+      expect(parseDepName('resolutions', '**/@angular/cli')).toBe(
+        '@angular/cli',
+      );
+    });
+
+    // https://github.com/renovatebot/renovate/discussions/44768
+    // A version discriminator on the final path segment is incorrectly
+    // treated as the package name instead of being stripped.
+    it('incorrectly returns version discriminator instead of unscoped package name', () => {
+      expect(parseDepName('resolutions', 'foo/bar@1.0.0')).toBe('1.0.0');
+    });
+
+    it('incorrectly returns version discriminator instead of package name behind scoped parent path', () => {
+      expect(parseDepName('resolutions', '@cypress/request/qs@~6.14.1')).toBe(
+        '~6.14.1',
+      );
+    });
+
+    it('incorrectly returns plain semver instead of package name', () => {
+      expect(parseDepName('resolutions', '@verdaccio/core/ajv@8.17.1')).toBe(
+        '8.17.1',
+      );
+    });
+
+    it('incorrectly returns version discriminator instead of scoped package name', () => {
+      expect(parseDepName('resolutions', 'foo/@babel/core@7.0.0')).toBe(
+        '7.0.0',
+      );
+    });
+  });
+});

--- a/lib/modules/manager/npm/extract/common/dependency.spec.ts
+++ b/lib/modules/manager/npm/extract/common/dependency.spec.ts
@@ -31,27 +31,25 @@ describe('modules/manager/npm/extract/common/dependency', () => {
     });
 
     // https://github.com/renovatebot/renovate/discussions/44768
-    // A version discriminator on the final path segment is incorrectly
-    // treated as the package name instead of being stripped.
-    it('incorrectly returns version discriminator instead of unscoped package name', () => {
-      expect(parseDepName('resolutions', 'foo/bar@1.0.0')).toBe('1.0.0');
+    it('strips version discriminator from unscoped final segment', () => {
+      expect(parseDepName('resolutions', 'foo/bar@1.0.0')).toBe('bar');
     });
 
-    it('incorrectly returns version discriminator instead of package name behind scoped parent path', () => {
+    it('strips version discriminator from scoped parent path', () => {
       expect(parseDepName('resolutions', '@cypress/request/qs@~6.14.1')).toBe(
-        '~6.14.1',
+        'qs',
       );
     });
 
-    it('incorrectly returns plain semver instead of package name', () => {
+    it('strips version discriminator with plain semver final segment', () => {
       expect(parseDepName('resolutions', '@verdaccio/core/ajv@8.17.1')).toBe(
-        '8.17.1',
+        'ajv',
       );
     });
 
-    it('incorrectly returns version discriminator instead of scoped package name', () => {
+    it('strips version discriminator when final segment is itself scoped', () => {
       expect(parseDepName('resolutions', 'foo/@babel/core@7.0.0')).toBe(
-        '7.0.0',
+        '@babel/core',
       );
     });
   });

--- a/lib/modules/manager/npm/extract/common/dependency.ts
+++ b/lib/modules/manager/npm/extract/common/dependency.ts
@@ -24,7 +24,26 @@ export function parseDepName(depType: string, key: string): string {
     return key;
   }
 
-  const [, depName] = regEx(/((?:@[^/]+\/)?[^/@]+)$/).exec(key) ?? [];
+  // Yarn selective dependency resolutions may nest a path of parent
+  // packages before the target package, e.g. `parent/child` or
+  // `@scope/parent/child`, and any segment (including the last) may carry
+  // a `@range` suffix used to disambiguate which version of that package
+  // to match, e.g. `@cypress/request/qs@~6.14.1`.
+  const parts = key.split('/');
+  const segments: string[] = [];
+  for (let i = 0; i < parts.length; i += 1) {
+    const part = parts[i];
+    if (part.startsWith('@') && i + 1 < parts.length) {
+      i += 1;
+      segments.push(`${part}/${parts[i]}`);
+    } else {
+      segments.push(part);
+    }
+  }
+
+  const lastSegment = segments.at(-1);
+  const [, depName] =
+    regEx(/^((?:@[^/]+\/)?[^@]+)/).exec(lastSegment ?? '') ?? [];
   return depName;
 }
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As noted in #44768, given the following in our `package.json`:

```json
{
"resolutions": {
"@cypress/request/qs@~6.14.1": "^6.15.1",
"@verdaccio/core/ajv@8.17.1": "^8.18.0"
}
}
```

Previously, Renovate would treat `~6.14.1` as the `depName`, which was
incorrect.

We can instead handle this by adding custom handling here.


<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
