### PR TITLE
fix(manager/mix): run mix commands from the lock file's directory

### DIFF
--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -444,7 +444,7 @@ describe('modules/manager/mix/artifacts', () => {
       { cmd: 'install-tool elixir v1.13.4' },
       {
         cmd: 'mix deps.update plug',
-        options: { cwd: '/tmp/github/some/repo/apps/foo' },
+        options: { cwd: '/tmp/github/some/repo' },
       },
     ]);
   });

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -154,7 +154,7 @@ export async function updateArtifacts({
       // TODO: should include a version constraint
       MIX_ARCHIVES: await ensureCacheDir('mix_archives'),
     },
-    cwdFile: packageFileName,
+    cwdFile: lockFileName,
     docker: {},
     toolConstraints: [
       {


### PR DESCRIPTION
## Changes

`updateArtifacts` in the mix manager now execs `mix deps.update` / `mix deps.get` with `cwdFile: lockFileName` instead of `cwdFile: packageFileName`.

In Elixir **umbrella projects**, each app under `apps/*` has its own `mix.exs`, but the whole umbrella shares a single `mix.lock` at the repository root. `updateArtifacts` already resolves that shared lock file (via `findLocalSiblingOrParent`, setting `isUmbrella`), but then runs `mix deps.update <dep>` from the *app's* directory. Mix resolves the shared lock while seeing only that one app's constraints, silently producing lock entries that violate sibling apps' requirements — e.g. a transitive `websock_adapter` bumped to 0.6.0 while a sibling app's `petal_components` requires `~> 0.5.7`, making the committed lock fail `mix deps.get` everywhere. In other cases the app-local resolution simply fails (`** (Mix) Hex dependency resolution failed`), producing artifact errors.

Running the command from the lock file's directory resolves the way a developer would at the umbrella root — mix sees every app's constraints. For regular (non-umbrella) projects `mix.lock` is a sibling of `mix.exs`, so the cwd is unchanged and behavior is identical.

Discussion with reproduction details: https://github.com/renovatebot/renovate/discussions/43827

The existing "returns updated mix.lock in umbrella project" spec now asserts the exec cwd is the repo root; the subdir (non-umbrella) spec is unchanged.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The fix, test change, and PR text were drafted by Claude (Fable 5) via Claude Code, driven and reviewed by me. The root-cause analysis comes from operating Renovate on production Elixir umbrella monorepos.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`pnpm vitest run lib/modules/manager/mix` — 89/89 pass. The repositories where the bug bites daily are private (wooga org) umbrella services; we currently work around it with `skipArtifactsUpdate` + a `postUpgradeTasks` command running `mix deps.update` at the umbrella root, which has been producing correct locks in production for two weeks — the same resolution this PR performs natively.