### PR TITLE
perf(package-rules): avoid re-cloning invariant packageRules array on every rule match

### DIFF
--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -1530,4 +1530,56 @@ describe('util/package-rules/index', () => {
     const res = await applyPackageRules(config);
     expect(res.sourceUrl).toBe('https://github.com/hashicorp/aws');
   });
+
+  describe('packageRules array handling', () => {
+    it('returns the input packageRules array without re-cloning it', async () => {
+      const config: TestConfig = {
+        packageName: 'a',
+        packageRules: [
+          {
+            matchPackageNames: ['a'],
+            // @ts-expect-error -- testing
+            x: 2,
+          },
+        ],
+      };
+      const res = await applyPackageRules(config);
+      expect(res.x).toBe(2);
+      expect(res.packageRules).toBe(config.packageRules);
+    });
+
+    it('does not add a packageRules key when the input has none', async () => {
+      const config: PackageRuleInputConfig = { packageName: 'a' };
+      const res = await applyPackageRules(config);
+      expect(res.packageRules).toBeUndefined();
+    });
+
+    it('keeps an empty packageRules array', async () => {
+      const config: PackageRuleInputConfig = {
+        packageName: 'a',
+        packageRules: [],
+      };
+      const res = await applyPackageRules(config);
+      expect(res.packageRules).toBe(config.packageRules);
+    });
+
+    it('appends nested packageRules carried by an applied rule', async () => {
+      const nestedRule = {
+        matchPackageNames: ['b'],
+        y: 3,
+      };
+      const config: TestConfig = {
+        packageName: 'a',
+        packageRules: [
+          {
+            matchPackageNames: ['a'],
+            packageRules: [nestedRule],
+          },
+        ],
+      };
+      const res = await applyPackageRules(config);
+      expect(res.packageRules).toHaveLength(2);
+      expect(res.packageRules![1]).toEqual(nestedRule);
+    });
+  });
 });

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -38,6 +38,12 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
 ): Promise<T> {
   let config = { ...inputConfig };
   const packageRules = config.packageRules ?? [];
+  // The `packageRules` array is invariant while rules are being applied, and
+  // can be very large (e.g. vulnerability alerts append rules embedding full
+  // advisory texts). Remove it from the working config so mergeChildConfig()
+  // does not deep-clone the whole array once per matched rule, then restore
+  // it afterwards.
+  delete config.packageRules;
   logger.trace(
     { dependency: config.depName, packageRules },
     `Checking against ${packageRules.length} packageRules`,
@@ -106,6 +112,14 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
       delete toApply.overridePackageName;
       config = mergeChildConfig(config, toApply);
     }
+  }
+  // Restore the rules. If any applied rule carried nested `packageRules`
+  // (e.g. from a resolved preset), preserve the concat-merge semantics that
+  // mergeChildConfig() would previously have applied.
+  if (config.packageRules) {
+    config.packageRules = packageRules.concat(config.packageRules);
+  } else if ('packageRules' in inputConfig) {
+    config.packageRules = inputConfig.packageRules;
   }
   return config;
 }

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -39,6 +39,12 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
 ): Promise<T> {
   let config = { ...inputConfig };
   const packageRules = coerceArray(config.packageRules);
+  // The `packageRules` array is invariant while rules are being applied, and
+  // can be very large (e.g. vulnerability alerts append rules embedding full
+  // advisory texts). Remove it from the working config so mergeChildConfig()
+  // does not deep-clone the whole array once per matched rule, then restore
+  // it afterwards.
+  delete config.packageRules;
   logger.trace(
     { dependency: config.depName, packageRules },
     `Checking against ${packageRules.length} packageRules`,
@@ -107,6 +113,14 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
       delete toApply.overridePackageName;
       config = mergeChildConfig(config, toApply);
     }
+  }
+  // Restore the rules. If any applied rule carried nested `packageRules`
+  // (e.g. from a resolved preset), preserve the concat-merge semantics that
+  // mergeChildConfig() would previously have applied.
+  if (config.packageRules) {
+    config.packageRules = packageRules.concat(config.packageRules);
+  } else if ('packageRules' in inputConfig) {
+    config.packageRules = inputConfig.packageRules;
   }
   return config;
 }


### PR DESCRIPTION
## Changes

`applyPackageRules()` merges each matching rule into the working config via `mergeChildConfig()`, which deep-clones the entire accumulated config on every call — including the invariant `packageRules` array itself. On repos with many dependency instances and large rule arrays (e.g. `vulnerabilityAlerts` compiling every open advisory into a forced rule), this cloning dominates the whole Renovate run — observed at ~66% of total CPU in a production profile.

This PR excludes `packageRules` from the working config while rules are applied and restores it afterwards, preserving the previous merge semantics for:
- rules that themselves carry nested `packageRules` (still merged/concatenated onto the restored array),
- `null` / empty / absent `packageRules` inputs (round-tripped unchanged),
- external callers that observe the returned config (the array reference survives the round-trip).

No behavior change; strictly a hot-path allocation removal.

## Context

- [x] This closes an existing Issue, Closes: #44459

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Claude Fable 5 (via Claude Code) was used to co-author the implementation and the added unit tests, based on a CPU profile and hypothesis I supplied. All final wording, review, and validation are mine.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

- [x] Both unit tests + ran on a real repository

New tests in `lib/util/package-rules/index.spec.ts` cover the round-trip guarantee (rules preserved), nested-rules concatenation, and null/empty input handling. The change was also validated on a large private monorepo where it eliminated the applyPackageRules hot path from the CPU profile (issue #44459 has the original profile).

The public repository: n/a (private profile source; behavior fully covered by the new specs)