### PR TITLE
fix(cache): re-add cacache.verify() to garbage collect orphaned content from put() overwrites

### DIFF
--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -56,6 +56,15 @@ export class PackageCacheFile extends PackageCacheBase {
     if (errorCount > 0) {
       logger.debug(`Error count cleaning up cache: ${errorCount}`);
     }
+
+     // Garbage collect content blobs orphaned by put() overwrites.
+     // rm.content only handles expiry; when put() writes new data for an existing
+     // key, the previous content blob is left on disk unreferenced.
+     const gcStats = await cacache.verify(this.cacheFileName);
+     logger.debug(
+       `Cache GC: kept ${gcStats.verifiedContent} content entries (${gcStats.keptSize} bytes), removed ${gcStats.reclaimedCount} orphaned (${gcStats.reclaimedSize} bytes) in ${gcStats.runTime.total}ms`,
+     );
+    
     const durationMs = Date.now() - startTime;
     logger.debug(
       `Deleted ${deletedCount} of ${totalCount} file cached entries in ${durationMs}ms`,

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -57,13 +57,13 @@ export class PackageCacheFile extends PackageCacheBase {
       logger.debug(`Error count cleaning up cache: ${errorCount}`);
     }
 
-     // Garbage collect content blobs orphaned by put() overwrites.
-     // rm.content only handles expiry; when put() writes new data for an existing
-     // key, the previous content blob is left on disk unreferenced.
-     const gcStats = await cacache.verify(this.cacheFileName);
-     logger.debug(
-       `Cache GC: kept ${gcStats.verifiedContent} content entries (${gcStats.keptSize} bytes), removed ${gcStats.reclaimedCount} orphaned (${gcStats.reclaimedSize} bytes) in ${gcStats.runTime.total}ms`,
-     );
+    // Garbage collect content blobs orphaned by put() overwrites.
+    // rm.content only handles expiry; when put() writes new data for an existing
+    // key, the previous content blob is left on disk unreferenced.
+    const gcStats = await cacache.verify(this.cacheFileName);
+    logger.debug(
+      `Cache GC: kept ${gcStats.verifiedContent} content entries (${gcStats.keptSize} bytes), removed ${gcStats.reclaimedCount} orphaned (${gcStats.reclaimedSize} bytes) in ${gcStats.runTime.total}ms`,
+    );
     
     const durationMs = Date.now() - startTime;
     logger.debug(

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -64,6 +64,7 @@ export class PackageCacheFile extends PackageCacheBase {
     logger.debug(
       `Cache GC: kept ${gcStats.verifiedContent} content entries (${gcStats.keptSize} bytes), removed ${gcStats.reclaimedCount} orphaned (${gcStats.reclaimedSize} bytes) in ${gcStats.runTime.total}ms`,
     );
+
     const durationMs = Date.now() - startTime;
     logger.debug(
       `Deleted ${deletedCount} of ${totalCount} file cached entries in ${durationMs}ms`,

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -64,7 +64,6 @@ export class PackageCacheFile extends PackageCacheBase {
     logger.debug(
       `Cache GC: kept ${gcStats.verifiedContent} content entries (${gcStats.keptSize} bytes), removed ${gcStats.reclaimedCount} orphaned (${gcStats.reclaimedSize} bytes) in ${gcStats.runTime.total}ms`,
     );
-    
     const durationMs = Date.now() - startTime;
     logger.debug(
       `Deleted ${deletedCount} of ${totalCount} file cached entries in ${durationMs}ms`,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Re-add `cacache.verify()` to the `destroy()` method to garbage collect content blobs orphaned by `cacache.put()` overwrites.

When `cacache.put()` is called with an existing key but different data (e.g., a version lookup result changes because a new release was published), cacache writes a new content blob and updates the index entry to point to it, but does **not** remove the previous content blob. Over many scheduled runs with many dependencies, these orphaned blobs accumulate indefinitely in `content-v2/`.

`rm.content` (added in #29860 when `verify()` was removed) only removes content when an entry
      **expires**. It does not handle orphans created by overwrites of still-live keys.

On a self-hosted instance running scheduled scans of ~100 repos over several months, the cache grew to multiple GB of orphaned content while the actual referenced data was only ~16 MB. Running `cacache.verify()` reclaimed ~5 GB by removing ~565k unreferenced content blobs. After GC, Renovate's cache behavior was unchanged (verified: identical package cache hits, HTTP request counts, and lookup results before and after).

### Performance

The concern in #29795 was that `verify()` is slow. However:

- On a healthy cache (after initial cleanup), `verify()` completes in under 1 second (~260ms for ~500 entries in testing)
- The slow times previously reported were caused by the orphan accumulation itself — scanning hundreds of thousands of orphaned blobs is slow, but that only happens once
- Without `verify()`, the cache grows until it causes CI cache upload failures (exceeding S3 size limits), pod evictions from ephemeral storage exhaustion, and minutes-long cache restore times — all worse than a sub-second GC pass

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: 
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related:
- #28275 — originally added `cacache.verify()` to fix #28169
- #29795 / #29860 — removed `verify()` for performance, replaced with `rm.content` per expired entry (does not cover put() orphans)
- #42543 — open PR with alternative GC approach (tracks digests during sweep, but does not handle pre-existing orphans)

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Investigation and drafting assisted by Claude. Root cause analysis, testing on real self-hosted instance, and code change were done collaboratively.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Tested `cacache.verify()` on a real self-hosted GitLab instance across three job types (local scan, 50-repo dry run, 100+ repo dry run). For each: ran cold (no cache), warm (with cache), GC, then warm again. Cache metrics (package cache gets/sets, HTTP requests) were identical between warm and warm-after-GC runs, confirming GC does not affect cache functionality.
