### PR TITLE
fix(bun): use --lockfile-only when updating artifacts

### DIFF
--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -106,15 +106,18 @@ describe('modules/manager/bun/artifacts', () => {
           },
         ]);
 
-        expect(exec).toHaveBeenCalledWith('bun install --ignore-scripts', {
-          cwdFile: 'bun.lockb',
-          docker: {},
-          toolConstraints: [
-            {
-              toolName: 'bun',
-            },
-          ],
-        });
+        expect(exec).toHaveBeenCalledWith(
+          'bun install --lockfile-only --ignore-scripts',
+          {
+            cwdFile: 'bun.lockb',
+            docker: {},
+            toolConstraints: [
+              {
+                toolName: 'bun',
+              },
+            ],
+          },
+        );
       });
 
       it('supports lockFileMaintenance', async () => {
@@ -322,47 +325,47 @@ describe('modules/manager/bun/artifacts', () => {
         {
           allowScripts: undefined,
           ignoreScripts: undefined,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: false,
           ignoreScripts: undefined,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: true,
           ignoreScripts: undefined,
-          expectedCmd: 'bun install',
+          expectedCmd: 'bun install --lockfile-only',
         },
         {
           allowScripts: undefined,
           ignoreScripts: true,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: undefined,
           ignoreScripts: false,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: false,
           ignoreScripts: true,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: false,
           ignoreScripts: false,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: true,
           ignoreScripts: true,
-          expectedCmd: 'bun install --ignore-scripts',
+          expectedCmd: 'bun install --lockfile-only --ignore-scripts',
         },
         {
           allowScripts: true,
           ignoreScripts: false,
-          expectedCmd: 'bun install',
+          expectedCmd: 'bun install --lockfile-only',
         },
       ];
 

--- a/lib/modules/manager/bun/artifacts.ts
+++ b/lib/modules/manager/bun/artifacts.ts
@@ -59,7 +59,7 @@ export async function updateArtifacts(
       await deleteLocalFile(lockFileName);
     }
 
-    let cmd = 'bun install';
+    let cmd = 'bun install --lockfile-only';
 
     if (!GlobalConfig.get('allowScripts') || config.ignoreScripts) {
       cmd += ' --ignore-scripts';


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

During Bun lockfile updates (especially `lockFileMaintenance`, which deletes the lockfile then regenerates it), Renovate currently runs a full `bun install`. That materializes `node_modules` even though Renovate only reads the updated lockfile afterward.

On large Bun workspaces (e.g. Expo / React Native monorepos), a full install can exceed Mend Community runner memory (3GB) and fail with kernel OOM. Measured cold `bun install --lockfile-only --ignore-scripts` for a Bun workspace used ~460MB RSS, while a full install of an Expo monorepo OOMs the same runners.

This change always passes `--lockfile-only`, matching how Renovate already treats pnpm (`--lockfile-only`) and npm (`--package-lock-only`).

- `lib/modules/manager/bun/artifacts.ts`: `bun install` → `bun install --lockfile-only` (optional `--ignore-scripts` unchanged)
- Update unit expectations in `artifacts.spec.ts`

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Used Cursor (model: Cursor Grok 4.5) to implement the command change, update unit expectations, draft the PR, and measure lockfile-only memory usage.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
