### PR TITLE
test(platform): cover comment check after cache reset

### DIFF
--- a/lib/modules/platform/comment.spec.ts
+++ b/lib/modules/platform/comment.spec.ts
@@ -1,19 +1,14 @@
 import { platform } from '~test/util.ts';
-import * as _cache from '../../util/cache/repository/index.ts';
+import { getCache, resetCache } from '../../util/cache/repository/index.ts';
 import type { RepoCacheData } from '../../util/cache/repository/types.ts';
 import { ensureComment, ensureCommentRemoval } from './comment.ts';
-
-vi.mock('../../util/cache/repository/index.ts');
-
-const cache = vi.mocked(_cache);
 
 describe('modules/platform/comment', () => {
   let repoCache: RepoCacheData = {};
 
   beforeEach(() => {
-    repoCache = {};
-
-    cache.getCache.mockReturnValue(repoCache);
+    resetCache();
+    repoCache = getCache();
   });
 
   describe('ensureComment', () => {
@@ -75,6 +70,17 @@ describe('modules/platform/comment', () => {
       await ensureComment({ number: 1, topic: 'aaa', content: '111' });
 
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
+    });
+
+    it('checks the platform after repository cache reset', async () => {
+      platform.ensureComment.mockResolvedValue(true);
+      const comment = { number: 1, topic: 'aaa', content: '111' };
+
+      await ensureComment(comment);
+      resetCache();
+      await ensureComment(comment);
+
+      expect(platform.ensureComment).toHaveBeenCalledTimes(2);
     });
 
     it('rewrites content hash', async () => {


### PR DESCRIPTION
## Changes

Adds regression coverage for the agreed repository-cache reset behavior from [discussion #44327](https://github.com/renovatebot/renovate/discussions/44327#discussioncomment-17524543).

The test verifies that `ensureComment()` calls the platform again after a repository-cache reset, rather than treating a prior in-memory comment hash as current platform state. This PR changes tests only; it does not alter runtime behavior.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI GPT-5/Codex was used to inspect the cache/comment code path, implement the regression test, and prepare this PR. I reviewed the resulting diff and validation output.
- [ ] Yes — other (please describe):

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

Validation:

- `pnpm vitest lib/modules/platform/comment.spec.ts --coverage=false`
- `pnpm check --all lib/modules/platform/comment.spec.ts`
