### PR TITLE
refactor(workers/repository): extract `minimumReleaseAge`/`minimumConfidence` checks

### DIFF
--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -15,6 +15,8 @@ import * as _mergeConfidence from '../../../../util/merge-confidence/index.ts';
 import { toMs } from '../../../../util/pretty-time.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
 import {
+  checkMinimumConfidence,
+  checkMinimumReleaseAge,
   filterInternalChecks,
   isMinimumConfidenceApplicable,
   isMinimumReleaseAgeApplicable,
@@ -401,6 +403,128 @@ describe('workers/repository/process/lookup/filter-checks', () => {
 
     it('returns true for updateType=undefined', () => {
       expect(isMinimumConfidenceApplicable(undefined)).toBeTrue();
+    });
+  });
+
+  describe('.checkMinimumReleaseAge()', () => {
+    beforeEach(() => {
+      // oxlint-disable-next-line renovate/no-redundant-mock-reset -- discards the once-values queued by the outer beforeEach
+      dateUtil.getElapsedMs.mockReset();
+    });
+
+    it('is not pending if minimumReleaseAge is not set', () => {
+      const res = checkMinimumReleaseAge(
+        {},
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: 0,
+        hasTimestamp: true,
+      });
+    });
+
+    it('is pending if the release is younger than minimumReleaseAge', () => {
+      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('1 day') ?? 0);
+      const res = checkMinimumReleaseAge(
+        { minimumReleaseAge: '3 days' },
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: true,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: true,
+      });
+    });
+
+    it('is not pending if the release is older than minimumReleaseAge', () => {
+      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('5 days') ?? 0);
+      const res = checkMinimumReleaseAge(
+        { minimumReleaseAge: '3 days' },
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: true,
+      });
+    });
+
+    it('is pending with a missing timestamp if minimumReleaseAgeBehaviour=timestamp-required', () => {
+      const res = checkMinimumReleaseAge(
+        {
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBehaviour: 'timestamp-required',
+        },
+        undefined,
+      );
+      expect(res).toEqual({
+        isPending: true,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: false,
+      });
+    });
+
+    it('is not pending with a missing timestamp if minimumReleaseAgeBehaviour=timestamp-optional', () => {
+      const res = checkMinimumReleaseAge(
+        {
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBehaviour: 'timestamp-optional',
+        },
+        undefined,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: false,
+      });
+    });
+  });
+
+  describe('.checkMinimumConfidence()', () => {
+    it('is not pending if minimumConfidence is not active', async () => {
+      mergeConfidence.isActiveConfidenceLevel.mockReturnValue(false);
+      const res = await checkMinimumConfidence(
+        { minimumConfidence: 'high' },
+        '1.0.0',
+        '1.0.1',
+        'patch',
+      );
+      expect(res).toEqual({ isPending: false });
+    });
+
+    it('is pending if the confidence level does not satisfy minimumConfidence', async () => {
+      mergeConfidence.isActiveConfidenceLevel.mockReturnValue(true);
+      mergeConfidence.getMergeConfidenceLevel.mockResolvedValueOnce('low');
+      mergeConfidence.satisfiesConfidenceLevel.mockReturnValueOnce(false);
+      const res = await checkMinimumConfidence(
+        {
+          minimumConfidence: 'high',
+          datasource: 'npm',
+          packageName: 'some-package',
+        },
+        '1.0.0',
+        '1.0.1',
+        'patch',
+      );
+      expect(res).toEqual({ isPending: true });
+    });
+
+    it('is not pending if the confidence level satisfies minimumConfidence', async () => {
+      mergeConfidence.isActiveConfidenceLevel.mockReturnValue(true);
+      mergeConfidence.getMergeConfidenceLevel.mockResolvedValueOnce('high');
+      mergeConfidence.satisfiesConfidenceLevel.mockReturnValueOnce(true);
+      const res = await checkMinimumConfidence(
+        {
+          minimumConfidence: 'high',
+          datasource: 'npm',
+          packageName: 'some-package',
+        },
+        '1.0.0',
+        '1.0.1',
+        'patch',
+      );
+      expect(res).toEqual({ isPending: false });
     });
   });
 });

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString, isNullOrUndefined } from '@sindresorhus/is';
+import { isNonEmptyString } from '@sindresorhus/is';
 import { mergeChildConfig } from '../../../../config/index.ts';
 import type {
   MinimumReleaseAgeBehaviour,
@@ -14,9 +14,11 @@ import {
   isActiveConfidenceLevel,
   satisfiesConfidenceLevel,
 } from '../../../../util/merge-confidence/index.ts';
+import type { MergeConfidence } from '../../../../util/merge-confidence/types.ts';
 import { coerceNumber } from '../../../../util/number.ts';
 import { applyPackageRules } from '../../../../util/package-rules/index.ts';
 import { toMs } from '../../../../util/pretty-time.ts';
+import type { Timestamp } from '../../../../util/timestamp.ts';
 import type { LookupUpdateConfig, UpdateResult } from './types.ts';
 import { getUpdateType } from './update-type.ts';
 
@@ -60,19 +62,95 @@ export function isMinimumConfidenceApplicable(
   );
 }
 
+export interface MinimumReleaseAgeCheckResult {
+  isPending: boolean;
+  minimumReleaseAgeMs: number;
+  hasTimestamp: boolean;
+}
+
+/**
+ * Checks whether a release satisfies `minimumConfidence`.
+ *
+ * Separate from `internalChecksFilter` to allow reuse.
+ */
+export function checkMinimumReleaseAge(
+  config: {
+    minimumReleaseAge?: string | null;
+    minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour | null;
+  },
+  releaseTimestamp: Timestamp | null | undefined,
+): MinimumReleaseAgeCheckResult {
+  const minimumReleaseAgeMs = isNonEmptyString(config.minimumReleaseAge)
+    ? coerceNumber(toMs(config.minimumReleaseAge), 0)
+    : 0;
+
+  if (!minimumReleaseAgeMs) {
+    return {
+      isPending: false,
+      minimumReleaseAgeMs,
+      hasTimestamp: !!releaseTimestamp,
+    };
+  }
+
+  if (releaseTimestamp) {
+    return {
+      isPending: getElapsedMs(releaseTimestamp) < minimumReleaseAgeMs,
+      minimumReleaseAgeMs,
+      hasTimestamp: true,
+    };
+  }
+
+  return {
+    isPending: config.minimumReleaseAgeBehaviour === 'timestamp-required',
+    minimumReleaseAgeMs,
+    hasTimestamp: false,
+  };
+}
+
+export interface MinimumConfidenceCheckResult {
+  isPending: boolean;
+}
+
+/**
+ * Checks whether a release satisfies `minimumConfidence`.
+ *
+ * Separate from `internalChecksFilter` to allow reuse.
+ */
+export async function checkMinimumConfidence(
+  config: {
+    minimumConfidence?: MergeConfidence;
+    datasource?: string;
+    packageName?: string;
+  },
+  currentVersion: string,
+  candidateVersion: string,
+  updateType: UpdateType,
+): Promise<MinimumConfidenceCheckResult> {
+  const { minimumConfidence, datasource, packageName } = config;
+  if (!isActiveConfidenceLevel(minimumConfidence!)) {
+    return { isPending: false };
+  }
+
+  const confidenceLevel =
+    (await getMergeConfidenceLevel(
+      datasource!,
+      packageName!,
+      currentVersion,
+      candidateVersion,
+      updateType,
+    )) ?? 'neutral';
+  return {
+    isPending: !satisfiesConfidenceLevel(confidenceLevel, minimumConfidence!),
+  };
+}
+
 export async function filterInternalChecks(
   config: Partial<LookupUpdateConfig & UpdateResult>,
   versioningApi: VersioningApi,
   bucket: string,
   sortedReleases: Release[],
 ): Promise<InternalChecksResult> {
-  const {
-    currentVersion,
-    datasource,
-    depName,
-    packageName,
-    internalChecksFilter,
-  } = config;
+  const { currentVersion, depName, internalChecksFilter } = config;
   let release: Release | undefined = undefined;
   let pendingChecks = false;
   let pendingReleases: Release[] = [];
@@ -117,74 +195,54 @@ export async function filterInternalChecks(
       candidateRelease = updatedCandidateRelease;
 
       // Now check for a minimumReleaseAge config
-      const { minimumConfidence, minimumReleaseAge, updateType } =
-        releaseConfig;
+      const { updateType } = releaseConfig;
 
-      const minimumReleaseAgeMs = isNonEmptyString(minimumReleaseAge)
-        ? coerceNumber(toMs(minimumReleaseAge), 0)
-        : 0;
-
-      if (minimumReleaseAgeMs) {
-        const minimumReleaseAgeBehaviour =
-          releaseConfig.minimumReleaseAgeBehaviour;
-
-        // if there is a releaseTimestamp, regardless of `minimumReleaseAgeBehaviour`, we should process it
-        // v8 ignore else -- TODO: add test #40625
-        if (candidateRelease.releaseTimestamp) {
-          // we should skip this if we have a timestamp that isn't passing checks:
+      const ageCheck = checkMinimumReleaseAge(
+        releaseConfig,
+        candidateRelease.releaseTimestamp,
+      );
+      if (ageCheck.minimumReleaseAgeMs) {
+        if (!ageCheck.hasTimestamp) {
+          const minimumReleaseAgeBehaviour =
+            releaseConfig.minimumReleaseAgeBehaviour;
+          // v8 ignore else -- TODO: add test #40625
           if (
-            getElapsedMs(candidateRelease.releaseTimestamp) <
-            minimumReleaseAgeMs
+            minimumReleaseAgeBehaviour === 'timestamp-required' ||
+            minimumReleaseAgeBehaviour === 'timestamp-optional'
           ) {
+            candidateVersionsWithoutReleaseTimestamp[
+              minimumReleaseAgeBehaviour
+            ].push(candidateRelease.version);
+          }
+        }
+
+        if (ageCheck.isPending) {
+          // v8 ignore else -- TODO: add test #40625
+          if (ageCheck.hasTimestamp) {
             // Skip it if it doesn't pass checks
             logger.trace(
               { depName, check: 'minimumReleaseAge' },
               `Release ${candidateRelease.version} is pending status checks`,
             );
-            pendingReleases.unshift(candidateRelease);
-            continue;
-          }
-        } // or if there is no timestamp, and we're running in `minimumReleaseAgeBehaviour=timestamp-required`
-        else if (
-          isNullOrUndefined(candidateRelease.releaseTimestamp) &&
-          minimumReleaseAgeBehaviour === 'timestamp-required'
-        ) {
-          // Skip it, as we require a timestamp
-          candidateVersionsWithoutReleaseTimestamp[
-            minimumReleaseAgeBehaviour
-          ].push(candidateRelease.version);
+          } // or if there is no timestamp, and we're running in `minimumReleaseAgeBehaviour=timestamp-required`, skip it as we require a timestamp
           pendingReleases.unshift(candidateRelease);
           continue;
-        } // if there is no timestamp, and we're running in `optional` mode, we can allow it
-        else if (
-          isNullOrUndefined(candidateRelease.releaseTimestamp) &&
-          minimumReleaseAgeBehaviour === 'timestamp-optional'
-        ) {
-          candidateVersionsWithoutReleaseTimestamp[
-            minimumReleaseAgeBehaviour
-          ].push(candidateRelease.version);
         }
       }
 
-      // TODO #22198
-      if (isActiveConfidenceLevel(minimumConfidence!)) {
-        const confidenceLevel =
-          (await getMergeConfidenceLevel(
-            datasource!,
-            packageName!,
-            currentVersion!,
-            candidateRelease.version,
-            updateType!,
-          )) ?? 'neutral';
-        // TODO #22198
-        if (!satisfiesConfidenceLevel(confidenceLevel, minimumConfidence!)) {
-          logger.trace(
-            { depName, check: 'minimumConfidence' },
-            `Release ${candidateRelease.version} is pending status checks`,
-          );
-          pendingReleases.unshift(candidateRelease);
-          continue;
-        }
+      const confidenceCheck = await checkMinimumConfidence(
+        releaseConfig,
+        currentVersion!,
+        candidateRelease.version,
+        updateType!,
+      );
+      if (confidenceCheck.isPending) {
+        logger.trace(
+          { depName, check: 'minimumConfidence' },
+          `Release ${candidateRelease.version} is pending status checks`,
+        );
+        pendingReleases.unshift(candidateRelease);
+        continue;
       }
       // If we get to here, then the release is OK and we can stop iterating
       release = candidateRelease;


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As part of follow-up changes, we'll need to call the checks in multiple
places, so should prefactor these into helper methods.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
