### PR TITLE
fix(manager/quadlet): make Image optional for volume

### DIFF
--- a/lib/modules/manager/quadlet/extract.spec.ts
+++ b/lib/modules/manager/quadlet/extract.spec.ts
@@ -80,6 +80,37 @@ describe('modules/manager/quadlet/extract', () => {
       });
     });
 
+    it('handles a volume unit without an image', () => {
+      const volume = codeBlock`
+      [Volume]
+      Driver=local
+      `;
+
+      const result = extractPackageFile(volume, packageFile, config);
+      expect(result).toBeNull();
+    });
+
+    it('extracts from a container unit alongside an imageless volume unit', () => {
+      const combined = codeBlock`
+      [Container]
+      Image=docker.io/library/alpine:3.22
+
+      [Volume]
+      Driver=local
+      `;
+
+      const result = extractPackageFile(combined, packageFile, config);
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '3.22',
+            depName: 'docker.io/library/alpine',
+            datasource: DockerDatasource.id,
+          },
+        ],
+      });
+    });
+
     it('handles docker prefix', () => {
       const simple = codeBlock`
       [Volume]

--- a/lib/modules/manager/quadlet/schema.ts
+++ b/lib/modules/manager/quadlet/schema.ts
@@ -15,7 +15,7 @@ export const QuadletFile = Ini.pipe(
       .optional(),
     Volume: z
       .object({
-        Image: z.string(),
+        Image: z.string().optional(),
       })
       .optional(),
   }),


### PR DESCRIPTION
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When using .volume quadlet files, you may have a `[Volume]` section without an `Image=` entry. Currently, Renovate does not support this behavior.  

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: [git.0x2a.pm/clesecq/gitops](https://git.0x2a.pm/clesecq/gitops)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
