### PR TITLE
fix(presets): add missing `updateTypes` to exclusions in `security:minimumReleaseAge*`

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -131,6 +131,14 @@ The recommendation is to set `internalChecksFilter=strict` when using `minimumRe
 
 Depending on your manager, datasource and the given package(s), it may be that some updates provide a release timestamp that can have `minimumReleaseAge` enforced.
 
+<!--
+  Keep the update types marked as not supported (❌) below in sync with the
+  `unsupportedUpdateTypeRules` carve-outs in
+  `lib/config/presets/internal/security.preset.ts`, so the
+  `security:minimumReleaseAge*` presets keep raising those update types (with a
+  warning) rather than holding them back indefinitely.
+-->
+
 <!-- markdownlint-disable MD060 -->
 
 | Update Type           | Supports `minimumReleaseAge`? | Notes                                                                                                     |

--- a/lib/config/presets/internal/security.preset.spec.ts
+++ b/lib/config/presets/internal/security.preset.spec.ts
@@ -33,7 +33,13 @@ describe('config/presets/internal/security.preset', () => {
         updateTypesWithoutReleaseTimestampSupport.map(
           (rule) => rule.matchUpdateTypes,
         ),
-      ).toEqual([['lockFileMaintenance'], ['replacement'], ['pin']]);
+      ).toEqual([
+        ['lockFileMaintenance'],
+        ['replacement'],
+        ['pin'],
+        ['bump', 'lockfileUpdate', 'rollback'],
+      ]);
+
       for (const rule of updateTypesWithoutReleaseTimestampSupport) {
         expect(rule.matchDatasources).toEqual([datasource]);
         expect(rule.minimumReleaseAge).toBeNull();

--- a/lib/config/presets/internal/security.preset.ts
+++ b/lib/config/presets/internal/security.preset.ts
@@ -33,6 +33,8 @@ const minimumReleaseAgeDatasources: Partial<
  *
  * Instead, we opt them out of `minimumReleaseAge`, and add a warning for the user.
  *
+ * This must stay in sync with the update types documented as _not_ supported (❌) in `docs/usage/key-concepts/minimum-release-age.md`, so we opt-out any unsupported `updateType`s.
+ *
  * These rules are datasource-agnostic (`matchDatasources` is added per preset), so they are shared across every generated `security:minimumReleaseAge*` preset to keep the warnings consistent.
  */
 const unsupportedUpdateTypeRules: PackageRule[] = [
@@ -61,6 +63,15 @@ const unsupportedUpdateTypeRules: PackageRule[] = [
     minimumReleaseAge: null,
     prBodyNotes: [
       "⚠️ Renovate's pin functionality [does not currently](https://github.com/renovatebot/renovate/issues/40288) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s).",
+    ],
+  },
+  {
+    description:
+      'Do not require Minimum Release Age for update types that do not provide a release timestamp',
+    matchUpdateTypes: ['bump', 'lockfileUpdate', 'rollback'],
+    minimumReleaseAge: null,
+    prBodyNotes: [
+      '⚠️ Renovate does not enforce Minimum Release Age for `bump`, `lockfileUpdate`, or `rollback` updates, so these are raised without a Minimum Release Age check. You will need to manually validate the Minimum Release Age for these package(s).',
     ],
   },
 ];


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As these have been out-of-sync with what is and is not currently
supported per our documentation.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
