### PR TITLE
fix(bump-versions): collect bumpVersions from all upgrades, not just upgrades[0]

### DIFF
--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -801,5 +801,104 @@ describe('workers/repository/update/branch/bump-versions', () => {
         'bumpVersions(test): No newVersion found in branch upgrades for sync type',
       );
     });
+
+    it('should collect bumpVersions from all upgrades, not just the first', async () => {
+      const config = partial<BranchConfig>({
+        // top-level bumpVersions mirrors upgrades[0]'s value, as set by generateBranchConfig()
+        bumpVersions: [
+          {
+            name: 'first',
+            filePatterns: ['first-file'],
+            bumpType: 'minor',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        upgrades: [
+          {
+            branchName: 'test-branch',
+            manager: 'npm',
+            bumpVersions: [
+              {
+                name: 'first',
+                filePatterns: ['first-file'],
+                bumpType: 'minor',
+                matchStrings: ['^(?<version>.+)$'],
+              },
+            ],
+          },
+          {
+            branchName: 'test-branch',
+            manager: 'npm',
+            bumpVersions: [
+              {
+                name: 'second',
+                filePatterns: ['second-file'],
+                bumpType: 'patch',
+                matchStrings: ['^(?<version>.+)$'],
+              },
+            ],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce([
+        'foo',
+        'first-file',
+        'second-file',
+      ]);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+      fs.readLocalFile.mockResolvedValueOnce('2.0.0');
+
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          { type: 'addition', path: 'first-file', contents: '1.1.0' },
+          { type: 'addition', path: 'second-file', contents: '2.0.1' },
+        ],
+      });
+    });
+
+    it('should fall back to top-level bumpVersions when no upgrade defines any', async () => {
+      const config = partial<BranchConfig>({
+        bumpVersions: [
+          {
+            name: 'first',
+            filePatterns: ['first-file'],
+            bumpType: 'minor',
+            matchStrings: ['^(?<version>.+)$'],
+          },
+        ],
+        upgrades: [
+          {
+            branchName: 'test-branch',
+            manager: 'npm',
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', 'first-file']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+
+      await bumpVersions(config);
+
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          { type: 'addition', path: 'first-file', contents: '1.1.0' },
+        ],
+      });
+    });
   });
 });

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -865,6 +865,50 @@ describe('workers/repository/update/branch/bump-versions', () => {
       });
     });
 
+    it('should deduplicate identical bumpVersions entries from multiple upgrades', async () => {
+      const sharedBumpVersionConfig = {
+        name: 'first',
+        filePatterns: ['first-file'],
+        bumpType: 'minor' as const,
+        matchStrings: ['^(?<version>.+)$'],
+      };
+      const config = partial<BranchConfig>({
+        upgrades: [
+          {
+            branchName: 'test-branch',
+            manager: 'npm',
+            bumpVersions: [sharedBumpVersionConfig],
+          },
+          {
+            branchName: 'test-branch',
+            manager: 'npm',
+            // identical entry as the previous upgrade - should not be applied twice
+            bumpVersions: [sharedBumpVersionConfig],
+          },
+        ],
+        updatedPackageFiles: [
+          {
+            type: 'addition',
+            path: 'foo',
+            contents: 'bar',
+          },
+        ],
+      });
+      scm.getFileList.mockResolvedValueOnce(['foo', 'first-file']);
+      fs.readLocalFile.mockResolvedValueOnce('1.0.0');
+
+      await bumpVersions(config);
+
+      // if the duplicate entry wasn't deduplicated, the file would be bumped
+      // twice (to 1.2.0) instead of once (to 1.1.0)
+      expect(config).toMatchObject({
+        updatedArtifacts: [
+          { type: 'addition', path: 'first-file', contents: '1.1.0' },
+        ],
+      });
+      expect(config.updatedArtifacts).toHaveLength(1);
+    });
+
     it('should fall back to top-level bumpVersions when no upgrade defines any', async () => {
       const config = partial<BranchConfig>({
         bumpVersions: [

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -17,8 +17,8 @@ type ParseFileChangesResult =
   | { state: 'unmodified' };
 
 export async function bumpVersions(config: BranchConfig): Promise<void> {
-  const bumpVersions = config.bumpVersions;
-  if (!bumpVersions?.length) {
+  const bumpVersions = getBumpVersions(config);
+  if (!bumpVersions.length) {
     return;
   }
 
@@ -46,6 +46,33 @@ export async function bumpVersions(config: BranchConfig): Promise<void> {
   // update the config with the new files
   config.updatedPackageFiles = Object.values(packageFileChanges).flat();
   config.updatedArtifacts = Object.values(artifactFileChanges).flat();
+}
+
+/**
+ * `config.bumpVersions` is derived from `upgrades[0]` only (see `generateBranchConfig()`), so
+ * relying on it alone would silently drop `bumpVersions` config attached (e.g. via a `packageRule`)
+ * to any upgrade other than the first one in the branch. Collect `bumpVersions` from every
+ * upgrade instead, de-duplicating identical entries, and fall back to the top-level value for
+ * back-compat (e.g. when `config.upgrades` is empty).
+ */
+function getBumpVersions(config: BranchConfig): BumpVersionConfig[] {
+  const seen = new Set<string>();
+  const bumpVersions: BumpVersionConfig[] = [];
+  for (const upgrade of config.upgrades ?? []) {
+    for (const bumpVersionConfig of upgrade.bumpVersions ?? []) {
+      const key = JSON.stringify(bumpVersionConfig);
+      if (!seen.has(key)) {
+        seen.add(key);
+        bumpVersions.push(bumpVersionConfig);
+      }
+    }
+  }
+
+  if (!bumpVersions.length) {
+    bumpVersions.push(...(config.bumpVersions ?? []));
+  }
+
+  return bumpVersions;
 }
 
 async function bumpVersion(

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -59,8 +59,8 @@ export async function bumpVersions(config: BranchConfig): Promise<void> {
 function getBumpVersions(config: BranchConfig): BumpVersionConfig[] {
   const seen = new Set<string>();
   const bumpVersions: BumpVersionConfig[] = [];
-  for (const upgrade of config.upgrades ?? []) {
-    for (const bumpVersionConfig of upgrade.bumpVersions ?? []) {
+  for (const upgrade of coerceArray(config.upgrades)) {
+    for (const bumpVersionConfig of coerceArray(upgrade.bumpVersions)) {
       const key = safeStringify(bumpVersionConfig);
       if (!seen.has(key)) {
         seen.add(key);
@@ -70,7 +70,7 @@ function getBumpVersions(config: BranchConfig): BumpVersionConfig[] {
   }
 
   if (!bumpVersions.length) {
-    bumpVersions.push(...(config.bumpVersions ?? []));
+    bumpVersions.push(...coerceArray(config.bumpVersions));
   }
 
   return bumpVersions;

--- a/lib/workers/repository/update/branch/bump-versions.ts
+++ b/lib/workers/repository/update/branch/bump-versions.ts
@@ -7,6 +7,7 @@ import { readLocalFile } from '../../../../util/fs/index.ts';
 import type { FileChange } from '../../../../util/git/types.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { matchRegexOrGlobList } from '../../../../util/string-match.ts';
+import { safeStringify } from '../../../../util/stringify.ts';
 import { compile } from '../../../../util/template/index.ts';
 import type { BranchConfig } from '../../../types.ts';
 import { getFilteredFileList } from '../../extract/file-match.ts';
@@ -60,7 +61,7 @@ function getBumpVersions(config: BranchConfig): BumpVersionConfig[] {
   const bumpVersions: BumpVersionConfig[] = [];
   for (const upgrade of config.upgrades ?? []) {
     for (const bumpVersionConfig of upgrade.bumpVersions ?? []) {
-      const key = JSON.stringify(bumpVersionConfig);
+      const key = safeStringify(bumpVersionConfig);
       if (!seen.has(key)) {
         seen.add(key);
         bumpVersions.push(bumpVersionConfig);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
config.bumpVersions on a BranchConfig only ever reflects upgrades[0]'s value (set via generateBranchConfig()), so in a branch that groups multiple upgrades (e.g. via group:allNonMajor), a bumpVersions rule attached via packageRules to any upgrade other than upgrades[0] was silently dropped. This mirrors the same class of bug fixed in #43422 for postUpgradeTasks. Fixed by aggregating bumpVersions from all config.upgrades (deduplicated), falling back to the top-level value for back-compat.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [X] Yes — other (please describe):
On troubleshooting the problem and finding a way in the codebase.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [X] Both unit tests + ran on a real repository

The public repository: <not a public available repository>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
