### PR TITLE
docs(minimum-release-age): indicate which Datasources support `releaseTimestamp`

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -203,14 +203,13 @@ To opt out a dependency from minimum release age checks, create a package rule w
 
 ### Which datasources support release timestamps?
 
-!!! tip
-  You can confirm if your datasource supports the release timestamp by viewing [the documentation for the given datasource](../modules/datasource/index.md).
-
 The datasource that Renovate uses must have a release timestamp for the `minimumReleaseAge` config option to work.
 Some datasources may have a release timestamp, but in a format Renovate does not support.
 In those cases a feature request needs to be implemented.
 
-Note that you will also need to [verify if the registry you're using](#which-registries-support-release-timestamps) provides the release timestamp.
+The table below lists every datasource Renovate supports, and whether it provides a release timestamp.
+
+<!-- Autogenerate datasourceReleaseTimestampSupport -->
 
 ### Which registries support release timestamps?
 

--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -11,6 +11,7 @@ import { generateManagerGithubActionsCommunity } from './manager/github-actions/
 import { generateManagers } from './manager.ts';
 import { generateManagerAsdfSupportedPlugins } from './manager-asdf-supported-plugins.ts';
 import { generateManagerMiseSupportedPlugins } from './manager-mise-supported-plugins.ts';
+import { generateDatasourceReleaseTimestampSupportForMinimumReleaseAge } from './minimum-release-age.ts';
 import { generatePlatforms } from './platforms.ts';
 import { generatePresets } from './presets.ts';
 import { generateSchema } from './schema.ts';
@@ -44,6 +45,10 @@ export async function generateDocs(
     // datasources
     logger.info('* datasources');
     await generateDatasources(dist, openItems.datasources);
+
+    // minimum release age: datasource release timestamp support
+    logger.info('* key-concepts/minimum-release-age');
+    await generateDatasourceReleaseTimestampSupportForMinimumReleaseAge(dist);
 
     // managers
     logger.info('* managers');

--- a/tools/docs/minimum-release-age.ts
+++ b/tools/docs/minimum-release-age.ts
@@ -1,0 +1,34 @@
+import { getDatasources } from '../../lib/modules/datasource/index.ts';
+import { readFile, updateFile } from '../utils/index.ts';
+import { getDisplayName, replaceContent } from './utils.ts';
+
+export async function generateDatasourceReleaseTimestampSupportForMinimumReleaseAge(
+  dist: string,
+): Promise<void> {
+  const datasources = getDatasources();
+
+  let tableContent = '| Datasource | Supports release timestamp? | Notes |\n';
+  tableContent += '| :-- | :-: | :-- |\n';
+
+  for (const [datasource, definition] of datasources) {
+    const displayName = getDisplayName(datasource, definition);
+    const { releaseTimestampSupport, releaseTimestampNote } = definition;
+    const supported = releaseTimestampSupport
+      ? '🟠<br>Maybe<sup>1</sup>'
+      : '❌';
+    tableContent += `| [${displayName}](../modules/datasource/${datasource}/index.md) | ${supported} | ${releaseTimestampNote ?? ''} |\n`;
+  }
+
+  tableContent +=
+    '\n<sup>1</sup> Whether release timestamps are actually available depends on the registry you use - check [Which registries support release timestamps?](#which-registries-support-release-timestamps).\n';
+
+  let content = await readFile(
+    'docs/usage/key-concepts/minimum-release-age.md',
+  );
+  content = replaceContent(
+    content,
+    `${tableContent}\n`,
+    '<!-- Autogenerate datasourceReleaseTimestampSupport -->',
+  );
+  await updateFile(`${dist}/key-concepts/minimum-release-age.md`, content);
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As noted in #30714, and to make the Minimum Release Age page a
"one-stop-shop", we can generate the documentation accordingly.

Using an orange "maybe" for support helps nudge folks to checking which
registry they're using, and noting that it still doesn't necessarily
work, even if the Datasource supports it.

Co-authored-by: Claude Sonnet 5 <jamie.tanna+claude-code@mend.io>

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #30714
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
