### PR TITLE
chore(gitlab): tidy up around gitlab codeowner role support

### DIFF
--- a/lib/modules/platform/gitlab/http.ts
+++ b/lib/modules/platform/gitlab/http.ts
@@ -1,6 +1,8 @@
 import { isEmptyArray } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { GitlabHttp } from '../../../util/http/gitlab.ts';
+import type { GitLabProjectMember } from './schema.ts';
+import { GitLabProjectMembers } from './schema.ts';
 import type { GitLabUser, GitlabUserStatus } from './types.ts';
 
 export const gitlabApi = new GitlabHttp();
@@ -48,12 +50,13 @@ export async function getMemberUsernames(group: string): Promise<string[]> {
   return members.map((u) => u.username);
 }
 
-async function getProjectMembers(repo: string): Promise<GitLabUser[]> {
+async function getProjectMembers(repo: string): Promise<GitLabProjectMember[]> {
   const repoEncoded = encodeURIComponent(repo);
   return (
-    await gitlabApi.getJsonUnchecked<GitLabUser[]>(
+    await gitlabApi.getJson(
       `projects/${repoEncoded}/members`,
       { paginate: true },
+      GitLabProjectMembers,
     )
   ).body;
 }
@@ -61,7 +64,7 @@ async function getProjectMembers(repo: string): Promise<GitLabUser[]> {
 export async function getProjectMembersByRole(
   repo: string,
   accessLevel: number,
-): Promise<GitLabUser[]> {
+): Promise<GitLabProjectMember[]> {
   const members = await getProjectMembers(repo);
   return members.filter((m) => m.access_level === accessLevel);
 }

--- a/lib/modules/platform/gitlab/roles.ts
+++ b/lib/modules/platform/gitlab/roles.ts
@@ -1,5 +1,3 @@
-import { regEx } from '../../../util/regex.ts';
-
 // See: https://docs.gitlab.com/api/users/#list-projects-and-groups-that-a-user-is-a-member-of
 const roleAccessLevels: Record<string, number> = {
   no_access: 0,
@@ -12,15 +10,15 @@ const roleAccessLevels: Record<string, number> = {
   owner: 50,
 } as const;
 
-const roleRegex = regEx(/^@@(?<role>\w+)$/);
-
 /**
  * Parse a GitLab CODEOWNERS role handle (`@@developer`, `@@maintainer`,
  * `@@owner`, etc) into its access level. Returns `null` when the handle is not a
  * recognized role, so `getRoleAccessLevel(x) !== null` doubles as a role check.
  */
 export function getRoleAccessLevel(handle: string): number | null {
-  const role = roleRegex.exec(handle)?.groups?.role;
-  const level = role ? roleAccessLevels[role.toLowerCase()] : undefined;
-  return level ?? null;
+  if (!handle.startsWith('@@')) {
+    return null;
+  }
+  const role = handle.slice(2).toLowerCase();
+  return roleAccessLevels[role] ?? null;
 }

--- a/lib/modules/platform/gitlab/roles.ts
+++ b/lib/modules/platform/gitlab/roles.ts
@@ -8,7 +8,7 @@ const roleAccessLevels: Record<string, number> = {
   developer: 30,
   maintainer: 40,
   owner: 50,
-} as const;
+};
 
 /**
  * Parse a GitLab CODEOWNERS role handle (`@@developer`, `@@maintainer`,

--- a/lib/modules/platform/gitlab/schema.spec.ts
+++ b/lib/modules/platform/gitlab/schema.spec.ts
@@ -1,0 +1,48 @@
+import { GitLabProjectMembers } from './schema.ts';
+
+describe('modules/platform/gitlab/schema', () => {
+  describe('GitLabProjectMembers', () => {
+    it('parses members with an access level', () => {
+      expect(
+        GitLabProjectMembers.parse([
+          { username: 'dev', access_level: 30 },
+          { username: 'maintainer', access_level: 40 },
+        ]),
+      ).toEqual([
+        { username: 'dev', access_level: 30 },
+        { username: 'maintainer', access_level: 40 },
+      ]);
+    });
+
+    it('treats access_level as optional', () => {
+      expect(GitLabProjectMembers.parse([{ username: 'dev' }])).toEqual([
+        { username: 'dev' },
+      ]);
+    });
+
+    it('ignores unspecified fields', () => {
+      expect(
+        GitLabProjectMembers.parse([
+          { id: 1, username: 'dev', access_level: 30, extra: 'ignored' },
+        ]),
+      ).toEqual([{ username: 'dev', access_level: 30 }]);
+    });
+
+    it('filters out malformed entries', () => {
+      expect(
+        GitLabProjectMembers.parse([
+          { username: 'dev', access_level: 30 },
+          { access_level: 40 },
+          { username: 42 },
+          null,
+        ]),
+      ).toEqual([{ username: 'dev', access_level: 30 }]);
+    });
+
+    it('rejects a non-array input', () => {
+      expect(GitLabProjectMembers.safeParse('not an array').success).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/lib/modules/platform/gitlab/schema.ts
+++ b/lib/modules/platform/gitlab/schema.ts
@@ -15,6 +15,14 @@ const GitlabUser = z.object({
   username: z.string(),
 });
 
+export const GitLabProjectMembers = LooseArray(
+  z.object({
+    username: z.string(),
+    access_level: z.number().optional(),
+  }),
+);
+export type GitLabProjectMember = z.infer<typeof GitLabProjectMembers>[number];
+
 export const GitLabMergeRequest = DeepNullish(
   z.object({
     iid: z.number(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Small tidy ups to follow up on the already merged https://github.com/renovatebot/renovate/pull/44621#pullrequestreview-4762110086

Addresses the following comments made post merge:
- https://github.com/renovatebot/renovate/pull/44621#discussion_r3636570880
- https://github.com/renovatebot/renovate/pull/44621#discussion_r3636585544
- https://github.com/renovatebot/renovate/pull/44621#discussion_r3636592878

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Opus 4.8) was used to help implement the zod schema and write related unit tests. All changes were reviewed by me.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
