### PR TITLE
fix(presets): fix javaLTSVersions not preserving partial semver for mise Java versions

### DIFF
--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -246,6 +246,14 @@ export const presets: Record<string, Preset> = {
         versioning: 'docker',
       },
       {
+        description:
+          'Use partial semver versioning for partial mise Java versions so rolling versions (e.g. 21) are not upgraded to full-precision versions (e.g. 21.0.11+9.0.LTS).',
+        matchCurrentValue: '/^\\d+(?:\\.\\d+)?$/',
+        matchDatasources: ['java-version'],
+        matchManagers: ['mise'],
+        versioning: 'semver-partial',
+      },
+      {
         allowedVersions: '/^(?:jdk|jdk-all|jre)-(?:8|11|17|21|25)(?:\\.|-|$)/',
         description:
           'Limit Java runtime versions to LTS releases. To receive all major releases add `workarounds:javaLTSVersions` to the `ignorePresets` array.',

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -334,7 +334,7 @@ describe('config/presets/internal/workarounds', () => {
             currentValue,
             packageRules,
             versioning: 'semver-partial',
-          } as PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>);
+          });
 
           expect(res.versioning).toEqual(expectedVersioning);
           expect(res.allowedVersions).toEqual(

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -240,11 +240,11 @@ describe('config/presets/internal/workarounds', () => {
   describe('javaLTSVersions', () => {
     const preset = presets.javaLTSVersions;
     const packageRules = preset.packageRules!;
-    // Indices: 0 regex+names, 1 regex+deps, 2 docker major-only+names, 3 docker major-only+deps, 4 liberica
+    // Indices: 0 regex+names, 1 regex+deps, 2 docker major-only+names, 3 docker major-only+deps, 4 mise partial, 5 liberica
     const regexPackageRule = packageRules[0];
     const majorOnlyPackageRule = packageRules[2];
     const majorOnlyDepRule = packageRules[3];
-    const libericaRule = packageRules[4];
+    const libericaRule = packageRules[5];
     const javaRegexVersioning = regexPackageRule.versioning;
 
     describe('major-only docker tag override', () => {
@@ -304,7 +304,7 @@ describe('config/presets/internal/workarounds', () => {
         expect(res.allowedVersions).toEqual('/^(?:8|11|17|21|25)(?:\\.|-|$)/');
       });
 
-      it('keeps regex versioning for java-version major-only values', async () => {
+      it('keeps regex versioning for java-version values outside mise', async () => {
         const res = await applyPackageRules<
           PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>
         >({
@@ -317,6 +317,31 @@ describe('config/presets/internal/workarounds', () => {
 
         expect(res.versioning).toEqual(javaRegexVersioning);
       });
+
+      it.each`
+        currentValue | expectedVersioning
+        ${'21'}      | ${'semver-partial'}
+        ${'21.0'}    | ${'semver-partial'}
+        ${'21.0.9'}  | ${javaRegexVersioning}
+      `(
+        'uses $expectedVersioning versioning for mise Java version $currentValue',
+        async ({ currentValue, expectedVersioning }) => {
+          const res = await applyPackageRules({
+            datasource: 'java-version',
+            depName: 'java',
+            manager: 'mise',
+            packageName: 'java-jdk',
+            currentValue,
+            packageRules,
+            versioning: 'semver-partial',
+          } as PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>);
+
+          expect(res.versioning).toEqual(expectedVersioning);
+          expect(res.allowedVersions).toEqual(
+            '/^(?:8|11|17|21|25)(?:\\.|-|$)/',
+          );
+        },
+      );
     });
 
     describe('bellsoft/liberica-runtime-container', () => {

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -326,7 +326,9 @@ describe('config/presets/internal/workarounds', () => {
       `(
         'uses $expectedVersioning versioning for mise Java version $currentValue',
         async ({ currentValue, expectedVersioning }) => {
-          const res = await applyPackageRules({
+          const res = await applyPackageRules<
+            PackageRuleInputConfig & Pick<PackageRule, 'allowedVersions'>
+          >({
             datasource: 'java-version',
             depName: 'java',
             manager: 'mise',


### PR DESCRIPTION
## Changes

#41179 makes it so a mise config of

```toml
[tools]
java = "temurin-21"
```

doesn't get expanded to

```toml
java = "temurin-21.0.12+8.0.LTS"
```

But the `javaLTSVersions` workaround preset was overwriting that behavior, which meant Java installs managed by mise would be rewritten to have a pinned version by Renovate. This PR updates `workaround.preset.ts` so that rolling versions are not upgraded to full-precision versions.

## Context

Please select one of the following:

- [ ] This closes an existing Issue
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository