### PR TITLE
fix(workers/repository): apply `minimumReleaseAge` to `pinDigest` updates

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -140,7 +140,7 @@ Depending on your manager, datasource and the given package(s), it may be that s
 | `patch`               | ✅                            | Depends on the Manager, Datasource, and package(s)                                                        |
 | `pin`                 | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/40288)                                 |
 | `digest`              | 🟡                            | Depends on the Manager, Datasource, and package(s). [See below for more info](#digest-updates).           |
-| `pinDigest`           | ❌                            | [Not yet supported](https://github.com/renovatebot/renovate/issues/44820)                                 |
+| `pinDigest`           | 🟡                            | Depends on the Manager, Datasource, and package(s). [See below for more info](#pindigest-updates).        |
 | `lockFileMaintenance` | ❌                            | Not possible, as we delegate to the package manager to perform the required changes to update package(s). |
 | `lockfileUpdate`      | ❌                            |                                                                                                           |
 | `rollback`            | ❌                            |                                                                                                           |
@@ -177,6 +177,58 @@ What this means in practice:
   If an existing tag is force-pushed to new commits, the digest update ages against the original release date, so it may pass Minimum Release Age immediately.
   - Note that this is not true when using `github-releases`, which has metadata to indicate when the GitHub Release was created and published, whereas `github-tags` uses the `committedDate`, which is separate from when it was pushed.
     GitHub no longer provides that metadata in their API.
+
+#### `pinDigest` updates
+
+A `pinDigest` update (enabled via [`pinDigests`](../configuration-options.md#pindigests)) pins an existing versioned tag to its currently resolved digest, without changing the tag itself.
+
+For instance:
+
+```diff
+-    - uses: actions/checkout@v7
++    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+```
+
+Unlike a `digest` update, `pinDigest` doesn't repoint the reference to a different value - it freezes whatever the current value already resolves to.
+The reference itself (e.g. the `v7` major tag above) is floating though, so what it resolves to right now may not be what `currentVersion` would resolve to under your configured `rangeStrategy` (for example, `rangeStrategy=bump` resolves `currentVersion` to the _oldest_ matching release).
+So, like `digest`, a `pinDigest` update is aged against the release timestamp of the newest version matching the current value, not whatever `currentVersion` resolves to.
+
+Unlike `digest` updates, an _unversioned_ current value (such as `latest`) is exempt from `minimumReleaseAge` entirely, rather than being held indefinitely: pinning a reference which already floats to the latest content is strictly safer than leaving it unpinned, so holding it back would only prolong the less-safe, unpinned state.
+
+If the current value _does_ resolve to a version, but that version's datasource doesn't expose a release timestamp (for example GHCR, Quay or ECR), the same caveats as [`digest` updates](#digest-updates) apply: the update is held indefinitely under the default `minimumReleaseAgeBehaviour=timestamp-required`, and needs `minimumReleaseAgeBehaviour=timestamp-optional` configured to raise it without an age check.
+
+##### Avoiding `pinDigest` updates not being raised due to frequently-releasing packages
+
+Because a `pinDigest` update ages against the newest matching version, a reference that releases faster than your configured `minimumReleaseAge` may never clear the check - leaving it perpetually unpinned, which is _less_ safe than pinning to a slightly-stale release.
+
+In particular, because Renovate raises a `pinDigest` PR across all applicable dependencies (by grouping them together), this can lead to the whole `pinDigest` update group being delayed.
+
+Renovate does not fall back to pinning an older, already-aged release instead: doing so would mean the pin no longer reflects what the reference currently, genuinely points to, which is the property `pinDigest` exists to preserve.
+
+If you want Renovate to raise `pinDigest` updates sooner than your regular version/digest updates, scope a shorter (or disabled) `minimumReleaseAge` to it specifically, using [`packageRules`](../configuration-options.md#packagerules) and [`matchUpdateTypes`](../configuration-options.md#packagerulesmatchupdatetypes):
+
+```json
+{
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pinDigest"],
+      "minimumReleaseAge": null
+    }
+  ]
+}
+```
+
+This decouples "how fresh must a release be before I trust it enough to upgrade to it" (your regular `minimumReleaseAge`) from "how long to wait before freezing whatever's already there" (the `pinDigest`-scoped override) - the same idea as using `digest.minimumReleaseAge`:
+
+```json
+{
+  "digest": {
+    "minimumReleaseAge": null
+  }
+}
+```
+
+These are functionally identical options.
 
 ### What happens to security updates?
 

--- a/lib/workers/repository/process/lookup/filter-checks.spec.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.spec.ts
@@ -352,7 +352,7 @@ describe('workers/repository/process/lookup/filter-checks', () => {
       minor: true,
       patch: true,
       digest: true,
-      pinDigest: false,
+      pinDigest: true,
       pin: false,
       replacement: false,
       lockFileMaintenance: false,

--- a/lib/workers/repository/process/lookup/filter-checks.ts
+++ b/lib/workers/repository/process/lookup/filter-checks.ts
@@ -33,8 +33,6 @@ export function isMinimumReleaseAgeApplicable(
     updateType !== 'rollback' &&
     // Not yet supported: TODO #40288
     updateType !== 'pin' &&
-    // Not yet supported: TODO #44820
-    updateType !== 'pinDigest' &&
     // Not yet supported: TODO #39400
     updateType !== 'replacement' &&
     // Not possible, as we delegate to the package manager to perform the required changes to update package(s).

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4951,6 +4951,168 @@ describe('workers/repository/process/lookup/index', () => {
       ]);
     });
 
+    it('marks github actions major-tag `pinDigest` updates as `pendingChecks` under `internalChecksFilter=strict`', async () => {
+      config.currentValue = 'v7';
+      config.pinDigests = true;
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          isPinDigest: true,
+          updateType: 'pinDigest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    it('does not mark github actions major-tag `pinDigest` updates as `pendingChecks` once `minimumReleaseAge` has elapsed', async () => {
+      config.currentValue = 'v7';
+      config.pinDigests = true;
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v7.0.0' },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: lastWeek.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          isPinDigest: true,
+          updateType: 'pinDigest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+    });
+
+    // `rangeStrategy=bump` makes `currentVersion` (and thus `res.currentVersionTimestamp`) resolve to the oldest
+    // matching release (v7.0.0, which already clears `minimumReleaseAge`), but the ref itself has moved on to
+    // v7.0.1 - which is what actually gets pinned, and hasn't yet cleared `minimumReleaseAge`.
+    it('ages a `pinDigest` update against the newest matching version, not whatever `rangeStrategy` resolves `currentVersion` to', async () => {
+      config.currentValue = 'v7';
+      config.pinDigests = true;
+      config.rangeStrategy = 'bump';
+      config.packageName = 'actions/checkout';
+      config.versioning = githubActionsVersioningId;
+      config.datasource = GithubTagsDatasource.id;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      const lastWeek = new Date();
+      lastWeek.setDate(lastWeek.getDate() - 7);
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          {
+            version: 'v7.0.0',
+            releaseTimestamp: lastWeek.toISOString() as Timestamp,
+          },
+          {
+            version: 'v7.0.1',
+            releaseTimestamp: yesterday.toISOString() as Timestamp,
+          },
+        ],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          isPinDigest: true,
+          updateType: 'pinDigest',
+          newValue: 'v7',
+          newDigest: fakeSha('new'),
+          pendingChecks: true,
+        },
+      ]);
+    });
+
+    // Unlike `digest`, an unversioned `currentValue` (e.g. `latest`) is exempt from `minimumReleaseAge` entirely for `pinDigest`:
+    // pinning a ref that already floats to latest is strictly safer, so holding it would only prolong the un-pinned state.
+    it('does not hold `pinDigest` updates for unversioned `currentValue`s (e.g. `latest`)', async () => {
+      config.currentValue = 'alpine';
+      config.packageName = 'node';
+      config.datasource = DockerDatasource.id;
+      config.pinDigests = true;
+      config.minimumReleaseAge = '3 days';
+      config.internalChecksFilter = 'strict';
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          { version: 'alpine' },
+          { version: '8.0.0' },
+          { version: '8.1.0' },
+        ],
+      });
+      getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          isPinDigest: true,
+          newDigest: 'sha256:abcdef1234567890',
+          newValue: 'alpine',
+          updateType: 'pinDigest',
+        },
+      ]);
+      // Short-circuited: no age check ran, so no "no releaseTimestamp to age against" log noise.
+      expect(logger.logger.once.debug).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.stringContaining('has no releaseTimestamp to age against'),
+      );
+    });
+
     it('handles no fitting version and no version in lock file', async () => {
       config.currentValue = '~9.5.0';
       config.packageName = 'typo3/cms-saltedpasswords';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -70,8 +70,8 @@ async function getTimestamp(
   return remoteRelease?.releaseTimestamp;
 }
 
-/** The only `updateType` that `applyMinimumReleaseAgeToDigestUpdate()` can be called with */
-type DigestLikeUpdate = LookupUpdate & { updateType: 'digest' };
+/** The only two `updateType`s that `applyMinimumReleaseAgeToDigestUpdate()` can be called with */
+type DigestLikeUpdate = LookupUpdate & { updateType: 'digest' | 'pinDigest' };
 
 /**
  * A helper function to allow a short-circuit for `minimumReleaseAge` functionality if a package may have config that applies it.
@@ -80,6 +80,7 @@ type DigestLikeUpdate = LookupUpdate & { updateType: 'digest' };
  */
 function couldApplyMinimumReleaseAgeToDigest(
   config: LookupUpdateConfig,
+  updateType: DigestLikeUpdate['updateType'],
 ): boolean {
   // Match filterInternalChecks(): under `none` the user opted out of internal
   // checks entirely, so do no merging, no package rules, no age check and no
@@ -90,7 +91,7 @@ function couldApplyMinimumReleaseAgeToDigest(
 
   return (
     isNonEmptyString(config.minimumReleaseAge) ||
-    isNonEmptyString(config.digest?.minimumReleaseAge) ||
+    isNonEmptyString(config[updateType]?.minimumReleaseAge) ||
     !!config.packageRules?.some((rule) =>
       isNonEmptyString(rule.minimumReleaseAge),
     )
@@ -98,7 +99,7 @@ function couldApplyMinimumReleaseAgeToDigest(
 }
 
 /**
- * Ensure `minimumReleaseAge`/`internalChecksFilter` applies to digest updates, as they don't currently get run through `filterInternalChecks()`.
+ * Ensure `minimumReleaseAge`/`internalChecksFilter` applies to digest/pinDigest updates, as they don't currently get run through `filterInternalChecks()`.
  *
  * NOTE that this should be kept in sync with `filterInternalChecks`()
  */
@@ -106,9 +107,23 @@ async function applyMinimumReleaseAgeToDigestUpdate(
   update: DigestLikeUpdate,
   config: LookupUpdateConfig,
   res: UpdateResult,
+  currentVersionWasResolved: boolean,
   newestMatchingVersionTimestamp: Timestamp | null | undefined,
 ): Promise<void> {
-  if (!couldApplyMinimumReleaseAgeToDigest(config)) {
+  if (!couldApplyMinimumReleaseAgeToDigest(config, update.updateType)) {
+    return;
+  }
+
+  if (update.updateType === 'pinDigest' && !currentVersionWasResolved) {
+    // Not `!res.currentVersion` - that's force-set to lockedVersion further down regardless of timestamp resolution.
+    // `pinDigest` doesn't repoint anywhere, unlike `digest` - it just freezes whatever the ref already resolves to.
+    // An unversioned tag (e.g. `latest`) has no versioned release to age against, and holding the pin would only
+    // prolong the less-pinned (less safe) state, so skip the check entirely rather than treating the missing
+    // timestamp as pending.
+    logger.once.debug(
+      { depName: config.depName, updateType: update.updateType },
+      `Skipping minimumReleaseAge check for ${update.updateType} update of ${config.depName}, as its current value does not resolve to a versioned release`,
+    );
     return;
   }
 
@@ -122,9 +137,12 @@ async function applyMinimumReleaseAgeToDigestUpdate(
   );
   releaseConfig = await applyPackageRules(releaseConfig, 'update-type');
 
+  // Not update.releaseTimestamp - that field means "age of the new release" elsewhere (generate.ts, libyear.ts).
+  // Not res.currentVersionTimestamp either - that tracks whatever rangeStrategy resolves currentVersion to (e.g.
+  // the oldest matching release under `bump`), whereas both `digest` and `pinDigest` reflect whatever the current
+  // value's ref actually resolves to *right now*, which is always the newest matching version.
   const ageCheck = checkMinimumReleaseAge(
     releaseConfig,
-    // intentionally used instead of `update.releaseTimestamp`
     newestMatchingVersionTimestamp,
   );
 
@@ -178,7 +196,7 @@ export async function lookupUpdates(
     updates: [],
     warnings: [],
   };
-  // Timestamp of the release a `digest` update repoints to (the newest version matching the current value), as opposed to `res.currentVersionTimestamp` which tracks whatever the configured rangeStrategy resolves `currentVersion` to (e.g. the oldest for `bump`)
+  // Timestamp of the release a `digest`/`pinDigest` update's current value currently resolves to (the newest version matching it, regardless of `rangeStrategy`), as opposed to `res.currentVersionTimestamp` which tracks whatever the configured rangeStrategy resolves `currentVersion` to (e.g. the oldest for `bump`)
   let newestMatchingVersionTimestamp: Timestamp | null | undefined;
   // The `digest` update for `config.currentDigest` (if one is added), so its age check can run after `newDigest` is fetched and no-op updates are stripped.
   let digestUpdate: DigestLikeUpdate | undefined;
@@ -474,7 +492,12 @@ export async function lookupUpdates(
         }
       }
 
-      if (config.currentDigest && couldApplyMinimumReleaseAgeToDigest(config)) {
+      if (
+        config.currentDigest
+          ? couldApplyMinimumReleaseAgeToDigest(config, 'digest')
+          : config.pinDigests &&
+            couldApplyMinimumReleaseAgeToDigest(config, 'pinDigest')
+      ) {
         // Resolve from `allVersions` (not `dependency.releases`) so that filters like followTag apply, preferring non-deprecated versions with a fallback - both like the `currentVersion` resolution above.
         const newestMatchingVersion =
           getCurrentVersion(
@@ -661,11 +684,13 @@ export async function lookupUpdates(
         ) {
           update.updateType = 'digest';
 
-          // As this has already been processed by `filterInternalChecks()`, but we're changing the `updateType`, we need to apply the digest-scoped minimumReleaseAge rules
+          // As this has already been processed by `filterInternalChecks()`, but we're changing the `updateType`, we need to apply the digest-scoped minimumReleaseAge rules.
+          // `currentVersionWasResolved` only matters for `pinDigest`, which `update.updateType` never is here - true is a safe constant.
           await applyMinimumReleaseAgeToDigestUpdate(
             update as DigestLikeUpdate,
             config,
             res,
+            true,
             release.releaseTimestamp,
           );
         }
@@ -797,11 +822,19 @@ export async function lookupUpdates(
         !res.updates.some((update) => update.updateType === 'pin')
       ) {
         // pin digest
-        res.updates.push({
+        const pinDigestUpdate: DigestLikeUpdate = {
           isPinDigest: true,
           updateType: 'pinDigest',
           newValue: config.currentValue,
-        });
+        };
+        await applyMinimumReleaseAgeToDigestUpdate(
+          pinDigestUpdate,
+          config,
+          res,
+          isValid || unconstrainedValue,
+          newestMatchingVersionTimestamp,
+        );
+        res.updates.push(pinDigestUpdate);
       }
       if (versioningApi.valueToVersion) {
         // TODO #22198
@@ -926,12 +959,14 @@ export async function lookupUpdates(
       );
     }
 
-    // If there is a digest update proposed which is in the pending updates for this dependency, ensure that `minimumReleaseAge` is applied
+    // If there is a digest update proposed which is in the pending updates for this dependency, ensure that `minimumReleaseAge` is applied.
+    // `currentVersionWasResolved` only matters for `pinDigest`, which `digestUpdate` never is - true is a safe constant.
     if (digestUpdate && res.updates.includes(digestUpdate)) {
       await applyMinimumReleaseAgeToDigestUpdate(
         digestUpdate,
         config,
         res,
+        true,
         newestMatchingVersionTimestamp,
       );
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As per #44820, `pinDigest` updates currently don't get
`minimumReleaseAge` checks applied to them.

We can extend the recent support for `digest`s being handled by also
introducing support for `pinDigest`s to receive `minimumReleaseAge`
enforcement.

This will:

- enforce `minimumReleaseAge` on all updates that `pinDigest`s has
  pending
- consider the newest resolved version's timestamp, ignoring
  `rangeStrategy`-related logic
- allow unversioned releases like `latest` to /not/ be bound by
  `minimumReleaseAge`, as they'll potentially not have a release
  timestamp and will be unpinned forever, which is less safe (and
  reduces reproducibility)

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44820
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
