### PR TITLE
feat(templates): always expose `renovateVersion`

### DIFF
--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -6,7 +6,6 @@ import type { z } from 'zod/v4';
 import { ZodType } from 'zod/v4';
 import { GlobalConfig } from '../../config/global.ts';
 import { HOST_DISABLED } from '../../constants/error-messages.ts';
-import { pkg } from '../../expose.ts';
 import { logger } from '../../logger/index.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
 import * as memCache from '../cache/memory/index.ts';
@@ -67,9 +66,7 @@ export function applyDefaultHeaders(options: OptionsInit): void {
   const userAgentTemplate = GlobalConfig.get('userAgent');
   options.headers = {
     ...options.headers,
-    'user-agent': compile(userAgentTemplate, {
-      renovateVersion: pkg.version,
-    }),
+    'user-agent': compile(userAgentTemplate, {}),
   };
 }
 

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -1,4 +1,5 @@
 import { getOptions } from '../../config/options/index.ts';
+import { pkg } from '../../expose.ts';
 import * as _execUtils from '../exec/utils.ts';
 import * as template from './index.ts';
 
@@ -38,6 +39,11 @@ describe('util/template/index', () => {
     };
     const output = template.compile(userTemplate, input);
     expect(output).toBe('github token = ""');
+  });
+
+  it('exposes renovateVersion to every template, without needing to pass it explicitly', () => {
+    const output = template.compile('{{renovateVersion}}', {});
+    expect(output).toBe(pkg.version);
   });
 
   it('containsString', () => {

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@sindresorhus/is';
 import handlebars, { type HelperOptions } from 'handlebars';
 import { GlobalConfig } from '../../config/global.ts';
+import { pkg } from '../../expose.ts';
 import { logger } from '../../logger/index.ts';
 import { toArray } from '../array.ts';
 import { getChildEnv } from '../exec/utils.ts';
@@ -238,8 +239,7 @@ export const allowedFields = {
   releases: 'An array of releases for an upgrade',
   releaseNotes: 'A ChangeLogNotes object for the release',
   releaseTimestamp: 'The timestamp of the release',
-  renovateVersion:
-    'The currently running Renovate version. Only supported in the `user-agent` configuration option.',
+  renovateVersion: 'The currently running Renovate version.',
   repository: 'The current repository',
   semanticPrefix: 'The fully generated semantic prefix for commit messages',
   sourceRepo: 'The repository in the sourceUrl, if present',
@@ -328,7 +328,12 @@ export function compile<T>(
   filterFields = true,
 ): string {
   const env = getChildEnv({});
-  const data = { ...GlobalConfig.get(), ...input, env };
+  const data = {
+    ...GlobalConfig.get(),
+    renovateVersion: pkg.version,
+    ...input,
+    env,
+  };
   const warnVariables = new Set<string>();
   const filteredInput = filterFields
     ? proxyCompileInput(data, warnVariables)

--- a/lib/workers/repository/dependency-dashboard.spec.ts
+++ b/lib/workers/repository/dependency-dashboard.spec.ts
@@ -8,6 +8,7 @@ import type { RenovateConfig } from '~test/util.ts';
 import { logger, platform } from '~test/util.ts';
 import { getConfig } from '../../config/defaults.ts';
 import { GlobalConfig } from '../../config/global.ts';
+import { pkg } from '../../expose.ts';
 import type {
   PackageDependency,
   PackageFile,
@@ -520,6 +521,24 @@ describe('workers/repository/dependency-dashboard', () => {
 
       // same with dry run
       await dryRun(branches, platform, 0, 1);
+    });
+
+    it('supports renovateVersion templating in header and footer', async () => {
+      const branches: BranchConfig[] = [];
+      config.dependencyDashboard = true;
+      config.dependencyDashboardHeader =
+        'This is a header for renovateVersion:{{renovateVersion}}';
+      config.dependencyDashboardFooter =
+        'And this is a footer for renovateVersion:{{renovateVersion}}';
+      await dependencyDashboard.ensureDependencyDashboard(
+        config,
+        branches,
+        {},
+        { result: 'no-migration' },
+      );
+      expect(platform.ensureIssue.mock.calls[0][0].body).toMatch(
+        `renovateVersion:${pkg.version}`,
+      );
     });
 
     it('checks an issue with 2 Pending Approvals, 2 not scheduled, 2 pr-hourly-limit-reached, 2 in error, 1 pending automerge and 1 other', async () => {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As noted in #44756, this would allow templates across Renovate's
different usages to be able to use the `renovateVersion` string as a
template variable.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
