### PR TITLE
fix(post-upgrade): skip executable detection for directories

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -539,7 +539,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
           postUpgradeTasks: {
             executionMode: 'branch',
             commands: ['post-upgrade-command'],
-            fileFilters: ['*.txt'],
+            fileFilters: ['*.txt', 'common-dev-assets'],
           },
         },
       ]);
@@ -595,7 +595,10 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         git.isFileModeEnabled.mockResolvedValue(true);
         mockRepositoryChanges({ created: ['script.txt'] });
         fs.statLocalFile.mockResolvedValue(
-          partial<Stats>({ mode: ownerExecutableMode }),
+          partial<Stats>({
+            mode: ownerExecutableMode,
+            isFile: () => true,
+          }),
         );
 
         const result = await runPostUpgradeTask();
@@ -614,7 +617,10 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         git.isFileModeEnabled.mockResolvedValue(true);
         mockRepositoryChanges({ modified: ['script.txt'] });
         fs.statLocalFile.mockResolvedValue(
-          partial<Stats>({ mode: ownerExecutableMode }),
+          partial<Stats>({
+            mode: ownerExecutableMode,
+            isFile: () => true,
+          }),
         );
 
         const result = await runPostUpgradeTask([
@@ -635,11 +641,36 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         ]);
       });
 
+      it('does not mark a submodule directory executable', async () => {
+        git.isFileModeEnabled.mockResolvedValue(true);
+        mockRepositoryChanges({ modified: ['common-dev-assets'] });
+        fs.readLocalFile.mockResolvedValueOnce(null);
+        fs.statLocalFile.mockResolvedValue(
+          partial<Stats>({
+            mode: ownerExecutableMode,
+            isFile: () => false,
+          }),
+        );
+
+        const result = await runPostUpgradeTask();
+
+        expect(result.updatedArtifacts).toEqual([
+          {
+            type: 'addition',
+            path: 'common-dev-assets',
+            contents: null,
+          },
+        ]);
+      });
+
       it('does not infer executability from group or other execute bits', async () => {
         git.isFileModeEnabled.mockResolvedValue(true);
         mockRepositoryChanges({ created: ['script.txt'] });
         fs.statLocalFile.mockResolvedValue(
-          partial<Stats>({ mode: groupAndOtherExecutableMode }),
+          partial<Stats>({
+            mode: groupAndOtherExecutableMode,
+            isFile: () => true,
+          }),
         );
 
         const result = await runPostUpgradeTask();
@@ -657,7 +688,10 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         git.isFileModeEnabled.mockResolvedValue(true);
         mockRepositoryChanges({ modified: ['script.txt'] });
         fs.statLocalFile.mockResolvedValue(
-          partial<Stats>({ mode: nonExecutableMode }),
+          partial<Stats>({
+            mode: nonExecutableMode,
+            isFile: () => true,
+          }),
         );
 
         const result = await runPostUpgradeTask([

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -539,7 +539,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
           postUpgradeTasks: {
             executionMode: 'branch',
             commands: ['post-upgrade-command'],
-            fileFilters: ['*.txt', 'common-dev-assets'],
+            fileFilters: ['*'],
           },
         },
       ]);
@@ -643,7 +643,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
 
       it('does not mark a submodule directory executable', async () => {
         git.isFileModeEnabled.mockResolvedValue(true);
-        mockRepositoryChanges({ modified: ['common-dev-assets'] });
+        mockRepositoryChanges({ modified: ['submodule'] });
         fs.readLocalFile.mockResolvedValueOnce(null);
         fs.statLocalFile.mockResolvedValue(
           partial<Stats>({
@@ -657,7 +657,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         expect(result.updatedArtifacts).toEqual([
           {
             type: 'addition',
-            path: 'common-dev-assets',
+            path: 'submodule',
             contents: null,
           },
         ]);

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -51,7 +51,11 @@ async function detectExecutable(
   }
 
   const fileStats = await statLocalFile(relativePath);
-  if (!fileStats || (fileStats.mode & ownerExecutePermission) === 0) {
+  if (!fileStats?.isFile()) {
+    return undefined;
+  }
+
+  if ((fileStats.mode & ownerExecutePermission) === 0) {
     return undefined;
   }
 


### PR DESCRIPTION
## Changes

Post-upgrade mode detection now records `isExecutable` only for regular files.

A checked-out submodule has an owner execute permission because it is a directory. When a post-upgrade task updated a matched submodule, Renovate treated that permission as a file executable bit and later ran `git update-index --chmod=+x` against a `160000` gitlink. Git rejects that operation.

Submodule updates remain staged as gitlinks. Regular executable files continue to preserve their executable mode.

This addresses the failure reported in https://github.com/renovatebot/renovate/discussions/44875.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g. code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g. IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI assistance covered investigation, implementation, tests, review, and this PR description.

Model used: GPT-5.6 Sol

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable.
