### PR TITLE
feat(replacements): add react-native-magic-modal to magic-modal

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -39,6 +39,7 @@
       "replacements:opencost-registry-move",
       "replacements:parcel-css-to-lightningcss",
       "replacements:passport-saml",
+      "replacements:react-native-magic-modal-to-magic-modal",
       "replacements:react-query-devtools-to-scoped",
       "replacements:react-query-to-scoped",
       "replacements:react-scripts-ts-to-react-scripts",
@@ -987,6 +988,17 @@
         "matchPackageNames": ["passport-saml"],
         "replacementName": "@node-saml/passport-saml",
         "replacementVersion": "4.0.4"
+      }
+    ]
+  },
+  "react-native-magic-modal-to-magic-modal": {
+    "description": "`react-native-magic-modal` was renamed to `magic-modal` in version 10.0.0. The old name is deprecated but still published at the same version, depending on and re-exporting `magic-modal`.",
+    "packageRules": [
+      {
+        "matchCurrentVersion": ">=10.0.0",
+        "matchDatasources": ["npm"],
+        "matchPackageNames": ["react-native-magic-modal"],
+        "replacementName": "magic-modal"
       }
     ]
   },


### PR DESCRIPTION
## Changes

Adds a `replacements:react-native-magic-modal-to-magic-modal` preset: `react-native-magic-modal` → `magic-modal`.

```json
"react-native-magic-modal-to-magic-modal": {
  "description": "`react-native-magic-modal` was renamed to `magic-modal` in version 10.0.0. The old name is deprecated but still published at the same version, depending on and re-exporting `magic-modal`.",
  "packageRules": [
    {
      "matchCurrentVersion": ">=10.0.0",
      "matchDatasources": ["npm"],
      "matchPackageNames": ["react-native-magic-modal"],
      "replacementName": "magic-modal"
    }
  ]
}
```

Evidence:

- Old name, deprecated: <https://www.npmjs.com/package/react-native-magic-modal> — the deprecation notice on every version including 10.0.0 reads "Renamed to `magic-modal`. This package still works and still tracks every release, since it depends on `magic-modal` and re-exports it, but new code should install `magic-modal` instead. See https://github.com/GSTJ/magic-modal"
- New name: <https://www.npmjs.com/package/magic-modal> (10.0.0)
- Release notes for the rename: <https://github.com/GSTJ/magic-modal/releases/tag/v10.0.0>

Two notes on the rule shape, since this isn't a clean-cutover rename:

- **`matchCurrentVersion: ">=10.0.0"` rather than matching all old versions.** v10 is where the rename landed, and it also dropped the React Native deps from the browser bundle, so it's a real major. Proposing the replacement only from 10.0.0 keeps the rename PR free of unrelated breaking changes, per the "propose a replacement only once the user is on a compatible version" rule in `creating-editing-renovate-presets.md`. Users on 9.x get the ordinary major bump to `react-native-magic-modal@10.0.0` first, then the replacement.
- **No `replacementVersion`.** The old name isn't frozen — it keeps shipping in lockstep at the identical version number as a dependency plus re-export of `magic-modal`, so `react-native-magic-modal@10.x` and `magic-modal@10.x` are the same code. Omitting `replacementVersion` makes the replacement version-preserving and avoids a downgrade once the pair moves past 10.0.0. Same reasoning as the existing `replacements:framer-motion-to-motion` entry, which is the closest precedent here (old name still published alongside the new one).

Happy to switch to a pinned `replacementVersion: "10.0.0"` or widen `matchCurrentVersion` if you'd rather stay consistent with the more common frozen-old-package entries.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR was written by Claude Code (Opus 5), including the data entry and this description. I maintain both packages and verified the rename facts, the constraint choice, and the test runs myself.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Ran the existing data/preset validation rather than adding new tests, since `replacements.json` entries are covered generically:

- `vitest run lib/data/index.spec.ts lib/config/presets/internal/index.spec.ts` — 1341 passed, including the new preset in the `config:recommended` validation
- `node tools/validate-schema.ts` — `lib/data/replacements.json` validates against `tools/schemas/replacements-schema.json`
- `prettier --check lib/data/replacements.json` — clean

The public repository: <https://github.com/GSTJ/magic-modal>
