### PR TITLE
fix(platform/gitlab): send sha on merge to support require-sha namespace setting

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -3947,6 +3947,28 @@ describe('modules/platform/gitlab/index', () => {
       );
     });
 
+    it('echoes the source branch HEAD sha when arming automerge', async () => {
+      await initPlatform('13.3.6-ee');
+      httpMock
+        .scope(gitlabApiHost)
+        .get('/api/v4/projects/undefined/merge_requests/12345')
+        .reply(200, {
+          sha: 'abc123',
+          merge_status: 'can_be_merged',
+          pipeline: {
+            status: 'running',
+          },
+        })
+        .put('/api/v4/projects/undefined/merge_requests/12345/merge', {
+          should_remove_source_branch: true,
+          merge_when_pipeline_succeeds: true,
+          sha: 'abc123',
+        })
+        .reply(200);
+
+      await expect(gitlab.reattemptPlatformAutomerge?.(pr)).toResolve();
+    });
+
     it('should skip retries when merge_when_pipeline_succeeds is already enabled', async () => {
       await initPlatform('13.3.6-ee');
       httpMock
@@ -3969,10 +3991,15 @@ describe('modules/platform/gitlab/index', () => {
   });
 
   describe('mergePr(pr)', () => {
-    it('merges the PR', async () => {
+    it('merges the PR, echoing the source branch HEAD sha', async () => {
       httpMock
         .scope(gitlabApiHost)
-        .put('/api/v4/projects/undefined/merge_requests/1/merge')
+        .get('/api/v4/projects/undefined/merge_requests/1')
+        .reply(200, { sha: 'abc123' })
+        .put('/api/v4/projects/undefined/merge_requests/1/merge', {
+          should_remove_source_branch: true,
+          sha: 'abc123',
+        })
         .reply(200);
       expect(
         await gitlab.mergePr({

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -609,9 +609,17 @@ async function tryPrAutomerge(
         250,
       );
 
+      // The HEAD sha of the source branch, captured from the most recent MR
+      // poll below. GitLab rejects the merge API call with
+      // `400 SHA must be provided when merging` when the target namespace
+      // enables the "require SHA when merging" setting, so we echo it back
+      // when arming automerge.
+      let headSha: string | undefined;
+
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         const { body } = await gitlabApi.getJsonUnchecked<{
+          sha?: string;
           merge_status?: string;
           detailed_merge_status?: string;
           merge_when_pipeline_succeeds?: boolean;
@@ -621,6 +629,7 @@ async function tryPrAutomerge(
         }>(`projects/${config.repository}/merge_requests/${pr}`, {
           memCache: false,
         });
+        headSha = body.sha;
 
         // Exit early if merge_when_pipeline_succeeds is already set
         if (body.merge_when_pipeline_succeeds === true) {
@@ -683,6 +692,7 @@ async function tryPrAutomerge(
                 body: {
                   should_remove_source_branch: true,
                   merge_when_pipeline_succeeds: true,
+                  sha: headSha,
                 },
               },
             );
@@ -844,11 +854,21 @@ export async function reattemptPlatformAutomerge({
 
 export async function mergePr({ id }: MergePRConfig): Promise<boolean> {
   try {
+    // GitLab rejects the merge API call with `400 SHA must be provided when
+    // merging` when the target namespace enables the "require SHA when
+    // merging" setting. Fetch the current HEAD sha of the source branch and
+    // echo it back so the merge is accepted (this also guards against merging
+    // a HEAD that moved since Renovate last looked at it).
+    const { body: mr } = await gitlabApi.getJsonUnchecked<{ sha?: string }>(
+      `projects/${config.repository}/merge_requests/${id}`,
+      { memCache: false },
+    );
     await gitlabApi.putJson(
       `projects/${config.repository}/merge_requests/${id}/merge`,
       {
         body: {
           should_remove_source_branch: true,
+          sha: mr.sha,
         },
       },
     );


### PR DESCRIPTION
GitLab's merge API rejects requests with '400 SHA must be provided when merging' when the target namespace enables the new 'require SHA when merging' setting. Both mergePr and the platform-automerge path omitted the sha, so automerge (and manual merge) failed on such namespaces. Echo the source branch HEAD sha on both merge calls.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Included the source-branch HEAD `sha` in both GitLab merge API calls:

- `mergePr()` - fetch the MR's current head `sha` and send it on `PUT .../merge`.
- `tryPrAutomerge()` - capture the head `sha` from the MR poll it already performs and send it when arming platform automerge (`merge_when_pipeline_succeeds`).

## Context

Please select one of the following:

**PENDING** - Discussion raised here: (see [gitlab-org/gitlab!44807](https://github.com/renovatebot/renovate/discussions/44807))  (awaiting Issue creation)

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

GitLab has a cascading namespace setting **"Require SHA when merging"** (see [gitlab-org/gitlab!236732](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/236732)). When it is in effect for a namespace, `PUT /projects/:id/merge_requests/:iid/merge` rejects any request without a `sha` parameter:

```
400 {"message":"SHA must be provided when merging"}
```

This check runs before any pipeline/auto-merge logic. Renovate omitted `sha` on both merge paths, so on such namespaces Renovate creates and approves MRs but can **never** merge them — automerge silently fails and the MR sits open and approved. Manual `mergePr` fails the same way.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

Added/updated unit tests in `lib/modules/platform/gitlab/index.spec.ts` (reattemptPlatformAutomerge)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
