### PR TITLE
feat(status-checks): report pending status check reasons

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -1624,6 +1624,18 @@ Set this to `false` if you prefer not to see abandoned packages in your dependen
 
 Configure this option if you prefer a different title for the Dependency Dashboard.
 
+## `dependencyDashboardVerbosePendingChecks`
+
+Set this to `true` to show a human-readable reason next to each branch listed under the "Pending Status Checks" and "Pending Branch Automerge" sections of the Dependency Dashboard.
+
+When enabled, each entry shows _why_ the branch is pending — for example:
+
+- _"Waiting 18h until minimum release age of 3 days"_
+- _"Test coverage below minimum confidence threshold"_
+- _"Waiting for status checks before creating PR"_
+
+This is disabled by default to keep the dashboard compact for existing users.
+
 ## `description`
 
 The description field can be used inside any configuration object to add a human-readable description of the object's config purpose.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -882,6 +882,13 @@ const options: Readonly<RenovateOptions>[] = [
     default: false,
   },
   {
+    name: 'dependencyDashboardVerbosePendingChecks',
+    description:
+      'Set to `true` to show the reason why each update is listed under "Pending Status Checks" or "Pending Branch Automerge" on the Dependency Dashboard.',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'dependencyDashboardAutoclose',
     description:
       'Set to `true` to let Renovate close the Dependency Dashboard issue if there are no more updates.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -430,6 +430,7 @@ export interface RenovateConfig
   dependencyDashboardFooter?: string;
   dependencyDashboardLabels?: string[];
   dependencyDashboardOSVVulnerabilitySummary?: 'none' | 'all' | 'unresolved';
+  dependencyDashboardVerbosePendingChecks?: boolean;
   dependencyDashboardReportAbandonment?: boolean;
   mode?: 'silent' | 'full';
   packageFile?: string;

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -5,7 +5,7 @@ import { vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
 import type { RenovateConfig } from '~test/util.ts';
-import { logger, platform } from '~test/util.ts';
+import { logger, partial, platform } from '~test/util.ts';
 import { getConfig } from '../../config/defaults.ts';
 import { GlobalConfig } from '../../config/global.ts';
 import type {
@@ -20,7 +20,10 @@ import { regEx } from '../../util/regex.ts';
 import { asTimestamp } from '../../util/timestamp.ts';
 import type { BranchConfig, BranchUpgradeConfig } from '../types.ts';
 import * as dependencyDashboard from './dependency-dashboard.ts';
-import { getDashboardMarkdownVulnerabilities } from './dependency-dashboard.ts';
+import {
+  getDashboardMarkdownVulnerabilities,
+  getPendingReason,
+} from './dependency-dashboard.ts';
 import { PackageFiles } from './package-files.ts';
 
 const createVulnerabilitiesMock = vi.fn();
@@ -2183,6 +2186,146 @@ None detected
         packageFiles,
       );
       expect(result).toEqual('');
+    });
+  });
+
+  describe('getPendingReason()', () => {
+    it('returns null when no pending reasons exist', () => {
+      const branch = partial<BranchConfig>({
+        upgrades: [],
+      });
+
+      const result = getPendingReason(branch);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns pending reasons from branch processing', () => {
+      const branch = partial<BranchConfig>({
+        pendingChecksReasons: [
+          '`react`: minimum release age not met (1 day required, 24h remaining)',
+        ],
+      });
+
+      const result = getPendingReason(branch);
+
+      expect(result).toBe(
+        '`react`: minimum release age not met (1 day required, 24h remaining)',
+      );
+    });
+
+    it('joins multiple pending reasons with semicolons', () => {
+      const branch = partial<BranchConfig>({
+        pendingChecksReasons: [
+          '`react`: minimum release age not met (1 day required, 24h remaining)',
+          '`eslint`: merge confidence too low (required: high)',
+        ],
+      });
+
+      const result = getPendingReason(branch);
+
+      expect(result).toBe(
+        '`react`: minimum release age not met (1 day required, 24h remaining); `eslint`: merge confidence too low (required: high)',
+      );
+    });
+
+    it('removes a dependency name already shown in the PR title', () => {
+      const branch = partial<BranchConfig>({
+        pendingChecksReasons: [
+          '`react`: minimum release age not met (1 day required, 24h remaining)',
+        ],
+        prTitle: 'chore(deps): update dependency react to v19',
+      });
+
+      const result = getPendingReason(branch);
+
+      expect(result).toBe(
+        'minimum release age not met (1 day required, 24h remaining)',
+      );
+    });
+
+    it('keeps dependency names for grouped updates', () => {
+      const branch = partial<BranchConfig>({
+        pendingChecksReasons: [
+          '`react`: minimum release age not met (1 day required, 24h remaining)',
+          '`eslint`: merge confidence too low (required: high)',
+        ],
+        prTitle: 'chore(deps): update frontend dependencies',
+      });
+
+      const result = getPendingReason(branch);
+
+      expect(result).toBe(
+        '`react`: minimum release age not met (1 day required, 24h remaining); `eslint`: merge confidence too low (required: high)',
+      );
+    });
+  });
+
+  describe('ensureDependencyDashboard() - verbose pending checks', () => {
+    beforeEach(() => {
+      PackageFiles.clear();
+      PackageFiles.add('main', null);
+      GlobalConfig.reset();
+      logger.getProblems.mockReturnValue([]);
+    });
+
+    it('keeps pending sections unchanged by default', async () => {
+      const branches: BranchConfig[] = [
+        partial<BranchConfig>({
+          branchName: 'pending-branch',
+          prTitle: 'pending pr',
+          result: 'pending',
+          pendingChecksReasons: [
+            '`eslint`: merge confidence too low (required: high)',
+          ],
+          upgrades: [
+            partial<BranchUpgradeConfig>({
+              depName: 'eslint',
+            }),
+          ],
+        }),
+      ];
+      config.dependencyDashboard = true;
+
+      await dependencyDashboard.ensureDependencyDashboard(
+        config,
+        branches,
+        {},
+        { result: 'no-migration' },
+      );
+
+      const body = platform.ensureIssue.mock.calls[0][0].body;
+
+      expect(body).toContain('## Pending Status Checks');
+      expect(body).toContain(
+        ' - [ ] <!-- approvePr-branch=pending-branch -->pending pr\n',
+      );
+      expect(body).not.toContain(
+        '`eslint`: merge confidence too low (required: high)',
+      );
+    });
+
+    it.each`
+      description                                      | branch                                                                                                                                                                                                                                                                                             | expectedSection                  | expectedReason
+      ${'shows release age reasons in pending checks'} | ${partial<BranchConfig>({ branchName: 'release-age-branch', prTitle: 'release age pr', result: 'pending', pendingChecksReasons: ['`react`: minimum release age not met (3 days required, 72h remaining)'], upgrades: [partial<BranchUpgradeConfig>({ depName: 'react' })] })}                      | ${'## Pending Status Checks'}    | ${'`react`: minimum release age not met (3 days required, 72h remaining)'}
+      ${'shows confidence reasons in pending checks'}  | ${partial<BranchConfig>({ branchName: 'confidence-branch', prTitle: 'confidence pr', result: 'pending', pendingChecksReasons: ['`eslint`: merge confidence too low (required: high)'], upgrades: [partial<BranchUpgradeConfig>({ depName: 'eslint' })] })}                                         | ${'## Pending Status Checks'}    | ${'`eslint`: merge confidence too low (required: high)'}
+      ${'shows branch automerge reasons'}              | ${partial<BranchConfig>({ branchName: 'automerge-branch', prTitle: 'automerge pr', result: 'done', prBlockedBy: 'BranchAutomerge', pendingChecksReasons: ['Awaiting status checks to pass before branch automerge'], upgrades: [partial<BranchUpgradeConfig>({ depName: 'typescript' })] })}       | ${'## Pending Branch Automerge'} | ${'Awaiting status checks to pass before branch automerge'}
+      ${'shows awaiting tests reasons'}                | ${partial<BranchConfig>({ branchName: 'awaiting-tests-branch', prTitle: 'awaiting tests pr', result: 'pending', prBlockedBy: 'AwaitingTests', pendingChecksReasons: ['Awaiting all status checks to pass before PR creation'], upgrades: [partial<BranchUpgradeConfig>({ depName: 'vitest' })] })} | ${'## Pending Status Checks'}    | ${'Awaiting all status checks to pass before PR creation'}
+    `('$description', async ({ branch, expectedReason, expectedSection }) => {
+      config.dependencyDashboard = true;
+      config.dependencyDashboardVerbosePendingChecks = true;
+
+      await dependencyDashboard.ensureDependencyDashboard(
+        config,
+        [branch],
+        {},
+        { result: 'no-migration' },
+      );
+
+      const body = platform.ensureIssue.mock.calls[0][0].body;
+
+      expect(body).toContain(expectedSection);
+      expect(body).toContain(expectedReason);
     });
   });
 });

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -219,7 +219,46 @@ function formatAsMarkdownLink(name: string, url?: string | null): string {
   return url ? `[${name}](${url})` : `\`${name}\``;
 }
 
-function getListItem(branch: BranchConfig, type: string): string {
+function getPendingReasonDepName(reason: string): string | null {
+  const prefixEnd = reason.indexOf('`: ');
+  return reason.startsWith('`') && prefixEnd > 1
+    ? reason.slice(1, prefixEnd)
+    : null;
+}
+
+export function getPendingReason(branch: BranchConfig): string | null {
+  if (!branch.pendingChecksReasons) {
+    return null;
+  }
+
+  const depNames = [
+    ...new Set(
+      branch.pendingChecksReasons
+        .map(getPendingReasonDepName)
+        .filter(isNonEmptyString),
+    ),
+  ];
+  const [depName] = depNames;
+  const repeatedDepName =
+    depName && depNames.length === 1 && branch.prTitle?.includes(depName)
+      ? depName
+      : null;
+  const reasonPrefix = repeatedDepName ? `\`${repeatedDepName}\`: ` : null;
+
+  return branch.pendingChecksReasons
+    .map((reason) =>
+      reasonPrefix && reason.startsWith(reasonPrefix)
+        ? reason.slice(reasonPrefix.length)
+        : reason,
+    )
+    .join('; ');
+}
+
+function getListItem(
+  branch: BranchConfig,
+  type: string,
+  reason?: string | null,
+): string {
   let item = getCheckbox(`${type}-branch=${branch.branchName}`);
   if (branch.prNo) {
     // TODO: types (#22198)
@@ -231,10 +270,13 @@ function getListItem(branch: BranchConfig, type: string): string {
     // TODO: types (#22198)
     ...new Set(branch.upgrades.map((upgrade) => `\`${upgrade.depName!}\``)),
   ];
-  if (uniquePackages.length < 2) {
-    return `${item}\n`;
+  if (uniquePackages.length >= 2) {
+    item += ` (${uniquePackages.join(', ')})`;
   }
-  return `${item} (${uniquePackages.join(', ')})\n`;
+  if (reason) {
+    item += ` - _${reason}_`;
+  }
+  return `${item}\n`;
 }
 
 function splitBranchesByCategory(filteredBranches: BranchConfig[]): {
@@ -260,9 +302,15 @@ function splitBranchesByCategory(filteredBranches: BranchConfig[]): {
   return { categories, uncategorized, hasCategorized, hasUncategorized };
 }
 
-function getBranchList(branches: BranchConfig[], listItemType: string): string {
+function getBranchList(
+  branches: BranchConfig[],
+  listItemType: string,
+  getReasonFn?: (branch: BranchConfig) => string | null,
+): string {
   return branches
-    .map((branch: BranchConfig): string => getListItem(branch, listItemType))
+    .map((branch: BranchConfig): string =>
+      getListItem(branch, listItemType, getReasonFn?.(branch)),
+    )
     .join('');
 }
 
@@ -279,6 +327,7 @@ function getBranchesListMd(
   bulkComment?: string,
   bulkMessage?: string,
   bulkIcon?: '🔐',
+  getReasonFn?: (branch: BranchConfig) => string | null,
 ): string {
   const filteredBranches = branches.filter(predicate);
   if (filteredBranches.length === 0) {
@@ -294,7 +343,7 @@ function getBranchesListMd(
     )) {
       result = `${result.trimEnd()}\n\n`;
       result += `### ${category}\n\n`;
-      result += getBranchList(branches, listItemType);
+      result += getBranchList(branches, listItemType, getReasonFn);
     }
     if (hasUncategorized) {
       result = `${result.trimEnd()}\n\n`;
@@ -302,7 +351,7 @@ function getBranchesListMd(
     }
   }
   result = `${result.trimEnd()}\n\n`;
-  result += getBranchList(uncategorized, listItemType);
+  result += getBranchList(uncategorized, listItemType, getReasonFn);
 
   if (bulkComment && bulkMessage && filteredBranches.length > 1) {
     if (hasCategorized) {
@@ -547,17 +596,30 @@ export async function ensureDependencyDashboard(
     'The following updates have been manually edited so Renovate will no longer make changes. To discard all commits and start over, click on a checkbox below.',
     'rebase',
   );
+  const verbosePendingFn = config.dependencyDashboardVerbosePendingChecks
+    ? getPendingReason
+    : undefined;
   issueBody += getBranchesListMd(
     branches,
     (branch) => branch.result === 'pending',
     'Pending Status Checks',
     'The following updates await pending status checks. To force their creation now, click on a checkbox below.',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    verbosePendingFn,
   );
   issueBody += getBranchesListMd(
     branches,
     (branch) => branch.prBlockedBy === 'BranchAutomerge',
     'Pending Branch Automerge',
     'The following updates await pending status checks before automerging. To abort the branch automerge and create a PR instead, click on a checkbox below.',
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    verbosePendingFn,
   );
 
   const warn = getDepWarningsDashboard(packageFiles, config);

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -187,6 +187,7 @@ export async function writeUpdates(
 
         const res = await processBranch(branch);
         branch.prBlockedBy = res?.prBlockedBy;
+        branch.pendingChecksReasons = res?.pendingChecksReasons;
         branch.prNo = res?.prNo;
         branch.result = res?.result;
         branch.commitFingerprint = res?.updatesVerified

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -217,9 +217,17 @@ describe('workers/repository/update/branch/index', () => {
       const res = await branchWorker.processBranch(config);
       expect(res).toEqual({
         branchExists: false,
+        pendingChecksReasons: [
+          expect.stringContaining(
+            'minimum release age not met (1 day required,',
+          ),
+        ],
         prNo: undefined,
         result: 'pending',
       });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining('minimum release age not met (1 day required,'),
+      );
     });
 
     it('skips branch if minimumReleaseAge not met', async () => {
@@ -227,6 +235,7 @@ describe('workers/repository/update/branch/index', () => {
       config.prCreation = 'not-pending';
       config.upgrades = partial<BranchUpgradeConfig>([
         {
+          depName: 'some-dep-name',
           releaseTimestamp: '2099-12-31' as Timestamp,
           minimumReleaseAge: '1 day',
         },
@@ -234,6 +243,11 @@ describe('workers/repository/update/branch/index', () => {
       const res = await branchWorker.processBranch(config);
       expect(res).toEqual({
         branchExists: false,
+        pendingChecksReasons: [
+          expect.stringContaining(
+            'minimum release age not met (1 day required,',
+          ),
+        ],
         prNo: undefined,
         result: 'pending',
       });
@@ -254,6 +268,9 @@ describe('workers/repository/update/branch/index', () => {
         const res = await branchWorker.processBranch(config);
         expect(res).toEqual({
           branchExists: false,
+          pendingChecksReasons: [
+            '`undefined`: release timestamp unavailable - minimum release age (100 days) cannot be evaluated',
+          ],
           prNo: undefined,
           result: 'pending',
         });
@@ -856,9 +873,73 @@ describe('workers/repository/update/branch/index', () => {
       config.pendingChecks = true;
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: false,
+        pendingChecksReasons: [
+          'Awaiting internal checks to pass before branch creation',
+        ],
         prNo: undefined,
         result: 'pending',
       });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting internal checks to pass before branch creation',
+        ),
+      );
+    });
+
+    it('returns generic pending check reason before status-success is evaluated', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      config.pendingChecks = true;
+      config.prCreation = 'status-success';
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: false,
+        pendingChecksReasons: [
+          'Awaiting internal checks to pass before branch creation',
+        ],
+        prNo: undefined,
+        result: 'pending',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting internal checks to pass before branch creation',
+        ),
+      );
+    });
+
+    it('returns generic pending check reason before status checks are evaluated', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      config.pendingChecks = true;
+      config.upgrades = partial<BranchUpgradeConfig>([
+        {
+          depName: 'some-dep-name',
+          minimumConfidence: 'high',
+          pendingChecks: true,
+        },
+      ]);
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: false,
+        pendingChecksReasons: [
+          'Awaiting internal checks to pass before branch creation',
+        ],
+        prNo: undefined,
+        result: 'pending',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting internal checks to pass before branch creation',
+        ),
+      );
     });
 
     it('returns if pending checks - but branch exists', async () => {
@@ -880,8 +961,16 @@ describe('workers/repository/update/branch/index', () => {
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: true,
         prNo: 5,
+        pendingChecksReasons: [
+          'Awaiting internal checks to pass before branch update',
+        ],
         result: 'pending',
       });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting internal checks to pass before branch update',
+        ),
+      );
     });
 
     // automerge should respect only automergeSchedule
@@ -992,7 +1081,7 @@ describe('workers/repository/update/branch/index', () => {
     });
 
     it('returns if branch exists but pending', async () => {
-      expect.assertions(1);
+      expect.assertions(2);
       getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
         partial<PackageFilesResult>({
           updatedPackageFiles: [partial<FileChange>()],
@@ -1008,13 +1097,91 @@ describe('workers/repository/update/branch/index', () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         type: 'without-pr',
         prBlockedBy: 'AwaitingTests',
+        pendingChecksReason: 'Awaiting status checks before PR creation',
       });
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: true,
         prBlockedBy: 'AwaitingTests',
+        pendingChecksReasons: ['Awaiting status checks before PR creation'],
         result: 'pending',
         commitSha: null,
       });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting status checks before PR creation',
+        ),
+      );
+    });
+
+    it('returns pending AwaitingTests reason for status-success PR creation', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>()],
+        }),
+      );
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>()],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      commit.commitFilesToBranch.mockResolvedValueOnce(null);
+      automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
+      prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
+        prBlockedBy: 'AwaitingTests',
+        pendingChecksReason:
+          'Awaiting all status checks to pass before PR creation',
+      });
+      config.prCreation = 'status-success';
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: true,
+        prBlockedBy: 'AwaitingTests',
+        pendingChecksReasons: [
+          'Awaiting all status checks to pass before PR creation',
+        ],
+        result: 'pending',
+        commitSha: null,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting all status checks to pass before PR creation',
+        ),
+      );
+    });
+
+    it('returns pending AwaitingTests reason for not-pending PR creation', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>()],
+        }),
+      );
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>()],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      commit.commitFilesToBranch.mockResolvedValueOnce(null);
+      automerge.tryBranchAutomerge.mockResolvedValueOnce('failed');
+      prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
+        prBlockedBy: 'AwaitingTests',
+        pendingChecksReason: 'Awaiting 25h status stability before PR creation',
+      });
+      config.prCreation = 'not-pending';
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: true,
+        prBlockedBy: 'AwaitingTests',
+        pendingChecksReasons: [
+          'Awaiting 25h status stability before PR creation',
+        ],
+        result: 'pending',
+        commitSha: null,
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting 25h status stability before PR creation',
+        ),
+      );
     });
 
     it('returns if branch automerge is pending', async () => {
@@ -1038,10 +1205,15 @@ describe('workers/repository/update/branch/index', () => {
       prWorker.ensurePr.mockResolvedValueOnce({
         type: 'without-pr',
         prBlockedBy: 'BranchAutomerge',
+        pendingChecksReason:
+          'Awaiting status checks to pass before branch automerge',
       });
       expect(await branchWorker.processBranch(config)).toEqual({
         branchExists: true,
         prBlockedBy: 'BranchAutomerge',
+        pendingChecksReasons: [
+          'Awaiting status checks to pass before branch automerge',
+        ],
         result: 'done',
         commitSha: null,
       });
@@ -1170,7 +1342,7 @@ describe('workers/repository/update/branch/index', () => {
     });
 
     it('returns if branch exists but updated', async () => {
-      expect.assertions(4);
+      expect.assertions(5);
       const setArtifactErrorStatus = vi.spyOn(
         artifacts,
         'setArtifactErrorStatus',
@@ -1195,14 +1367,98 @@ describe('workers/repository/update/branch/index', () => {
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
         updatesVerified: true,
-        prNo: undefined,
-        result: 'pending',
+        prNo: 5,
+        result: 'pr-created',
         commitSha,
       });
 
-      expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(0);
-      expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
-      expect(setArtifactErrorStatus).toHaveBeenCalledTimes(1);
+      expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(1);
+      expect(prWorker.ensurePr).toHaveBeenCalledTimes(1);
+      expect(setArtifactErrorStatus).toHaveBeenCalledTimes(2);
+      expect(logger.debug).not.toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Pending status check reason for branch renovate/some-branch: Awaiting branch status checks for the new commit before PR creation',
+        ),
+      );
+    });
+
+    it.each([
+      {
+        description: 'PR creation is awaiting approval',
+        override: { prCreation: 'approval' },
+      },
+      {
+        description: 'PR creation is forced',
+        override: { forcePr: true, prCreation: 'not-pending' },
+      },
+      {
+        description: 'PR creation is approved in the Dependency Dashboard',
+        override: {
+          dependencyDashboardChecks: {
+            'renovate/some-branch': 'approvePr',
+          },
+          prCreation: 'not-pending',
+        },
+      },
+    ] satisfies {
+      description: string;
+      override: Partial<BranchConfig>;
+    }[])(
+      'continues after a new commit when $description',
+      async ({ override }) => {
+        getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+          partial<PackageFilesResult>({
+            updatedPackageFiles: [partial<FileChange>()],
+          }),
+        );
+        npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+          artifactErrors: [],
+          updatedArtifacts: [partial<FileChange>()],
+        });
+
+        expect(
+          await branchWorker.processBranch({
+            ...config,
+            ...override,
+          }),
+        ).toEqual({
+          branchExists: true,
+          updatesVerified: true,
+          prNo: 5,
+          result: 'pr-created',
+          commitSha,
+        });
+        expect(prWorker.ensurePr).toHaveBeenCalledTimes(1);
+      },
+    );
+
+    it('still awaits successful status checks when PR creation is forced', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>()],
+        }),
+      );
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>()],
+      });
+
+      expect(
+        await branchWorker.processBranch({
+          ...config,
+          forcePr: true,
+          prCreation: 'status-success',
+        }),
+      ).toEqual({
+        branchExists: true,
+        updatesVerified: true,
+        pendingChecksReasons: [
+          'Awaiting branch status checks for the new commit before PR creation',
+        ],
+        result: 'pending',
+        commitSha,
+      });
+      expect(prWorker.ensurePr).not.toHaveBeenCalled();
     });
 
     it('compiles commit trailers', async () => {
@@ -1297,14 +1553,14 @@ describe('workers/repository/update/branch/index', () => {
       expect(await branchWorker.processBranch(inconfig)).toEqual({
         branchExists: true,
         updatesVerified: true,
-        prNo: undefined,
-        result: 'pending',
+        prNo: 5,
+        result: 'pr-created',
         commitSha,
       });
 
-      expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(0);
-      expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
-      expect(setArtifactErrorStatus).toHaveBeenCalledTimes(1);
+      expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(1);
+      expect(prWorker.ensurePr).toHaveBeenCalledTimes(1);
+      expect(setArtifactErrorStatus).toHaveBeenCalledTimes(2);
     });
 
     it('updates branch when forceRebase=true', async () => {
@@ -1330,13 +1586,13 @@ describe('workers/repository/update/branch/index', () => {
       expect(await branchWorker.processBranch(inconfig, true)).toEqual({
         branchExists: true,
         updatesVerified: true,
-        prNo: undefined,
-        result: 'pending',
+        prNo: 5,
+        result: 'pr-created',
         commitSha,
       });
 
-      expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(0);
-      expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
+      expect(automerge.tryBranchAutomerge).toHaveBeenCalledTimes(1);
+      expect(prWorker.ensurePr).toHaveBeenCalledTimes(1);
     });
 
     it('ensures PR and comments notice', async () => {

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -1,11 +1,6 @@
-import { isNonEmptyString } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { GlobalConfig } from '../../../../config/global.ts';
-import {
-  type MinimumReleaseAgeBehaviour,
-  type RenovateConfig,
-  type UpdateType,
-} from '../../../../config/types.ts';
+import type { RenovateConfig } from '../../../../config/types.ts';
 import {
   CONFIG_VALIDATION,
   MANAGER_LOCKFILE_ERROR,
@@ -28,16 +23,8 @@ import type { Pr } from '../../../../modules/platform/index.ts';
 import { platform } from '../../../../modules/platform/index.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
-import { getElapsedMs } from '../../../../util/date.ts';
 import { emojify } from '../../../../util/emoji.ts';
 import { filterValidCommitTrailers } from '../../../../util/git/commit-trailers.ts';
-import {
-  getMergeConfidenceLevel,
-  isActiveConfidenceLevel,
-  satisfiesConfidenceLevel,
-} from '../../../../util/merge-confidence/index.ts';
-import { coerceNumber } from '../../../../util/number.ts';
-import { toMs } from '../../../../util/pretty-time.ts';
 import * as template from '../../../../util/template/index.ts';
 import { getCount, isLimitReached } from '../../../global/limits.ts';
 import type {
@@ -48,6 +35,7 @@ import type {
 import { embedChangelogs } from '../../changelog/index.ts';
 import { checkAutoMerge } from '../pr/automerge.ts';
 import { ensurePr, getPlatformPrOptions } from '../pr/index.ts';
+import { getPrCreationStatusRequirement } from '../pr/status-checks.ts';
 import { setArtifactErrorStatus } from './artifacts.ts';
 import { tryBranchAutomerge } from './automerge.ts';
 import { bumpVersions } from './bump-versions.ts';
@@ -56,9 +44,24 @@ import { commitFilesToBranch } from './commit.ts';
 import executePostUpgradeCommands from './execute-post-upgrade-commands.ts';
 import { getUpdatedPackageFiles } from './get-updated.ts';
 import { handleClosedPr, handleModifiedPr } from './handle-existing.ts';
+import { applyInternalChecksStatus } from './internal-checks.ts';
 import { shouldReuseExistingBranch } from './reuse.ts';
 import { isScheduledNow } from './schedule.ts';
 import { setConfidence, setStability } from './status-checks.ts';
+
+function getPendingBranchReasons(
+  config: BranchConfig,
+  pendingChecksReason?: string,
+  fallbackReason = 'Awaiting status checks before PR creation',
+): string[] {
+  const reasons = [...(config.pendingChecksReasons ?? [])];
+
+  if (pendingChecksReason) {
+    reasons.push(pendingChecksReason);
+  }
+
+  return reasons.length > 0 ? reasons : [fallbackReason];
+}
 
 async function setBranchStatusChecks(config: BranchConfig): Promise<void> {
   await setStability(config);
@@ -126,6 +129,7 @@ export interface ProcessBranchResult {
   updatesVerified?: boolean;
   prBlockedBy?: PrBlockedBy;
   prNo?: number;
+  pendingChecksReasons?: string[];
   result: BranchResult;
   commitSha?: string | null;
 }
@@ -210,6 +214,12 @@ export async function processBranch(
       };
     }
     if (
+      !dependencyDashboardCheck &&
+      (branchConfig.pendingChecks || config.pendingChecks)
+    ) {
+      await applyInternalChecksStatus(config);
+    }
+    if (
       !branchExists &&
       branchConfig.pendingChecks &&
       !dependencyDashboardCheck
@@ -217,8 +227,20 @@ export async function processBranch(
       logger.debug(
         `Branch ${config.branchName} creation is disabled because internalChecksFilter was not met`,
       );
+      const pendingChecksReasons = getPendingBranchReasons(
+        config,
+        undefined,
+        'Awaiting internal checks to pass before branch creation',
+      );
+      const pendingReason = pendingChecksReasons.join('; ');
+      if (pendingReason) {
+        logger.debug(
+          `Pending status check reason for branch ${config.branchName}: ${pendingReason}`,
+        );
+      }
       return {
         branchExists: false,
+        pendingChecksReasons,
         result: 'pending',
       };
     }
@@ -309,9 +331,21 @@ export async function processBranch(
           logger.info(
             'Branch updating is skipped because internalChecksFilter was not met',
           );
+          const pendingChecksReasons = getPendingBranchReasons(
+            config,
+            undefined,
+            'Awaiting internal checks to pass before branch update',
+          );
+          const pendingReason = pendingChecksReasons.join('; ');
+          if (pendingReason) {
+            logger.debug(
+              `Pending status check reason for branch ${config.branchName}: ${pendingReason}`,
+            );
+          }
           return {
             branchExists: true,
             prNo: branchPr?.number,
+            pendingChecksReasons,
             result: 'pending',
           };
         }
@@ -406,131 +440,33 @@ export async function processBranch(
         'Branch + PR exists but is not scheduled -- will update if necessary',
       );
     }
-    //stability checks
+    await applyInternalChecksStatus(config);
+    // Don't create a branch if we know it will be status 'pending'
     if (
-      config.upgrades.some(
-        (upgrade) =>
-          isNonEmptyString(upgrade.minimumReleaseAge) ||
-          isActiveConfidenceLevel(upgrade.minimumConfidence!),
-      )
+      !dependencyDashboardCheck &&
+      !branchExists &&
+      config.stabilityStatus === 'yellow' &&
+      ['not-pending', 'status-success'].includes(config.prCreation!)
     ) {
-      const depNamesWithoutReleaseTimestamp: Record<
-        MinimumReleaseAgeBehaviour,
-        {
-          depName: string;
-          updateType: UpdateType;
-        }[]
-      > = {
-        'timestamp-required': [],
-        'timestamp-optional': [],
-      };
-
-      // Only set a stability status check if one or more of the updates contain
-      // both a minimumReleaseAge setting and a releaseTimestamp
-      config.stabilityStatus = 'green';
-      // Default to 'success' but set 'pending' if any update is pending
-      for (const upgrade of config.upgrades) {
-        const minimumReleaseAgeMs = isNonEmptyString(upgrade.minimumReleaseAge)
-          ? coerceNumber(toMs(upgrade.minimumReleaseAge), 0)
-          : 0;
-
-        if (minimumReleaseAgeMs) {
-          const minimumReleaseAgeBehaviour: MinimumReleaseAgeBehaviour =
-            upgrade.minimumReleaseAgeBehaviour ?? 'timestamp-required';
-
-          // regardless of the value of `minimumReleaseAgeBehaviour`, if there is a timestamp, we will process it according to `minimumReleaseAge`
-          if (upgrade.releaseTimestamp) {
-            const timeElapsed = getElapsedMs(upgrade.releaseTimestamp);
-            if (timeElapsed < minimumReleaseAgeMs) {
-              logger.debug(
-                {
-                  depName: upgrade.depName,
-                  timeElapsed,
-                  minimumReleaseAge: upgrade.minimumReleaseAge,
-                },
-                'Update has not passed minimum release age',
-              );
-              config.stabilityStatus = 'yellow';
-              continue;
-            }
-          } else {
-            // if we're set to `minimumReleaseAgeBehaviour=timestamp-required`, and there isn't a timestamp, always mark the update as pending
-            if (minimumReleaseAgeBehaviour === 'timestamp-required') {
-              depNamesWithoutReleaseTimestamp['timestamp-required'].push({
-                depName: upgrade.depName!,
-                updateType: upgrade.updateType!,
-              });
-              config.stabilityStatus = 'yellow';
-              continue;
-            } else {
-              // if there is no timestamp, and we're running in `optional` mode, we can allow it, but make sure to warn the user
-              depNamesWithoutReleaseTimestamp['timestamp-optional'].push({
-                depName: upgrade.depName!,
-                updateType: upgrade.updateType!,
-              });
-            }
-          }
-        }
-        const datasource = upgrade.datasource!;
-        const depName = upgrade.depName!;
-        const packageName = upgrade.packageName!;
-        const minimumConfidence = upgrade.minimumConfidence!;
-        const updateType = upgrade.updateType!;
-        const currentVersion = upgrade.currentVersion!;
-        const newVersion = upgrade.newVersion!;
-        if (isActiveConfidenceLevel(minimumConfidence)) {
-          const confidence =
-            (await getMergeConfidenceLevel(
-              datasource,
-              packageName,
-              currentVersion,
-              newVersion,
-              updateType,
-            )) ?? 'neutral';
-          if (satisfiesConfidenceLevel(confidence, minimumConfidence)) {
-            config.confidenceStatus = 'green';
-          } else {
-            logger.debug(
-              { depName, confidence, minimumConfidence },
-              'Update does not meet minimum confidence scores',
-            );
-            config.confidenceStatus = 'yellow';
-            continue;
-          }
-        }
-      }
-
-      if (depNamesWithoutReleaseTimestamp['timestamp-required'].length) {
-        logger.once.debug(
-          { updates: depNamesWithoutReleaseTimestamp['timestamp-required'] },
-          `Marking ${depNamesWithoutReleaseTimestamp['timestamp-required'].length} release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required`,
-        );
-      }
-      if (depNamesWithoutReleaseTimestamp['timestamp-optional'].length) {
-        logger.once.warn(
-          "Some upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information",
-        );
-        logger.once.debug(
-          { updates: depNamesWithoutReleaseTimestamp['timestamp-optional'] },
-          `${depNamesWithoutReleaseTimestamp['timestamp-optional'].length} upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding`,
-        );
-      }
-
-      // Don't create a branch if we know it will be status 'pending'
-      if (
-        !dependencyDashboardCheck &&
-        !branchExists &&
-        config.stabilityStatus === 'yellow' &&
-        ['not-pending', 'status-success'].includes(config.prCreation!)
-      ) {
+      logger.debug(
+        'Skipping branch creation due to internal status checks not met',
+      );
+      const pendingChecksReasons = getPendingBranchReasons(
+        config,
+        undefined,
+        'Awaiting internal checks to pass before branch creation',
+      );
+      const pendingReason = pendingChecksReasons.join('; ');
+      if (pendingReason) {
         logger.debug(
-          'Skipping branch creation due to internal status checks not met',
+          `Pending status check reason for branch ${config.branchName}: ${pendingReason}`,
         );
-        return {
-          branchExists,
-          result: 'pending',
-        };
       }
+      return {
+        branchExists,
+        pendingChecksReasons,
+        result: 'pending',
+      };
     }
 
     let userRebaseRequested =
@@ -798,20 +734,31 @@ export async function processBranch(
       logger.info({ commitSha }, `Branch ${action}`);
     }
     await setBranchStatusChecks(config);
-    // new commit means status check are pretty sure pending but maybe not reported yet
-    // if PR has not been created + new commit + prCreation !== immediate skip
+    // New commit status checks are likely pending but may not be reported yet.
     // but do not break when there are artifact errors
     if (
       !branchPr &&
       !config.artifactErrors?.length &&
       !userRebaseRequested &&
       commitSha &&
-      config.prCreation !== 'immediate'
+      getPrCreationStatusRequirement(config)
     ) {
       logger.debug(`Branch status pending, current sha: ${commitSha}`);
+      const pendingChecksReasons = getPendingBranchReasons(
+        config,
+        undefined,
+        'Awaiting branch status checks for the new commit before PR creation',
+      );
+      const pendingReason = pendingChecksReasons.join('; ');
+      if (pendingReason) {
+        logger.debug(
+          `Pending status check reason for branch ${config.branchName}: ${pendingReason}`,
+        );
+      }
       return {
         branchExists: true,
         updatesVerified,
+        pendingChecksReasons,
         result: 'pending',
         commitSha,
       };
@@ -991,17 +938,31 @@ export async function processBranch(
         };
       }
       if (prBlockedBy === 'AwaitingTests') {
+        const pendingChecksReasons = getPendingBranchReasons(
+          config,
+          ensurePrResult.pendingChecksReason,
+        );
+        const pendingReason = pendingChecksReasons.join('; ');
+        logger.debug(
+          `Pending status check reason for branch ${config.branchName}: ${pendingReason}`,
+        );
         return {
           branchExists,
           prBlockedBy,
+          pendingChecksReasons,
           result: 'pending',
           commitSha,
         };
       }
       if (prBlockedBy === 'BranchAutomerge') {
+        const pendingChecksReasons = getPendingBranchReasons(
+          config,
+          ensurePrResult.pendingChecksReason,
+        );
         return {
           branchExists,
           prBlockedBy,
+          pendingChecksReasons,
           result: 'done',
           commitSha,
         };

--- a/lib/workers/repository/update/branch/internal-checks.ts
+++ b/lib/workers/repository/update/branch/internal-checks.ts
@@ -1,0 +1,151 @@
+import { isNonEmptyString } from '@sindresorhus/is';
+import type {
+  MinimumReleaseAgeBehaviour,
+  UpdateType,
+} from '../../../../config/types.ts';
+import { logger } from '../../../../logger/index.ts';
+import { getElapsedMs } from '../../../../util/date.ts';
+import {
+  getMergeConfidenceLevel,
+  isActiveConfidenceLevel,
+  satisfiesConfidenceLevel,
+} from '../../../../util/merge-confidence/index.ts';
+import { coerceNumber } from '../../../../util/number.ts';
+import { toMs } from '../../../../util/pretty-time.ts';
+import type { BranchConfig } from '../../../types.ts';
+
+function addPendingChecksReason(config: BranchConfig, reason: string): void {
+  config.pendingChecksReasons ??= [];
+  config.pendingChecksReasons.push(reason);
+}
+
+export async function applyInternalChecksStatus(
+  config: BranchConfig,
+): Promise<void> {
+  if (
+    !config.upgrades.some(
+      (upgrade) =>
+        isNonEmptyString(upgrade.minimumReleaseAge) ||
+        isActiveConfidenceLevel(upgrade.minimumConfidence!),
+    )
+  ) {
+    return;
+  }
+
+  const depNamesWithoutReleaseTimestamp: Record<
+    MinimumReleaseAgeBehaviour,
+    {
+      depName: string;
+      updateType: UpdateType;
+    }[]
+  > = {
+    'timestamp-required': [],
+    'timestamp-optional': [],
+  };
+
+  // Only set a stability status check if one or more of the updates contain
+  // both a minimumReleaseAge setting and a releaseTimestamp.
+  config.stabilityStatus = 'green';
+  // Default to 'success' but set 'pending' if any update is pending.
+  for (const upgrade of config.upgrades) {
+    const minimumReleaseAgeMs = isNonEmptyString(upgrade.minimumReleaseAge)
+      ? coerceNumber(toMs(upgrade.minimumReleaseAge), 0)
+      : 0;
+
+    if (minimumReleaseAgeMs) {
+      const minimumReleaseAgeBehaviour: MinimumReleaseAgeBehaviour =
+        upgrade.minimumReleaseAgeBehaviour ?? 'timestamp-required';
+
+      // Regardless of minimumReleaseAgeBehaviour, if there is a timestamp,
+      // process it according to minimumReleaseAge.
+      if (upgrade.releaseTimestamp) {
+        const timeElapsed = getElapsedMs(upgrade.releaseTimestamp);
+        if (timeElapsed < minimumReleaseAgeMs) {
+          const remainingHours = Math.ceil(
+            (minimumReleaseAgeMs - timeElapsed) / 3_600_000,
+          );
+          logger.debug(
+            {
+              depName: upgrade.depName,
+              timeElapsed,
+              minimumReleaseAge: upgrade.minimumReleaseAge,
+            },
+            'Update has not passed minimum release age',
+          );
+          config.stabilityStatus = 'yellow';
+          addPendingChecksReason(
+            config,
+            `\`${upgrade.depName}\`: minimum release age not met (${upgrade.minimumReleaseAge} required, ${remainingHours}h remaining)`,
+          );
+          continue;
+        }
+      } else if (minimumReleaseAgeBehaviour === 'timestamp-required') {
+        depNamesWithoutReleaseTimestamp['timestamp-required'].push({
+          depName: upgrade.depName!,
+          updateType: upgrade.updateType!,
+        });
+        config.stabilityStatus = 'yellow';
+        addPendingChecksReason(
+          config,
+          `\`${upgrade.depName}\`: release timestamp unavailable - minimum release age (${upgrade.minimumReleaseAge}) cannot be evaluated`,
+        );
+        continue;
+      } else {
+        // If there is no timestamp and we're running in optional mode, allow it
+        // but make sure to warn the user.
+        depNamesWithoutReleaseTimestamp['timestamp-optional'].push({
+          depName: upgrade.depName!,
+          updateType: upgrade.updateType!,
+        });
+      }
+    }
+
+    const datasource = upgrade.datasource!;
+    const depName = upgrade.depName!;
+    const packageName = upgrade.packageName!;
+    const minimumConfidence = upgrade.minimumConfidence!;
+    const updateType = upgrade.updateType!;
+    const currentVersion = upgrade.currentVersion!;
+    const newVersion = upgrade.newVersion!;
+    if (isActiveConfidenceLevel(minimumConfidence)) {
+      const confidence =
+        (await getMergeConfidenceLevel(
+          datasource,
+          packageName,
+          currentVersion,
+          newVersion,
+          updateType,
+        )) ?? 'neutral';
+      if (satisfiesConfidenceLevel(confidence, minimumConfidence)) {
+        config.confidenceStatus = 'green';
+      } else {
+        logger.debug(
+          { depName, confidence, minimumConfidence },
+          'Update does not meet minimum confidence scores',
+        );
+        config.confidenceStatus = 'yellow';
+        addPendingChecksReason(
+          config,
+          `\`${depName}\`: merge confidence too low (required: ${minimumConfidence})`,
+        );
+        continue;
+      }
+    }
+  }
+
+  if (depNamesWithoutReleaseTimestamp['timestamp-required'].length) {
+    logger.once.debug(
+      { updates: depNamesWithoutReleaseTimestamp['timestamp-required'] },
+      `Marking ${depNamesWithoutReleaseTimestamp['timestamp-required'].length} release(s) as pending, as they do not have a releaseTimestamp and we're running with minimumReleaseAgeBehaviour=timestamp-required`,
+    );
+  }
+  if (depNamesWithoutReleaseTimestamp['timestamp-optional'].length) {
+    logger.once.warn(
+      "Some upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information",
+    );
+    logger.once.debug(
+      { updates: depNamesWithoutReleaseTimestamp['timestamp-optional'] },
+      `${depNamesWithoutReleaseTimestamp['timestamp-optional'].length} upgrade(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding`,
+    );
+  }
+}

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -151,6 +151,8 @@ describe('workers/repository/update/pr/index', () => {
         expect(res).toEqual({
           type: 'without-pr',
           prBlockedBy: 'AwaitingTests',
+          pendingChecksReason:
+            'Awaiting all status checks to pass before PR creation',
         });
         expect(prCache.setPrCache).not.toHaveBeenCalled();
       });
@@ -194,6 +196,8 @@ describe('workers/repository/update/pr/index', () => {
         expect(res).toEqual({
           type: 'without-pr',
           prBlockedBy: 'AwaitingTests',
+          pendingChecksReason:
+            'Awaiting 2h status stability before PR creation',
         });
         expect(prCache.setPrCache).not.toHaveBeenCalled();
       });
@@ -214,6 +218,8 @@ describe('workers/repository/update/pr/index', () => {
         expect(res).toEqual({
           type: 'without-pr',
           prBlockedBy: 'AwaitingTests',
+          pendingChecksReason:
+            'Awaiting branch status checks to become non-pending before PR creation',
         });
         expect(prCache.setPrCache).not.toHaveBeenCalled();
       });
@@ -570,6 +576,8 @@ describe('workers/repository/update/pr/index', () => {
         expect(res).toEqual({
           type: 'without-pr',
           prBlockedBy: 'BranchAutomerge',
+          pendingChecksReason:
+            'Awaiting status checks to pass before branch automerge',
         });
         expect(platform.updatePr).not.toHaveBeenCalled();
         expect(platform.createPr).not.toHaveBeenCalled();
@@ -690,6 +698,8 @@ describe('workers/repository/update/pr/index', () => {
         expect(res).toEqual({
           type: 'without-pr',
           prBlockedBy: 'BranchAutomerge',
+          pendingChecksReason:
+            'Awaiting status checks to pass before branch automerge',
         });
         expect(platform.createPr).not.toHaveBeenCalled();
       });

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -48,6 +48,7 @@ import {
   validatePrCache,
 } from './pr-fingerprint.ts';
 import { tryReuseAutoclosedPr } from './pr-reuse.ts';
+import { getPrCreationStatusRequirement } from './status-checks.ts';
 
 export function getPlatformPrOptions(
   config: RenovateConfig & PlatformPrOptions,
@@ -79,6 +80,7 @@ export interface ResultWithPr {
 export interface ResultWithoutPr {
   type: 'without-pr';
   prBlockedBy: PrBlockedBy;
+  pendingChecksReason?: string;
 }
 
 export type EnsurePrResult = ResultWithPr | ResultWithoutPr;
@@ -206,6 +208,8 @@ export async function ensurePr(
     config.forcePr = true;
   }
 
+  const statusRequirement = getPrCreationStatusRequirement(config);
+
   if (!existingPr) {
     // Only create a PR if a branch automerge has failed
     if (
@@ -232,14 +236,24 @@ export async function ensurePr(
         logger.debug(`Branch tests failed, so will create PR`);
       } else {
         // Branch should be automerged, so we don't want to create a PR
-        return { type: 'without-pr', prBlockedBy: 'BranchAutomerge' };
+        return {
+          type: 'without-pr',
+          prBlockedBy: 'BranchAutomerge',
+          pendingChecksReason:
+            'Awaiting status checks to pass before branch automerge',
+        };
       }
     }
-    if (config.prCreation === 'status-success') {
+    if (statusRequirement === 'green') {
       logger.debug('Checking branch combined status');
       if ((await getBranchStatus()) !== 'green') {
         logger.debug(`Branch status isn't green - not creating PR`);
-        return { type: 'without-pr', prBlockedBy: 'AwaitingTests' };
+        return {
+          type: 'without-pr',
+          prBlockedBy: 'AwaitingTests',
+          pendingChecksReason:
+            'Awaiting all status checks to pass before PR creation',
+        };
       }
       logger.debug('Branch status success');
     } else if (
@@ -247,7 +261,7 @@ export async function ensurePr(
       dependencyDashboardCheck !== 'approvePr'
     ) {
       return { type: 'without-pr', prBlockedBy: 'NeedsApproval' };
-    } else if (config.prCreation === 'not-pending' && !config.forcePr) {
+    } else if (statusRequirement === 'not-pending') {
       logger.debug('Checking branch combined status');
       if ((await getBranchStatus()) === 'yellow') {
         logger.debug(`Branch status is yellow - checking timeout`);
@@ -259,12 +273,16 @@ export async function ensurePr(
             (isNumber(config.prNotPendingHours) &&
               elapsedHours < config.prNotPendingHours))
         ) {
+          const pendingChecksReason = isNumber(config.prNotPendingHours)
+            ? `Awaiting ${config.prNotPendingHours}h status stability before PR creation`
+            : 'Awaiting branch status checks to become non-pending before PR creation';
           logger.debug(
             `Branch is ${elapsedHours} hours old - skipping PR creation as prNotPendingHours is set to ${config.prNotPendingHours}`,
           );
           return {
             type: 'without-pr',
             prBlockedBy: 'AwaitingTests',
+            pendingChecksReason,
           };
         }
         const prNotPendingHours = String(config.prNotPendingHours);

--- a/lib/workers/repository/update/pr/status-checks.spec.ts
+++ b/lib/workers/repository/update/pr/status-checks.spec.ts
@@ -1,0 +1,80 @@
+import { partial } from '~test/util.ts';
+import type { BranchConfig } from '../../../types.ts';
+import {
+  type PrCreationStatusRequirement,
+  getPrCreationStatusRequirement,
+} from './status-checks.ts';
+
+type TestCase = [
+  prCreation: NonNullable<BranchConfig['prCreation']>,
+  ignoreTests: boolean,
+  forcePr: boolean,
+  approvePr: boolean,
+  expected: PrCreationStatusRequirement | null,
+];
+
+describe('workers/repository/update/pr/status-checks', () => {
+  const config = partial<BranchConfig>({
+    branchName: 'renovate/test',
+  });
+
+  it.each([
+    ['immediate', false, false, false, null],
+    ['immediate', false, false, true, null],
+    ['immediate', false, true, false, null],
+    ['immediate', false, true, true, null],
+    ['immediate', true, false, false, null],
+    ['immediate', true, false, true, null],
+    ['immediate', true, true, false, null],
+    ['immediate', true, true, true, null],
+    ['approval', false, false, false, null],
+    ['approval', false, false, true, null],
+    ['approval', false, true, false, null],
+    ['approval', false, true, true, null],
+    ['approval', true, false, false, null],
+    ['approval', true, false, true, null],
+    ['approval', true, true, false, null],
+    ['approval', true, true, true, null],
+    ['not-pending', false, false, false, 'not-pending'],
+    ['not-pending', false, false, true, null],
+    ['not-pending', false, true, false, null],
+    ['not-pending', false, true, true, null],
+    ['not-pending', true, false, false, null],
+    ['not-pending', true, false, true, null],
+    ['not-pending', true, true, false, null],
+    ['not-pending', true, true, true, null],
+    ['status-success', false, false, false, 'green'],
+    ['status-success', false, false, true, 'green'],
+    ['status-success', false, true, false, 'green'],
+    ['status-success', false, true, true, 'green'],
+    ['status-success', true, false, false, null],
+    ['status-success', true, false, true, null],
+    ['status-success', true, true, false, null],
+    ['status-success', true, true, true, null],
+  ] satisfies TestCase[])(
+    'handles prCreation=%s, ignoreTests=%s, forcePr=%s, approvePr=%s',
+    (prCreation, ignoreTests, forcePr, approvePr, expected) => {
+      expect(
+        getPrCreationStatusRequirement({
+          ...config,
+          dependencyDashboardChecks: approvePr
+            ? { 'renovate/test': 'approvePr' }
+            : undefined,
+          forcePr,
+          ignoreTests,
+          prCreation,
+        }),
+      ).toBe(expected);
+    },
+  );
+
+  it('allows not-pending PR creation when artifact errors exist', () => {
+    expect(
+      getPrCreationStatusRequirement({
+        ...config,
+        artifactErrors: [{}],
+        prCreation: 'not-pending',
+      }),
+    ).toBeNull();
+  });
+});

--- a/lib/workers/repository/update/pr/status-checks.ts
+++ b/lib/workers/repository/update/pr/status-checks.ts
@@ -1,0 +1,24 @@
+import type { BranchConfig } from '../../../types.ts';
+
+export type PrCreationStatusRequirement = 'green' | 'not-pending';
+
+export function getPrCreationStatusRequirement(
+  config: BranchConfig,
+): PrCreationStatusRequirement | null {
+  if (config.ignoreTests) {
+    return null;
+  }
+
+  if (config.prCreation === 'status-success') {
+    return 'green';
+  }
+
+  const dependencyDashboardCheck =
+    config.dependencyDashboardChecks?.[config.branchName];
+  const forcePr =
+    config.forcePr === true ||
+    !!config.artifactErrors?.length ||
+    dependencyDashboardCheck === 'approvePr';
+
+  return config.prCreation === 'not-pending' && !forcePr ? 'not-pending' : null;
+}

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -194,6 +194,7 @@ export interface BranchConfig
   packageFiles?: Record<string, PackageFile[]>;
   prBlockedBy?: PrBlockedBy;
   prNo?: number;
+  pendingChecksReasons?: string[];
   stabilityStatus?: BranchStatus;
   stopUpdating?: boolean;
   isConflicted?: boolean;


### PR DESCRIPTION
## Changes

_This is my first OSS contribution. And I hate that it's so much code to review. I fear the feature crosses a lot of files. I found no way to squeeze it in a central place. Also I and gpt found discussion-worthy discrepancies :-/ Let me know what you think_

Adds precise diagnostic information for branches that remain pending while Renovate waits for status checks.

Pending reasons are recorded where the corresponding decision is made, avoiding duplicated decision logic. Reasons include minimum release age, missing release timestamps, insufficient merge confidence, `prCreation=status-success`, `prCreation=not-pending`, and pending branch automerge.

The reasons are written to debug logs and can optionally be displayed in the Dependency Dashboard using:

```json
{
  "dependencyDashboardVerbosePendingChecks": true
}
```

The option is disabled by default to preserve the existing compact dashboard format. For individual updates, the dependency name is omitted from the reason when it is already present in the PR title. Grouped updates retain dependency names so each reason remains attributable.

The status-check flow also respects `ignoreTests`, forced PR creation, and Dependency Dashboard approval without duplicating the PR creation decision logic.

Example Dependency Dashboard output:

```
**Pending Status Checks**

The following updates await pending status checks.

chore(deps): update dependency org.openapitools:jackson-databind-nullable to v0.2.11 - *minimum release age not met (7 days required, 44h remaining)*
```

### Discussion
1️⃣ Opinion?

There is an existing discrepancy between the documented behavior of `ignoreTests` and the new-commit PR creation path.

The documentation states that `ignoreTests: true` causes Renovate to ignore all status checks. However, the existing new-commit path returns `pending` before status resolution for every non-immediate `prCreation` mode, including when `ignoreTests` is enabled. Existing unit tests currently codify this one-run delay.

This PR follows the documented behavior: when `ignoreTests` is enabled, the new-commit status-check wait is skipped and PR processing continues immediately.

Opinion?

2️⃣ Opinion?

A similar discrepancy exists for forced PR creation.

`ensurePr()` already allows `forcePr` and Dependency Dashboard `approvePr` to bypass `prCreation=not-pending`. However, immediately after a new commit, an earlier pending return can prevent execution from reaching `ensurePr()`.

This PR aligns the early new-commit path with `ensurePr()` by allowing these explicit PR creation overrides to continue processing. `prCreation=status-success` remains strict and still requires successful status checks.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40370 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI assistance was used to implement and review the changes, add tests and documentation, and prepare this PR description.

Tool: OpenAI Codex / GPT-5. The agent was instructed to avoid duplicating decision logic. Pending reasons are captured where status decisions are made and passed through the existing branch-processing result.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: N/A — tested against a private Azure DevOps repository.