### PR TITLE
docs: abandoned prs

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4503,6 +4503,7 @@ It usually doesn't _know_ why they're there, instead it simply knows that it has
 
 If a branch appears stale but has been modified by a different git author, then Renovate won't delete the branch or autoclose any associated PR.
 Instead, it will update the title to append " - abandoned" plus add a comment noting that autoclosing is skipped.
+Read the [Abandoned PRs](./key-concepts/pull-requests.md#abandoned-prs) docs to learn more.
 
 If a branch appears stale and hasn't been modified, then:
 

--- a/docs/usage/key-concepts/pull-requests.md
+++ b/docs/usage/key-concepts/pull-requests.md
@@ -92,7 +92,7 @@ If someone other than Renovate modified the branch, Renovate will not destroy th
 
 Instead, Renovate flags the PR as abandoned by:
 
-- Appending ` - abandoned` to the PR title
+- Appending `- abandoned` to the PR title
 - Adding a comment to the PR explaining that autoclosing was skipped
 
 This tells you that Renovate no longer considers the branch or PR its own, and will not touch it again.

--- a/docs/usage/key-concepts/pull-requests.md
+++ b/docs/usage/key-concepts/pull-requests.md
@@ -92,7 +92,7 @@ If someone other than Renovate modified the branch, Renovate will not destroy th
 
 Instead, Renovate flags the PR as abandoned by:
 
-- Appending `- abandoned` to the PR title
+- Appending ` - abandoned` to the PR title
 - Adding a comment to the PR explaining that autoclosing was skipped
 
 This tells you that Renovate no longer considers the branch or PR its own, and will not touch it again.

--- a/docs/usage/key-concepts/pull-requests.md
+++ b/docs/usage/key-concepts/pull-requests.md
@@ -83,6 +83,29 @@ If you have immortal PRs which you want to keep closed, then set `"recreateWhen"
 Avoid grouping major upgrades together unless they are related dependencies.
 Instead, set `"dependencyDashboardApproval": true` for major updates so that you have control about when they are created.
 
+## Abandoned PRs
+
+Renovate normally cleans up its own branches and PRs once it decides they are no longer needed, for example after you merge or close a PR.
+Depending on the state of the branch, Renovate either autocloses the PR and deletes the branch, or leaves the branch alone.
+
+If someone other than Renovate modified the branch, Renovate will not destroy that work by autoclosing the PR and deleting the branch.
+Instead, Renovate:
+
+- Appends ` - abandoned` to the PR title
+- Adds a comment to the PR explaining that autoclosing was skipped
+
+This tells you that Renovate no longer considers the branch or PR its own, and will not touch it again.
+
+### Recommended actions for abandoned PRs
+
+Renovate will not rebase, update, or close an abandoned PR again, so you need to deal with it manually:
+
+- If the changes are still wanted, review and merge the PR yourself
+- If the changes are no longer wanted, close the PR and delete the branch yourself
+- If you want Renovate to manage the update again, delete the branch so Renovate can recreate it on its next run, if still needed
+
+Related config option: [`pruneStaleBranches`](../configuration-options.md#prunestalebranches).
+
 ## Ignoring PRs
 
 Close a Renovate PR to ignore it.

--- a/docs/usage/key-concepts/pull-requests.md
+++ b/docs/usage/key-concepts/pull-requests.md
@@ -89,6 +89,7 @@ Renovate normally cleans up its own branches and PRs once it decides they are no
 Depending on the state of the branch, Renovate either autocloses the PR and deletes the branch, or leaves the branch alone.
 
 If someone other than Renovate modified the branch, Renovate will not destroy that work by autoclosing the PR and deleting the branch.
+
 Instead, Renovate:
 
 - Appends ` - abandoned` to the PR title

--- a/docs/usage/key-concepts/pull-requests.md
+++ b/docs/usage/key-concepts/pull-requests.md
@@ -90,10 +90,10 @@ Depending on the state of the branch, Renovate either autocloses the PR and dele
 
 If someone other than Renovate modified the branch, Renovate will not destroy that work by autoclosing the PR and deleting the branch.
 
-Instead, Renovate:
+Instead, Renovate flags the PR as abandoned by:
 
-- Appends ` - abandoned` to the PR title
-- Adds a comment to the PR explaining that autoclosing was skipped
+- Appending ` - abandoned` to the PR title
+- Adding a comment to the PR explaining that autoclosing was skipped
 
 This tells you that Renovate no longer considers the branch or PR its own, and will not touch it again.
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds documentation for Abandoned PRs

<!-- Describe what behavior is changed by this PR. -->

## Context

Closes #21331

Please select one of the following:

- [x] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [x] Yes — other (please describe): reviewed draft docs

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
