### PR TITLE
fix(datasource/go): resolve `sourceUrl` from `GOPROXY` `Origin`

### DIFF
--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -160,7 +160,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
       });
     });
 
-    it('resolves sourceUrl from goproxy Origin without go-get', async () => {
+    it('resolves sourceUrl from goproxy Origin without calling the vanity domain', async () => {
       process.env.GOPROXY = baseUrl;
 
       httpMock

--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -160,6 +160,51 @@ describe('modules/datasource/go/releases-goproxy', () => {
       });
     });
 
+    it('resolves sourceUrl from goproxy Origin without go-get', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/k8s.io/api`)
+        .get('/@v/list')
+        .reply(
+          200,
+          codeBlock`
+            v0.28.0 2023-08-15T19:57:34Z
+            v0.36.3 2026-07-23T01:42:44Z
+          `,
+        )
+        .get('/@latest')
+        .reply(200, {
+          Version: 'v0.36.3',
+          Time: '2026-07-23T01:42:44Z',
+          Origin: {
+            VCS: 'git',
+            URL: 'https://github.com/kubernetes/api.git',
+          },
+        })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      const res = await datasource.getReleases({
+        packageName: 'k8s.io/api',
+      });
+
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v0.28.0',
+            releaseTimestamp: '2023-08-15T19:57:34.000Z',
+          },
+          {
+            version: 'v0.36.3',
+            releaseTimestamp: '2026-07-23T01:42:44.000Z',
+          },
+        ],
+        sourceUrl: 'https://github.com/kubernetes/api',
+        tags: { latest: 'v0.36.3' },
+      });
+    });
+
     it('handles timestamp fetch errors', async () => {
       process.env.GOPROXY = baseUrl;
 

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -1,4 +1,8 @@
-import { isNonEmptyStringAndNotWhitespace, isTruthy } from '@sindresorhus/is';
+import {
+  isNonEmptyString,
+  isNonEmptyStringAndNotWhitespace,
+  isTruthy,
+} from '@sindresorhus/is';
 import type { ConstraintsFilter } from '../../../config/types.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
@@ -257,7 +261,7 @@ export class GoProxyDatasource extends Datasource {
   async getLatestVersion(
     baseUrl: string,
     packageName: string,
-  ): Promise<string | null> {
+  ): Promise<{ version: string; sourceUrl?: string } | null> {
     try {
       const url = joinUrlParts(
         baseUrl,
@@ -265,7 +269,13 @@ export class GoProxyDatasource extends Datasource {
         '@latest',
       );
       const res = await this.http.getJson(url, VersionInfo);
-      return res.body.Version;
+      const { Version: version, Origin: origin } = res.body;
+      // Prefer Origin from the proxy when present (avoids go-get to vanity hosts)
+      const sourceUrl =
+        origin?.VCS === 'git' && isNonEmptyString(origin.URL)
+          ? origin.URL.replace(regEx(/\.git$/), '')
+          : undefined;
+      return { version, sourceUrl };
     } catch (err) {
       logger.trace({ err }, 'Failed to get latest version');
       return null;
@@ -365,12 +375,16 @@ export class GoProxyDatasource extends Datasource {
         throw err;
       }
 
-      const latestVersion = await this.getLatestVersion(baseUrl, pkg);
-      if (latestVersion) {
+      const latest = await this.getLatestVersion(baseUrl, pkg);
+      if (latest) {
+        const { version: latestVersion, sourceUrl } = latest;
         result.tags ??= {};
         result.tags.latest ??= latestVersion;
         if (goVersioning.isGreaterThan(latestVersion, result.tags.latest)) {
           result.tags.latest = latestVersion;
+        }
+        if (sourceUrl) {
+          result.sourceUrl ??= sourceUrl;
         }
         if (!result.releases.length) {
           const releaseFromLatest = pseudoVersionToRelease(latestVersion);

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -270,7 +270,8 @@ export class GoProxyDatasource extends Datasource {
       );
       const res = await this.http.getJson(url, VersionInfo);
       const { Version: version, Origin: origin } = res.body;
-      // Prefer Origin from the proxy when present (avoids go-get to vanity hosts)
+      // Extract sourceUrl from GOPROXY Origin when present, avoiding go-get to
+      // vanity hosts (https://github.com/renovatebot/renovate/discussions/44898)
       const sourceUrl =
         origin?.VCS === 'git' && isNonEmptyString(origin.URL)
           ? origin.URL.replace(regEx(/\.git$/), '')

--- a/lib/modules/datasource/go/schema.ts
+++ b/lib/modules/datasource/go/schema.ts
@@ -4,6 +4,13 @@ import { MaybeTimestamp } from '../../../util/timestamp.ts';
 export const VersionInfo = z.object({
   Version: z.string(),
   Time: MaybeTimestamp,
+  // https://go.dev/ref/mod#goproxy-protocol
+  Origin: z
+    .object({
+      VCS: z.string().optional(),
+      URL: z.string().optional(),
+    })
+    .optional(),
 });
 
 export type VersionInfo = z.infer<typeof VersionInfo>;

--- a/lib/modules/datasource/go/schema.ts
+++ b/lib/modules/datasource/go/schema.ts
@@ -1,10 +1,11 @@
 import { z } from 'zod/v4';
 import { MaybeTimestamp } from '../../../util/timestamp.ts';
 
+// https://go.dev/ref/mod#goproxy-protocol
 export const VersionInfo = z.object({
   Version: z.string(),
   Time: MaybeTimestamp,
-  // https://go.dev/ref/mod#goproxy-protocol
+  // https://github.com/golang/go/blob/dd612356d8bfe352ec7812ce6c93c9fd2bc10c81/src/cmd/go/internal/modfetch/codehost/codehost.go#L93
   Origin: z
     .object({
       VCS: z.string().optional(),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When looking up Go modules via `GOPROXY`, extract `sourceUrl` from the `Origin` field already returned by the `@latest` endpoint. That avoids a separate `?go-get=1` request to the vanity host when the proxy has already resolved the real VCS URL.

`?go-get=1` remains as a fallback when `Origin` is missing.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an existing Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: https://github.com/renovatebot/renovate/discussions/44898

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Grok Build was used to implement this change and tests.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/felipecrs/renovate-repro-go-source-url-vanity-import/pulls?q=is%3Apr

Include this in the global config:

```js
{
  hostRules: [
    {
      matchHost: 'k8s.io',
      enabled: false,
    },  
  ] 
}
```

Also important to clear cache between executions with `rm -rf /tmp/renovate`.