### PR TITLE
feat(onboarding): show "What to Expect" first in summary view

### DIFF
--- a/lib/workers/repository/onboarding/pr/index.spec.ts
+++ b/lib/workers/repository/onboarding/pr/index.spec.ts
@@ -155,6 +155,10 @@ describe('workers/repository/onboarding/pr/index', () => {
         // the summary groups them under a manager heading instead
         expect(prBody).not.toContain('`package.json` (npm)');
         expect(prBody).toContain('#### npm\n\n * `package.json`');
+        // in the summary view, "What to Expect" should render before "Detected Package Files"
+        expect(prBody.indexOf('### What to Expect')).toBeLessThan(
+          prBody.indexOf('### Detected Package Files'),
+        );
       });
 
       it('does not attempt to replace package files when none were detected', async () => {

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -86,10 +86,35 @@ async function ensureOnboardingAutoCloseAge(existingPr: Pr): Promise<boolean> {
   return false;
 }
 
+/**
+ * Full onboarding PRs list package files before the PR list.
+ */
+const FULL_SECTION_ORDER = [
+  'PACKAGE FILES',
+  'CONFIG',
+  'BASEBRANCH',
+  'PRLIST',
+  'WARNINGS',
+  'ERRORS',
+] as const;
+
+/**
+ * "Summarised" onboarding PRs list PRs before other sections.
+ */
+const SUMMARY_SECTION_ORDER = [
+  'PRLIST',
+  'CONFIG',
+  'BASEBRANCH',
+  'PACKAGE FILES',
+  'WARNINGS',
+  'ERRORS',
+] as const;
+
 function buildOnboardingPrTemplate(
   config: RenovateConfig,
   configFile: string,
   rebaseCheckBox: string,
+  sectionOrder: readonly string[],
 ): string {
   let prTemplate = `Welcome to [Renovate](${
     GlobalConfig.get('productLinks').homepage
@@ -121,12 +146,7 @@ function buildOnboardingPrTemplate(
     `
 
 ---
-{{PACKAGE FILES}}
-{{CONFIG}}
-{{BASEBRANCH}}
-{{PRLIST}}
-{{WARNINGS}}
-{{ERRORS}}
+${sectionOrder.map((section) => `{{${section}}}`).join('\n')}
 
 ---
 
@@ -249,7 +269,12 @@ export async function ensureOnboardingPr(
 
   let prBody = finalizeOnboardingPrBody(
     fillOnboardingPrBody(
-      buildOnboardingPrTemplate(config, configFile, rebaseCheckBox),
+      buildOnboardingPrTemplate(
+        config,
+        configFile,
+        rebaseCheckBox,
+        FULL_SECTION_ORDER,
+      ),
       {
         packageFiles: packageFilesDesc,
         config: configDesc,
@@ -267,12 +292,33 @@ export async function ensureOnboardingPr(
     logger.debug(
       'Onboarding PR body exceeds platform limit, switching to summary PR list and package files',
     );
-    prBody = prBody.replace(prList, getExpectedPrListSummary(config, branches));
+    const prListSummary = getExpectedPrListSummary(config, branches);
     if (packageFilesDesc) {
-      prBody = prBody.replace(
-        packageFilesDesc,
-        `### Detected Package Files\n\n${getPackageFilesSummary(packageFiles)}`,
+      const packageFilesSummary = `### Detected Package Files\n\n${getPackageFilesSummary(packageFiles)}`;
+      // "What to Expect" should render before "Detected Package Files" in the summary view,
+      // so rebuild from a template with that section order rather than reordering the rendered body.
+      prBody = finalizeOnboardingPrBody(
+        fillOnboardingPrBody(
+          buildOnboardingPrTemplate(
+            config,
+            configFile,
+            rebaseCheckBox,
+            SUMMARY_SECTION_ORDER,
+          ),
+          {
+            packageFiles: packageFilesSummary,
+            config: configDesc,
+            baseBranch: baseBranchDesc,
+            prList: prListSummary,
+            warnings,
+            errors,
+          },
+        ),
+        config,
+        onboardingConfigHashComment,
       );
+    } else {
+      prBody = prBody.replace(prList, prListSummary);
     }
   }
 

--- a/lib/workers/repository/reconfigure/comment.spec.ts
+++ b/lib/workers/repository/reconfigure/comment.spec.ts
@@ -114,6 +114,10 @@ describe('workers/repository/reconfigure/comment', () => {
         // the summary groups them under a manager heading instead
         expect(prBody).not.toContain('`package.json` (npm)');
         expect(prBody).toContain('#### npm\n\n * `package.json`');
+        // in the summary view, "What to Expect" should render before "Detected Package Files"
+        expect(prBody.indexOf('### What to Expect')).toBeLessThan(
+          prBody.indexOf('### Detected Package Files'),
+        );
       });
 
       it('does not attempt to replace package files when none were detected', async () => {

--- a/lib/workers/repository/reconfigure/comment.ts
+++ b/lib/workers/repository/reconfigure/comment.ts
@@ -24,16 +24,37 @@ import {
 } from '../onboarding/pr/pr-list.ts';
 import type { ReconfigurePrCommentSections } from '../onboarding/pr/types.ts';
 
-// TODO #22198
-const RECONFIGURE_PR_COMMENT_TEMPLATE = `This is a reconfigure PR comment to help you understand and re-configure your renovate bot settings. If this Reconfigure PR were to be merged, we'd expect to see the following outcome:\n\n
+// Full reconfigure PR comments list package files before the PR list.
+const SECTION_ORDER = [
+  'PACKAGE FILES',
+  'CONFIG',
+  'BASEBRANCH',
+  'PRLIST',
+  'WARNINGS',
+  'ERRORS',
+] as const;
+// Once the body is summarised, "What to Expect" should render before "Detected Package Files".
+const SUMMARY_SECTION_ORDER = [
+  'PRLIST',
+  'CONFIG',
+  'BASEBRANCH',
+  'PACKAGE FILES',
+  'WARNINGS',
+  'ERRORS',
+] as const;
+
+function buildReconfigurePrCommentTemplate(
+  sectionOrder: readonly string[],
+): string {
+  let prCommentTemplate = `This is a reconfigure PR comment to help you understand and re-configure your renovate bot settings. If this Reconfigure PR were to be merged, we'd expect to see the following outcome:\n\n`;
+
+  // TODO #22198
+  prCommentTemplate += `
 ---
-{{PACKAGE FILES}}
-{{CONFIG}}
-{{BASEBRANCH}}
-{{PRLIST}}
-{{WARNINGS}}
-{{ERRORS}}
+${sectionOrder.map((section) => `{{${section}}}`).join('\n')}
 `;
+  return prCommentTemplate;
+}
 
 function fillReconfigurePrCommentBody(
   prCommentTemplate: string,
@@ -76,25 +97,40 @@ export async function ensureReconfigurePrComment(
   const baseBranchDesc = getBaseBranchDesc(config);
   const prList = getExpectedPrList(config, branches);
 
-  let prBody = fillReconfigurePrCommentBody(RECONFIGURE_PR_COMMENT_TEMPLATE, {
-    packageFiles: packageFilesDesc,
-    config: configDesc,
-    baseBranch: baseBranchDesc,
-    prList,
-    warnings,
-    errors,
-  });
+  let prBody = fillReconfigurePrCommentBody(
+    buildReconfigurePrCommentTemplate(SECTION_ORDER),
+    {
+      packageFiles: packageFilesDesc,
+      config: configDesc,
+      baseBranch: baseBranchDesc,
+      prList,
+      warnings,
+      errors,
+    },
+  );
 
   if (prBody.length > platform.maxBodyLength()) {
     logger.debug(
       'Reconfigure PR body exceeds platform limit, switching to summary PR list and package files',
     );
-    prBody = prBody.replace(prList, getExpectedPrListSummary(config, branches));
+    const prListSummary = getExpectedPrListSummary(config, branches);
     if (packageFilesDesc) {
-      prBody = prBody.replace(
-        packageFilesDesc,
-        `### Detected Package Files\n\n${getPackageFilesSummary(packageFiles)}`,
+      const packageFilesSummary = `### Detected Package Files\n\n${getPackageFilesSummary(packageFiles)}`;
+      // "What to Expect" should render before "Detected Package Files" in the summary view,
+      // so rebuild from a template with that section order rather than reordering the rendered body.
+      prBody = fillReconfigurePrCommentBody(
+        buildReconfigurePrCommentTemplate(SUMMARY_SECTION_ORDER),
+        {
+          packageFiles: packageFilesSummary,
+          config: configDesc,
+          baseBranch: baseBranchDesc,
+          prList: prListSummary,
+          warnings,
+          errors,
+        },
       );
+    } else {
+      prBody = prBody.replace(prList, prListSummary);
     }
   }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When using the "summary view", in the case we hit platform limits, in
Onboarding PRs or Reconfigure PR comments, we should prioritise the
"What to Expect" as it provides a more actionable "executive summary" of
what's needed in the repository.

(Could also be a `fix`)
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/ag-ui/pull/3

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
