### PR TITLE
feat(versioning): support ranges for the regex scheme

### DIFF
--- a/lib/modules/versioning/generic-range.ts
+++ b/lib/modules/versioning/generic-range.ts
@@ -1,0 +1,68 @@
+import { isNonEmptyString } from '@sindresorhus/is';
+import { regEx } from '../../util/regex.ts';
+
+export interface RangeComparator {
+  operator: string;
+  version: string;
+}
+
+// Comparator operators, longest first so `<=` is matched ahead of `<`, `>=`
+// ahead of `>`, and `==` ahead of `=`.
+const operators = ['<=', '>=', '==', '<', '>', '='];
+const separator = regEx(/[\s,]+/);
+
+/**
+ * Parse a comparator range (for example `<=1.2.3`, `>1.0 <2.0`, or `=1.2.3`)
+ * into its `{ operator, version }` terms, which are ANDed together. Returns
+ * `null` when the input is not a comparator range (such as a bare version), so
+ * callers can fall back to treating it as a version.
+ *
+ * The `isVersion` predicate validates each operand against the caller's own
+ * version format and the caller compares with its own ordering, so this parser
+ * stays independent of any single versioning scheme (unlike npm `semver`,
+ * whose parser also coerces and normalizes the operands).
+ */
+export function parseRange(
+  range: string,
+  isVersion: (version: string) => boolean,
+): RangeComparator[] | null {
+  if (!isNonEmptyString(range)) {
+    return null;
+  }
+  const comparators: RangeComparator[] = [];
+  for (const term of range.trim().split(separator)) {
+    const operator = operators.find((op) => term.startsWith(op));
+    if (!operator) {
+      return null;
+    }
+    const version = term.slice(operator.length);
+    if (!isVersion(version)) {
+      return null;
+    }
+    comparators.push({ operator, version });
+  }
+  return comparators;
+}
+
+/**
+ * Given the result of comparing a version against a comparator's version
+ * (negative when lower, zero when equal, positive when higher), return whether
+ * the comparator's operator is satisfied.
+ */
+export function satisfiesComparator(
+  comparison: number,
+  operator: string,
+): boolean {
+  switch (operator) {
+    case '<':
+      return comparison < 0;
+    case '<=':
+      return comparison <= 0;
+    case '>':
+      return comparison > 0;
+    case '>=':
+      return comparison >= 0;
+    default:
+      return comparison === 0;
+  }
+}

--- a/lib/modules/versioning/regex/index.spec.ts
+++ b/lib/modules/versioning/regex/index.spec.ts
@@ -418,4 +418,101 @@ describe('modules/versioning/regex/index', () => {
       ).toBeNull();
     });
   });
+
+  describe('comparator ranges', () => {
+    // `-ee.N` is captured as an ordered `build` component (with `-ee` a
+    // literal), so ranges resolve through the inherited `_compare` without any
+    // semver prerelease involved.
+    const re = get(
+      'regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ee\\.(?<build>\\d+)$',
+    );
+    const tags = ['19.0.0-ee.0', '19.1.2-ee.0', '19.2.0-ee.0', '19.5.1-ee.0'];
+
+    it.each`
+      input                | expected
+      ${'19.1.2-ee.0'}     | ${true}
+      ${'<=19.1.2-ee.0'}   | ${true}
+      ${'=19.1.2-ee.0'}    | ${true}
+      ${'<=19.1.2-ee.foo'} | ${false}
+      ${'<=notaversion'}   | ${false}
+      ${'notaversion'}     | ${false}
+      ${''}                | ${false}
+    `('isValid("$input") === $expected', ({ input, expected }) => {
+      expect(re.isValid(input)).toBe(expected);
+    });
+
+    it('isValid is true for a compound range', () => {
+      expect(re.isValid('>=19.0.0-ee.0 <20.0.0-ee.0')).toBe(true);
+    });
+
+    it.each`
+      input              | expected
+      ${'19.1.2-ee.0'}   | ${true}
+      ${'=19.1.2-ee.0'}  | ${true}
+      ${'==19.1.2-ee.0'} | ${true}
+      ${'<=19.1.2-ee.0'} | ${false}
+      ${'notaversion'}   | ${false}
+    `('isSingleVersion("$input") === $expected', ({ input, expected }) => {
+      expect(re.isSingleVersion(input)).toBe(expected);
+    });
+
+    it('isSingleVersion is false for a compound range', () => {
+      expect(re.isSingleVersion('>=19.0.0-ee.0 <20.0.0-ee.0')).toBe(false);
+    });
+
+    it.each`
+      input              | expected
+      ${'19.1.2-ee.0'}   | ${true}
+      ${'<=19.1.2-ee.0'} | ${false}
+      ${'notaversion'}   | ${false}
+    `('isVersion("$input") === $expected', ({ input, expected }) => {
+      expect(re.isVersion(input)).toBe(expected);
+    });
+
+    it.each`
+      version          | range              | expected
+      ${'19.0.0-ee.0'} | ${'<=19.1.2-ee.0'} | ${true}
+      ${'19.1.2-ee.0'} | ${'<=19.1.2-ee.0'} | ${true}
+      ${'19.2.0-ee.0'} | ${'<=19.1.2-ee.0'} | ${false}
+      ${'19.0.0-ee.0'} | ${'<19.1.2-ee.0'}  | ${true}
+      ${'19.1.2-ee.0'} | ${'<19.1.2-ee.0'}  | ${false}
+      ${'19.2.0-ee.0'} | ${'>=19.1.2-ee.0'} | ${true}
+      ${'19.0.0-ee.0'} | ${'>19.0.0-ee.0'}  | ${false}
+      ${'19.2.0-ee.0'} | ${'>19.0.0-ee.0'}  | ${true}
+      ${'19.1.2-ee.0'} | ${'=19.1.2-ee.0'}  | ${true}
+      ${'19.1.2-ee.0'} | ${'==19.1.2-ee.0'} | ${true}
+      ${'19.1.2-ee.0'} | ${'19.1.2-ee.0'}   | ${true}
+      ${'19.1.3-ee.0'} | ${'19.1.2-ee.0'}   | ${false}
+    `(
+      'matches("$version", "$range") === $expected',
+      ({ version, range, expected }) => {
+        expect(re.matches(version, range)).toBe(expected);
+      },
+    );
+
+    it('matches compound ranges', () => {
+      expect(re.matches('19.1.0-ee.0', '>=19.0.0-ee.0 <20.0.0-ee.0')).toBe(
+        true,
+      );
+      expect(re.matches('20.1.0-ee.0', '>=19.0.0-ee.0 <20.0.0-ee.0')).toBe(
+        false,
+      );
+    });
+
+    it('getSatisfyingVersion caps at the required stop', () => {
+      expect(re.getSatisfyingVersion(tags, '<=19.1.2-ee.0')).toBe(
+        '19.1.2-ee.0',
+      );
+      expect(re.getSatisfyingVersion(tags, '19.2.0-ee.0')).toBe('19.2.0-ee.0');
+      expect(re.getSatisfyingVersion(tags, '<19.0.0-ee.0')).toBeNull();
+    });
+
+    it('minSatisfyingVersion returns the lowest match', () => {
+      expect(re.minSatisfyingVersion(tags, '>=19.1.2-ee.0')).toBe(
+        '19.1.2-ee.0',
+      );
+      expect(re.minSatisfyingVersion(tags, '19.0.0-ee.0')).toBe('19.0.0-ee.0');
+      expect(re.minSatisfyingVersion(tags, '>99.0.0-ee.0')).toBeNull();
+    });
+  });
 });

--- a/lib/modules/versioning/regex/index.ts
+++ b/lib/modules/versioning/regex/index.ts
@@ -2,6 +2,7 @@ import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
+import { parseRange, satisfiesComparator } from '../generic-range.ts';
 import type { VersioningApiConstructor } from '../types.ts';
 
 export const id = 'regex';
@@ -90,6 +91,65 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
       parsedVersion &&
       parsedVersion.compatibility === parsedCurrent?.compatibility
     );
+  }
+
+  override isValid(input: string): boolean {
+    return (
+      this.isVersion(input) ||
+      parseRange(input, (v) => this.isVersion(v)) !== null
+    );
+  }
+
+  override isVersion(version: string): boolean {
+    return this._parse(version) !== null;
+  }
+
+  override isSingleVersion(input: string): boolean {
+    const range = parseRange(input, (v) => this.isVersion(v));
+    if (range) {
+      return (
+        range.length === 1 &&
+        (range[0].operator === '=' || range[0].operator === '==')
+      );
+    }
+    return this.isVersion(input);
+  }
+
+  override matches(version: string, range: string): boolean {
+    const comparators = parseRange(range, (v) => this.isVersion(v));
+    if (!comparators) {
+      return this.equals(version, range);
+    }
+    return comparators.every((comparator) =>
+      satisfiesComparator(
+        this._compare(version, comparator.version),
+        comparator.operator,
+      ),
+    );
+  }
+
+  override getSatisfyingVersion(
+    versions: string[],
+    range: string,
+  ): string | null {
+    if (parseRange(range, (v) => this.isVersion(v)) === null) {
+      return super.getSatisfyingVersion(versions, range);
+    }
+    const matching = versions.filter((v) => this.matches(v, range));
+    matching.sort((a, b) => this._compare(a, b));
+    return matching.at(-1) ?? null;
+  }
+
+  override minSatisfyingVersion(
+    versions: string[],
+    range: string,
+  ): string | null {
+    if (parseRange(range, (v) => this.isVersion(v)) === null) {
+      return super.minSatisfyingVersion(versions, range);
+    }
+    const matching = versions.filter((v) => this.matches(v, range));
+    matching.sort((a, b) => this._compare(a, b));
+    return matching.at(0) ?? null;
   }
 }
 

--- a/lib/modules/versioning/regex/readme.md
+++ b/lib/modules/versioning/regex/readme.md
@@ -83,3 +83,22 @@ Here is another example, this time for handling `ghcr.io/linuxserver/openssh-ser
   ]
 }
 ```
+
+The `regex` scheme also accepts a comparator range wherever a version is matched against a constraint, such as `allowedVersions` and `matchCurrentVersion`, evaluated through the same capture-group ordering.
+The supported operators are `<`, `<=`, `>`, `>=`, `=` and `==`, and several comparators separated by whitespace or a comma are combined with logical AND.
+Because the comparison uses the scheme's own ordering rather than npm `semver`, a numeric suffix captured as `build` is ordered correctly, where `semver` would treat it as a prerelease and reject the range.
+
+For example, to hold a GitLab EE image at or below a required upgrade stop, capture the `-ee` suffix as a numeric `build` group and cap it with `allowedVersions`:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["gitlab/gitlab-ee"],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-ee\\.(?<build>\\d+)$",
+      "allowedVersions": "<=19.1.2-ee.0"
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Changes

The `regex` versioning scheme orders versions by the release array assembled from its captured groups, but it matches every range by exact equality (inherited from `GenericVersioningApi`). So a comparator range in `allowedVersions` (for example `<=1.2.3`, a documented constraint) never resolves against a `regex`-versioned dependency: `isValid` rejects the range, and filter.ts falls back to `semver.satisfies`, which cannot compare versions the scheme parses but semver does not.

This adds comparator range support to the `regex` scheme:

- `lib/modules/versioning/generic-range.ts`: a small, scheme-independent comparator parser. It strips the operator (`<`, `<=`, `>`, `>=`, `=`, `==`; whitespace/comma-separated comparators are ANDed) and defers operand validation and comparison to the caller, so it never coerces or normalizes operands the way npm `semver` does.
- The `regex` scheme overrides `isValid`/`matches`/`getSatisfyingVersion`/`minSatisfyingVersion` (and `isVersion`/`isSingleVersion`, to keep a range distinct from a version) to use the helper, evaluating each comparator through the scheme's own `_compare`.

Because the comparison uses the scheme's own ordering, a numeric suffix captured as a `build` group orders correctly, where semver cannot: as a prerelease it breaks the range, as build metadata it is ignored, and a four-part release is invalid semver. The same comparator ranges also work in `matchCurrentVersion`, which goes through the same `versioningApi.matches`.

Dependency values remain exact tags, so `supportsRanges` stays `false` (the scheme does not update range dependencies). `generic.ts` and the other generic-based schemes are untouched. The `regex` readme documents the capability with an example.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI was used substantively for the code, tests, and documentation. Multiple models were used.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (verified with unit tests; coverage is 100% on both new and changed files, and the full versioning suite passes)