### PR TITLE
docs: clarify prCreation=not-pending fallback and no-check caveat

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -334,7 +334,7 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 - Create the branch, wait for test results
 - Rebase it any time it gets out of date with the base branch
 - Automerge the branch commit if it's: (a) up-to-date with the base branch, and (b) passing all tests
-- As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 24 hours)
+- As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 25 hours, see [`prNotPendingHours`](#prnotpendinghours))
 
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.
@@ -2935,6 +2935,10 @@ Examples of how you can use `minimumReleaseAge`:
 If you use `minimumReleaseAge=3 days`, `prCreation="not-pending"` and `internalChecksFilter="strict"` then Renovate only creates branches when 3 (or more days) have passed since the version was released.
 We recommend you set `dependencyDashboard=true`, so you can see these pending PRs.
 
+!!! warning
+  `prCreation="not-pending"` only opens the PR once branch checks complete.
+  If your CI runs only on `pull_request` events (so Renovate branches have no checks), also set `internalChecksAsSuccess=true` so the release-age check can turn the branch green - otherwise PR creation may be [deferred indefinitely](#prcreation).
+
 #### Prevent holding broken npm packages
 
 npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result in a service impact if you have already updated to it.
@@ -4418,7 +4422,14 @@ You'll have to wait until the checks have been performed, before you can decide 
 
 When prCreation is set to `not-pending`, Renovate creates the PR only once all tests have passed or failed.
 When you get the PR notification, you can take action immediately, as you have the full test results.
-If there are no checks associated, Renovate will create the PR once 24 hours have elapsed since creation of the commit.
+If there are no checks associated, Renovate will create the PR once [`prNotPendingHours`](#prnotpendinghours) have elapsed since the branch's latest commit (default: 25 hours).
+
+!!! warning "`not-pending` can stall PR creation when there are no branch-level checks"
+  A branch with no external status checks is reported as `pending`, so `not-pending` never sees checks "complete" and instead relies on the `prNotPendingHours` fallback.
+  That fallback is measured from the branch's _latest commit_, not from when the branch was created, so anything that rewrites the branch (rebase, re-lock, etc.) restarts the timer.
+  On repositories whose branches are rebased or re-locked more often than `prNotPendingHours`, PRs can be deferred indefinitely.
+  This commonly happens when CI only runs on `pull_request` events, so bare Renovate branches carry no checks.
+  If you rely on `minimumReleaseAge`/`internalChecksFilter` for the "wait" behavior, set [`internalChecksAsSuccess`](#internalchecksassuccess)`=true` so the green internal stability check counts as success and the branch can go green without external checks, or use `prCreation=immediate` instead.
 
 When prCreation is set to `status-success`, Renovate creates the PR only if all tests have passed.
 When a branch remains without PR due to a failing test: select the corresponding PR from the Dependency Dashboard, and push your fixes to the branch.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Documents the `prCreation=not-pending` behavior discussed in https://github.com/renovatebot/renovate/discussions/44161:

- Correct the fallback timeout from "24 hours" to the actual `prNotPendingHours` default of 25 hours, and link the option (both in the `prCreation` section and the `automergeType=branch` backup-PR note).
- Note that the fallback is measured from the branch's latest commit, so rebases/re-locks reset the timer.
- Warn that `not-pending` can stall PR creation when branches have no external checks (e.g. CI only on `pull_request`), and point to `internalChecksAsSuccess=true` / `prCreation=immediate` as fixes.
- Add the same caveat to the "Suppress branch/PR creation for X days" example.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Docs drafted with Claude (Opus 4.8); figures verified against `lib/config/options/index.ts` and `lib/workers/repository/update/pr/index.ts`.
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->