### PR TITLE
fix(composer): detect already-updated lockfile updates for dev dependencies

### DIFF
--- a/lib/modules/manager/composer/__fixtures__/composer5.lock
+++ b/lib/modules/manager/composer/__fixtures__/composer5.lock
@@ -24,5 +24,16 @@
         "reference": "3j5b345j3b45j345j345h34j5h345j34h5j34h5j"
       }
     }
+  ],
+  "packages-dev": [
+    {
+      "name": "awesome/dev-tool",
+      "version": "2.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://my-vcs.example/my-dev-tool",
+        "reference": "3j5b345j3b45j345j345h34j5h345j34h5j34h5j"
+      }
+    }
   ]
 }

--- a/lib/modules/manager/composer/update-locked.spec.ts
+++ b/lib/modules/manager/composer/update-locked.spec.ts
@@ -19,6 +19,18 @@ describe('modules/manager/composer/update-locked', () => {
     expect(updateLockedDependency(config).status).toBe('already-updated');
   });
 
+  it('detects already updated dev dependency', () => {
+    const config: UpdateLockedConfig = {
+      packageFile: 'composer.json',
+      lockFile,
+      lockFileContent,
+      depName: 'awesome/dev-tool',
+      newVersion: '2.1.0',
+      currentVersion: '2.0.0',
+    };
+    expect(updateLockedDependency(config).status).toBe('already-updated');
+  });
+
   it('returns unsupported', () => {
     const config: UpdateLockedConfig = {
       packageFile: 'composer.json',

--- a/lib/modules/manager/composer/update-locked.ts
+++ b/lib/modules/manager/composer/update-locked.ts
@@ -15,7 +15,7 @@ export function updateLockedDependency(
   try {
     const lockfile = Json.pipe(Lockfile).parse(lockFileContent);
     if (
-      lockfile?.packages.find(
+      [...lockfile.packages, ...lockfile.packagesDev].find(
         ({ name, version }) =>
           name === depName && composer.equals(version, newVersion),
       )


### PR DESCRIPTION
## Changes

`composer.updateLockedDependency()` only searches the `packages` section of `composer.lock`, never `packages-dev` — even though the `Lockfile` schema already parses both. Any lockfile-only update of a dev dependency (`require-dev`) therefore returns `unsupported` instead of `already-updated`.

The practical consequence: for a branch whose updates are already committed, the fast-path verification fails for the dev-dependency updates, `getUpdatedPackageFiles()` logs `Existing branch needs updating. Restarting processBranch() with a clean branch`, and the branch is rebuilt from the current base HEAD. On a busy base branch this force-pushes the PR on **every** Renovate run with byte-identical content (only the parent commit changes), re-triggering CI each time.

Observed on a private repo with an hourly self-hosted run and a grouped composer PR (`rangeStrategy: in-range-only`) containing 4 prod + 3 dev dependencies: debug logs show `Upgrade of <dep> to <version> is already done in existing branch` for exactly the 4 `packages` entries and the restart-with-clean-branch fallback caused by the 3 `packages-dev` entries (`phpstan/phpstan-doctrine`, `rector/rector`, `zircote/swagger-php`), followed by a force-push every time the base branch had advanced. Diffing consecutive force-pushed commits confirmed identical `composer.lock` content.

Fix: search both `packages` and `packagesDev`. Added a `packages-dev` entry to the `composer5.lock` fixture and a spec case covering the dev-dependency path.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Diagnosis, code, tests, and this PR description were produced with Claude Code (model: Claude Fable 5), driven and reviewed by me.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

(`pnpm vitest run lib/modules/manager/composer` — 102 passed; `tsc --noEmit` clean. The failure mode itself was reproduced on a real private repository via debug logs as described above.)