### PR TITLE
docs(manager): indicate where `lockFileMaintenance` runs external commands

### DIFF
--- a/lib/modules/manager/bazel-module/index.ts
+++ b/lib/modules/manager/bazel-module/index.ts
@@ -26,3 +26,4 @@ export const supportedDatasources = [
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['MODULE.bazel.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;

--- a/lib/modules/manager/bazelisk/index.ts
+++ b/lib/modules/manager/bazelisk/index.ts
@@ -18,3 +18,4 @@ export const supportedDatasources = [GithubReleasesDatasource.id];
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['MODULE.bazel.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;

--- a/lib/modules/manager/bun/index.ts
+++ b/lib/modules/manager/bun/index.ts
@@ -12,6 +12,7 @@ export const categories: Category[] = ['js'];
 export const supersedesManagers = ['npm'];
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['bun.lockb', 'bun.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const defaultConfig = {
   managerFilePatterns: ['/(^|/)bun\\.lockb?$/', '/(^|/)package\\.json$/'],

--- a/lib/modules/manager/bundler/index.ts
+++ b/lib/modules/manager/bundler/index.ts
@@ -8,6 +8,7 @@ import { updateLockedDependency } from './update-locked.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['Gemfile.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 /*
  * Each of the below functions contain some explanations within their own files.

--- a/lib/modules/manager/cargo/index.ts
+++ b/lib/modules/manager/cargo/index.ts
@@ -13,6 +13,7 @@ export { updateLockedDependency } from './update-locked.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['Cargo.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export { extractPackageFile, updateArtifacts };
 

--- a/lib/modules/manager/composer/index.ts
+++ b/lib/modules/manager/composer/index.ts
@@ -10,6 +10,7 @@ import { composerVersioningId } from './utils.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['composer.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export {
   extractPackageFile,

--- a/lib/modules/manager/conan/index.ts
+++ b/lib/modules/manager/conan/index.ts
@@ -11,6 +11,7 @@ import * as conan from '../../versioning/conan/index.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['conan.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 export const url = 'https://docs.conan.io';
 export const categories: Category[] = ['c'];
 

--- a/lib/modules/manager/deno/index.ts
+++ b/lib/modules/manager/deno/index.ts
@@ -17,6 +17,7 @@ export const categories: Category[] = ['js'];
 export const supersedesManagers = ['npm'];
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['deno.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 export const supportedDatasources = [
   NpmDatasource.id,
   JsrDatasource.id,

--- a/lib/modules/manager/devbox/index.ts
+++ b/lib/modules/manager/devbox/index.ts
@@ -5,6 +5,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['devbox.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const defaultConfig = {
   managerFilePatterns: ['/(^|/)devbox\\.json$/'],

--- a/lib/modules/manager/gleam/index.ts
+++ b/lib/modules/manager/gleam/index.ts
@@ -19,4 +19,5 @@ export const defaultConfig = {
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['manifest.toml'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 export const supportedDatasources = [HexDatasource.id];

--- a/lib/modules/manager/gradle/index.ts
+++ b/lib/modules/manager/gradle/index.ts
@@ -9,6 +9,7 @@ export { updateDependency } from './update.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['gradle.lockfile'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const url =
   'https://docs.gradle.org/current/userguide/getting_started_dep_man.html';

--- a/lib/modules/manager/helmfile/index.ts
+++ b/lib/modules/manager/helmfile/index.ts
@@ -7,6 +7,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['helmfile.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const url = 'https://helmfile.readthedocs.io';
 export const categories: Category[] = ['cd', 'helm', 'kubernetes'];

--- a/lib/modules/manager/helmv3/index.ts
+++ b/lib/modules/manager/helmv3/index.ts
@@ -8,6 +8,7 @@ export { bumpPackageVersion } from './update.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['Chart.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const displayName = 'Helm v3';
 export const url = 'https://helm.sh/docs';

--- a/lib/modules/manager/index.spec.ts
+++ b/lib/modules/manager/index.spec.ts
@@ -34,6 +34,18 @@ describe('modules/manager/index', () => {
     }
   });
 
+  describe('lockFileMaintenanceIsDelegatedToPackageManager', () => {
+    for (const [name, mgr] of [...manager.getManagers()].filter(
+      ([_, mgr]) => mgr.supportsLockFileMaintenance,
+    )) {
+      it(`has lockFileMaintenanceIsDelegatedToPackageManager for ${name}`, () => {
+        expect(mgr.lockFileMaintenanceIsDelegatedToPackageManager).toSatisfy(
+          (value) => typeof value === 'boolean' || typeof value === 'string',
+        );
+      });
+    }
+  });
+
   describe('get()', () => {
     it('gets something', () => {
       expect(manager.get('dockerfile', 'extractPackageFile')).not.toBeNull(); // gets built-in manager

--- a/lib/modules/manager/jsonnet-bundler/index.ts
+++ b/lib/modules/manager/jsonnet-bundler/index.ts
@@ -6,6 +6,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['jsonnetfile.lock.json'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const displayName = 'jsonnet-bundler';
 export const url = 'https://github.com/jsonnet-bundler/jsonnet-bundler#readme';

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -22,6 +22,7 @@ export { updateLockedDependency } from './update-locked.ts';
 export const displayName = 'mise-en-place';
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['mise.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 export const url = 'https://mise.jdx.dev';
 
 export const defaultConfig = {

--- a/lib/modules/manager/mix/index.ts
+++ b/lib/modules/manager/mix/index.ts
@@ -17,6 +17,7 @@ export const defaultConfig = {
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['mix.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 export const supportedDatasources = [
   GithubTagsDatasource.id,
   GitTagsDatasource.id,

--- a/lib/modules/manager/nix/index.ts
+++ b/lib/modules/manager/nix/index.ts
@@ -6,6 +6,7 @@ export { getRangeStrategy } from './range.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['flake.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const url = 'https://nix.dev';
 

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -19,6 +19,8 @@ export const lockFileNames = [
   'pnpm-lock.yaml',
   'yarn.lock',
 ];
+export const lockFileMaintenanceIsDelegatedToPackageManager =
+  'Delegated to the underlying package manager CLI - `npm`, `pnpm`, or Yarn - depending on which lock file is present.';
 
 export const displayName = 'npm';
 export const url = 'https://docs.npmjs.com';

--- a/lib/modules/manager/nuget/index.ts
+++ b/lib/modules/manager/nuget/index.ts
@@ -9,6 +9,7 @@ export { bumpPackageVersion } from './update.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['packages.lock.json'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const displayName = 'NuGet';
 export const url = 'https://learn.microsoft.com/nuget';

--- a/lib/modules/manager/pep621/index.ts
+++ b/lib/modules/manager/pep621/index.ts
@@ -7,6 +7,8 @@ export { bumpPackageVersion } from './update.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['pdm.lock', 'uv.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager =
+  'Delegated to the underlying package manager CLI - `pdm` or `uv` - depending on which lockfile format the project uses.';
 
 export const displayName = 'PEP 621';
 export const url = 'https://peps.python.org/pep-0621';

--- a/lib/modules/manager/pip-compile/index.ts
+++ b/lib/modules/manager/pip-compile/index.ts
@@ -7,6 +7,7 @@ export { extractAllPackageFiles, extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['requirements.txt'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const displayName = 'pip-compile';
 export const url =

--- a/lib/modules/manager/pipenv/index.ts
+++ b/lib/modules/manager/pipenv/index.ts
@@ -6,6 +6,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['Pipfile.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const url = 'https://pipenv.pypa.io/en/latest';
 export const categories: Category[] = ['python'];

--- a/lib/modules/manager/pixi/index.ts
+++ b/lib/modules/manager/pixi/index.ts
@@ -7,6 +7,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['pixi.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const url = 'https://github.com/prefix-dev/pixi/';
 export const categories: Category[] = ['python'];

--- a/lib/modules/manager/poetry/index.ts
+++ b/lib/modules/manager/poetry/index.ts
@@ -14,6 +14,7 @@ export { updateLockedDependency } from './update-locked.ts';
 export const supersedesManagers = ['pep621'];
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['poetry.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const url = 'https://python-poetry.org/docs';
 export const categories: Category[] = ['python'];

--- a/lib/modules/manager/pub/index.ts
+++ b/lib/modules/manager/pub/index.ts
@@ -8,6 +8,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['pubspec.lock'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const displayName = 'pub';
 export const url = 'https://dart.dev/tools/pub/packages';

--- a/lib/modules/manager/terraform/index.ts
+++ b/lib/modules/manager/terraform/index.ts
@@ -14,6 +14,7 @@ export { updateLockedDependency } from './lockfile/update-locked.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['.terraform.lock.hcl'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = false;
 
 export const url = 'https://developer.hashicorp.com/terraform/docs';
 export const categories: Category[] = ['iac', 'terraform'];

--- a/lib/modules/manager/terragrunt/index.ts
+++ b/lib/modules/manager/terragrunt/index.ts
@@ -12,6 +12,8 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['.terraform.lock.hcl'];
+export const lockFileMaintenanceIsDelegatedToPackageManager =
+  "Lock file maintenance is not implemented separately for Terragrunt. It reuses the [Terraform manager](../terraform/index.md)'s lock file logic in-process, so Renovate computes the updated `.terraform.lock.hcl` hashes directly instead of calling the `terragrunt` or `terraform` CLI.";
 
 export const url = 'https://terragrunt.gruntwork.io/docs';
 export const categories: Category[] = ['iac', 'terraform'];

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -335,6 +335,13 @@ interface ManagerApiBase extends ModuleApi {
   /** Markdown note about dynamically generated depTypes not covered by `knownDepTypes` */
   supportsDynamicDepTypesNote?: string;
   supportsLockFileMaintenance?: boolean;
+  /**
+   * Whether Renovate delegates to external command(s)/package manager to perform lockFileMaintenance.
+   * A `string` value is a Markdown note describing the nuance of the support, e.g. when it's partial
+   * or conditional, instead of a plain `true`/`false`.
+   */
+  lockFileMaintenanceIsDelegatedToPackageManager?: boolean | string;
+
   lockFileNames?: string[];
   supersedesManagers?: string[];
   supportedDatasources: string[];
@@ -378,6 +385,16 @@ export type ManagerApi = ManagerApiBase &
   // this ensures at compile time that lockFileNames are set when manager has supportsLockFileMaintenance=true
   (| { supportsLockFileMaintenance: true; lockFileNames: string[] }
     | { supportsLockFileMaintenance?: false; lockFileNames?: string[] }
+  ) &
+  // this ensures at compile time that lockFileMaintenanceIsDelegatedToPackageManager is set when manager has supportsLockFileMaintenance=true
+  (| {
+        supportsLockFileMaintenance: true;
+        lockFileMaintenanceIsDelegatedToPackageManager: boolean | string;
+      }
+    | {
+        supportsLockFileMaintenance?: false;
+        lockFileMaintenanceIsDelegatedToPackageManager?: boolean | string;
+      }
   );
 
 // TODO: name and properties used by npm manager

--- a/lib/modules/manager/vendir/index.ts
+++ b/lib/modules/manager/vendir/index.ts
@@ -10,6 +10,7 @@ export { extractPackageFile } from './extract.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['vendir.lock.yml'];
+export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const displayName = 'vendir';
 export const url = 'https://carvel.dev/vendir/docs/latest';

--- a/tools/docs/manager.ts
+++ b/tools/docs/manager.ts
@@ -202,6 +202,18 @@ export async function generateManagers(
         md += `- \`${lockFile}\`\n`;
       }
       md += '\n';
+
+      const delegated =
+        definition.lockFileMaintenanceIsDelegatedToPackageManager;
+      if (typeof delegated === 'string') {
+        md += `${delegated}\n\n`;
+      } else if (delegated === true) {
+        md +=
+          'Lock file maintenance is delegated to the underlying package manager, which Renovate runs as an external command.\n\n';
+      } else if (delegated === false) {
+        md +=
+          'Renovate performs lock file maintenance itself, without calling the underlying package manager.\n\n';
+      }
     }
 
     if (!isCustomMgr) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As found with recent changes to the Terraform manager, although we
generally have `lockFileMaintenance` being executed by an external
package manager being invoked by `exec(...)`, there are a few package
managers that do not do so.

(This surprised me in https://github.com/renovatebot/renovate/pull/42326)

To make it very clear how this happens, we can add a new field to the
Manager API, which will provide a means to document this.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
