### PR TITLE
ci: don't allow breaking changes in PR commit messages

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
   statuses: write
 
 jobs:
@@ -53,3 +54,39 @@ jobs:
             } else {
               core.info('✓ No commits with issue closing keywords found');
             }
+
+  # Fails when any commit in the PR would make semantic-release publish a new major version (a `!` breaking-change marker or a `BREAKING CHANGE:` note).
+  # Major releases are prepared deliberately (see docs/development/major-release.md), so when a major bump is intended, override/ignore this check manually
+  no-unexpected-major-release:
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: 24
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      # use the GitHub API to avoid needing a full repository checkout
+      - name: Collect PR commit messages
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const commits = await github.paginate(github.rest.pulls.listCommits, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const messages = commits.map((commit) => commit.commit.message);
+            require('node:fs').writeFileSync('pr-commits.json', JSON.stringify(messages));
+            core.info(`Collected ${messages.length} commit message(s)`);
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          os: ${{ runner.os }}
+
+      - name: Check for unexpected major release
+        run: node tools/check-major-release.ts pr-commits.json

--- a/package.json
+++ b/package.json
@@ -280,6 +280,7 @@
     "@hyrious/marshal": "0.3.3",
     "@ls-lint/ls-lint": "2.3.1",
     "@openpgp/web-stream-tools": "0.3.1",
+    "@semantic-release/commit-analyzer": "13.0.1",
     "@semantic-release/exec": "7.1.0",
     "@smithy/util-stream": "4.7.11",
     "@types/adm-zip": "0.5.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       '@openpgp/web-stream-tools':
         specifier: 0.3.1
         version: 0.3.1(@types/node@24.13.3)(typescript@7.0.2)
+      '@semantic-release/commit-analyzer':
+        specifier: 13.0.1
+        version: 13.0.1(semantic-release@25.0.8)(supports-color@7.2.0)
       '@semantic-release/exec':
         specifier: 7.1.0
         version: 7.1.0(semantic-release@25.0.8)(supports-color@7.2.0)

--- a/tools/check-major-release.spec.ts
+++ b/tools/check-major-release.spec.ts
@@ -1,0 +1,52 @@
+import { findMajorCommits, getReleaseType } from './check-major-release.ts';
+
+describe('tools/check-major-release', () => {
+  describe('getReleaseType', () => {
+    it('returns null when there is no release', async () => {
+      expect(await getReleaseType(['chore(deps): bump x', 'ci: tweak'])).toBe(
+        null,
+      );
+    });
+
+    it('returns patch for a fix', async () => {
+      expect(await getReleaseType(['fix: correct a bug'])).toBe('patch');
+    });
+
+    it('returns minor for a feature', async () => {
+      expect(await getReleaseType(['feat: add a thing'])).toBe('minor');
+    });
+
+    it.each`
+      message
+      ${'feat!: drop node 20 support'}
+      ${'feat(config)!: rename option'}
+      ${'fix: something\n\nBREAKING CHANGE: removes the old API'}
+      ${'refactor: cleanup\n\nBREAKING-CHANGE: hyphenated form'}
+    `('returns major for breaking commit: $message', async ({ message }) => {
+      expect(await getReleaseType([message as string])).toBe('major');
+    });
+
+    it('uses the highest release type across commits', async () => {
+      expect(
+        await getReleaseType(['fix: a', 'feat!: breaking', 'chore: nothing']),
+      ).toBe('major');
+    });
+  });
+
+  describe('findMajorCommits', () => {
+    it('lists only the commits that trigger a major', async () => {
+      const messages = [
+        'feat: normal',
+        'feat(config)!: rename option',
+        'fix: another',
+      ];
+      expect(await findMajorCommits(messages)).toEqual([
+        'feat(config)!: rename option',
+      ]);
+    });
+
+    it('returns an empty array when nothing is breaking', async () => {
+      expect(await findMajorCommits(['feat: a', 'fix: b'])).toEqual([]);
+    });
+  });
+});

--- a/tools/check-major-release.ts
+++ b/tools/check-major-release.ts
@@ -1,0 +1,124 @@
+// Co-authored-by: Claude Opus 4.8
+import { readFile } from 'node:fs/promises';
+import { argv, env, stdin } from 'node:process';
+import { pathToFileURL } from 'node:url';
+import { analyzeCommits } from '@semantic-release/commit-analyzer';
+import releaseRc from '../.releaserc.json' with { type: 'json' };
+
+export type ReleaseType = 'major' | 'minor' | 'patch' | null;
+
+// semantic-release merges the root-level `preset`/`presetConfig` and the
+// `analyzeCommits.releaseRules` from `.releaserc.json` into the plugin config it
+// hands to `@semantic-release/commit-analyzer` (see its `plugins/index.js` and
+// `plugins/normalize.js`). We reconstruct exactly that config here so our
+// verdict matches what a real release would decide.
+const pluginConfig = {
+  preset: releaseRc.preset,
+  presetConfig: releaseRc.presetConfig,
+  releaseRules: releaseRc.analyzeCommits?.releaseRules,
+};
+
+// commit-analyzer only calls `logger.log` for progress; silence it.
+const context = {
+  logger: { log: (): void => undefined },
+  cwd: process.cwd(),
+  env,
+};
+
+/**
+ * Determine the release type that the given commit messages would produce,
+ * using semantic-release's own commit-analyzer with this repo's config.
+ */
+export function getReleaseType(messages: string[]): Promise<ReleaseType> {
+  const commits = messages.map((message, index) => ({
+    message,
+    // synthetic but unique hashes, so revert-filtering behaves predictably
+    hash: index.toString(16).padStart(7, '0'),
+  }));
+  return analyzeCommits(pluginConfig, { ...context, commits });
+}
+
+/**
+ * Return the subset of commit messages that would, on their own, trigger a
+ * major release. Used only to produce a helpful report.
+ */
+export async function findMajorCommits(messages: string[]): Promise<string[]> {
+  const major: string[] = [];
+  for (const message of messages) {
+    if ((await getReleaseType([message])) === 'major') {
+      major.push(message);
+    }
+  }
+  return major;
+}
+
+function firstLine(message: string): string {
+  return message.split('\n')[0];
+}
+
+async function readInput(source: string | undefined): Promise<string> {
+  if (source && source !== '-') {
+    return readFile(source, 'utf8');
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of stdin) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function parseMessages(raw: string): string[] {
+  const parsed: unknown = JSON.parse(raw);
+  if (!Array.isArray(parsed) || parsed.some((m) => typeof m !== 'string')) {
+    throw new Error(
+      'Expected input to be a JSON array of commit-message strings',
+    );
+  }
+  return parsed as string[];
+}
+
+async function main(): Promise<void> {
+  const messages = parseMessages(await readInput(argv[2]));
+
+  if (messages.length === 0) {
+    console.log('No commit messages to analyze.');
+    return;
+  }
+
+  const releaseType = await getReleaseType(messages);
+  console.log(`Computed release type: ${releaseType ?? 'none'}`);
+
+  if (releaseType !== 'major') {
+    console.log('✓ No commit would trigger a new major version.');
+    return;
+  }
+
+  const offenders = await findMajorCommits(messages);
+  const title = 'Unexpected major release';
+  const hint =
+    'A commit uses a breaking-change marker (`!` in the header, or a ' +
+    '`BREAKING CHANGE:`/`BREAKING-CHANGE:` note), which makes semantic-release ' +
+    'publish a new major version. Remove the marker, or — if a major bump is ' +
+    'intended (e.g. preparing the next major) — override this check manually.';
+
+  if (env.CI) {
+    for (const message of offenders) {
+      console.log(`::error title=${title}::${firstLine(message)} — ${hint}`);
+    }
+    if (offenders.length === 0) {
+      console.log(`::error title=${title}::${hint}`);
+    }
+  } else {
+    console.error(`${title}: ${hint}`);
+    for (const message of offenders) {
+      console.error(`- ${firstLine(message)}`);
+    }
+  }
+
+  process.exitCode = 1;
+}
+
+// Only run when executed directly, so tests can import the helpers.
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  await main();
+}

--- a/tools/commit-analyzer.d.ts
+++ b/tools/commit-analyzer.d.ts
@@ -1,0 +1,13 @@
+// `@semantic-release/commit-analyzer` ships no type declarations, so we declare
+// the single function we use. The signature matches its `analyzeCommits` export.
+declare module '@semantic-release/commit-analyzer' {
+  export function analyzeCommits(
+    pluginConfig: unknown,
+    context: {
+      commits: { message: string; hash: string }[];
+      logger: { log: (...args: unknown[]) => void };
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+    },
+  ): Promise<'major' | 'minor' | 'patch' | null>;
+}


### PR DESCRIPTION




<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Renovate 44.0.0 was incorrectly released from #44004 due to the
`BREAKING ...` reference in the commit message.

Renovate uses Squash Merge as our method for merging commits into
`main`, and when enabled with the Merge Queue[0], this doesn't provide
maintainers with the ability to inspect the commit messages before
merging (which would be the case if not using the Merge Queue, we would
likely rewrite the commit message prior to merge.

With this in mind, Renovate maintainers often don't inspect the commit
messages, allowing them to stay as they are, as they'll be squashed into
the final commit.

In the case of #44004, this led to us missing the `BREAKING ...`
trailing message - from changes that were split into #44939 - and
because of this, semantic-release published this as a major release.

As a means to prevent this happening again, we can introduce a CI check
that validates - with the same underlying library as semantic-release -
whether a major release is being suggested, and if so, rejecting it.

Tested with: https://github.com/renovatebot/renovate/actions/runs/30451433399/job/90574167521?pr=44943#step:5:11

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
