### PR TITLE
feat(github-actions): update mise checksums

### DIFF
--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 
 import { escapeRegExp, regEx } from '../../../util/regex.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
+import { GithubReleaseAttachmentsDatasource } from '../../datasource/github-release-attachments/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
@@ -92,6 +93,17 @@ const InstallBinaryWith = z
   .object({ repo: z.string(), tag: z.string() })
   .transform(({ repo, tag }) => ({ packageName: repo, val: tag }));
 
+const sha256Regex = regEx(/^[a-f0-9]{64}$/);
+const MiseWith = z
+  .object({
+    version: z.string().optional(),
+    sha256: z.string().optional(),
+  })
+  .transform(({ version, sha256 }) => ({
+    val: version,
+    ...(sha256 && sha256Regex.test(sha256) ? { currentDigest: sha256 } : {}),
+  }));
+
 /**
  * Community contributed actions with known version input schemas.
  */
@@ -168,8 +180,9 @@ export const communityActions: Record<string, CommunityActionConfig> = {
     withSchema: InstallBinaryWith,
   },
   'jdx/mise-action': {
-    datasource: GithubReleasesDatasource.id,
+    datasource: GithubReleaseAttachmentsDatasource.id,
     packageName: 'jdx/mise',
+    withSchema: MiseWith,
   },
   'oven-sh/setup-bun': {
     datasource: NpmDatasource.id,

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1170,35 +1170,45 @@ describe('modules/manager/github-actions/extract', () => {
       ]);
     });
 
-    it('extracts the mise version from jdx/mise-action', () => {
-      const yamlContent = codeBlock`
+    it.each`
+      sha256                                                                | currentDigest
+      ${'dad54e0b843908324282b8673f9c0ebc3a4da0c49ad2da309a49bfbc918ba180'} | ${'dad54e0b843908324282b8673f9c0ebc3a4da0c49ad2da309a49bfbc918ba180'}
+      ${'${{ inputs.mise-sha256 }}'}                                        | ${undefined}
+      ${undefined}                                                          | ${undefined}
+    `(
+      'extracts the mise version and checksum from jdx/mise-action',
+      ({ sha256, currentDigest }) => {
+        const yamlContent = codeBlock`
         jobs:
           build:
             steps:
               - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
                 with:
                   version: 2026.7.10
+                  ${sha256 ? `sha256: ${sha256}` : ''}
                   install_args: cargo:cargo-deny
         `;
 
-      const res = extractPackageFile(yamlContent, 'workflow.yml');
-      expect(res?.deps).toMatchObject([
-        {
-          currentDigest: 'e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d',
-          currentValue: 'v4.2.0',
-          datasource: 'github-tags',
-          depName: 'jdx/mise-action',
-          depType: 'action',
-        },
-        {
-          currentValue: '2026.7.10',
-          datasource: 'github-releases',
-          depName: 'jdx/mise',
-          depType: 'uses-with',
-          packageName: 'jdx/mise',
-        },
-      ]);
-    });
+        const res = extractPackageFile(yamlContent, 'workflow.yml');
+        expect(res?.deps).toMatchObject([
+          {
+            currentDigest: 'e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d',
+            currentValue: 'v4.2.0',
+            datasource: 'github-tags',
+            depName: 'jdx/mise-action',
+            depType: 'action',
+          },
+          {
+            ...(currentDigest ? { currentDigest } : {}),
+            currentValue: '2026.7.10',
+            datasource: 'github-release-attachments',
+            depName: 'jdx/mise',
+            depType: 'uses-with',
+            packageName: 'jdx/mise',
+          },
+        ]);
+      },
+    );
 
     it('extracts steps nested in nested parallel blocks', () => {
       const yamlContent = codeBlock`

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1173,6 +1173,7 @@ describe('modules/manager/github-actions/extract', () => {
     it.each`
       sha256                                                                | currentDigest
       ${'dad54e0b843908324282b8673f9c0ebc3a4da0c49ad2da309a49bfbc918ba180'} | ${'dad54e0b843908324282b8673f9c0ebc3a4da0c49ad2da309a49bfbc918ba180'}
+      ${'DAD54E0B843908324282B8673F9C0EBC3A4DA0C49AD2DA309A49BFBC918BA180'} | ${undefined}
       ${'${{ inputs.mise-sha256 }}'}                                        | ${undefined}
       ${undefined}                                                          | ${undefined}
     `(

--- a/lib/modules/manager/github-actions/integration.spec.ts
+++ b/lib/modules/manager/github-actions/integration.spec.ts
@@ -4,6 +4,7 @@ import { getConfig } from '../../../config/defaults.ts';
 import { Result } from '../../../util/result.ts';
 import * as lookup from '../../../workers/repository/process/lookup/index.ts';
 import type { LookupUpdateConfig } from '../../../workers/repository/process/lookup/types.ts';
+import { GithubReleaseAttachmentsDatasource } from '../../datasource/github-release-attachments/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import type { PackageDependency } from '../types.ts';
 import { extractPackageFile } from './index.ts';
@@ -11,6 +12,14 @@ import { extractPackageFile } from './index.ts';
 describe('modules/manager/github-actions/integration', () => {
   const getGithubTags = vi.spyOn(GithubTagsDatasource.prototype, 'getReleases');
   const getGithubDigest = vi.spyOn(GithubTagsDatasource.prototype, 'getDigest');
+  const getGithubReleaseAttachments = vi.spyOn(
+    GithubReleaseAttachmentsDatasource.prototype,
+    'getReleases',
+  );
+  const getGithubReleaseAttachmentDigest = vi.spyOn(
+    GithubReleaseAttachmentsDatasource.prototype,
+    'getDigest',
+  );
 
   let baseConfig: LookupUpdateConfig;
 
@@ -29,6 +38,51 @@ describe('modules/manager/github-actions/integration', () => {
       packageName: dep.packageName ?? dep.depName!,
     };
   }
+
+  it('updates the mise version and checksum together', async () => {
+    const currentDigest =
+      '429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c';
+    const newDigest =
+      'dad54e0b843908324282b8673f9c0ebc3a4da0c49ad2da309a49bfbc918ba180';
+    const workflow = codeBlock`
+      on: push
+      jobs:
+        test:
+          runs-on: ubuntu-latest
+          steps:
+            - uses: jdx/mise-action@v4
+              with:
+                version: v2026.7.7
+                sha256: ${currentDigest}
+    `;
+
+    const extracted = extractPackageFile(
+      workflow,
+      '.github/workflows/test.yml',
+      {},
+    );
+    const dep = extracted!.deps.find(
+      (dependency) => dependency.depType === 'uses-with',
+    );
+    getGithubReleaseAttachments.mockResolvedValueOnce({
+      releases: [{ version: 'v2026.7.7' }, { version: 'v2026.7.12' }],
+    });
+    getGithubReleaseAttachmentDigest.mockImplementation((_config, newValue) =>
+      Promise.resolve(newValue === 'v2026.7.12' ? newDigest : currentDigest),
+    );
+
+    const { updates } = await Result.wrap(
+      lookup.lookupUpdates(makeConfig(dep!)),
+    ).unwrapOrThrow();
+
+    expect(updates).toEqual([
+      expect.objectContaining({
+        newDigest,
+        newValue: 'v2026.7.12',
+        updateType: 'patch',
+      }),
+    ]);
+  });
 
   it('proposes major update when using tagged major, if a major is available', async () => {
     const workflow = codeBlock`


### PR DESCRIPTION
## Changes

Teach the GitHub Actions manager to treat a literal `jdx/mise-action` `with.sha256` input as the digest paired with `with.version`.

The manager now uses the `github-release-attachments` datasource, so Renovate maps the checksum of the currently selected mise binary to the corresponding asset in the new release and updates both fields together. Non-literal checksums and configurations without `sha256` continue to update only the version.

This follows up on #44660. Its native `with.version` support overlaps checksum-aware custom managers: the native update can change the version while leaving the old checksum behind, as seen in https://github.com/grafana/oats/pull/444.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (OpenAI Codex helped investigate the regression and implement the code and tests).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Commands:

- `pnpm vitest lib/modules/manager/github-actions/extract.spec.ts lib/modules/manager/github-actions/integration.spec.ts --run`
- `pnpm check --all lib/modules/manager/github-actions/community.ts lib/modules/manager/github-actions/extract.spec.ts lib/modules/manager/github-actions/integration.spec.ts`
