### PR TITLE
fix(datasource/npm): handle absent `homepage`s

### DIFF
--- a/lib/modules/datasource/npm/schema.spec.ts
+++ b/lib/modules/datasource/npm/schema.spec.ts
@@ -118,6 +118,14 @@ describe('modules/datasource/npm/schema', () => {
     });
   });
 
+  it('drops an invalid package-level `homepage` (e.g. `null`)', () => {
+    const result = CachedPackument.parse({
+      homepage: null,
+      versions: { '1.0.0': {} },
+    });
+    expect(result.homepage).toBeUndefined();
+  });
+
   describe('NpmResponseSchema', () => {
     it('parses a full npm registry response and preserves extra version fields', () => {
       const input = {

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -41,15 +41,17 @@ export const NpmResponseVersion = z.object({
 });
 export type NpmResponseVersion = z.infer<typeof NpmResponseVersion>;
 
-export const CachedPackument = z.object({
-  versions: z.record(z.string(), NpmResponseVersion).optional(),
-  repository: Repository.optional(),
-  homepage: z.string().optional().catch(undefined),
-  // `LooseRecord` drops non-string entries (e.g. Artifactory's
-  // `"unpublished": null`) instead of invalidating the whole packument.
-  time: LooseRecord(z.string()).optional(),
-  'dist-tags': z.record(z.string(), z.string()).optional(),
-});
+export const CachedPackument = DeepNullish(
+  z.object({
+    versions: z.record(z.string(), NpmResponseVersion).optional(),
+    repository: Repository.optional(),
+    homepage: z.string().optional(),
+    // `LooseRecord` drops non-string entries (e.g. Artifactory's
+    // `"unpublished": null`) instead of invalidating the whole packument.
+    time: LooseRecord(z.string()).optional(),
+    'dist-tags': z.record(z.string(), z.string()).optional(),
+  }),
+);
 
 /**
  * Full NpmResponse schema — used when fetching from the npm registry.

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -66,7 +66,7 @@ export const NpmResponse = z.object({
   name: z.string().optional(),
   versions: z.record(z.string(), NpmResponseVersionLoose).optional(),
   repository: RepositoryNpmResponse.optional(),
-  homepage: z.string().optional().catch(undefined),
+  homepage: z.string().optional(),
   time: LooseRecord(z.string()).optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -44,7 +44,7 @@ export type NpmResponseVersion = z.infer<typeof NpmResponseVersion>;
 export const CachedPackument = z.object({
   versions: z.record(z.string(), NpmResponseVersion).optional(),
   repository: Repository.optional(),
-  homepage: z.string().optional(),
+  homepage: z.string().optional().catch(undefined),
   // `LooseRecord` drops non-string entries (e.g. Artifactory's
   // `"unpublished": null`) instead of invalidating the whole packument.
   time: LooseRecord(z.string()).optional(),
@@ -64,7 +64,7 @@ export const NpmResponse = z.object({
   name: z.string().optional(),
   versions: z.record(z.string(), NpmResponseVersionLoose).optional(),
   repository: RepositoryNpmResponse.optional(),
-  homepage: z.string().optional(),
+  homepage: z.string().optional().catch(undefined),
   time: LooseRecord(z.string()).optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Co-authored-by: Claude Sonnet 5 <jamie.tanna+claude-code@mend.io>

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: Closes #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
