### PR TITLE
refactor(oxlint): enable no-undef

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -5,6 +5,10 @@
   "options": {
     "typeAware": true
   },
+  "env": {
+    "node": true,
+    "es2025": true
+  },
   "categories": {
     "correctness": "error"
   },
@@ -63,6 +67,7 @@
       }
     ],
     "no-unassigned-vars": "error",
+    "no-undef": "error",
     "prefer-template": "error",
     "prefer-arrow-callback": ["error", { "allowUnboundThis": false }],
     "func-style": ["error", "declaration"],
@@ -198,6 +203,12 @@
     },
     {
       "files": ["**/*.spec.ts", "test/**"],
+      "env": {
+        "vitest": true
+      },
+      "globals": {
+        "fixtures": "readonly"
+      },
       "rules": {
         "no-template-curly-in-string": "off",
         "jest/valid-title": "error",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Enables the `no-undef` rule at `error`. The rule was previously unusable because `.oxlintrc.json` declared no `env`/`globals`, so every reference to a runtime global was reported (36,672 diagnostics).

Adds the missing environment configuration:

- Top level `env`: `node` (Node.js + CommonJS globals such as `process`, `Buffer`, `console`, `require`, `module`, `__dirname`, needed by `lib/`, `tools/` and the `.github` scripts) and `es2025`, matching `"lib": ["ES2025"]` in `tsconfig.json`.
- Test-only globals are scoped to the existing `["**/*.spec.ts", "test/**"]` override instead of polluting the top level: the built-in `vitest` env covers `describe`, `it`, `test`, `expect`, `expectTypeOf`, `vi`, `beforeEach`/`afterEach`/ `beforeAll`/`afterAll`, mirroring `"types": ["vitest/globals"]`.
- The repo's own `fixtures` global, installed in `test/setup.ts` via `Object.defineProperty(global, 'fixtures', ...)`, is declared as a readonly global in the same override.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
