### PR TITLE
ci: don't allow breaking changes in PR commit messages

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -11,6 +11,10 @@ permissions:
   contents: read
   statuses: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   closes-issue-or-discussion:
     runs-on: ubuntu-latest
@@ -53,3 +57,65 @@ jobs:
             } else {
               core.info('✓ No commits with issue closing keywords found');
             }
+
+  # Runs a full `semantic-release` dry-run for the state that would exist right
+  # after this PR merges, and fails if it would publish a new *major* version.
+  # Major releases are prepared deliberately (see docs/development/major-release.md),
+  # so when a major bump is intended, override this check manually.
+  dry-run-major:
+    runs-on: ubuntu-latest
+    env:
+      NODE_VERSION: 24
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
+          show-progress: false
+          # semantic-release needs the full history and all tags to find the
+          # previous release and the commits since it.
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          os: ${{ runner.os }}
+
+      - name: Full semantic-release dry-run
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # `tools/check-release-dry-run.ts` runs a full `semantic-release` dry-run
+          # via its programmatic API and inspects the returned `nextRelease.type`.
+          # A real release needs a writable remote and GitHub-authenticating plugins
+          # - neither is available for fork PRs - so the run is fully offline:
+          #   * a local bare mirror stands in for the remote (no network, no token);
+          #   * only the analysis plugins run (see the script); dropping the publish
+          #     plugins does not change the computed version;
+          #   * it is presented as a push to the base branch at the merge commit,
+          #     i.e. exactly the state that would exist right after this PR merges.
+
+          # Only main / next / maint/* ever publish a release.
+          case "$BASE_REF" in
+            main | next | maint/*) ;;
+            *)
+              echo "Base branch '$BASE_REF' is not a release branch; skipping."
+              exit 0
+              ;;
+          esac
+
+          # The checkout is a detached merge commit; semantic-release runs
+          # `git tag --merged <baseRef>`, so the base ref must exist locally.
+          git branch -f "$BASE_REF" "$HEAD_SHA"
+
+          mirror="$RUNNER_TEMP/release-mirror.git"
+          git clone --bare --quiet . "$mirror"
+          # Pin the mirror's base branch to the PR base so the checked-out merge
+          # commit is strictly ahead of it (semantic-release treats it as releasable).
+          git -C "$mirror" branch -f "$BASE_REF" "$BASE_SHA"
+
+          node tools/check-release-dry-run.ts "file://$mirror" "$BASE_REF" "$HEAD_SHA"

--- a/tools/check-release-dry-run.spec.ts
+++ b/tools/check-release-dry-run.spec.ts
@@ -1,0 +1,67 @@
+import {
+  type DryRunResultLike,
+  evaluateResult,
+} from './check-release-dry-run.ts';
+
+function result(
+  nextType: string | null,
+  version = '0.0.0',
+  lastVersion: string | null = '44.0.0',
+): DryRunResultLike | false {
+  return {
+    nextRelease: nextType ? { type: nextType, version } : null,
+    lastRelease: lastVersion ? { version: lastVersion } : null,
+  };
+}
+
+describe('tools/check-release-dry-run', () => {
+  describe('evaluateResult', () => {
+    it('flags a major release', () => {
+      expect(evaluateResult(result('major', '45.0.0'))).toEqual({
+        willRelease: true,
+        type: 'major',
+        version: '45.0.0',
+        lastVersion: '44.0.0',
+        isMajor: true,
+      });
+    });
+
+    it('flags a premajor release (next prerelease branch)', () => {
+      expect(evaluateResult(result('premajor', '45.0.0-next.1'))).toMatchObject(
+        {
+          isMajor: true,
+        },
+      );
+    });
+
+    it('does not flag a minor release', () => {
+      expect(evaluateResult(result('minor', '44.1.0'))).toMatchObject({
+        isMajor: false,
+        type: 'minor',
+      });
+    });
+
+    it('does not flag a patch release', () => {
+      expect(evaluateResult(result('patch', '44.0.1'))).toMatchObject({
+        isMajor: false,
+      });
+    });
+
+    it('handles no release (result is false)', () => {
+      expect(evaluateResult(false)).toEqual({
+        willRelease: false,
+        type: null,
+        version: null,
+        lastVersion: null,
+        isMajor: false,
+      });
+    });
+
+    it('handles no release (no nextRelease)', () => {
+      expect(evaluateResult(result(null))).toMatchObject({
+        willRelease: false,
+        isMajor: false,
+      });
+    });
+  });
+});

--- a/tools/check-release-dry-run.ts
+++ b/tools/check-release-dry-run.ts
@@ -1,0 +1,122 @@
+import { argv, env } from 'node:process';
+import { pathToFileURL } from 'node:url';
+import semanticRelease from 'semantic-release';
+
+// Release types that introduce a new major version. `premajor` is what the
+// `next` prerelease branch reports for the same breaking change.
+const MAJOR_TYPES = new Set(['major', 'premajor']);
+
+// Structural subset of semantic-release's `Result` that we care about. The real
+// result (`false | { lastRelease, nextRelease, ... }`) is assignable to this.
+export interface DryRunResultLike {
+  nextRelease?: { type: string; version: string } | null;
+  lastRelease?: { version: string } | null;
+}
+
+export interface Verdict {
+  willRelease: boolean;
+  type: string | null;
+  version: string | null;
+  lastVersion: string | null;
+  isMajor: boolean;
+}
+
+export function evaluateResult(result: DryRunResultLike | false): Verdict {
+  if (!result || !result.nextRelease) {
+    return {
+      willRelease: false,
+      type: null,
+      version: null,
+      lastVersion: null,
+      isMajor: false,
+    };
+  }
+  const { type, version } = result.nextRelease;
+  return {
+    willRelease: true,
+    type,
+    version,
+    lastVersion: result.lastRelease?.version ?? null,
+    isMajor: MAJOR_TYPES.has(type),
+  };
+}
+
+/**
+ * Run a full, offline semantic-release dry-run for the state that would exist
+ * right after a PR merges, and return its structured result.
+ *
+ * - `repositoryUrl` is a local bare mirror, so no network or token is needed
+ *   (works for fork PRs).
+ * - Only the analysis plugins run; the publish plugins are dropped, which does
+ *   not change the computed version.
+ * - The spoofed `GITHUB_*` env presents the run as a push to `baseRef`, so
+ *   `env-ci` does not treat it as a (non-releasing) pull request.
+ */
+function runDryRun(
+  repositoryUrl: string,
+  baseRef: string,
+  headSha: string,
+): Promise<DryRunResultLike | false> {
+  return semanticRelease(
+    {
+      dryRun: true,
+      repositoryUrl,
+      plugins: [
+        '@semantic-release/commit-analyzer',
+        '@semantic-release/release-notes-generator',
+      ],
+    },
+    {
+      env: {
+        ...env,
+        GITHUB_ACTIONS: 'true',
+        GITHUB_EVENT_NAME: 'push',
+        GITHUB_REF: `refs/heads/${baseRef}`,
+        GITHUB_SHA: headSha,
+      },
+    },
+  );
+}
+
+async function main(): Promise<void> {
+  const [repositoryUrl, baseRef, headSha] = argv.slice(2);
+  if (!repositoryUrl || !baseRef || !headSha) {
+    throw new Error(
+      'Usage: check-release-dry-run <repositoryUrl> <baseRef> <headSha>',
+    );
+  }
+
+  const { willRelease, type, version, lastVersion, isMajor } = evaluateResult(
+    await runDryRun(repositoryUrl, baseRef, headSha),
+  );
+
+  if (!willRelease) {
+    console.log('semantic-release would not publish a new version.');
+    return;
+  }
+
+  console.log(
+    `semantic-release would publish ${version} (${type}); previous release: ${lastVersion ?? 'none'}.`,
+  );
+
+  if (!isMajor) {
+    console.log('✓ Not a new major version.');
+    return;
+  }
+
+  const title = 'Unexpected major release';
+  const hint =
+    `Merging this PR would make semantic-release publish a new major version ` +
+    `(${lastVersion ?? '?'} → ${version}), because a commit carries a breaking-change ` +
+    'marker (`!` in the header, or a `BREAKING CHANGE:`/`BREAKING-CHANGE:` note). ' +
+    'Remove the marker, or — if a major bump is intended (e.g. preparing the next ' +
+    'major) — override this check manually.';
+
+  console.log(env.CI ? `::error title=${title}::${hint}` : `${title}: ${hint}`);
+  process.exitCode = 1;
+}
+
+// Only run when executed directly, so tests can import the helpers.
+if (argv[1] && import.meta.url === pathToFileURL(argv[1]).href) {
+  await main();
+}


### PR DESCRIPTION




<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Renovate 44.0.0 was incorrectly released from #44004 due to the
`BREAKING ...` reference in the commit message.

Renovate uses Squash Merge as our method for merging commits into
`main`, and when enabled with the Merge Queue[0], this doesn't provide
maintainers with the ability to inspect the commit messages before
merging (which would be the case if not using the Merge Queue, we would
likely rewrite the commit message prior to merge.

With this in mind, Renovate maintainers often don't inspect the commit
messages, allowing them to stay as they are, as they'll be squashed into
the final commit.

In the case of #44004, this led to us missing the `BREAKING ...`
trailing message - from changes that were split into #44939 - and
because of this, semantic-release published this as a major release.

As a means to prevent this happening again, we can introduce a CI check
that validates - with the same underlying library as semantic-release -
whether a major release is being suggested, and if so, rejecting it.

Tested with: https://github.com/renovatebot/renovate/actions/runs/30455613636/job/90588296364#step:4:136

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
