### PR TITLE
refactor: move checkMinimumReleaseAge to lib/util/minimum-release-age.ts

### DIFF
--- a/lib/util/minimum-release-age.spec.ts
+++ b/lib/util/minimum-release-age.spec.ts
@@ -1,0 +1,79 @@
+import * as _dateUtil from './date.ts';
+import { checkMinimumReleaseAge } from './minimum-release-age.ts';
+import { toMs } from './pretty-time.ts';
+import type { Timestamp } from './timestamp.ts';
+
+vi.mock('./date.ts');
+const dateUtil = vi.mocked(_dateUtil);
+
+describe('util/minimum-release-age', () => {
+  describe('.checkMinimumReleaseAge()', () => {
+    it('is not pending if minimumReleaseAge is not set', () => {
+      const res = checkMinimumReleaseAge(
+        {},
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: 0,
+        hasTimestamp: true,
+      });
+    });
+
+    it('is pending if the release is younger than minimumReleaseAge', () => {
+      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('1 day') ?? 0);
+      const res = checkMinimumReleaseAge(
+        { minimumReleaseAge: '3 days' },
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: true,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: true,
+      });
+    });
+
+    it('is not pending if the release is older than minimumReleaseAge', () => {
+      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('5 days') ?? 0);
+      const res = checkMinimumReleaseAge(
+        { minimumReleaseAge: '3 days' },
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: true,
+      });
+    });
+
+    it('is pending with a missing timestamp if minimumReleaseAgeBehaviour=timestamp-required', () => {
+      const res = checkMinimumReleaseAge(
+        {
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBehaviour: 'timestamp-required',
+        },
+        undefined,
+      );
+      expect(res).toEqual({
+        isPending: true,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: false,
+      });
+    });
+
+    it('is not pending with a missing timestamp if minimumReleaseAgeBehaviour=timestamp-optional', () => {
+      const res = checkMinimumReleaseAge(
+        {
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBehaviour: 'timestamp-optional',
+        },
+        undefined,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: false,
+      });
+    });
+  });
+});

--- a/lib/util/minimum-release-age.ts
+++ b/lib/util/minimum-release-age.ts
@@ -1,0 +1,52 @@
+import { isNonEmptyString } from '@sindresorhus/is';
+import type { MinimumReleaseAgeBehaviour } from '../config/types.ts';
+import { getElapsedMs } from './date.ts';
+import { coerceNumber } from './number.ts';
+import { toMs } from './pretty-time.ts';
+import type { Timestamp } from './timestamp.ts';
+
+export interface MinimumReleaseAgeCheckResult {
+  isPending: boolean;
+  minimumReleaseAgeMs: number;
+  hasTimestamp: boolean;
+}
+
+/**
+ * Checks whether a release satisfies `minimumReleaseAge`.
+ *
+ * Separate from `internalChecksFilter` to allow reuse, and lives here so that
+ * managers can import it without an import cycle.
+ */
+export function checkMinimumReleaseAge(
+  config: {
+    minimumReleaseAge?: string | null;
+    minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour | null;
+  },
+  releaseTimestamp: Timestamp | null | undefined,
+): MinimumReleaseAgeCheckResult {
+  const minimumReleaseAgeMs = isNonEmptyString(config.minimumReleaseAge)
+    ? coerceNumber(toMs(config.minimumReleaseAge), 0)
+    : 0;
+
+  if (!minimumReleaseAgeMs) {
+    return {
+      isPending: false,
+      minimumReleaseAgeMs,
+      hasTimestamp: !!releaseTimestamp,
+    };
+  }
+
+  if (releaseTimestamp) {
+    return {
+      isPending: getElapsedMs(releaseTimestamp) < minimumReleaseAgeMs,
+      minimumReleaseAgeMs,
+      hasTimestamp: true,
+    };
+  }
+
+  return {
+    isPending: config.minimumReleaseAgeBehaviour === 'timestamp-required',
+    minimumReleaseAgeMs,
+    hasTimestamp: false,
+  };
+}

--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -16,7 +16,6 @@ import { toMs } from '../../../../util/pretty-time.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
 import {
   checkMinimumConfidence,
-  checkMinimumReleaseAge,
   filterInternalChecks,
   isMinimumConfidenceApplicable,
   isMinimumReleaseAgeApplicable,
@@ -403,81 +402,6 @@ describe('workers/repository/process/lookup/filter-checks', () => {
 
     it('returns true for updateType=undefined', () => {
       expect(isMinimumConfidenceApplicable(undefined)).toBeTrue();
-    });
-  });
-
-  describe('.checkMinimumReleaseAge()', () => {
-    beforeEach(() => {
-      // oxlint-disable-next-line renovate/no-redundant-mock-reset -- discards the once-values queued by the outer beforeEach
-      dateUtil.getElapsedMs.mockReset();
-    });
-
-    it('is not pending if minimumReleaseAge is not set', () => {
-      const res = checkMinimumReleaseAge(
-        {},
-        '2021-01-01T00:00:00.000Z' as Timestamp,
-      );
-      expect(res).toEqual({
-        isPending: false,
-        minimumReleaseAgeMs: 0,
-        hasTimestamp: true,
-      });
-    });
-
-    it('is pending if the release is younger than minimumReleaseAge', () => {
-      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('1 day') ?? 0);
-      const res = checkMinimumReleaseAge(
-        { minimumReleaseAge: '3 days' },
-        '2021-01-01T00:00:00.000Z' as Timestamp,
-      );
-      expect(res).toEqual({
-        isPending: true,
-        minimumReleaseAgeMs: toMs('3 days'),
-        hasTimestamp: true,
-      });
-    });
-
-    it('is not pending if the release is older than minimumReleaseAge', () => {
-      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('5 days') ?? 0);
-      const res = checkMinimumReleaseAge(
-        { minimumReleaseAge: '3 days' },
-        '2021-01-01T00:00:00.000Z' as Timestamp,
-      );
-      expect(res).toEqual({
-        isPending: false,
-        minimumReleaseAgeMs: toMs('3 days'),
-        hasTimestamp: true,
-      });
-    });
-
-    it('is pending with a missing timestamp if minimumReleaseAgeBehaviour=timestamp-required', () => {
-      const res = checkMinimumReleaseAge(
-        {
-          minimumReleaseAge: '3 days',
-          minimumReleaseAgeBehaviour: 'timestamp-required',
-        },
-        undefined,
-      );
-      expect(res).toEqual({
-        isPending: true,
-        minimumReleaseAgeMs: toMs('3 days'),
-        hasTimestamp: false,
-      });
-    });
-
-    it('is not pending with a missing timestamp if minimumReleaseAgeBehaviour=timestamp-optional', () => {
-      const res = checkMinimumReleaseAge(
-        {
-          minimumReleaseAge: '3 days',
-          minimumReleaseAgeBehaviour: 'timestamp-optional',
-        },
-        undefined,
-      );
-      expect(res).toEqual({
-        isPending: false,
-        minimumReleaseAgeMs: toMs('3 days'),
-        hasTimestamp: false,
-      });
     });
   });
 

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -1,4 +1,3 @@
-import { isNonEmptyString } from '@sindresorhus/is';
 import { mergeChildConfig } from '../../../../config/index.ts';
 import type {
   MinimumReleaseAgeBehaviour,
@@ -8,17 +7,14 @@ import { logger } from '../../../../logger/index.ts';
 import type { Release } from '../../../../modules/datasource/index.ts';
 import { postprocessRelease } from '../../../../modules/datasource/postprocess-release.ts';
 import type { VersioningApi } from '../../../../modules/versioning/index.ts';
-import { getElapsedMs } from '../../../../util/date.ts';
 import {
   getMergeConfidenceLevel,
   isActiveConfidenceLevel,
   satisfiesConfidenceLevel,
 } from '../../../../util/merge-confidence/index.ts';
 import type { MergeConfidence } from '../../../../util/merge-confidence/types.ts';
-import { coerceNumber } from '../../../../util/number.ts';
+import { checkMinimumReleaseAge } from '../../../../util/minimum-release-age.ts';
 import { applyPackageRules } from '../../../../util/package-rules/index.ts';
-import { toMs } from '../../../../util/pretty-time.ts';
-import type { Timestamp } from '../../../../util/timestamp.ts';
 import type { LookupUpdateConfig, UpdateResult } from './types.ts';
 import { getUpdateType } from './update-type.ts';
 
@@ -60,51 +56,6 @@ export function isMinimumConfidenceApplicable(
     // data collection doesn't include digest updates
     updateType !== 'pinDigest'
   );
-}
-
-export interface MinimumReleaseAgeCheckResult {
-  isPending: boolean;
-  minimumReleaseAgeMs: number;
-  hasTimestamp: boolean;
-}
-
-/**
- * Checks whether a release satisfies `minimumConfidence`.
- *
- * Separate from `internalChecksFilter` to allow reuse.
- */
-export function checkMinimumReleaseAge(
-  config: {
-    minimumReleaseAge?: string | null;
-    minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour | null;
-  },
-  releaseTimestamp: Timestamp | null | undefined,
-): MinimumReleaseAgeCheckResult {
-  const minimumReleaseAgeMs = isNonEmptyString(config.minimumReleaseAge)
-    ? coerceNumber(toMs(config.minimumReleaseAge), 0)
-    : 0;
-
-  if (!minimumReleaseAgeMs) {
-    return {
-      isPending: false,
-      minimumReleaseAgeMs,
-      hasTimestamp: !!releaseTimestamp,
-    };
-  }
-
-  if (releaseTimestamp) {
-    return {
-      isPending: getElapsedMs(releaseTimestamp) < minimumReleaseAgeMs,
-      minimumReleaseAgeMs,
-      hasTimestamp: true,
-    };
-  }
-
-  return {
-    isPending: config.minimumReleaseAgeBehaviour === 'timestamp-required',
-    minimumReleaseAgeMs,
-    hasTimestamp: false,
-  };
 }
 
 export interface MinimumConfidenceCheckResult {


### PR DESCRIPTION
## Changes

Prefactor split out of #42326, as requested in https://github.com/renovatebot/renovate/pull/42326#discussion_r3658178018.

Moves `checkMinimumReleaseAge` (and `MinimumReleaseAgeCheckResult`) from `lib/workers/repository/process/lookup/filter-checks.ts` to a new `lib/util/minimum-release-age.ts`, with its tests.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Opus 5) was used to verify the import-cycle claim and to perform the file move; the moved code and tests are unchanged from what already exists on `main`.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The moved tests are unchanged and pass in their new location (`lib/util/minimum-release-age.spec.ts`, 100% coverage of the moved file on its own). `lib/workers/repository/process/lookup/` remains green, and `tsc --noEmit` plus repo-wide `oxlint` (which enforces `import/no-cycle`) both pass.
