### PR TITLE
refactor(platform/gitlab): use detailed merge status

### DIFF
--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2471,7 +2471,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: { status: 'running' },
         })
         .post(
@@ -2523,7 +2523,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: { status: 'running' },
         })
         .put('/api/v4/projects/some%2Frepo/merge_requests/12345/merge')
@@ -2576,7 +2576,7 @@ describe('modules/platform/gitlab/index', () => {
         })
         .get('/api/v4/projects/some%2Frepo/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: { status: 'running' },
         })
         .post('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/12345')
@@ -2601,10 +2601,13 @@ describe('modules/platform/gitlab/index', () => {
       });
     });
 
-    it('should parse merge_status attribute if detailed_merge_status is not set (on < 15.6)', async () => {
+    it('does not use deprecated merge_status if detailed_merge_status is missing', async () => {
       await initPlatform('13.3.6-ee');
       const reply_body = {
-        merge_status: 'pending',
+        merge_status: 'can_be_merged',
+        pipeline: {
+          status: 'running',
+        },
       };
       httpMock
         .scope(gitlabApiHost)
@@ -2953,7 +2956,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             id: 29626725,
             sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
@@ -3055,7 +3058,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             id: 29626725,
             sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
@@ -3117,7 +3120,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             id: 29626725,
             sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
@@ -3190,7 +3193,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             id: 29626725,
             sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
@@ -3273,7 +3276,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             id: 29626725,
             sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
@@ -3327,7 +3330,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             id: 29626725,
             sha: '2be7ddb704c7b6b83732fdd5b9f09d5a397b5f8f',
@@ -3932,7 +3935,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200)
         .get('/api/v4/projects/undefined/merge_requests/12345')
         .reply(200, {
-          merge_status: 'can_be_merged',
+          detailed_merge_status: 'mergeable',
           pipeline: {
             status: 'running',
           },

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -596,7 +596,6 @@ async function tryPrAutomerge(
         'failed', // don't lose time if pipeline failed
         'running', // pipeline is running, no need to wait for it
       ];
-      const desiredStatus = 'can_be_merged';
       const env = getEnv();
       // The default value of 5 attempts results in max. 13.75 seconds timeout if no pipeline created.
       const retryTimes = parseInteger(
@@ -612,12 +611,11 @@ async function tryPrAutomerge(
       // Check for correct merge request status before setting `merge_when_pipeline_succeeds` to  `true`.
       for (let attempt = 1; attempt <= retryTimes; attempt += 1) {
         const { body } = await gitlabApi.getJsonUnchecked<{
-          merge_status?: string;
           detailed_merge_status?: string;
           merge_when_pipeline_succeeds?: boolean;
           pipeline: {
             status: string;
-          };
+          } | null;
         }>(`projects/${config.repository}/merge_requests/${pr}`, {
           memCache: false,
         });
@@ -629,18 +627,13 @@ async function tryPrAutomerge(
           );
           return;
         }
-        // detailed_merge_status is available with Gitlab >=15.6.0
-        const use_detailed_merge_status = !!body.detailed_merge_status;
         const detailed_merge_status_check =
-          use_detailed_merge_status &&
-          desiredDetailedMergeStatus.includes(body.detailed_merge_status!);
-        // merge_status is deprecated with Gitlab >= 15.6
-        const deprecated_merge_status_check =
-          !use_detailed_merge_status && body.merge_status === desiredStatus;
+          body.detailed_merge_status !== undefined &&
+          desiredDetailedMergeStatus.includes(body.detailed_merge_status);
 
         // Only continue if the merge request can be merged and has a pipeline.
         if (
-          (detailed_merge_status_check || deprecated_merge_status_check) &&
+          detailed_merge_status_check &&
           body.pipeline !== null &&
           desiredPipelineStatus.includes(body.pipeline.status)
         ) {


### PR DESCRIPTION
## Changes

- Use `detailed_merge_status` when checking GitLab merge request automerge readiness.
- Stop falling back to the deprecated `merge_status` field when `detailed_merge_status` is missing.
- Update GitLab platform tests to exercise the detailed status field and the deprecated-field retry behavior.

- Closes #44114

## Documentation

- [x] I have not updated documentation because this is an internal GitLab platform API refactor.

## How I've tested

- `./node_modules/.bin/vitest run lib/modules/platform/gitlab/index.spec.ts --coverage=false`
- `./node_modules/.bin/biome check lib/modules/platform/gitlab/index.ts lib/modules/platform/gitlab/index.spec.ts`
- `git diff --check`

## AI assistance disclosure

- [x] Yes — substantive assistance. OpenAI Codex helped inspect the issue and code path, make this scoped code/test change, and draft this PR body; I ran the checks above.