### PR TITLE
fix(presets/helpers): ensure that `pinGitHubActionDigestsToSemver` preset only applies to actions

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -303,6 +303,24 @@ describe('config/presets/index', () => {
       });
     });
 
+    it('resolves pin GitHub Action digests to SemVer', async () => {
+      config.extends = ['helpers:pinGitHubActionDigestsToSemver'];
+      const { config: res } = await presets.resolveConfigPresets(config);
+
+      expect(res.packageRules).toEqual([
+        {
+          matchDepTypes: ['action'],
+          pinDigests: true,
+        },
+        {
+          matchDepTypes: ['action'],
+          extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
+          versioning:
+            'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
+        },
+      ]);
+    });
+
     it('resolves eslint', async () => {
       config.extends = ['packages:eslint'];
       const { config: res } = await presets.resolveConfigPresets(config);

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -126,10 +126,11 @@ export const presets: Record<string, Preset> = {
   },
   pinGitHubActionDigestsToSemver: {
     description: 'Convert pinned GitHub Action digests to SemVer.',
+    extends: ['helpers:pinGitHubActionDigests'],
     packageRules: [
       {
-        extends: ['helpers:pinGitHubActionDigests'],
         extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
+        matchDepTypes: ['action'],
         versioning:
           'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
       },


### PR DESCRIPTION
## Changes

Adjusts the preset `pinGitHubActionDigestsToSemver` to ensure that the versioning does not "leak" outside of the actions context.

This is related to https://github.com/renovatebot/renovate/discussions/44828

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Codex used to help debug and identify where/how to test to reproduce.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository