### PR TITLE
feat(datasource/aws-machine-image): support AWS AMI host rule credentials

### DIFF
--- a/lib/modules/datasource/aws-machine-image/index.spec.ts
+++ b/lib/modules/datasource/aws-machine-image/index.spec.ts
@@ -1,6 +1,7 @@
 import type { DescribeImagesResult, Image } from '@aws-sdk/client-ec2';
 import { DescribeImagesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { mockClient } from 'aws-sdk-client-mock';
+import * as hostRules from '../../../util/host-rules.ts';
 import { getDigest, getPkgReleases } from '../index.ts';
 import { AwsMachineImageDatasource } from './index.ts';
 
@@ -133,6 +134,10 @@ function mockDescribeImagesCommand(result: DescribeImagesResult): void {
 }
 
 describe('modules/datasource/aws-machine-image/index', () => {
+  beforeEach(() => {
+    hostRules.clear();
+  });
+
   describe('getSortedAwsMachineImages()', () => {
     it('with 3 returned images', async () => {
       mockDescribeImagesCommand(mock3Images);
@@ -152,6 +157,31 @@ describe('modules/datasource/aws-machine-image/index', () => {
       );
       expect(res).toStrictEqual([image3]);
       expect(ec2Mock.calls()).toHaveLength(1);
+    });
+
+    it('uses host rule credentials', async () => {
+      hostRules.add({
+        hostType: datasource,
+        username: 'access-key-id',
+        password: 'secret-access-key',
+        token: 'session-token',
+      });
+      mockDescribeImagesCommand(mock1Image);
+
+      const ec2DataSource = new AwsMachineImageDatasource();
+      await ec2DataSource.getSortedAwsMachineImages(
+        '[{"Name":"name","Values":["host-rule-credentials"]}]',
+      );
+
+      const ec2 = ec2Mock.call(0).thisValue as EC2Client;
+      expect(await ec2.config.credentials()).toEqual({
+        accessKeyId: 'access-key-id',
+        secretAccessKey: 'secret-access-key',
+        sessionToken: 'session-token',
+        $source: {
+          CREDENTIALS_CODE: 'e',
+        },
+      });
     });
 
     it('without returned images', async () => {

--- a/lib/modules/datasource/aws-machine-image/index.spec.ts
+++ b/lib/modules/datasource/aws-machine-image/index.spec.ts
@@ -159,7 +159,7 @@ describe('modules/datasource/aws-machine-image/index', () => {
       expect(ec2Mock.calls()).toHaveLength(1);
     });
 
-    it('uses host rule credentials', async () => {
+    it('prefers host rule credentials over the configured profile', async () => {
       hostRules.add({
         hostType: datasource,
         username: 'access-key-id',
@@ -170,7 +170,7 @@ describe('modules/datasource/aws-machine-image/index', () => {
 
       const ec2DataSource = new AwsMachineImageDatasource();
       await ec2DataSource.getSortedAwsMachineImages(
-        '[{"Name":"name","Values":["host-rule-credentials"]}]',
+        '[{"Name":"name","Values":["host-rule-credentials"]},{"profile":"ignored-profile"}]',
       );
 
       const ec2 = ec2Mock.call(0).thisValue as EC2Client;

--- a/lib/modules/datasource/aws-machine-image/index.ts
+++ b/lib/modules/datasource/aws-machine-image/index.ts
@@ -2,6 +2,7 @@ import type { Filter, Image } from '@aws-sdk/client-ec2';
 import { DescribeImagesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import * as hostRules from '../../../util/host-rules.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import * as amazonMachineImageVersioning from '../../versioning/aws-machine-image/index.ts';
 import { Datasource } from '../datasource.ts';
@@ -49,9 +50,19 @@ export class AwsMachineImageDatasource extends Datasource {
 
   private getEC2Client(config: AwsClientConfig): EC2Client {
     const { profile, region } = config;
+    const { password, token, username } = hostRules.find({
+      hostType: AwsMachineImageDatasource.id,
+    });
     return new EC2Client({
       region,
-      credentials: fromNodeProviderChain({ profile }),
+      credentials:
+        username && password
+          ? {
+              accessKeyId: username,
+              secretAccessKey: password,
+              sessionToken: token,
+            }
+          : fromNodeProviderChain({ profile }),
     });
   }
 

--- a/lib/modules/datasource/aws-machine-image/readme.md
+++ b/lib/modules/datasource/aws-machine-image/readme.md
@@ -11,6 +11,25 @@ You can use common AWS configuration options, for example (partial list):
 - Provide credentials via `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (environment variable) or your `~/.aws/credentials` file
 - Select the profile to use via `AWS_PROFILE` environment variable
 
+You can also provide credentials specifically for this datasource with a `hostRules` entry.
+Set `hostType` to `aws-machine-image`, `username` to the access key ID, `password` to the secret access key, and optionally `token` to the session token:
+
+```json
+{
+  "hostRules": [
+    {
+      "hostType": "aws-machine-image",
+      "username": "access-key-id",
+      "password": "secret-access-key",
+      "token": "session-token"
+    }
+  ]
+}
+```
+
+These credentials only apply to Amazon Machine Image lookups.
+When this host rule is absent or incomplete, Renovate uses the default AWS credential provider chain.
+
 Read the [Developer guide](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/configuring-the-jssdk.html) for more information on configuration options.
 
 The least IAM privileges required for this datasource are:


### PR DESCRIPTION
## Changes

The `aws-machine-image` datasource now reads credentials from a `hostRules` entry with `hostType: aws-machine-image`. `username`, `password`, and optional `token` map to the AWS access key ID, secret access key, and session token. The default AWS credential provider chain remains unchanged when the host rule is absent or incomplete.

Documentation and focused credential coverage are included.

## Context

- [x] This closes an existing Issue, Closes: #42987
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI Codex (GPT-5) assisted with implementation, tests, and documentation; all changes were reviewed and validated locally.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`pnpm check --all lib/modules/datasource/aws-machine-image/index.ts lib/modules/datasource/aws-machine-image/index.spec.ts lib/modules/datasource/aws-machine-image/readme.md`