### PR TITLE
fix(packagist): Throw on transient errors

### DIFF
--- a/lib/modules/datasource/packagist/index.spec.ts
+++ b/lib/modules/datasource/packagist/index.spec.ts
@@ -1,6 +1,7 @@
 import { Fixtures } from '~test/fixtures.ts';
 import { hostRules } from '~test/host-rules.ts';
 import * as httpMock from '~test/http-mock.ts';
+import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import * as composerVersioning from '../../versioning/composer/index.ts';
 import { id as versioning } from '../../versioning/loose/index.ts';
 import { getPkgReleases } from '../index.ts';
@@ -88,6 +89,100 @@ describe('modules/datasource/packagist/index', () => {
         versioning,
         packageName: 'vendor/package-name2',
       });
+      expect(res).toBeNull();
+    });
+
+    it('throws for default registry timeouts', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/packages.json')
+        .replyWithError(httpMock.error({ code: 'ETIMEDOUT' }));
+      config.registryUrls = [baseUrl];
+
+      await expect(
+        getPkgReleases({
+          ...config,
+          datasource,
+          versioning,
+          packageName: 'vendor/default-timeout',
+        }),
+      ).rejects.toThrow(ExternalHostError);
+    });
+
+    it('throws for legacy default registry host timeouts', async () => {
+      const legacyBaseUrl = 'https://packagist.org';
+      httpMock
+        .scope(legacyBaseUrl)
+        .get('/packages.json')
+        .replyWithError(httpMock.error({ code: 'ETIMEDOUT' }));
+      config.registryUrls = [legacyBaseUrl];
+
+      await expect(
+        getPkgReleases({
+          ...config,
+          datasource,
+          versioning,
+          packageName: 'vendor/legacy-default-timeout',
+        }),
+      ).rejects.toThrow(ExternalHostError);
+    });
+
+    it('throws for default registry rate limiting', async () => {
+      httpMock.scope(baseUrl).get('/packages.json').reply(429);
+      config.registryUrls = [baseUrl];
+
+      await expect(
+        getPkgReleases({
+          ...config,
+          datasource,
+          versioning,
+          packageName: 'vendor/default-rate-limit',
+        }),
+      ).rejects.toThrow(ExternalHostError);
+    });
+
+    it('throws for default registry server errors', async () => {
+      httpMock.scope(baseUrl).get('/packages.json').reply(500);
+      config.registryUrls = [baseUrl];
+
+      await expect(
+        getPkgReleases({
+          ...config,
+          datasource,
+          versioning,
+          packageName: 'vendor/default-server-error',
+        }),
+      ).rejects.toThrow(ExternalHostError);
+    });
+
+    it('returns null for default registry not found responses', async () => {
+      httpMock.scope(baseUrl).get('/packages.json').reply(404);
+      config.registryUrls = [baseUrl];
+
+      const res = await getPkgReleases({
+        ...config,
+        datasource,
+        versioning,
+        packageName: 'vendor/default-not-found',
+      });
+
+      expect(res).toBeNull();
+    });
+
+    it('returns null for default registry unknown errors', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/packages.json')
+        .replyWithError('unknown error');
+      config.registryUrls = [baseUrl];
+
+      const res = await getPkgReleases({
+        ...config,
+        datasource,
+        versioning,
+        packageName: 'vendor/default-unknown-error',
+      });
+
       expect(res).toBeNull();
     });
 

--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -1,4 +1,4 @@
-import { isObject } from '@sindresorhus/is';
+import { isNumber, isObject } from '@sindresorhus/is';
 import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
@@ -6,7 +6,7 @@ import { withCache } from '../../../util/cache/package/with-cache.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
 import * as p from '../../../util/promises.ts';
-import { replaceUrlPath, resolveBaseUrl } from '../../../util/url.ts';
+import { parseUrl, replaceUrlPath, resolveBaseUrl } from '../../../util/url.ts';
 import * as composerVersioning from '../../versioning/composer/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
@@ -18,6 +18,40 @@ import {
   extractDepReleases,
   parsePackagesResponses,
 } from './schema.ts';
+
+interface PackagistLookupError {
+  code?: string;
+  statusCode?: number;
+}
+
+function isDefaultPackagistHost(registryUrl: string): boolean {
+  const url = parseUrl(registryUrl);
+
+  /* v8 ignore if -- typescript strict null check */
+  if (!url) {
+    return false;
+  }
+
+  return ['repo.packagist.org', 'packagist.org'].includes(url.host);
+}
+
+function isTransientPackagistError(err: PackagistLookupError): boolean {
+  const { code: errCode, statusCode } = err;
+
+  if (errCode && ['ECONNRESET', 'ETIMEDOUT'].includes(errCode)) {
+    return true;
+  }
+
+  if (!isNumber(statusCode)) {
+    return false;
+  }
+
+  if (statusCode === 429 || (statusCode >= 500 && statusCode < 600)) {
+    return true;
+  }
+
+  return false;
+}
 
 export class PackagistDatasource extends Datasource {
   static readonly id = 'packagist';
@@ -257,13 +291,11 @@ export class PackagistDatasource extends Datasource {
       logger.trace({ dep }, 'dep');
       return dep;
     } catch (err) /* istanbul ignore next */ {
-      if (err.host === 'packagist.org') {
-        if (err.code === 'ECONNRESET' || err.code === 'ETIMEDOUT') {
-          throw new ExternalHostError(err);
-        }
-        if (err.statusCode && err.statusCode >= 500 && err.statusCode < 600) {
-          throw new ExternalHostError(err);
-        }
+      if (
+        isDefaultPackagistHost(registryUrl) &&
+        isTransientPackagistError(err)
+      ) {
+        throw new ExternalHostError(err);
       }
       throw err;
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Rebased https://github.com/renovatebot/renovate/pull/44328 against [43.285.6](https://github.com/renovatebot/renovate/releases/tag/43.285.6):

> Treat transient failures from the default Packagist registries as external host errors instead of normal lookup misses.
>
> This covers repo.packagist.org and packagist.org for timeout/reset errors, rate limiting, and 5xx responses.
> This prevents temporary Packagist availability failures from being converted into no-result lookup outcomes.

Related discussion: https://github.com/renovatebot/renovate/discussions/43643#discussioncomment-17488306



<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
