### PR TITLE
fix(workers/repository): apply `minimumReleaseAge` to `digest` updates

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -139,7 +139,7 @@ Depending on your manager, datasource and the given package(s), it may be that s
 | `minor`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                        |
 | `patch`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                        |
 | `pin`                 | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/40288)                                 |
-| `digest`              | 🟡                            | Generally not supported. Depends on the Manager, Datasource, and package(s)                               |
+| `digest`              | 🟡                            | Depends on the Manager, Datasource, and package(s). [See below for more info](#digest-updates).           |
 | `pinDigest`           | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/44820)                                 |
 | `lockFileMaintenance` | ❌                            | Not possible, as we delegate to the package manager to perform the required changes to update package(s). |
 | `lockfileUpdate`      | ❌                            |                                                                                                           |
@@ -148,6 +148,35 @@ Depending on your manager, datasource and the given package(s), it may be that s
 | `replacement`         | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/39400)                                 |
 
 You can validate which update types may have release timestamps by following something similar to how [verify if the registry you're using](#which-registries-support-release-timestamps).
+
+#### `digest` updates
+
+A `digest` update repoints an existing digest - usually a `sha256:...` Docker image digest, or the commit a floating tag like `v7` points to - at whatever the current version resolves to now.
+
+For instance:
+
+```diff
+   steps:
+-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
++    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+```
+
+In this case, the version `v7` is not updated, but the digest is.
+When Renovate resolves this update, it looks for the _newest_ version matching the current value (which would be the `v7.0.1` version in this case), and then ages the update against the release timestamp for this new version.
+
+!!! warning
+  Most registries do not expose when a digest itself was published, so to determine the Minimum Release Age cutoff, we age against the release timestamp of the matched _version_.
+  The strength of the guarantee depends on what that timestamp means for your datasource.
+
+What this means in practice:
+
+- On Docker Hub, the release timestamp is the tag's `tag_last_pushed` field, so re-pushing an existing tag restarts the delay and the digest update is held.
+- Registries which do not return release timestamps (such as GHCR, Quay or ECR) cannot be aged, and the same applies to unversioned tags like `latest`, where no matching version exists to age against.
+  With the default `minimumReleaseAgeBehaviour=timestamp-required`, these digest updates are held indefinitely - configure `minimumReleaseAgeBehaviour=timestamp-optional` to raise them without an age check instead.
+- Datasources whose timestamps reflect when the matched version was first released (such as `github-tags` for digest-pinned GitHub Actions) cannot detect re-published content.
+  If an existing tag is force-pushed to new commits, the digest update ages against the original release date, so it may pass Minimum Release Age immediately.
+  - Note that this is not true when using `github-releases`, which has metadata to indicate when the GitHub Release was created and published, whereas `github-tags` uses the `committedDate`, which is separate from when it was pushed.
+    GitHub no longer provides that metadata in their API.
 
 ### What happens to security updates?
 

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -95,6 +95,9 @@ export async function checkMinimumConfidence(
   };
 }
 
+/*
+ * NOTE that this should be kept in sync with `applyMinimumReleaseAgeToDigestUpdate`()
+ */
 export async function filterInternalChecks(
   config: Partial<LookupUpdateConfig & UpdateResult>,
   versioningApi: VersioningApi,

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -1,7 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
-import { partial } from '~test/util.ts';
+import { fakeSha, logger, partial } from '~test/util.ts';
 import * as hostRules from '../../../../../lib/util/host-rules.ts';
 import { getConfig } from '../../../../config/defaults.ts';
 import { supportedDatasources as presetSupportedDatasources } from '../../../../config/presets/internal/merge-confidence.preset.ts';
@@ -4428,6 +4428,529 @@ describe('workers/repository/process/lookup/index', () => {
       });
     });
 
+    it('marks a too-new GitHub Actions major-tag digest update as pending when using `internalChecksFilter=strict`', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    // when using `rangeStrategy=bump`, this makes `currentVersion` resolve to the oldest matching release (v7.0.0)
+    // however, when we're performing a digest update, we want to repoint to the newest version available, so have to ignore what `rangeStrategy` is telling us
+    it('ages a digest update against the newest matching version, not whatever `rangeStrategy` resolves `currentVersion` to', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.rangeStrategy = 'bump';
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          {
+            version: 'v7.0.0',
+            releaseTimestamp: lastWeek.toISOString() as Timestamp,
+          },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    // `rangeStrategy=update-lockfile` forces `currentVersion` to `lockedVersion` unconditionally, even though no release actually satisfies the range - so there's no "newest matching version" to age the digest update against.
+    // With no timestamp available, the safe default (with `minimumReleaseAgeBehaviour=timestamp-required`) is to treat it as pending
+    it('marks digest updates as pendingChecks when no release satisfies the current range with `rangeStrategy=update-lockfile`', async () => {
+      config.currentValue = '^2.0.0';
+      config.lockedVersion = '1.0.0';
+      config.rangeStrategy = 'update-lockfile';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = npmVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: '1.0.0' }],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: '^2.0.0',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    it('respects a minimumReleaseAge packageRule scoped to matchUpdateTypes=digest', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.internalChecksFilter = 'strict';
+      config.packageRules = [
+        { matchUpdateTypes: ['digest'], minimumReleaseAge: '3 days' },
+      ];
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    it('respects a `digest.minimumReleaseAge` config for digest updates', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.internalChecksFilter = 'strict';
+      config.digest = { minimumReleaseAge: '3 days' };
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    // Deprecated releases are only dispreferred, not unusable - a digest update repointing to one must still be aged against its timestamp, not held forever for lack of one
+    it('ages digest updates against a deprecated newest matching version when no non-deprecated version matches', async () => {
+      config.currentValue = '^1.0.0';
+      config.currentDigest = fakeSha('current');
+      config.rangeStrategy = 'replace';
+      config.packageName = 'actions/checkout';
+      config.versioning = npmVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          {
+            version: '1.0.0',
+            isDeprecated: true,
+            releaseTimestamp: lastWeek.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: '^1.0.0',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+    });
+
+    // `followTag` narrows the candidate versions, so the digest update must be aged against the followed tag's version, not the newest release overall
+    it('ages digest updates against the followed tag version when `followTag` is configured', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.followTag = 'stable';
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        tags: { stable: 'v7.0.0' },
+        releases: [
+          {
+            version: 'v7.0.0',
+            releaseTimestamp: lastWeek.toISOString() as Timestamp,
+          },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+    });
+
+    // The digest didn't change, so no update is proposed - no age check should run, and no timestamp-optional warn should fire
+    it('does not warn about missing releaseTimestamps when the digest is unchanged', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.minimumReleaseAgeBehaviour = 'timestamp-optional';
+      config.internalChecksFilter = 'strict';
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v7.0.0' }, { version: 'v7.0.1' }],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('current'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toBeEmptyArray();
+      expect(logger.logger.once.warn).not.toHaveBeenCalled();
+    });
+
+    // `currentValue` is a range, so unlike `matchUpdateTypes`, which is read from the incoming `config`, matching against `matchCurrentVersion` needs the resolved `currentVersion`
+    it('respects a minimumReleaseAge packageRule scoped to matchCurrentVersion for digest updates', async () => {
+      config.currentValue = '^1.0.0';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'some/image';
+      config.datasource = DockerDatasource.id;
+      config.internalChecksFilter = 'strict';
+      config.packageRules = [
+        { matchCurrentVersion: '<2.0.0', minimumReleaseAge: '3 days' },
+      ];
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          { version: '1.0.0' },
+          {
+            version: '1.1.0',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      getDockerDigest.mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: '^1.0.0',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    it('does not mark github actions major-tag digest updates as `pendingChecks` once `minimumReleaseAge` has elapsed', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: lastWeek.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+    });
+
+    it('marks github actions major-tag digest updates as `pendingChecks` when no releaseTimestamp is available (when `minimumReleaseAgeBehaviour=timestamp-required`)', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.minimumReleaseAgeBehaviour = 'timestamp-required';
+      config.internalChecksFilter = 'strict';
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v7.0.0' }, { version: 'v7.0.1' }],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    it('does not mark github actions major-tag digest updates as `pendingChecks` when no `releaseTimestamp` is available (when `minimumReleaseAgeBehaviour=timestamp-optional`)', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.minimumReleaseAgeBehaviour = 'timestamp-optional';
+      config.internalChecksFilter = 'strict';
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v7.0.0' }, { version: 'v7.0.1' }],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+      // A digest update passing un-aged is exactly the event a timestamp-optional
+      // user needs surfaced, so it must warn - just like the version-update path in
+      // filterInternalChecks().
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        "Some release(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information",
+      );
+    });
+
+    it('does not run minimumReleaseAge checks for digest updates under `internalChecksFilter=none`', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.minimumReleaseAgeBehaviour = 'timestamp-required';
+      config.internalChecksFilter = 'none';
+      // No releaseTimestamp: under `strict`/`timestamp-required` this would be held
+      // as pending, but `none` opts out of internal checks entirely.
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v7.0.0' }, { version: 'v7.0.1' }],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+      // Short-circuited like filterInternalChecks(): no age check ran, so no
+      // "no releaseTimestamp to age against" log noise.
+      expect(logger.logger.once.debug).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('has no releaseTimestamp to age against'),
+      );
+    });
+
+    // The `pendingChecks` short-circuit is gated on `internalChecksFilter=strict`: under `flexible` the update proceeds, without setting a pending status
+    it('does not mark digest updates as `pendingChecks` under `internalChecksFilter=flexible`, even when `minimumReleaseAge` has not elapsed', async () => {
+      config.currentValue = 'v7';
+      config.currentDigest = fakeSha('current');
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'flexible';
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+    });
+
     it('handles no fitting version and no version in lock file', async () => {
       config.currentValue = '~9.5.0';
       config.packageName = 'typo3/cms-saltedpasswords';
@@ -4637,6 +5160,120 @@ describe('workers/repository/process/lookup/index', () => {
         versioning: 'npm',
         warnings: [],
       });
+    });
+
+    // An unversioned tag like `alpine` has no versioned release to age against. As we're repointing to newer content we apply `minimumReleaseAge`, but as there's no timestamp, this needs to be held
+    it('marks digest updates for unversioned `currentValue`s as `pendingChecks` under `timestamp-required`', async () => {
+      config.currentValue = 'alpine';
+      config.packageName = 'node';
+      config.datasource = DockerDatasource.id;
+      config.currentDigest = 'sha256:zzzzzzzzzzzzzzz';
+      config.pinDigests = true;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: 'alpine',
+          },
+          {
+            version: '8.0.0',
+          },
+          {
+            version: '8.1.0',
+          },
+        ],
+      });
+      getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          newDigest: 'sha256:abcdef1234567890',
+          newValue: 'alpine',
+          updateType: 'digest',
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    it('lets digest updates for unversioned `currentValue`s through under `timestamp-optional`', async () => {
+      config.currentValue = 'alpine';
+      config.packageName = 'node';
+      config.datasource = DockerDatasource.id;
+      config.currentDigest = 'sha256:zzzzzzzzzzzzzzz';
+      config.pinDigests = true;
+      config.minimumReleaseAge = '3 days';
+      config.minimumReleaseAgeBehaviour = 'timestamp-optional';
+      config.internalChecksFilter = 'strict';
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: 'alpine',
+          },
+          {
+            version: '8.0.0',
+          },
+          {
+            version: '8.1.0',
+          },
+        ],
+      });
+      getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          newDigest: 'sha256:abcdef1234567890',
+          newValue: 'alpine',
+          updateType: 'digest',
+        },
+      ]);
+    });
+
+    // when `config.lockVersion` is set, `res.currentVersion` is implied even for unversioned values (like `alpine`), which means we can't compute a timestamp
+    it('marks digest updates for unversioned currentValues as pendingChecks when lockedVersion is set', async () => {
+      config.currentValue = 'alpine';
+      config.lockedVersion = '8.1.0';
+      config.packageName = 'node';
+      config.datasource = DockerDatasource.id;
+      config.currentDigest = 'sha256:zzzzzzzzzzzzzzz';
+      config.pinDigests = true;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: 'alpine',
+          },
+          {
+            version: '8.0.0',
+          },
+          {
+            version: '8.1.0',
+          },
+        ],
+      });
+      getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          newDigest: 'sha256:abcdef1234567890',
+          newValue: 'alpine',
+          updateType: 'digest',
+          pendingChecks: true,
+        },
+      ]);
     });
 
     it('handles git submodule update', async () => {
@@ -5674,6 +6311,62 @@ describe('workers/repository/process/lookup/index', () => {
           releaseTimestamp: '2024-05-09T18:34:42.000Z' as Timestamp,
           updateType: 'digest',
           hasAttestation: undefined,
+        },
+      ]);
+    });
+
+    // gomod pseudo-version updates are relabelled to `updateType=digest` after filterInternalChecks()
+    // has already age-checked them under the version-derived updateType, so digest-scoped rules must be re-applied
+    it('applies digest-scoped minimumReleaseAge packageRules to gomod pseudo-version updates', async () => {
+      config.manager = 'gomod';
+      config.datasource = GoDatasource.id;
+      config.currentValue = 'v0.0.0-20240506185236-b8a5c65736ae';
+      config.currentDigest = 'b8a5c65736ae';
+      config.packageName = 'google.golang.org/genproto/googleapis/rpc';
+      config.digestOneAndOnly = true;
+      config.internalChecksFilter = 'strict';
+      config.packageRules = [
+        { matchUpdateTypes: ['digest'], minimumReleaseAge: '3 days' },
+      ];
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      yesterday.setMilliseconds(0);
+      const pseudoTimestamp = yesterday
+        .toISOString()
+        .replace(/[-:T]/g, '')
+        .slice(0, 14);
+      const newVersion = `v0.0.0-${pseudoTimestamp}-62759503f434`;
+
+      httpMock
+        .scope(
+          'https://proxy.golang.org/google.golang.org/genproto/googleapis/rpc',
+        )
+        .get('/@v/list')
+        .reply(200, '')
+        .get('/v2/@v/list')
+        .reply(404)
+        .get('/@latest')
+        .reply(200, { Version: newVersion });
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          bucket: 'non-major',
+          isBreaking: true,
+          newDigest: '62759503f434',
+          newMajor: 0,
+          newMinor: 0,
+          newPatch: 0,
+          newValue: newVersion,
+          newVersion,
+          newVersionAgeInDays: expect.any(Number),
+          releaseTimestamp: yesterday.toISOString() as Timestamp,
+          updateType: 'digest',
+          hasAttestation: undefined,
+          pendingChecks: true,
         },
       ]);
     });

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -21,11 +21,13 @@ import {
 } from '../../../../modules/datasource/index.ts';
 import { postprocessRelease } from '../../../../modules/datasource/postprocess-release.ts';
 import { getRangeStrategy } from '../../../../modules/manager/index.ts';
+import type { LookupUpdate } from '../../../../modules/manager/types.ts';
 import { id as dockerVersioningId } from '../../../../modules/versioning/docker/index.ts';
 import * as allVersioning from '../../../../modules/versioning/index.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
 import { assignKeys } from '../../../../util/assign-keys.ts';
 import { getElapsedDays } from '../../../../util/date.ts';
+import { checkMinimumReleaseAge } from '../../../../util/minimum-release-age.ts';
 import { applyPackageRules } from '../../../../util/package-rules/index.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
@@ -68,6 +70,100 @@ async function getTimestamp(
   return remoteRelease?.releaseTimestamp;
 }
 
+/** The only `updateType` that `applyMinimumReleaseAgeToDigestUpdate()` can be called with */
+type DigestLikeUpdate = LookupUpdate & { updateType: 'digest' };
+
+/**
+ * A helper function to allow a short-circuit for `minimumReleaseAge` functionality if a package may have config that applies it.
+ *
+ * Allows avoiding unnecessary calls to more expensive checks like merge + `applyPackageRules()` and `getTimestamp()`.
+ */
+function couldApplyMinimumReleaseAgeToDigest(
+  config: LookupUpdateConfig,
+): boolean {
+  // Match filterInternalChecks(): under `none` the user opted out of internal
+  // checks entirely, so do no merging, no package rules, no age check and no
+  // logging claiming an age check ran.
+  if (config.internalChecksFilter === 'none') {
+    return false;
+  }
+
+  return (
+    isNonEmptyString(config.minimumReleaseAge) ||
+    isNonEmptyString(config.digest?.minimumReleaseAge) ||
+    !!config.packageRules?.some((rule) =>
+      isNonEmptyString(rule.minimumReleaseAge),
+    )
+  );
+}
+
+/**
+ * Ensure `minimumReleaseAge`/`internalChecksFilter` applies to digest updates, as they don't currently get run through `filterInternalChecks()`.
+ *
+ * NOTE that this should be kept in sync with `filterInternalChecks`()
+ */
+async function applyMinimumReleaseAgeToDigestUpdate(
+  update: DigestLikeUpdate,
+  config: LookupUpdateConfig,
+  res: UpdateResult,
+  newestMatchingVersionTimestamp: Timestamp | null | undefined,
+): Promise<void> {
+  if (!couldApplyMinimumReleaseAgeToDigest(config)) {
+    return;
+  }
+
+  let releaseConfig: LookupUpdateConfig = {
+    ...mergeChildConfig(config, res),
+    updateType: update.updateType,
+  };
+  releaseConfig = mergeChildConfig(
+    releaseConfig,
+    releaseConfig[update.updateType]!,
+  );
+  releaseConfig = await applyPackageRules(releaseConfig, 'update-type');
+
+  const ageCheck = checkMinimumReleaseAge(
+    releaseConfig,
+    // intentionally used instead of `update.releaseTimestamp`
+    newestMatchingVersionTimestamp,
+  );
+
+  // Mirror filterInternalChecks()'s logging so a held/passed digest update is diagnosable.
+  if (ageCheck.minimumReleaseAgeMs && !ageCheck.hasTimestamp) {
+    if (releaseConfig.minimumReleaseAgeBehaviour === 'timestamp-optional') {
+      logger.once.warn(
+        "Some release(s) did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding. See debug logs for more information",
+      );
+    }
+
+    logger.once.debug(
+      {
+        depName: config.depName,
+        updateType: update.updateType,
+        minimumReleaseAgeBehaviour: releaseConfig.minimumReleaseAgeBehaviour,
+        check: 'minimumReleaseAge',
+      },
+      `${update.updateType} update of ${config.depName} has no releaseTimestamp to age against`,
+    );
+  }
+  if (ageCheck.isPending) {
+    logger.trace(
+      {
+        depName: config.depName,
+        updateType: update.updateType,
+        releaseTimestamp: newestMatchingVersionTimestamp,
+        check: 'minimumReleaseAge',
+      },
+      `${update.updateType} update is pending minimumReleaseAge status checks`,
+    );
+
+    // internalChecksFilter is read from the unmerged top-level config, like filterInternalChecks().
+    if (config.internalChecksFilter === 'strict') {
+      update.pendingChecks = true;
+    }
+  }
+}
+
 export async function lookupUpdates(
   inconfig: LookupUpdateConfig,
 ): Promise<Result<UpdateResult>> {
@@ -82,6 +178,10 @@ export async function lookupUpdates(
     updates: [],
     warnings: [],
   };
+  // Timestamp of the release a `digest` update repoints to (the newest version matching the current value), as opposed to `res.currentVersionTimestamp` which tracks whatever the configured rangeStrategy resolves `currentVersion` to (e.g. the oldest for `bump`)
+  let newestMatchingVersionTimestamp: Timestamp | null | undefined;
+  // The `digest` update for `config.currentDigest` (if one is added), so its age check can run after `newDigest` is fetched and no-op updates are stripped.
+  let digestUpdate: DigestLikeUpdate | undefined;
 
   try {
     logger.trace(
@@ -374,6 +474,35 @@ export async function lookupUpdates(
         }
       }
 
+      if (config.currentDigest && couldApplyMinimumReleaseAgeToDigest(config)) {
+        // Resolve from `allVersions` (not `dependency.releases`) so that filters like followTag apply, preferring non-deprecated versions with a fallback - both like the `currentVersion` resolution above.
+        const newestMatchingVersion =
+          getCurrentVersion(
+            compareValue!,
+            '',
+            versioningApi,
+            'replace',
+            latestVersion!,
+            allVersions.filter((v) => !v.isDeprecated).map((v) => v.version),
+          ) ??
+          getCurrentVersion(
+            compareValue!,
+            '',
+            versioningApi,
+            'replace',
+            latestVersion!,
+            allVersions.map((v) => v.version),
+          );
+        if (newestMatchingVersion) {
+          newestMatchingVersionTimestamp = await getTimestamp(
+            config,
+            allVersions,
+            newestMatchingVersion,
+            versioningApi,
+          );
+        }
+      }
+
       if (
         compareValue &&
         currentVersion &&
@@ -531,6 +660,14 @@ export async function lookupUpdates(
           config.currentDigest !== update.newDigest
         ) {
           update.updateType = 'digest';
+
+          // As this has already been processed by `filterInternalChecks()`, but we're changing the `updateType`, we need to apply the digest-scoped minimumReleaseAge rules
+          await applyMinimumReleaseAgeToDigestUpdate(
+            update as DigestLikeUpdate,
+            config,
+            res,
+            release.releaseTimestamp,
+          );
         }
 
         if (pendingChecks) {
@@ -646,11 +783,12 @@ export async function lookupUpdates(
     if (supportsDigests(config.datasource)) {
       if (config.currentDigest) {
         if (!config.digestOneAndOnly || !res.updates.length) {
-          // digest update
-          res.updates.push({
+          // digest update - age-checked after the strip below, once newDigest is known
+          digestUpdate = {
             updateType: 'digest',
             newValue: config.currentValue,
-          });
+          };
+          res.updates.push(digestUpdate);
         }
       } else if (
         config.pinDigests &&
@@ -785,6 +923,16 @@ export async function lookupUpdates(
       res.updates = res.updates.filter(
         (update) =>
           update.updateType !== 'rollback' || res.updates.length === 1,
+      );
+    }
+
+    // If there is a digest update proposed which is in the pending updates for this dependency, ensure that `minimumReleaseAge` is applied
+    if (digestUpdate && res.updates.includes(digestUpdate)) {
+      await applyMinimumReleaseAgeToDigestUpdate(
+        digestUpdate,
+        config,
+        res,
+        newestMatchingVersionTimestamp,
       );
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

In some cases, we hadn't correctly wired in the `minimumReleaseAge`
checks for `digest`, due to the `currentValue` not changing.

To handle this, we need to:

- use our helper methods for calculating whether the `minimumReleaseAge`
  has passed
- handle a new digest's new `releaseTimestamp`
  the current timestamp
- intentionally not gate `minimumConfidence`, as this is only computed
  per-release, not at the digest level
- note the fixed behaviour, and clarify when it will/will not work
- add coverage for all generated updates for `digest`s, including when
  remapping a Go Modules update as a `digest`
- clarify that `filterInternalChecks` and
  `applyMinimumReleaseAgeToDigestUpdate` should stay in sync

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Fable 5, Claude Opus 4.8, Claude Sonnet 5

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
