### PR TITLE
refactor(workers/repository): add `isMinimumReleaseAgeApplicable`/`isMinimumConfidenceApplicable`

### DIFF
--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -8,12 +8,17 @@ import type {
   ReleaseResult,
 } from '../../../../modules/datasource/index.ts';
 import * as allVersioning from '../../../../modules/versioning/index.ts';
+import type { UpdateType } from '../../../../types/index.ts';
 import { clone } from '../../../../util/clone.ts';
 import * as _dateUtil from '../../../../util/date.ts';
 import * as _mergeConfidence from '../../../../util/merge-confidence/index.ts';
 import { toMs } from '../../../../util/pretty-time.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
-import { filterInternalChecks } from './filter-checks.ts';
+import {
+  filterInternalChecks,
+  isMinimumConfidenceApplicable,
+  isMinimumReleaseAgeApplicable,
+} from './filter-checks.ts';
 import type { LookupUpdateConfig, UpdateResult } from './types.ts';
 
 vi.mock('../../../../util/date.ts');
@@ -336,6 +341,66 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       expect(res.pendingChecks).toBeFalse();
       expect(res.pendingReleases).toHaveLength(3);
       expect(res.release?.version).toBe('1.0.1');
+    });
+  });
+
+  describe('.isMinimumReleaseAgeApplicable()', () => {
+    // Exhaustive by construction, so we get a type error if we add a new UpdateType
+    const expectedByUpdateType: Record<UpdateType, boolean> = {
+      major: true,
+      minor: true,
+      patch: true,
+      digest: true,
+      pinDigest: false,
+      pin: false,
+      replacement: false,
+      lockFileMaintenance: false,
+      lockfileUpdate: false,
+      rollback: false,
+      bump: false,
+    };
+
+    it.each(Object.entries(expectedByUpdateType))(
+      'updateType=%s returns %s',
+      (updateType, expected) => {
+        expect(isMinimumReleaseAgeApplicable(updateType as UpdateType)).toBe(
+          expected,
+        );
+      },
+    );
+
+    it('returns true for updateType=undefined', () => {
+      expect(isMinimumReleaseAgeApplicable(undefined)).toBeTrue();
+    });
+  });
+
+  describe('.isMinimumConfidenceApplicable()', () => {
+    // Exhaustive by construction, so we get a type error if we add a new UpdateType
+    const expectedByUpdateType: Record<UpdateType, boolean> = {
+      digest: false,
+      pinDigest: false,
+      major: true,
+      minor: true,
+      patch: true,
+      pin: true,
+      rollback: true,
+      replacement: true,
+      lockFileMaintenance: true,
+      lockfileUpdate: true,
+      bump: true,
+    };
+
+    it.each(Object.entries(expectedByUpdateType))(
+      'updateType=%s returns %s',
+      (updateType, expected) => {
+        expect(isMinimumConfidenceApplicable(updateType as UpdateType)).toBe(
+          expected,
+        );
+      },
+    );
+
+    it('returns true for updateType=undefined', () => {
+      expect(isMinimumConfidenceApplicable(undefined)).toBeTrue();
     });
   });
 });

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -1,6 +1,9 @@
 import { isNonEmptyString, isNullOrUndefined } from '@sindresorhus/is';
 import { mergeChildConfig } from '../../../../config/index.ts';
-import type { MinimumReleaseAgeBehaviour } from '../../../../config/types.ts';
+import type {
+  MinimumReleaseAgeBehaviour,
+  UpdateType,
+} from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import type { Release } from '../../../../modules/datasource/index.ts';
 import { postprocessRelease } from '../../../../modules/datasource/postprocess-release.ts';
@@ -21,6 +24,40 @@ export interface InternalChecksResult {
   release?: Release;
   pendingChecks: boolean;
   pendingReleases: Release[];
+}
+
+/** Given an UpdateType, should `minimumReleaseAge` apply to it? **/
+export function isMinimumReleaseAgeApplicable(
+  updateType: UpdateType | undefined,
+): boolean {
+  return (
+    // Possible, but not wanted, as this is intentionally rolling back to a previous (generally older) release to unblock the build
+    updateType !== 'rollback' &&
+    // Not yet supported: TODO #40288
+    updateType !== 'pin' &&
+    // Not yet supported: TODO #44820
+    updateType !== 'pinDigest' &&
+    // Not yet supported: TODO #39400
+    updateType !== 'replacement' &&
+    // Not possible, as we delegate to the package manager to perform the required changes to update package(s).
+    updateType !== 'lockFileMaintenance' &&
+    // Not supported
+    updateType !== 'bump' &&
+    // Not supported
+    updateType !== 'lockfileUpdate'
+  );
+}
+
+/** Given an UpdateType, should `minimumConfidence` apply to it? **/
+export function isMinimumConfidenceApplicable(
+  updateType: UpdateType | undefined,
+): boolean {
+  return (
+    // data collection doesn't include digest updates
+    updateType !== 'digest' &&
+    // data collection doesn't include digest updates
+    updateType !== 'pinDigest'
+  );
 }
 
 export async function filterInternalChecks(

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -1,8 +1,10 @@
 import fs from 'fs-extra';
 import { glob } from 'glob';
 import { getOptions } from '../../lib/config/options/index.ts';
+import type { UpdateType } from '../../lib/config/types.ts';
 import { regEx } from '../../lib/util/regex.ts';
 import { templateHelperNames } from '../../lib/util/template/index.ts';
+import { isMinimumReleaseAgeApplicable } from '../../lib/workers/repository/process/lookup/filter-checks.ts';
 
 const options = getOptions();
 const markdownGlob = '{docs,lib}/**/*.md';
@@ -258,6 +260,50 @@ describe('docs/documentation', () => {
         expect(additionalHandlebarsHelpers).toEqual(
           templateHelperNames.toSorted(),
         );
+      });
+    });
+
+    describe('docs/usage/key-concepts/minimum-release-age.md', () => {
+      const supportEmoji: Record<string, boolean> = {
+        '✅': true,
+        '🟡': true,
+        '❌': false,
+      };
+
+      async function getUpdateTypeSupportTable(): Promise<
+        Record<string, boolean>
+      > {
+        const content = await fs.readFile(
+          'docs/usage/key-concepts/minimum-release-age.md',
+          'utf8',
+        );
+        // RE2 (renovate's regex engine) doesn't support lookahead, so bound
+        // the section with plain index lookups instead of `(?=\n### )`.
+        const start = regEx(/### Which update types take/).exec(content)?.index;
+        let section: string | undefined;
+        if (start !== undefined) {
+          const end = content.indexOf('\n### ', start + 1);
+          section = content.slice(start, end === -1 ? undefined : end);
+        }
+        const rows =
+          section?.matchAll(
+            /^\|\s*`(?<updateType>\w+)`\s*\|\s*(?<emoji>[^\s|]+)\s*\|/gm,
+          ) ?? [];
+        const table: Record<string, boolean> = {};
+        for (const row of rows) {
+          const { updateType, emoji } = row.groups!;
+          table[updateType] = supportEmoji[emoji];
+        }
+        return table;
+      }
+
+      it('matches isMinimumReleaseAgeApplicable() for every documented update type', async () => {
+        const table = await getUpdateTypeSupportTable();
+        for (const [updateType, docsSupport] of Object.entries(table)) {
+          expect(isMinimumReleaseAgeApplicable(updateType as UpdateType)).toBe(
+            docsSupport,
+          );
+        }
       });
     });
   });


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As part of follow-up changes, we'll use these functions to centrally
determine as to whether to execute `minimumReleaseAge` or
`minimumConfidence` checks against a given updateType.

For now, we can wire this into our documentation tests, to make sure
that this stays in sync with `isMinimumReleaseAgeApplicable`.





<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
