### PR TITLE
fix(presets): refactor `security:minimumReleaseAge*` to reduce duplication

### DIFF
--- a/lib/config/presets/internal/security.preset.spec.ts
+++ b/lib/config/presets/internal/security.preset.spec.ts
@@ -1,0 +1,54 @@
+import { getDatasources } from '../../../modules/datasource/index.ts';
+import {
+  minimumReleaseAgeDatasourceNames,
+  presets,
+} from './security.preset.ts';
+
+describe('config/presets/internal/security.preset', () => {
+  it('generates a preset for each configured datasource', () => {
+    expect(Object.keys(presets)).toEqual(
+      expect.arrayContaining([
+        'minimumReleaseAgeCrate',
+        'minimumReleaseAgeNpm',
+      ]),
+    );
+  });
+
+  it.each(minimumReleaseAgeDatasourceNames)(
+    'generates a strict rule plus unsupported-update-type warnings for datasource %s',
+    (datasource) => {
+      const suffix = datasource[0].toUpperCase() + datasource.slice(1);
+      const packageRules = presets[`minimumReleaseAge${suffix}`].packageRules!;
+
+      // the first rule strictly enforces minimumReleaseAge for this datasource
+      expect(packageRules[0]).toEqual({
+        internalChecksFilter: 'strict',
+        matchDatasources: [datasource],
+        minimumReleaseAge: expect.any(String),
+      });
+
+      // then we opt-out updateTypes that aren't supported
+      const updateTypesWithoutReleaseTimestampSupport = packageRules.slice(1);
+      expect(
+        updateTypesWithoutReleaseTimestampSupport.map(
+          (rule) => rule.matchUpdateTypes,
+        ),
+      ).toEqual([['lockFileMaintenance'], ['replacement'], ['pin']]);
+      for (const rule of updateTypesWithoutReleaseTimestampSupport) {
+        expect(rule.matchDatasources).toEqual([datasource]);
+        expect(rule.minimumReleaseAge).toBeNull();
+        expect(rule.prBodyNotes).toHaveLength(1);
+      }
+    },
+  );
+
+  it.each(minimumReleaseAgeDatasourceNames)(
+    'only exposes datasource %s because it supports release timestamps',
+    (datasource) => {
+      // A `minimumReleaseAge` preset only makes sense when the datasource can report a release timestamp, otherwise every update would be held back under the default `minimumReleaseAgeBehaviour`
+      expect(getDatasources().get(datasource)).toMatchObject({
+        releaseTimestampSupport: true,
+      });
+    },
+  );
+});

--- a/lib/config/presets/internal/security.preset.ts
+++ b/lib/config/presets/internal/security.preset.ts
@@ -1,5 +1,103 @@
+import type { DatasourceName } from '../../../datasource-list.generated.ts';
+import type { PackageRule } from '../../types.ts';
 import { UpdateTypesOptions } from '../../types.ts';
 import type { Preset } from '../types.ts';
+
+interface MinimumReleaseAgeDatasource {
+  description: string;
+  minimumReleaseAge: string;
+}
+
+/**
+ * Datasources for which we expose a `security:minimumReleaseAge*` preset.
+ *
+ * Only supported for Datasources that have `releaseTimestampSupport`.
+ */
+const minimumReleaseAgeDatasources: Partial<
+  Record<DatasourceName, MinimumReleaseAgeDatasource>
+> = {
+  crate: {
+    description:
+      "Wait until the Crate version is three days old before raising the update. This a) introduces a short delay to allow for malware researchers and scanners to (possibly) detect any malicious behaviour in crates, and b) reduces the risk of upgrading to a newly published crate that its owner deletes during crates.io's initial 72-hour deletion window.",
+    minimumReleaseAge: '3 days',
+  },
+  npm: {
+    description:
+      'Wait until the npm package is three days old before raising the update. This a) introduces a short delay to allow for malware researchers and scanners to (possibly) detect any malicious behaviour in packages, and b) prevents the maintainer and/or NPM from unpublishing a package you already upgraded to, breaking builds.',
+    minimumReleaseAge: '3 days',
+  },
+};
+
+/**
+ * Certain update types don't currently support `releaseTimestamp`s, so applying `minimumReleaseAge` to them results in updates that will never come.
+ *
+ * Instead, we opt them out of `minimumReleaseAge`, and add a warning for the user.
+ *
+ * These rules are datasource-agnostic (`matchDatasources` is added per preset), so they are shared across every generated `security:minimumReleaseAge*` preset to keep the warnings consistent.
+ */
+const unsupportedUpdateTypeRules: PackageRule[] = [
+  {
+    description:
+      'Do not require Minimum Release Age for update types that are controlled by the package manager',
+    matchUpdateTypes: ['lockFileMaintenance'],
+    minimumReleaseAge: null,
+    prBodyNotes: [
+      "⚠️ Renovate's lock file maintenance functionality does not support validating Minimum Release Age, as the package manager performs the required changes to update package(s). Confirm whether your package manager perform its own validation for the Minimum Release Age of packages.",
+    ],
+  },
+  // TODO #39400
+  {
+    description: 'Do not require Minimum Release Age for package replacements',
+    matchUpdateTypes: ['replacement'],
+    minimumReleaseAge: null,
+    prBodyNotes: [
+      "⚠️ Renovate's replacement functionality [does not currently](https://github.com/renovatebot/renovate/issues/39400) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
+    ],
+  },
+  // TODO #40288
+  {
+    description: 'Do not require Minimum Release Age for package pinning',
+    matchUpdateTypes: ['pin'],
+    minimumReleaseAge: null,
+    prBodyNotes: [
+      "⚠️ Renovate's pin functionality [does not currently](https://github.com/renovatebot/renovate/issues/40288) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
+    ],
+  },
+];
+
+function buildMinimumReleaseAgePreset(
+  datasource: string,
+  { description, minimumReleaseAge }: MinimumReleaseAgeDatasource,
+): Preset {
+  const packageRules: PackageRule[] = [
+    {
+      internalChecksFilter: 'strict',
+      matchDatasources: [datasource],
+      minimumReleaseAge,
+    },
+    ...unsupportedUpdateTypeRules.map(
+      (rule): PackageRule => ({ ...rule, matchDatasources: [datasource] }),
+    ),
+  ];
+
+  return { description, packageRules };
+}
+
+function loadMinimumReleaseAgePresets(): Record<string, Preset> {
+  const presets: Record<string, Preset> = {};
+
+  for (const [datasource, config] of Object.entries(
+    minimumReleaseAgeDatasources,
+  )) {
+    const suffix = datasource[0].toUpperCase() + datasource.slice(1);
+    presets[`minimumReleaseAge${suffix}`] = buildMinimumReleaseAgePreset(
+      datasource,
+      config,
+    );
+  }
+
+  return presets;
+}
 
 export const presets: Record<string, Preset> = {
   gomodIndirectSecurityUpdates: {
@@ -23,86 +121,7 @@ export const presets: Record<string, Preset> = {
       },
     ],
   },
-  minimumReleaseAgeCrate: {
-    description:
-      "Wait until the Crate version is three days old before raising the update. This a) introduces a short delay to allow for malware researchers and scanners to (possibly) detect any malicious behaviour in crates, and b) reduces the risk of upgrading to a newly published crate that its owner deletes during crates.io's initial 72-hour deletion window.",
-    packageRules: [
-      {
-        internalChecksFilter: 'strict',
-        matchDatasources: ['crate'],
-        minimumReleaseAge: '3 days',
-      },
-      {
-        description:
-          'Do not require Minimum Release Age for update types that are controlled by the package manager',
-        matchDatasources: ['crate'],
-        matchUpdateTypes: ['lockFileMaintenance'],
-        minimumReleaseAge: null,
-        prBodyNotes: [
-          "⚠️ Renovate's lock file maintenance functionality does not support validating Minimum Release Age, as the package manager performs the required changes to update package(s). Confirm whether your package manager perform its own validation for the Minimum Release Age of packages.",
-        ],
-      },
-      {
-        description:
-          'Do not require Minimum Release Age for package replacements',
-        matchDatasources: ['crate'],
-        matchUpdateTypes: ['replacement'],
-        minimumReleaseAge: null,
-        prBodyNotes: [
-          "⚠️ Renovate's replacement functionality [does not currently](https://github.com/renovatebot/renovate/issues/39400) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
-        ],
-      },
-      {
-        description: 'Do not require Minimum Release Age for package pinning',
-        matchDatasources: ['crate'],
-        matchUpdateTypes: ['pin'],
-        minimumReleaseAge: null,
-        prBodyNotes: [
-          "⚠️ Renovate's pin functionality [does not currently](https://github.com/renovatebot/renovate/issues/40288) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
-        ],
-      },
-    ],
-  },
-  minimumReleaseAgeNpm: {
-    description:
-      'Wait until the npm package is three days old before raising the update. This a) introduces a short delay to allow for malware researchers and scanners to (possibly) detect any malicious behaviour in packages, and b) prevents the maintainer and/or NPM from unpublishing a package you already upgraded to, breaking builds.',
-    packageRules: [
-      {
-        internalChecksFilter: 'strict',
-        matchDatasources: ['npm'],
-        minimumReleaseAge: '3 days',
-      },
-      {
-        description:
-          'Do not require Minimum Release Age for update types that are controlled by the package manager',
-        matchDatasources: ['npm'],
-        matchUpdateTypes: ['lockFileMaintenance'],
-        minimumReleaseAge: null,
-        prBodyNotes: [
-          "⚠️ Renovate's lock file maintenance functionality does not support validating Minimum Release Age, as the package manager performs the required changes to update package(s). Confirm whether your package manager perform its own validation for the Minimum Release Age of packages.",
-        ],
-      },
-      {
-        description:
-          'Do not require Minimum Release Age for package replacements',
-        matchDatasources: ['npm'],
-        matchUpdateTypes: ['replacement'],
-        minimumReleaseAge: null,
-        prBodyNotes: [
-          "⚠️ Renovate's replacement functionality [does not currently](https://github.com/renovatebot/renovate/issues/39400) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
-        ],
-      },
-      {
-        description: 'Do not require Minimum Release Age for package pinning',
-        matchDatasources: ['npm'],
-        matchUpdateTypes: ['pin'],
-        minimumReleaseAge: null,
-        prBodyNotes: [
-          "⚠️ Renovate's pin functionality [does not currently](https://github.com/renovatebot/renovate/issues/40288) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
-        ],
-      },
-    ],
-  },
+  ...loadMinimumReleaseAgePresets(),
   'only-security-updates': {
     description:
       'Only update dependencies if vulnerabilities have been detected.',
@@ -139,3 +158,7 @@ export const presets: Record<string, Preset> = {
     ],
   },
 };
+
+export const minimumReleaseAgeDatasourceNames = Object.keys(
+  minimumReleaseAgeDatasources,
+);


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
As a means to make it easier - in the future - to add new
`security:minimumReleaseAge*` presets, we can refactor the 2  mostly
duplicated presets into dynamically generated presets.

Although this is not quite a "rule of 3" scenario, this shape does look
consistent, and so we can perform an early refactor.

Although this should be like-for-like, we can release this as a `fix` to
get early feedback on whether it changes anything.



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
