### PR TITLE
fix(manager/pep621): support array form of tool.uv.sources

### DIFF
--- a/lib/modules/manager/pep621/extract.spec.ts
+++ b/lib/modules/manager/pep621/extract.spec.ts
@@ -409,6 +409,33 @@ describe('modules/manager/pep621/extract', () => {
       ]);
     });
 
+    it('should apply the index registryUrl for array form uv sources', async () => {
+      const result = await extractPackageFile(
+        codeBlock`
+        [project]
+        dependencies = ["dep1==0.1.0"]
+
+        [[tool.uv.index]]
+        name = "custom"
+        url = "https://custom.example.com/simple"
+        explicit = true
+
+        [tool.uv.sources]
+        dep1 = [{ index = "custom" }]
+        `,
+        'pyproject.toml',
+      );
+
+      expect(result?.deps).toMatchObject([
+        {
+          depName: 'dep1',
+          depType: depTypes.uvSources,
+          currentValue: '==0.1.0',
+          registryUrls: ['https://custom.example.com/simple'],
+        },
+      ]);
+    });
+
     it('should handle SSH git URLs correctly for GitHub sources', async () => {
       const result = await extractPackageFile(
         codeBlock`

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -240,6 +240,11 @@ describe('modules/manager/pep621/processors/uv', () => {
         { index = "unknown", marker = "sys_platform == 'darwin'" },
         { index = "foo", marker = "sys_platform == 'linux'" },
       ]
+      dep6 = [
+        { index = "unknown", marker = "sys_platform == 'darwin'" },
+        { index = "unknown2", marker = "sys_platform == 'linux'" },
+      ]
+      dep7 = [{ index = "unknown" }]
 
       [[tool.uv.index]]
       name = "foo"
@@ -274,6 +279,14 @@ describe('modules/manager/pep621/processors/uv', () => {
         {
           depName: 'dep5',
           packageName: 'dep5',
+        },
+        {
+          depName: 'dep6',
+          packageName: 'dep6',
+        },
+        {
+          depName: 'dep7',
+          packageName: 'dep7',
         },
       ];
 
@@ -311,6 +324,16 @@ describe('modules/manager/pep621/processors/uv', () => {
           depType: depTypes.uvSources,
           registryUrls: ['https://foo.com/simple'],
           packageName: 'dep5',
+        },
+        {
+          depName: 'dep6',
+          depType: depTypes.uvSources,
+          packageName: 'dep6',
+        },
+        {
+          depName: 'dep7',
+          depType: depTypes.uvSources,
+          packageName: 'dep7',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -17,6 +17,7 @@ import { getPkgReleases as _getPkgReleases } from '../../../datasource/index.ts'
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
 import type { UpdateArtifact, UpdateArtifactsConfig } from '../../types.ts';
 import { parsePyProject } from '../extract.ts';
+import type { PyProject, UvSource } from '../schema.ts';
 import { depTypes } from '../utils.ts';
 import { UvProcessor } from './uv.ts';
 
@@ -334,6 +335,33 @@ describe('modules/manager/pep621/processors/uv', () => {
           depName: 'dep7',
           depType: depTypes.uvSources,
           packageName: 'dep7',
+        },
+      ]);
+    });
+
+    it('skips source types the schema does not produce', () => {
+      // Cannot be expressed in pyproject.toml, as the schema only emits the
+      // known source shapes. Exercises the defensive fallback.
+      const uv = partial<NonNullable<NonNullable<PyProject['tool']>['uv']>>({
+        sources: { dep1: [partial<UvSource>({})] },
+      });
+      const pyproject = partial<PyProject>({ tool: { uv } });
+
+      const dependencies = [
+        {
+          depName: 'dep1',
+          packageName: 'dep1',
+        },
+      ];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          depName: 'dep1',
+          depType: depTypes.uvSources,
+          packageName: 'dep1',
+          skipReason: 'unknown-registry',
         },
       ]);
     });

--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -223,6 +223,98 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
     });
 
+    it('handles the array form of uv sources', () => {
+      const pyproject = parsePyProject(codeBlock`
+      [tool.uv.sources]
+      dep1 = [{ index = "foo" }]
+      dep2 = [
+        { index = "foo", marker = "sys_platform == 'darwin'" },
+        { index = "bar", marker = "sys_platform == 'linux'" },
+      ]
+      dep3 = [{ git = "https://github.com/foo/dep3", tag = "0.3.0" }]
+      dep4 = [
+        { index = "foo", marker = "sys_platform == 'darwin'" },
+        { git = "https://github.com/foo/dep4", marker = "sys_platform == 'linux'" },
+      ]
+      dep5 = [
+        { index = "unknown", marker = "sys_platform == 'darwin'" },
+        { index = "foo", marker = "sys_platform == 'linux'" },
+      ]
+
+      [[tool.uv.index]]
+      name = "foo"
+      url = "https://foo.com/simple"
+      default = false
+      explicit = true
+
+      [[tool.uv.index]]
+      name = "bar"
+      url = "https://bar.com/simple"
+      default = false
+      explicit = true
+    `)!;
+
+      const dependencies = [
+        {
+          depName: 'dep1',
+          packageName: 'dep1',
+        },
+        {
+          depName: 'dep2',
+          packageName: 'dep2',
+        },
+        {
+          depName: 'dep3',
+          packageName: 'dep3',
+        },
+        {
+          depName: 'dep4',
+          packageName: 'dep4',
+        },
+        {
+          depName: 'dep5',
+          packageName: 'dep5',
+        },
+      ];
+
+      const result = processor.process(pyproject, dependencies);
+
+      expect(result).toEqual([
+        {
+          depName: 'dep1',
+          depType: depTypes.uvSources,
+          registryUrls: ['https://foo.com/simple'],
+          packageName: 'dep1',
+        },
+        {
+          depName: 'dep2',
+          depType: depTypes.uvSources,
+          registryUrls: ['https://foo.com/simple', 'https://bar.com/simple'],
+          packageName: 'dep2',
+        },
+        {
+          depName: 'dep3',
+          depType: depTypes.uvSources,
+          datasource: GithubTagsDatasource.id,
+          registryUrls: ['https://github.com'],
+          packageName: 'foo/dep3',
+          currentValue: '0.3.0',
+        },
+        {
+          depName: 'dep4',
+          depType: depTypes.uvSources,
+          skipReason: 'unsupported',
+          packageName: 'dep4',
+        },
+        {
+          depName: 'dep5',
+          depType: depTypes.uvSources,
+          registryUrls: ['https://foo.com/simple'],
+          packageName: 'dep5',
+        },
+      ]);
+    });
+
     it('index with optional name', () => {
       const pyproject = parsePyProject(codeBlock`
       [[tool.uv.index]]

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -25,12 +25,18 @@ import type {
   Upgrade,
 } from '../../types.ts';
 import { applyGitSource } from '../../util.ts';
-import { type PyProject, UvLockfile } from '../schema.ts';
+import { type PyProject, UvLockfile, type UvSource } from '../schema.ts';
 import { depTypes } from '../utils.ts';
 
 import { BasePyProjectProcessor } from './abstract.ts';
 
 const uvUpdateCMD = 'uv lock';
+
+function isUvIndexSource(
+  source: UvSource,
+): source is Extract<UvSource, { index: string }> {
+  return 'index' in source;
+}
 
 export class UvProcessor extends BasePyProjectProcessor {
   override lockfileName = 'uv.lock';
@@ -71,34 +77,50 @@ export class UvProcessor extends BasePyProjectProcessor {
 
         // Using `packageName` as it applies PEP 508 normalization, which is
         // also applied by uv when matching a source to a dependency.
-        const depSource = uv.sources?.[dep.packageName];
-        if (depSource) {
-          // Dependency is pinned to a specific source.
+        const depSources = uv.sources?.[dep.packageName];
+        if (depSources) {
+          // Dependency is pinned to one or more specific sources.
           dep.depType = depTypes.uvSources;
-          if ('index' in depSource) {
-            const index = uv.index?.find(
-              ({ name }) => name === depSource.index,
-            );
-            if (index) {
-              dep.registryUrls = [index.url];
+          if (depSources.every(isUvIndexSource)) {
+            // Sources referencing an index, possibly disambiguated by
+            // environment markers. Any of the indexes can serve the package,
+            // so use all of them as registries.
+            const registryUrls: string[] = [];
+            for (const depSource of depSources) {
+              const index = uv.index?.find(
+                ({ name }) => name === depSource.index,
+              );
+              if (index) {
+                registryUrls.push(index.url);
+              }
             }
-          } else if ('git' in depSource) {
-            applyGitSource(
-              dep,
-              depSource.git,
-              depSource.rev,
-              depSource.tag,
-              depSource.branch,
-            );
-          } else if ('url' in depSource) {
-            dep.skipReason = 'unsupported-url';
-          } else if ('path' in depSource) {
-            dep.skipReason = 'path-dependency';
-          } else if ('workspace' in depSource) {
-            dep.skipReason = 'inherited-dependency';
+            if (registryUrls.length) {
+              dep.registryUrls = [...new Set(registryUrls)];
+            }
+          } else if (depSources.length === 1) {
+            const depSource = depSources[0];
+            if ('git' in depSource) {
+              applyGitSource(
+                dep,
+                depSource.git,
+                depSource.rev,
+                depSource.tag,
+                depSource.branch,
+              );
+            } else if ('url' in depSource) {
+              dep.skipReason = 'unsupported-url';
+            } else if ('path' in depSource) {
+              dep.skipReason = 'path-dependency';
+            } else if ('workspace' in depSource) {
+              dep.skipReason = 'inherited-dependency';
+            } else {
+              /* v8 ignore next -- unreachable through schema */
+              dep.skipReason = 'unknown-registry';
+            }
           } else {
-            /* v8 ignore next -- unreachable through schema */
-            dep.skipReason = 'unknown-registry';
+            // Multiple sources that are not all indexes (e.g. a git source
+            // per platform) cannot be represented as a single update.
+            dep.skipReason = 'unsupported';
           }
         } else {
           // Dependency is not pinned to a specific source, so we need to

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -114,7 +114,6 @@ export class UvProcessor extends BasePyProjectProcessor {
             } else if ('workspace' in depSource) {
               dep.skipReason = 'inherited-dependency';
             } else {
-              /* v8 ignore next -- unreachable through schema */
               dep.skipReason = 'unknown-registry';
             }
           } else {

--- a/lib/modules/manager/pep621/schema.ts
+++ b/lib/modules/manager/pep621/schema.ts
@@ -147,6 +147,14 @@ const UvSource = z.union([
   UvPathSource,
   UvWorkspaceSource,
 ]);
+export type UvSource = z.infer<typeof UvSource>;
+
+// A dependency can declare a single source or, when disambiguated by
+// environment markers, an array of sources. Normalize both to an array.
+// https://docs.astral.sh/uv/concepts/projects/dependencies/#multiple-sources
+const UvSources = z
+  .union([UvSource, z.array(UvSource).min(1)])
+  .transform((source) => (Array.isArray(source) ? source : [source]));
 
 const UvConfig = z.object({
   'dev-dependencies': LooseArray(
@@ -156,7 +164,7 @@ const UvConfig = z.object({
   sources: LooseRecord(
     // uv applies the same normalization as for Python dependencies on sources
     z.string().transform((source) => normalizePythonDepName(source)),
-    UvSource,
+    UvSources,
   ).optional(),
   index: z
     .array(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes
<!-- Describe what behavior is changed by this PR. -->

Reported in #44948

uv allows `tool.uv.sources` entries to be written as an array of sources, disambiguated by environment markers. A single-element array is valid too. 
The pep621 schema only accepted the single-table form, and `LooseRecord` silently drops entries it can't parse, so array-form sources were ignored and lookups fell back to pypi.org. 
For packages that only exist on the declared index this shows up as `WARN: Package lookup failures`. 
For packages that also exist on pypi.org the problem is harder to notice: there is no warning, and Renovate silently proposes versions from the wrong registry.

What this PR does:

- schema: `sources` now accepts a single source or an array of sources, normalized to an array
- processor: when all sources of a dependency reference an index, all resolved index URLs are set as `registryUrls` (the pypi datasource merges releases across registries). A single non-index source behaves exactly as before.
- multiple sources that are not all indexes (e.g. a git source per platform) get `skipReason: 'unsupported'`. Renovate can't represent them as a single update, and skipping is still better than the previous behavior of silently looking up pypi.org. 

One thing this PR does not attempt: when markers don't cover every environment, uv falls back to the default index for the rest. Renovate doesn't evaluate markers, and the existing single-table handling has the same simplification, so I kept that behavior.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/ntsk/reproduce-array-form-uv-sources

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

The repo pins a package that only exists on test.pypi.org to a custom index using the array form. 

```
DEBUG: GET https://pypi.org/pypi/ntsk-reproduce-array-form-uv-sources/json = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=404 ...)
DEBUG: Failed to look up pypi package ntsk-reproduce-array-form-uv-sources: no-result
```

With this branch (`node lib/renovate.ts --platform=local` in that repo):

```
"registryUrls": ["https://test.pypi.org/simple/"]
```

and the lookup failure is gone.


<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
