### PR TITLE
feat(managers/mise): set `depType` for tools and task tools

### DIFF
--- a/lib/modules/manager/mise/dep-types.ts
+++ b/lib/modules/manager/mise/dep-types.ts
@@ -5,8 +5,7 @@ export const knownDepTypes = [
     depType: 'tools',
     description: 'A tool defined under the top-level `[tools]` table',
   },
-  {
-    depType: 'task-tools',
-    description: 'A tool defined under `tasks.*.tools`',
-  },
 ] as const satisfies readonly DepTypeMetadata[];
+
+export const supportsDynamicDepTypesNote =
+  'Tools defined under `tasks.<name>.tools` produce dynamic `depType` values in the form `task-<name>-tools`, where `<name>` is the task name (e.g. `task-lint-tools`).';

--- a/lib/modules/manager/mise/dep-types.ts
+++ b/lib/modules/manager/mise/dep-types.ts
@@ -1,0 +1,12 @@
+import type { DepTypeMetadata } from '../types.ts';
+
+export const knownDepTypes = [
+  {
+    depType: 'tools',
+    description: 'A tool defined under the top-level `[tools]` table',
+  },
+  {
+    depType: 'task-tools',
+    description: 'A tool defined under `tasks.*.tools`',
+  },
+] as const satisfies readonly DepTypeMetadata[];

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1315,12 +1315,10 @@ describe('modules/manager/mise/extract', () => {
   describe('extractPackageFile() with tasks', () => {
     const RUST_197 = {
       depName: 'rust',
-      depType: 'task-tools',
       currentValue: '1.97.0',
     };
     const ZOXIDE = {
       depName: 'cargo:zoxide',
-      depType: 'task-tools',
       currentValue: '0.9.6',
     };
 
@@ -1332,7 +1330,7 @@ describe('modules/manager/mise/extract', () => {
           run = "cargo build"
           tools = {rust = "1.97.0"}
         `,
-        expectedDeps: [RUST_197],
+        expectedDeps: [{ ...RUST_197, depType: 'task-build-tools' }],
       },
       {
         description: 'dotted key tools under [tasks.build]',
@@ -1340,7 +1338,7 @@ describe('modules/manager/mise/extract', () => {
           [tasks.build]
           tools.rust = "1.97.0"
         `,
-        expectedDeps: [RUST_197],
+        expectedDeps: [{ ...RUST_197, depType: 'task-build-tools' }],
       },
       {
         description: 'subtable [tasks.<name>.tools]',
@@ -1349,7 +1347,10 @@ describe('modules/manager/mise/extract', () => {
           rust = "1.97.0"
           "cargo:zoxide" = "0.9.6"
         `,
-        expectedDeps: [RUST_197, ZOXIDE],
+        expectedDeps: [
+          { ...RUST_197, depType: 'task-build-tools' },
+          { ...ZOXIDE, depType: 'task-build-tools' },
+        ],
       },
       {
         description: 'top level and task tools',
@@ -1362,7 +1363,11 @@ describe('modules/manager/mise/extract', () => {
         `,
         expectedDeps: [
           { ...RUST_197, depType: 'tools' },
-          { ...RUST_197, currentValue: '1.80.0' },
+          {
+            ...RUST_197,
+            depType: 'task-lint-tools',
+            currentValue: '1.80.0',
+          },
         ],
       },
       {

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -37,11 +37,13 @@ describe('modules/manager/mise/extract', () => {
         deps: [
           {
             depName: 'erlang',
+            depType: 'tools',
             currentValue: '23.3',
             datasource: 'github-tags',
           },
           {
             depName: 'node',
+            depType: 'tools',
             currentValue: '16',
             datasource: 'node-version',
           },
@@ -1311,8 +1313,16 @@ describe('modules/manager/mise/extract', () => {
 
   // https://mise.jdx.dev/tasks/task-configuration.html#task-properties
   describe('extractPackageFile() with tasks', () => {
-    const RUST_197 = { depName: 'rust', currentValue: '1.97.0' };
-    const ZOXIDE = { depName: 'cargo:zoxide', currentValue: '0.9.6' };
+    const RUST_197 = {
+      depName: 'rust',
+      depType: 'task-tools',
+      currentValue: '1.97.0',
+    };
+    const ZOXIDE = {
+      depName: 'cargo:zoxide',
+      depType: 'task-tools',
+      currentValue: '0.9.6',
+    };
 
     it.each([
       {
@@ -1350,7 +1360,10 @@ describe('modules/manager/mise/extract', () => {
           [tasks.lint.tools]
           rust = "1.80.0"
         `,
-        expectedDeps: [RUST_197, { ...RUST_197, currentValue: '1.80.0' }],
+        expectedDeps: [
+          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
+          { ...RUST_197, currentValue: '1.80.0' },
+        ],
       },
       {
         description: 'inline table task with top level tools',
@@ -1361,7 +1374,9 @@ describe('modules/manager/mise/extract', () => {
           [tasks]
           build = { run = "cargo build" }
         `,
-        expectedDeps: [RUST_197],
+        expectedDeps: [
+          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
+        ],
       },
       {
         description: 'string shorthand task with top level tools',
@@ -1372,7 +1387,9 @@ describe('modules/manager/mise/extract', () => {
           [tasks]
           build = "echo 'rust is a must'"
         `,
-        expectedDeps: [RUST_197],
+        expectedDeps: [
+          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
+        ],
       },
       {
         description: 'array shorthand task with top level tools',
@@ -1383,7 +1400,9 @@ describe('modules/manager/mise/extract', () => {
           [tasks]
           test = ["echo '🦀🦀🦀'"]
         `,
-        expectedDeps: [RUST_197],
+        expectedDeps: [
+          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
+        ],
       },
     ])(
       'extracts task tools - $description',

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1313,14 +1313,8 @@ describe('modules/manager/mise/extract', () => {
 
   // https://mise.jdx.dev/tasks/task-configuration.html#task-properties
   describe('extractPackageFile() with tasks', () => {
-    const RUST_197 = {
-      depName: 'rust',
-      currentValue: '1.97.0',
-    };
-    const ZOXIDE = {
-      depName: 'cargo:zoxide',
-      currentValue: '0.9.6',
-    };
+    const RUST_197 = { depName: 'rust', currentValue: '1.97.0' };
+    const ZOXIDE = { depName: 'cargo:zoxide', currentValue: '0.9.6' };
 
     it.each([
       {

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1357,11 +1357,7 @@ describe('modules/manager/mise/extract', () => {
         `,
         expectedDeps: [
           { ...RUST_197, depType: 'tools' },
-          {
-            ...RUST_197,
-            depType: 'task-lint-tools',
-            currentValue: '1.80.0',
-          },
+          { ...RUST_197, depType: 'task-lint-tools', currentValue: '1.80.0' },
         ],
       },
       {

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1361,7 +1361,7 @@ describe('modules/manager/mise/extract', () => {
           rust = "1.80.0"
         `,
         expectedDeps: [
-          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
+          { ...RUST_197, depType: 'tools' },
           { ...RUST_197, currentValue: '1.80.0' },
         ],
       },
@@ -1374,9 +1374,7 @@ describe('modules/manager/mise/extract', () => {
           [tasks]
           build = { run = "cargo build" }
         `,
-        expectedDeps: [
-          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
-        ],
+        expectedDeps: [{ ...RUST_197, depType: 'tools' }],
       },
       {
         description: 'string shorthand task with top level tools',
@@ -1387,9 +1385,7 @@ describe('modules/manager/mise/extract', () => {
           [tasks]
           build = "echo 'rust is a must'"
         `,
-        expectedDeps: [
-          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
-        ],
+        expectedDeps: [{ ...RUST_197, depType: 'tools' }],
       },
       {
         description: 'array shorthand task with top level tools',
@@ -1400,9 +1396,7 @@ describe('modules/manager/mise/extract', () => {
           [tasks]
           test = ["echo '🦀🦀🦀'"]
         `,
-        expectedDeps: [
-          { depName: 'rust', depType: 'tools', currentValue: '1.97.0' },
-        ],
+        expectedDeps: [{ ...RUST_197, depType: 'tools' }],
       },
     ])(
       'extracts task tools - $description',

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -61,9 +61,9 @@ export async function extractPackageFile(
     deps.push(extractToolEntry(name, toolData, 'tools'));
   }
 
-  for (const taskData of Object.values(misefile.tasks)) {
+  for (const [taskName, taskData] of Object.entries(misefile.tasks)) {
     for (const [name, toolData] of Object.entries(taskData.tools ?? {})) {
-      deps.push(extractToolEntry(name, toolData, 'task-tools'));
+      deps.push(extractToolEntry(name, toolData, `task-${taskName}-tools`));
     }
   }
 

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -58,12 +58,12 @@ export async function extractPackageFile(
   const deps: PackageDependency[] = [];
 
   for (const [name, toolData] of Object.entries(misefile.tools)) {
-    deps.push(extractToolEntry(name, toolData));
+    deps.push(extractToolEntry(name, toolData, 'tools'));
   }
 
   for (const taskData of Object.values(misefile.tasks)) {
     for (const [name, toolData] of Object.entries(taskData.tools ?? {})) {
-      deps.push(extractToolEntry(name, toolData));
+      deps.push(extractToolEntry(name, toolData, 'task-tools'));
     }
   }
 
@@ -249,7 +249,11 @@ function getConfigFromTooling(
   ); // Ensure null is returned instead of undefined
 }
 
-function extractToolEntry(name: string, toolData: MiseTool): PackageDependency {
+function extractToolEntry(
+  name: string,
+  toolData: MiseTool,
+  depType: string,
+): PackageDependency {
   const version = parseVersion(toolData);
   const { name: depName, options: optionsInName } = optionInToolNameRegex.exec(
     name.trim(),
@@ -265,29 +269,33 @@ function extractToolEntry(name: string, toolData: MiseTool): PackageDependency {
     version === null
       ? null
       : getToolConfig(backend, toolName, version, options);
-  return createDependency(depName, version, toolConfig);
+  return createDependency(depName, version, toolConfig, depType);
 }
 
 function createDependency(
   name: string,
   version: string | null,
   config: StaticTooling | BackendToolingConfig | null,
+  depType: string,
 ): PackageDependency {
   if (version === null) {
     return {
       depName: name,
+      depType,
       skipReason: 'unspecified-version',
     };
   }
   if (config === null) {
     return {
       depName: name,
+      depType,
       skipReason: 'unsupported-datasource',
     };
   }
 
   return {
     depName: name,
+    depType,
     currentValue: version,
     // Spread the config last to override other properties
     ...config,

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -15,6 +15,7 @@ import { RubygemsDatasource } from '../../datasource/rubygems/index.ts';
 import { supportedDatasources as asdfSupportedDatasources } from '../asdf/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
+export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 export { updateLockedDependency } from './update-locked.ts';
 

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -15,7 +15,7 @@ import { RubygemsDatasource } from '../../datasource/rubygems/index.ts';
 import { supportedDatasources as asdfSupportedDatasources } from '../asdf/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
-export { knownDepTypes } from './dep-types.ts';
+export { knownDepTypes, supportsDynamicDepTypesNote } from './dep-types.ts';
 export { extractPackageFile } from './extract.ts';
 export { updateLockedDependency } from './update-locked.ts';
 


### PR DESCRIPTION
## Changes

The mise manager did not set `depType` on extracted dependencies, so `packageRules.matchDepTypes` could not target them.

This sets:

| Source | `depType` |
|--------|-----------|
| Top-level `[tools]` | `tools` |
| `tasks.*.tools` | `task-tools` |

Also exports `knownDepTypes` for manager docs metadata, matching other managers.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Grok Build was used to implement this PR.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A