### PR TITLE
refactor(manager/pixi): extract shared pixi.lock update helper

### DIFF
--- a/lib/modules/manager/pep621/processors/pixi.spec.ts
+++ b/lib/modules/manager/pep621/processors/pixi.spec.ts
@@ -6,7 +6,6 @@ import type {
   InternalGlobalConfigOptions,
   RepoGlobalConfig,
 } from '../../../../config/types.ts';
-import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import * as docker from '../../../../util/exec/docker/index.ts';
 import { getPkgReleases as _getPkgReleases } from '../../../datasource/index.ts';
 import type { UpdateArtifactsConfig } from '../../types.ts';
@@ -84,88 +83,21 @@ describe('modules/manager/pep621/processors/pixi', () => {
     });
   });
 
+  // The exec flow, the `allowedUnsafeExecutions` gate, and the error handling
+  // live in the shared `updatePixiLockfile` helper and are covered by
+  // `../../pixi/lockfile.spec.ts`. These tests only assert the `pep621`
+  // processor's own behavior: how it derives the `pixi` constraint and that it
+  // delegates without writing the package file (the `pep621` manager writes it
+  // elsewhere).
   describe('updateArtifacts()', () => {
-    it('throws TEMPORARY_ERROR', async () => {
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      fs.ensureCacheDir.mockRejectedValueOnce(new Error(TEMPORARY_ERROR));
-
-      const result = processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      await expect(result).rejects.toThrow(TEMPORARY_ERROR);
-    });
-
-    it('returns null when no updated deps and not lock file maintenance', async () => {
-      const execSnapshots = mockExecAll();
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toBeNull();
-      expect(execSnapshots).toEqual([]);
-    });
-
-    it('returns null when pixi.lock does not exist', async () => {
+    it('delegates to the shared helper without writing the package file', async () => {
       const execSnapshots = mockExecAll();
       fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toBeNull();
-      expect(execSnapshots).toEqual([]);
-    });
-
-    it('returns null when pixi is not in allowedUnsafeExecutions', async () => {
-      GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toBeNull();
-      expect(execSnapshots).toEqual([]);
-    });
-
-    it('returns null when lock file is unchanged', async () => {
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
       fs.ensureCacheDir.mockResolvedValueOnce(
         '/tmp/renovate/cache/others/pixi',
       );
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
 
       const result = await processor.updateArtifacts(
         {
@@ -177,145 +109,22 @@ describe('modules/manager/pep621/processors/pixi', () => {
         parsePyProject('')!,
       );
 
-      expect(result).toBeNull();
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pixi.lock',
+            contents: 'New pixi.lock',
+          },
+        },
+      ]);
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
       expect(execSnapshots).toMatchObject([
         { cmd: 'pixi lock --no-progress --color=never --quiet' },
       ]);
     });
 
-    it('returns updated pixi.lock for dep update', async () => {
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
-      fs.ensureCacheDir.mockResolvedValueOnce(
-        '/tmp/renovate/cache/others/pixi',
-      );
-      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pixi.lock',
-            contents: 'New pixi.lock',
-          },
-        },
-      ]);
-      expect(execSnapshots).toMatchObject([
-        {
-          cmd: 'pixi lock --no-progress --color=never --quiet',
-          options: {
-            cwd: '/tmp/github/some/repo',
-            env: { PIXI_CACHE_DIR: '/tmp/renovate/cache/others/pixi' },
-          },
-        },
-      ]);
-    });
-
-    it('returns updated pixi.lock for dep update using docker', async () => {
-      GlobalConfig.set({
-        ...adminConfig,
-        binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
-      });
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
-      fs.ensureCacheDir.mockResolvedValueOnce(
-        '/tmp/renovate/cache/others/pixi',
-      );
-      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      // pixi version lookup
-      getPkgReleases.mockResolvedValueOnce({
-        releases: [{ version: '0.41.4' }, { version: '0.42.0' }],
-      });
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pixi.lock',
-            contents: 'New pixi.lock',
-          },
-        },
-      ]);
-      expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
-        { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
-        {
-          cmd:
-            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
-            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
-            '-v "/tmp/cache":"/tmp/cache" ' +
-            '-e PIXI_CACHE_DIR ' +
-            '-e RATTLER_CACHE_DIR ' +
-            '-e CONTAINERBASE_CACHE_DIR ' +
-            '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/renovatebot/base-image ' +
-            'bash -l -c "' +
-            'install-tool pixi 0.42.0 ' +
-            '&& ' +
-            'pixi lock --no-progress --color=never --quiet' +
-            '"',
-        },
-      ]);
-    });
-
-    it('returns updated pixi.lock for lock file maintenance', async () => {
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
-      fs.ensureCacheDir.mockResolvedValueOnce(
-        '/tmp/renovate/cache/others/pixi',
-      );
-      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config: { isLockFileMaintenance: true },
-          updatedDeps: [],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pixi.lock',
-            contents: 'New pixi.lock',
-          },
-        },
-      ]);
-      expect(fs.deleteLocalFile).toHaveBeenCalledWith('pixi.lock');
-      expect(execSnapshots).toMatchObject([
-        { cmd: 'pixi lock --no-progress --color=never --quiet' },
-      ]);
-    });
-
-    it('uses requires-pixi version constraint from pyproject.toml', async () => {
+    it('derives the pixi constraint from requires-pixi in the pyproject', async () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
@@ -384,7 +193,7 @@ requires-pixi = ">=0.40,<0.41"
       ]);
     });
 
-    it('uses requires-pixi version constraint from workspace table', async () => {
+    it('prefers config.constraints.pixi over the pyproject requires-pixi', async () => {
       GlobalConfig.set({
         ...adminConfig,
         binarySource: 'docker',
@@ -405,18 +214,18 @@ requires-pixi = ">=0.40,<0.41"
         ],
       });
       const project = parsePyProject(`
-[tool.pixi.workspace]
+[tool.pixi.project]
 name = "test"
 channels = ["conda-forge"]
 platforms = ["linux-64"]
-requires-pixi = ">=0.40,<0.41"
+requires-pixi = ">=0.38,<0.39"
 `);
 
       const result = await processor.updateArtifacts(
         {
           packageFileName: 'pyproject.toml',
           newPackageFileContent: '',
-          config: { constraints: {} },
+          config: { constraints: { pixi: '>=0.40,<0.41' } },
           updatedDeps: [{ depName: 'dep1' }],
         },
         project!,
@@ -451,93 +260,6 @@ requires-pixi = ">=0.40,<0.41"
             '"',
         },
       ]);
-    });
-
-    it('uses pixi version constraint from config.constraints', async () => {
-      GlobalConfig.set({
-        ...adminConfig,
-        binarySource: 'docker',
-        dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
-      });
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
-      fs.ensureCacheDir.mockResolvedValueOnce(
-        '/tmp/renovate/cache/others/pixi',
-      );
-      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      getPkgReleases.mockResolvedValueOnce({
-        releases: [{ version: '0.40.1' }, { version: '0.41.4' }],
-      });
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config: { constraints: { pixi: '>=0.40,<0.41' } },
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pixi.lock',
-            contents: 'New pixi.lock',
-          },
-        },
-      ]);
-      expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
-        { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
-        {
-          cmd:
-            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
-            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
-            '-v "/tmp/cache":"/tmp/cache" ' +
-            '-e PIXI_CACHE_DIR ' +
-            '-e RATTLER_CACHE_DIR ' +
-            '-e CONTAINERBASE_CACHE_DIR ' +
-            '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/renovatebot/base-image ' +
-            'bash -l -c "' +
-            'install-tool pixi 0.40.1 ' +
-            '&& ' +
-            'pixi lock --no-progress --color=never --quiet' +
-            '"',
-        },
-      ]);
-    });
-
-    it('returns artifact error on exec failure', async () => {
-      const execSnapshots = mockExecAll();
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
-      fs.ensureCacheDir.mockImplementationOnce(() => {
-        throw new Error('exec failed');
-      });
-
-      const result = await processor.updateArtifacts(
-        {
-          packageFileName: 'pyproject.toml',
-          newPackageFileContent: '',
-          config,
-          updatedDeps: [{ depName: 'dep1' }],
-        },
-        parsePyProject('')!,
-      );
-
-      expect(result).toEqual([
-        {
-          artifactError: {
-            fileName: 'pixi.lock',
-            stderr: 'Error: exec failed',
-          },
-        },
-      ]);
-      expect(execSnapshots).toEqual([]);
     });
   });
 });

--- a/lib/modules/manager/pep621/processors/pixi.ts
+++ b/lib/modules/manager/pep621/processors/pixi.ts
@@ -1,16 +1,9 @@
-import { isNonEmptyArray } from '@sindresorhus/is';
-import { GlobalConfig } from '../../../../config/global.ts';
-import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
-import { exec } from '../../../../util/exec/index.ts';
-import type { ExecOptions } from '../../../../util/exec/types.ts';
 import {
-  deleteLocalFile,
-  ensureCacheDir,
   getSiblingFileName,
   localPathExists,
-  readLocalFile,
 } from '../../../../util/fs/index.ts';
+import { updatePixiLockfile } from '../../pixi/lockfile.ts';
 import type {
   PackageDependency,
   UpdateArtifact,
@@ -18,8 +11,6 @@ import type {
 } from '../../types.ts';
 import type { PyProject } from '../schema.ts';
 import { BasePyProjectProcessor } from './abstract.ts';
-
-export const commandLock = 'pixi lock --no-progress --color=never --quiet';
 
 export class PixiProcessor extends BasePyProjectProcessor {
   process(_project: PyProject, deps: PackageDependency[]): PackageDependency[] {
@@ -46,84 +37,20 @@ export class PixiProcessor extends BasePyProjectProcessor {
     return [];
   }
 
-  async updateArtifacts(
+  updateArtifacts(
     { config, updatedDeps, packageFileName }: UpdateArtifact,
     project: PyProject,
   ): Promise<UpdateArtifactsResult[] | null> {
-    const { isLockFileMaintenance } = config;
-
-    if (!isNonEmptyArray(updatedDeps) && !isLockFileMaintenance) {
-      logger.debug('No updated pixi deps - returning null');
-      return null;
-    }
-
-    const lockFileName = getSiblingFileName(packageFileName, 'pixi.lock');
-    const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
-    if (!existingLockFileContent) {
-      logger.debug('No pixi.lock found');
-      return null;
-    }
-
-    // `pixi lock` can execute arbitrary code from conda package hooks, so it is
-    // gated behind `allowedUnsafeExecutions`.
-    // https://pixi.prefix.dev/latest/security/#4-treat-package-hooks-as-code-execution
-    if (!GlobalConfig.get('allowedUnsafeExecutions').includes('pixi')) {
-      logger.once.warn(
-        '`pixi lock` was requested to run, but `pixi` is not permitted in the allowedUnsafeExecutions',
-      );
-      return null;
-    }
-
     const constraint =
       config.constraints?.pixi ?? project.tool?.pixi?.['requires-pixi'];
 
-    try {
-      if (isLockFileMaintenance) {
-        await deleteLocalFile(lockFileName);
-      }
-
-      // https://pixi.sh/latest/features/environment/#caching-packages
-      const PIXI_CACHE_DIR = await ensureCacheDir('pixi');
-      const extraEnv = {
-        PIXI_CACHE_DIR,
-        RATTLER_CACHE_DIR: PIXI_CACHE_DIR,
-      };
-
-      const execOptions: ExecOptions = {
-        cwdFile: packageFileName,
-        extraEnv,
-        docker: {},
-        toolConstraints: [{ toolName: 'pixi', constraint }],
-      };
-      await exec([commandLock], execOptions);
-
-      const newPixiLockContent = await readLocalFile(lockFileName, 'utf8');
-      if (existingLockFileContent === newPixiLockContent) {
-        logger.debug(`${lockFileName} is unchanged`);
-        return null;
-      }
-      return [
-        {
-          file: {
-            type: 'addition',
-            path: lockFileName,
-            contents: newPixiLockContent,
-          },
-        },
-      ];
-    } catch (err) {
-      if (err.message === TEMPORARY_ERROR) {
-        throw err;
-      }
-      logger.debug({ err }, `Failed to update ${lockFileName} file`);
-      return [
-        {
-          artifactError: {
-            fileName: lockFileName,
-            stderr: `${err}`,
-          },
-        },
-      ];
-    }
+    // The `pep621` manager has already written the updated package file, so
+    // `newPackageFileContent` is intentionally left unset here.
+    return updatePixiLockfile({
+      packageFileName,
+      updatedDeps,
+      isLockFileMaintenance: config.isLockFileMaintenance,
+      constraint,
+    });
   }
 }

--- a/lib/modules/manager/pixi/artifacts.spec.ts
+++ b/lib/modules/manager/pixi/artifacts.spec.ts
@@ -9,40 +9,10 @@ import type {
   InternalGlobalConfigOptions,
   RepoGlobalConfig,
 } from '../../../config/types.ts';
-import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import * as docker from '../../../util/exec/docker/index.ts';
 import * as _datasource from '../../datasource/index.ts';
 import type { UpdateArtifactsConfig } from '../types.ts';
 import { updateArtifacts } from './index.ts';
-
-const pixiToml = `
-[project]
-authors = []
-channels = ["conda-forge"]
-name = "data"
-platforms = ["win-64"]
-version = "0.1.0"
-
-[tasks]
-
-[dependencies]
-python = "3.12.*"
-geographiclib = ">=2.0,<3"
-geopy = ">=2.4.1,<3"
-cartopy = ">=0.24.0,<0.25"
-pydantic = "2.*"
-matplotlib = ">=3.10.0,<4"
-pyqt = ">=5.15.9,<6"
-pandas = ">=2.2.3,<3"
-python-dateutil = ">=2.9.0.post0,<3"
-rich = ">=13.9.4,<14"
-scipy = ">=1.15.2,<2"
-tqdm = ">=4.67.1,<5"
-tzdata = ">=2025a"
-numpy = "2.*"
-adjusttext = ">=1.3.0,<2"
-iris = ">=3.11.1,<4"
-`;
 
 vi.mock('../../../util/exec/env.ts');
 vi.mock('../../../util/fs/index.ts');
@@ -63,6 +33,11 @@ const adminConfig: RepoGlobalConfig & InternalGlobalConfigOptions = {
 
 const config: UpdateArtifactsConfig = {};
 
+// The exec flow, the `allowedUnsafeExecutions` gate, and the error handling
+// live in the shared `updatePixiLockfile` helper and are covered by
+// `lockfile.spec.ts`. These tests only assert the `pixi` manager's own
+// behavior: how it derives the `pixi` constraint and that it delegates while
+// writing the updated package file.
 describe('modules/manager/pixi/artifacts', () => {
   describe('updateArtifacts', () => {
     beforeEach(() => {
@@ -71,118 +46,23 @@ describe('modules/manager/pixi/artifacts', () => {
       docker.resetPrefetchedImages();
     });
 
-    it('returns null if no pixi.lock found', async () => {
-      const execSnapshots = mockExecAll();
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps: [],
-          newPackageFileContent: '',
-          config: { ...config, isLockFileMaintenance: true },
-        }),
-      ).toBeNull();
-      expect(execSnapshots).toEqual([]);
-    });
-
-    it('returns null if updatedDeps is empty', async () => {
-      const execSnapshots = mockExecAll();
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps: [],
-          newPackageFileContent: '',
-          config,
-        }),
-      ).toBeNull();
-      expect(execSnapshots).toEqual([]);
-    });
-
-    it('returns null when pixi is not in allowedUnsafeExecutions', async () => {
-      GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
+    it('writes the updated package file and returns the new pixi.lock', async () => {
       const execSnapshots = mockExecAll();
       fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps: [{ depName: 'dep1' }],
-          newPackageFileContent: '',
-          config,
-        }),
-      ).toBeNull();
-      expect(execSnapshots).toEqual([]);
-    });
-
-    it('returns null if unchanged', async () => {
-      const execSnapshots = mockExecAll();
+      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
       fs.ensureCacheDir.mockResolvedValueOnce(
         '/tmp/renovate/cache/others/pixi',
       );
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps: [],
-          newPackageFileContent: '',
-          config: { ...config, isLockFileMaintenance: true },
-        }),
-      ).toBeNull();
-      expect(execSnapshots).toMatchObject([
-        {
-          cmd: 'pixi lock --no-progress --color=never --quiet',
-          options: {
-            cwd: '/tmp/github/some/repo',
-            env: { PIXI_CACHE_DIR: '/tmp/renovate/cache/others/pixi' },
-          },
-        },
-      ]);
-    });
-
-    it('handle TEMPORARY_ERROR', async () => {
-      fs.ensureCacheDir.mockResolvedValueOnce(
-        '/tmp/renovate/cache/others/pixi',
-      );
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      fs.writeLocalFile.mockRejectedValueOnce(new Error(TEMPORARY_ERROR));
-
-      await expect(
-        updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps: [],
-          newPackageFileContent: '',
-          config: { ...config, isLockFileMaintenance: true },
-        }),
-      ).rejects.toThrow(new Error(TEMPORARY_ERROR));
-    });
-
-    it('returns updated pixi.lock using docker', async () => {
-      GlobalConfig.set({
-        ...adminConfig,
-        binarySource: 'docker',
-      });
-      const execSnapshots = mockExecAll();
-      fs.ensureCacheDir.mockResolvedValueOnce(
-        '/tmp/renovate/cache/others/pixi',
-      );
-      // pixi.lock
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('version: 7');
       fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      // pixi
-      datasource.getPkgReleases.mockResolvedValueOnce({
-        releases: [{ version: '2.7.5' }, { version: '0.41.4' }],
+
+      const result = await updateArtifacts({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        newPackageFileContent: '',
+        config,
       });
-      const updatedDeps = [{ depName: 'dep1' }];
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pixi.toml',
-          updatedDeps,
-          newPackageFileContent: pixiToml,
-          config: { ...config, isLockFileMaintenance: true },
-        }),
-      ).toEqual([
+
+      expect(result).toEqual([
         {
           file: {
             type: 'addition',
@@ -191,113 +71,18 @@ describe('modules/manager/pixi/artifacts', () => {
           },
         },
       ]);
+      expect(fs.writeLocalFile).toHaveBeenCalledWith('pyproject.toml', '');
       expect(execSnapshots).toMatchObject([
-        { cmd: 'docker pull ghcr.io/renovatebot/base-image' },
-        { cmd: 'docker ps --filter name=renovate_sidecar -aq' },
-        {
-          cmd:
-            'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
-            '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
-            '-v "/tmp/cache":"/tmp/cache" ' +
-            '-e PIXI_CACHE_DIR ' +
-            '-e RATTLER_CACHE_DIR ' +
-            '-e CONTAINERBASE_CACHE_DIR ' +
-            '-w "/tmp/github/some/repo" ' +
-            'ghcr.io/renovatebot/base-image ' +
-            'bash -l -c "' +
-            'install-tool pixi 0.41.4 ' +
-            '&& ' +
-            'pixi lock --no-progress --color=never --quiet' +
-            '"',
-        },
-      ]);
-    });
-
-    it('returns updated pixi.lock using install mode', async () => {
-      GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-      const execSnapshots = mockExecAll();
-      // pixi.lock
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('version: 6');
-      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      // pixi
-      datasource.getPkgReleases.mockResolvedValueOnce({
-        releases: [{ version: '2.7.5' }, { version: '0.41.4' }],
-      });
-      const updatedDeps = [{ depName: 'dep1' }];
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps,
-          newPackageFileContent: pixiToml,
-          config: {
-            ...config,
-            constraints: {},
-            isLockFileMaintenance: true,
-          },
-        }),
-      ).toEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pixi.lock',
-            contents: 'New pixi.lock',
-          },
-        },
-      ]);
-
-      expect(execSnapshots).toMatchObject([
-        { cmd: 'install-tool pixi 0.41.4' },
         { cmd: 'pixi lock --no-progress --color=never --quiet' },
       ]);
     });
 
-    it('returns updated pixi.lock using install mode for old version lock file', async () => {
+    it('derives the pixi constraint from requires-pixi in the package file', async () => {
       GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
       const execSnapshots = mockExecAll();
-      // pixi.lock
       fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
       fs.readLocalFile.mockResolvedValueOnce('version: 5');
       fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      // pixi
-      datasource.getPkgReleases.mockResolvedValueOnce({
-        releases: [{ version: '0.38.0' }, { version: '0.41.4' }],
-      });
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pixi.toml',
-          updatedDeps: [],
-          newPackageFileContent: pixiToml,
-          config: {
-            ...config,
-            constraints: {},
-            isLockFileMaintenance: true,
-          },
-        }),
-      ).toEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pixi.lock',
-            contents: 'New pixi.lock',
-          },
-        },
-      ]);
-
-      expect(execSnapshots).toMatchObject([
-        { cmd: 'install-tool pixi 0.41.4' },
-        { cmd: 'pixi lock --no-progress --color=never --quiet' },
-      ]);
-    });
-
-    it('returns pixi version defined in requires-pixi', async () => {
-      GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-      const execSnapshots = mockExecAll();
-      // pixi.lock
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('version: 5');
-      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      // pixi
       datasource.getPkgReleases.mockResolvedValueOnce({
         releases: [
           { version: '0.38.0' },
@@ -305,31 +90,26 @@ describe('modules/manager/pixi/artifacts', () => {
           { version: '0.41.4' },
         ],
       });
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pixi.toml',
-          updatedDeps: [],
-          newPackageFileContent: codeBlock`
-                              [project]
-                              authors = []
-                              channels = ["conda-forge"]
-                              name = "data"
-                              platforms = ["win-64"]
-                              version = "0.1.0"
-                              requires-pixi = '>=0.40,<0.41'
 
-                              [tasks]
+      const result = await updateArtifacts({
+        packageFileName: 'pixi.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        newPackageFileContent: codeBlock`
+          [project]
+          authors = []
+          channels = ["conda-forge"]
+          name = "data"
+          platforms = ["win-64"]
+          version = "0.1.0"
+          requires-pixi = '>=0.40,<0.41'
 
-                              [dependencies]
-                              python = "3.12.*"
-                              `,
-          config: {
-            ...config,
-            constraints: {},
-            isLockFileMaintenance: true,
-          },
-        }),
-      ).toEqual([
+          [dependencies]
+          python = "3.12.*"
+        `,
+        config: { ...config, constraints: {} },
+      });
+
+      expect(result).toEqual([
         {
           file: {
             type: 'addition',
@@ -338,59 +118,55 @@ describe('modules/manager/pixi/artifacts', () => {
           },
         },
       ]);
-
       expect(execSnapshots).toMatchObject([
         { cmd: 'install-tool pixi 0.40.1' },
         { cmd: 'pixi lock --no-progress --color=never --quiet' },
       ]);
     });
 
-    it('catches errors', async () => {
+    it('prefers config.constraints.pixi over the package file requires-pixi', async () => {
+      GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
       const execSnapshots = mockExecAll();
-      // pixi.lock
       fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
-      fs.writeLocalFile.mockImplementationOnce(() => {
-        throw new Error('not found');
-      });
-      const updatedDeps = [{ depName: 'dep1' }];
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pixi.toml',
-          updatedDeps,
-          newPackageFileContent: '{}',
-          config,
-        }),
-      ).toMatchObject([{ artifactError: { fileName: 'pixi.lock' } }]);
-      expect(execSnapshots).toMatchObject([]);
-    });
-
-    it('returns updated pixi.lock when doing lockfile maintenance', async () => {
-      const execSnapshots = mockExecAll();
-      // pixi.lock
-      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
-      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('version: 5');
       fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
-      expect(
-        await updateArtifacts({
-          packageFileName: 'pyproject.toml',
-          updatedDeps: [],
-          newPackageFileContent: '{}',
-          config: {
-            ...config,
-            isLockFileMaintenance: true,
-          },
-        }),
-      ).toEqual([
+      datasource.getPkgReleases.mockResolvedValueOnce({
+        releases: [
+          { version: '0.38.0' },
+          { version: '0.40.1' },
+          { version: '0.41.4' },
+        ],
+      });
+
+      const result = await updateArtifacts({
+        packageFileName: 'pixi.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        newPackageFileContent: codeBlock`
+          [project]
+          authors = []
+          channels = ["conda-forge"]
+          name = "data"
+          platforms = ["win-64"]
+          version = "0.1.0"
+          requires-pixi = '>=0.38,<0.39'
+
+          [dependencies]
+          python = "3.12.*"
+        `,
+        config: { ...config, constraints: { pixi: '>=0.40,<0.41' } },
+      });
+
+      expect(result).toEqual([
         {
           file: {
-            contents: 'New pixi.lock',
-            path: 'pixi.lock',
             type: 'addition',
+            path: 'pixi.lock',
+            contents: 'New pixi.lock',
           },
         },
       ]);
       expect(execSnapshots).toMatchObject([
+        { cmd: 'install-tool pixi 0.40.1' },
         { cmd: 'pixi lock --no-progress --color=never --quiet' },
       ]);
     });

--- a/lib/modules/manager/pixi/artifacts.ts
+++ b/lib/modules/manager/pixi/artifacts.ts
@@ -1,20 +1,7 @@
-import { isNonEmptyArray } from '@sindresorhus/is';
-import { GlobalConfig } from '../../../config/global.ts';
-import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { exec } from '../../../util/exec/index.ts';
-import type { ExecOptions } from '../../../util/exec/types.ts';
-import {
-  deleteLocalFile,
-  ensureCacheDir,
-  getSiblingFileName,
-  readLocalFile,
-  writeLocalFile,
-} from '../../../util/fs/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { getUserPixiConfig } from './extract.ts';
-
-export const commandLock = 'pixi lock --no-progress --color=never --quiet';
+import { updatePixiLockfile } from './lockfile.ts';
 
 export async function updateArtifacts({
   packageFileName,
@@ -23,86 +10,16 @@ export async function updateArtifacts({
   config,
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
   logger.debug(`pixi.updateArtifacts(${packageFileName})`);
-  const { isLockFileMaintenance } = config;
-
-  if (!isNonEmptyArray(updatedDeps) && !isLockFileMaintenance) {
-    logger.debug('No updated pixi deps - returning null');
-    return null;
-  }
-
-  const lockFileName = getSiblingFileName(packageFileName, 'pixi.lock');
-  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
-  if (!existingLockFileContent) {
-    logger.debug(`No lock file found`);
-    return null;
-  }
-
-  // `pixi lock` can execute arbitrary code from conda package hooks, so it is
-  // gated behind `allowedUnsafeExecutions`.
-  // https://pixi.prefix.dev/latest/security/#4-treat-package-hooks-as-code-execution
-  if (!GlobalConfig.get('allowedUnsafeExecutions').includes('pixi')) {
-    logger.once.warn(
-      '`pixi lock` was requested to run, but `pixi` is not permitted in the allowedUnsafeExecutions',
-    );
-    return null;
-  }
-
-  logger.trace(`Updating ${lockFileName}`);
-
-  const cmd = [commandLock];
 
   const pixiConfig = getUserPixiConfig(newPackageFileContent, packageFileName);
-
   const constraint =
     config.constraints?.pixi ?? pixiConfig?.project['requires-pixi'];
 
-  try {
-    await writeLocalFile(packageFileName, newPackageFileContent);
-    if (isLockFileMaintenance) {
-      await deleteLocalFile(lockFileName);
-    }
-
-    // https://pixi.sh/latest/features/environment/#caching-packages
-    const PIXI_CACHE_DIR = await ensureCacheDir('pixi');
-    const extraEnv = {
-      PIXI_CACHE_DIR,
-      RATTLER_CACHE_DIR: PIXI_CACHE_DIR,
-    };
-
-    const execOptions: ExecOptions = {
-      cwdFile: packageFileName,
-      extraEnv,
-      docker: {},
-      toolConstraints: [{ toolName: 'pixi', constraint }],
-    };
-    await exec(cmd, execOptions);
-    const newPixiLockContent = await readLocalFile(lockFileName, 'utf8');
-    if (existingLockFileContent === newPixiLockContent) {
-      logger.debug(`${lockFileName} is unchanged`);
-      return null;
-    }
-    return [
-      {
-        file: {
-          type: 'addition',
-          path: lockFileName,
-          contents: newPixiLockContent,
-        },
-      },
-    ];
-  } catch (err) {
-    if (err.message === TEMPORARY_ERROR) {
-      throw err;
-    }
-
-    logger.debug({ err }, `Failed to update ${lockFileName} file`);
-    return [
-      {
-        artifactError: {
-          fileName: lockFileName,
-          stderr: `${err}`,
-        },
-      },
-    ];
-  }
+  return await updatePixiLockfile({
+    packageFileName,
+    updatedDeps,
+    isLockFileMaintenance: config.isLockFileMaintenance,
+    constraint,
+    newPackageFileContent,
+  });
 }

--- a/lib/modules/manager/pixi/lockfile.spec.ts
+++ b/lib/modules/manager/pixi/lockfile.spec.ts
@@ -1,0 +1,291 @@
+import upath from 'upath';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+import { envMock, mockExecAll } from '~test/exec-util.ts';
+import { env, fs } from '~test/util.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import type {
+  InternalGlobalConfigOptions,
+  RepoGlobalConfig,
+} from '../../../config/types.ts';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
+import * as docker from '../../../util/exec/docker/index.ts';
+import * as _datasource from '../../datasource/index.ts';
+import { updatePixiLockfile } from './lockfile.ts';
+
+vi.mock('../../../util/exec/env.ts');
+vi.mock('../../../util/fs/index.ts');
+vi.mock('../../datasource/index.ts', () => mockDeep());
+
+process.env.CONTAINERBASE = 'true';
+
+const datasource = vi.mocked(_datasource);
+
+const adminConfig: RepoGlobalConfig & InternalGlobalConfigOptions = {
+  localDir: upath.join('/tmp/github/some/repo'),
+  cacheDir: upath.join('/tmp/cache'),
+  containerbaseDir: upath.join('/tmp/cache/containerbase'),
+  dockerSidecarImage: 'ghcr.io/renovatebot/base-image',
+  binarySource: 'global',
+  allowedUnsafeExecutions: ['pixi'],
+};
+
+describe('modules/manager/pixi/lockfile', () => {
+  describe('updatePixiLockfile', () => {
+    beforeEach(() => {
+      env.getChildProcessEnv.mockReturnValue(envMock.basic);
+      GlobalConfig.set(adminConfig);
+      docker.resetPrefetchedImages();
+    });
+
+    it('returns null when there are no updated deps and no lockfile maintenance', async () => {
+      const execSnapshots = mockExecAll();
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+      });
+
+      expect(result).toBeNull();
+      expect(execSnapshots).toEqual([]);
+    });
+
+    it('returns null when no pixi.lock exists', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+      });
+
+      expect(result).toBeNull();
+      expect(execSnapshots).toEqual([]);
+    });
+
+    it('returns null when pixi is not in allowedUnsafeExecutions', async () => {
+      GlobalConfig.set({ ...adminConfig, allowedUnsafeExecutions: [] });
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+        newPackageFileContent: 'content',
+      });
+
+      expect(result).toBeNull();
+      expect(execSnapshots).toEqual([]);
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+    });
+
+    it('writes the package file before running pixi lock when newPackageFileContent is set', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
+      fs.ensureCacheDir.mockResolvedValueOnce(
+        '/tmp/renovate/cache/others/pixi',
+      );
+      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+        newPackageFileContent: 'new content',
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pixi.lock',
+            contents: 'New pixi.lock',
+          },
+        },
+      ]);
+      expect(fs.writeLocalFile).toHaveBeenCalledWith(
+        'pyproject.toml',
+        'new content',
+      );
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'pixi lock --no-progress --color=never --quiet',
+          options: {
+            cwd: '/tmp/github/some/repo',
+            env: { PIXI_CACHE_DIR: '/tmp/renovate/cache/others/pixi' },
+          },
+        },
+      ]);
+    });
+
+    it('does not write the package file when newPackageFileContent is omitted', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
+      fs.ensureCacheDir.mockResolvedValueOnce(
+        '/tmp/renovate/cache/others/pixi',
+      );
+      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pixi.lock',
+            contents: 'New pixi.lock',
+          },
+        },
+      ]);
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'pixi lock --no-progress --color=never --quiet' },
+      ]);
+    });
+
+    it('deletes the existing lock file during lockfile maintenance', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Old pixi.lock');
+      fs.ensureCacheDir.mockResolvedValueOnce(
+        '/tmp/renovate/cache/others/pixi',
+      );
+      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [],
+        isLockFileMaintenance: true,
+        constraint: undefined,
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pixi.lock',
+            contents: 'New pixi.lock',
+          },
+        },
+      ]);
+      expect(fs.deleteLocalFile).toHaveBeenCalledWith('pixi.lock');
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'pixi lock --no-progress --color=never --quiet' },
+      ]);
+    });
+
+    it('returns null when the lock file is unchanged', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+      fs.ensureCacheDir.mockResolvedValueOnce(
+        '/tmp/renovate/cache/others/pixi',
+      );
+      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+      });
+
+      expect(result).toBeNull();
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'pixi lock --no-progress --color=never --quiet' },
+      ]);
+    });
+
+    it('passes the pixi constraint to the tool installer', async () => {
+      GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('version: 5');
+      fs.readLocalFile.mockResolvedValueOnce('New pixi.lock');
+      datasource.getPkgReleases.mockResolvedValueOnce({
+        releases: [
+          { version: '0.38.0' },
+          { version: '0.40.1' },
+          { version: '0.41.4' },
+        ],
+      });
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pixi.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: '>=0.40,<0.41',
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pixi.lock',
+            contents: 'New pixi.lock',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        { cmd: 'install-tool pixi 0.40.1' },
+        { cmd: 'pixi lock --no-progress --color=never --quiet' },
+      ]);
+    });
+
+    it('throws TEMPORARY_ERROR', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+      fs.ensureCacheDir.mockRejectedValueOnce(new Error(TEMPORARY_ERROR));
+
+      await expect(
+        updatePixiLockfile({
+          packageFileName: 'pyproject.toml',
+          updatedDeps: [{ depName: 'dep1' }],
+          isLockFileMaintenance: false,
+          constraint: undefined,
+        }),
+      ).rejects.toThrow(TEMPORARY_ERROR);
+    });
+
+    it('returns an artifact error when pixi lock fails', async () => {
+      const execSnapshots = mockExecAll();
+      fs.getSiblingFileName.mockReturnValueOnce('pixi.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Current pixi.lock');
+      fs.ensureCacheDir.mockImplementationOnce(() => {
+        throw new Error('exec failed');
+      });
+
+      const result = await updatePixiLockfile({
+        packageFileName: 'pyproject.toml',
+        updatedDeps: [{ depName: 'dep1' }],
+        isLockFileMaintenance: false,
+        constraint: undefined,
+      });
+
+      expect(result).toEqual([
+        {
+          artifactError: {
+            fileName: 'pixi.lock',
+            stderr: 'Error: exec failed',
+          },
+        },
+      ]);
+      expect(execSnapshots).toEqual([]);
+    });
+  });
+});

--- a/lib/modules/manager/pixi/lockfile.ts
+++ b/lib/modules/manager/pixi/lockfile.ts
@@ -1,0 +1,117 @@
+import { isNonEmptyArray } from '@sindresorhus/is';
+import { GlobalConfig } from '../../../config/global.ts';
+import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
+import { logger } from '../../../logger/index.ts';
+import { exec } from '../../../util/exec/index.ts';
+import type { ExecOptions } from '../../../util/exec/types.ts';
+import {
+  deleteLocalFile,
+  ensureCacheDir,
+  getSiblingFileName,
+  readLocalFile,
+  writeLocalFile,
+} from '../../../util/fs/index.ts';
+import type { PackageDependency, UpdateArtifactsResult } from '../types.ts';
+
+export const commandLock = 'pixi lock --no-progress --color=never --quiet';
+
+export interface UpdatePixiLockfile {
+  packageFileName: string;
+  updatedDeps: PackageDependency[] | undefined;
+  isLockFileMaintenance: boolean | undefined;
+  /** `pixi` version constraint passed to the tool installer. */
+  constraint: string | undefined;
+  /**
+   * When set, the content is written to `packageFileName` before running
+   * `pixi lock`. Callers that have already written the package file to disk
+   * (e.g. the `pep621` manager) should leave this `undefined`.
+   */
+  newPackageFileContent?: string;
+}
+
+/**
+ * Regenerate the sibling `pixi.lock` of a package file by running `pixi lock`.
+ *
+ * Shared by the standalone `pixi` manager and the `pep621` pixi processor.
+ */
+export async function updatePixiLockfile({
+  packageFileName,
+  updatedDeps,
+  isLockFileMaintenance,
+  constraint,
+  newPackageFileContent,
+}: UpdatePixiLockfile): Promise<UpdateArtifactsResult[] | null> {
+  if (!isNonEmptyArray(updatedDeps) && !isLockFileMaintenance) {
+    logger.debug('No updated pixi deps - returning null');
+    return null;
+  }
+
+  const lockFileName = getSiblingFileName(packageFileName, 'pixi.lock');
+  const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
+  if (!existingLockFileContent) {
+    logger.debug('No pixi.lock found');
+    return null;
+  }
+
+  // `pixi lock` can execute arbitrary code from conda package hooks, so it is
+  // gated behind `allowedUnsafeExecutions`.
+  // https://pixi.prefix.dev/latest/security/#4-treat-package-hooks-as-code-execution
+  if (!GlobalConfig.get('allowedUnsafeExecutions').includes('pixi')) {
+    logger.once.warn(
+      '`pixi lock` was requested to run, but `pixi` is not permitted in the allowedUnsafeExecutions',
+    );
+    return null;
+  }
+
+  try {
+    if (newPackageFileContent !== undefined) {
+      await writeLocalFile(packageFileName, newPackageFileContent);
+    }
+    if (isLockFileMaintenance) {
+      await deleteLocalFile(lockFileName);
+    }
+
+    // https://pixi.sh/latest/features/environment/#caching-packages
+    const PIXI_CACHE_DIR = await ensureCacheDir('pixi');
+    const extraEnv = {
+      PIXI_CACHE_DIR,
+      RATTLER_CACHE_DIR: PIXI_CACHE_DIR,
+    };
+
+    const execOptions: ExecOptions = {
+      cwdFile: packageFileName,
+      extraEnv,
+      docker: {},
+      toolConstraints: [{ toolName: 'pixi', constraint }],
+    };
+    await exec([commandLock], execOptions);
+
+    const newPixiLockContent = await readLocalFile(lockFileName, 'utf8');
+    if (existingLockFileContent === newPixiLockContent) {
+      logger.debug(`${lockFileName} is unchanged`);
+      return null;
+    }
+    return [
+      {
+        file: {
+          type: 'addition',
+          path: lockFileName,
+          contents: newPixiLockContent,
+        },
+      },
+    ];
+  } catch (err) {
+    if (err.message === TEMPORARY_ERROR) {
+      throw err;
+    }
+    logger.debug({ err }, `Failed to update ${lockFileName} file`);
+    return [
+      {
+        artifactError: {
+          fileName: lockFileName,
+          stderr: `${err}`,
+        },
+      },
+    ];
+  }
+}


### PR DESCRIPTION
## Changes

Pure refactor, no behavior change. Extracts the duplicated `pixi.lock` update logic — shared by the standalone `pixi` manager (`lib/modules/manager/pixi/artifacts.ts`) and the `pep621` pixi processor (`lib/modules/manager/pep621/processors/pixi.ts`) — into a single shared helper `updatePixiLockfile` in `lib/modules/manager/pixi/lockfile.ts`.

Both call sites now only derive the `pixi` version constraint from their own config source and delegate to the helper. The helper owns `commandLock`, the updated-deps/lockfile existence checks, the `allowedUnsafeExecutions` (`pixi`) gate, and the `pixi lock` exec flow.

Behavior is preserved for both managers:

- The `allowedUnsafeExecutions` gate stays before the write/exec, so both managers still no-op the lockfile refresh (package file still updated) when `pixi` isn't allowed.
- The package file is written before running `pixi lock` only when the caller passes `newPackageFileContent` (the `pixi` manager). The `pep621` manager writes the package file itself and leaves it unset, matching its prior behavior.

Follow-up to #44004, which landed the `allowedUnsafeExecutions` gate and `pep621` `pixi.lock` support. This extraction was originally part of that PR but was reverted on maintainer request to keep it focused; this re-lands it as a standalone refactor.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Claude Code (model: Claude Opus 4.8) performed the extraction and delegation, then ran type-check, the existing `pixi` + `pep621` unit tests, and lint/format. The approach and every change were reviewed by me before opening.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests, or

The existing `pixi` and `pep621` pixi unit tests exercise the shared helper through both call sites and pass unchanged, giving 100% coverage of the three touched files. No new tests were needed since behavior is unchanged.
