### PR TITLE
fix(copier): preserve executable file mode

### DIFF
--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs';
 import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { mockExecAll } from '~test/exec-util.ts';
@@ -394,6 +395,14 @@ describe('modules/manager/copier/artifacts', () => {
       );
       fs.readLocalFile.mockResolvedValueOnce('new file contents');
       fs.readLocalFile.mockResolvedValueOnce('renamed file contents');
+      fs.statLocalFile.mockImplementation((path) =>
+        Promise.resolve(
+          partial<Stats>({
+            isFile: () => true,
+            mode: path === 'new_file.py' ? 0o755 : 0o644,
+          }),
+        ),
+      );
 
       const result = await updateArtifacts({
         packageFileName: '.copier-answers.yml',
@@ -415,6 +424,7 @@ describe('modules/manager/copier/artifacts', () => {
             type: 'addition',
             path: 'new_file.py',
             contents: 'new file contents',
+            isExecutable: true,
           },
         },
         {

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -4,9 +4,10 @@ import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
-import { readLocalFile } from '../../../util/fs/index.ts';
+import { readLocalFile, statLocalFile } from '../../../util/fs/index.ts';
 import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
+import type { FileAddition } from '../../../util/git/types.ts';
 import type {
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -18,6 +19,20 @@ import {
 } from './utils.ts';
 
 const DEFAULT_COMMAND_OPTIONS = ['--skip-answered', '--defaults'];
+const ownerExecutePermission = 0o100;
+
+async function readFileAddition(path: string): Promise<FileAddition> {
+  const file: FileAddition = {
+    type: 'addition',
+    path,
+    contents: await readLocalFile(path),
+  };
+  const stats = await statLocalFile(path);
+  if (stats?.isFile() && (stats.mode & ownerExecutePermission) !== 0) {
+    file.isExecutable = true;
+  }
+  return file;
+}
 
 function buildCommand(
   config: UpdateArtifactsConfig,
@@ -116,11 +131,7 @@ export async function updateArtifacts({
     ...status.conflicted,
   ]) {
     const fileRes: UpdateArtifactsResult = {
-      file: {
-        type: 'addition',
-        path: f,
-        contents: await readLocalFile(f),
-      },
+      file: await readFileAddition(f),
     };
     if (status.conflicted.includes(f)) {
       // Make the reviewer aware of the conflicts.
@@ -151,11 +162,7 @@ export async function updateArtifacts({
       },
     });
     res.push({
-      file: {
-        type: 'addition',
-        path: f.to,
-        contents: await readLocalFile(f.to),
-      },
+      file: await readFileAddition(f.to),
     });
   }
   return res;


### PR DESCRIPTION
## Changes

- Preserve the owner executable bit when Copier returns added or modified artifacts.
- Apply the same mode detection to renamed files.
- Add regression coverage for executable and regular generated files.

Tested with:

- `vitest run lib/modules/manager/copier/artifacts.spec.ts --coverage --coverage.include=lib/modules/manager/copier/artifacts.ts` (17 tests; 100% statements, branches, functions, and lines for `artifacts.ts`)
- Prettier, Biome, and Oxlint on the changed files

## Context

- [x] This closes an existing Issue, Closes: #42239
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5) was used for codebase navigation, implementation, regression tests, local verification, and pull request wording.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A