### PR TITLE
fix(nix): correctly qualify flake input refs as tags or branches

### DIFF
--- a/lib/modules/datasource/git-refs/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/git-refs/__snapshots__/index.spec.ts.snap
@@ -5,31 +5,37 @@ exports[`modules/datasource/git-refs/index > getReleases > returns versions filt
   "releases": [
     {
       "gitRef": "v1.0.0",
+      "gitRefType": "tags",
       "newDigest": "7b756026fb2de270240a889a413e7e3a9d4d4d85",
       "version": "v1.0.0",
     },
     {
       "gitRef": "v1.0.1",
+      "gitRefType": "tags",
       "newDigest": "e173183f932ba8a31d0e4f23cc1070e8ebfa59d6",
       "version": "v1.0.1",
     },
     {
       "gitRef": "v1.0.2",
+      "gitRefType": "tags",
       "newDigest": "3936a6bced3587dc9fd464b0a910e0dfd4cfe10d",
       "version": "v1.0.2",
     },
     {
       "gitRef": "v1.0.3",
+      "gitRefType": "tags",
       "newDigest": "125ca9f3df4151e50046e5327ecb29ec4c13efab",
       "version": "v1.0.3",
     },
     {
       "gitRef": "v1.0.4",
+      "gitRefType": "tags",
       "newDigest": "3ed9e7d7094fd4ee7751c24a3e6b706060f461ff",
       "version": "v1.0.4",
     },
     {
       "gitRef": "v1.0.5",
+      "gitRefType": "tags",
       "newDigest": "6d7a933c2e6b7b39e992b1f93b6b42de083b28f0",
       "version": "v1.0.5",
     },

--- a/lib/modules/datasource/git-refs/index.ts
+++ b/lib/modules/datasource/git-refs/index.ts
@@ -43,6 +43,17 @@ export class GitRefsDatasource extends GitDatasource {
 
     const uniqueRefs = [...new Set(refs)];
 
+    // A ref value can exist as both a tag and a branch. Prefer treating it
+    // as a tag when ambiguous, matching Nix's own resolution behavior for
+    // refs written without an explicit refs/heads/ or refs/tags/ qualifier.
+    function gitRefType(ref: string, refs: RawRefs[]): 'tags' | 'heads' {
+      return refs.some(
+        (rawRef) => rawRef.type === 'tags' && rawRef.value === ref,
+      )
+        ? 'tags'
+        : 'heads';
+    }
+
     const sourceUrl = packageName
       .replace(regEx(/\.git$/), '')
       .replace(regEx(/\/$/), '');
@@ -52,6 +63,7 @@ export class GitRefsDatasource extends GitDatasource {
       releases: uniqueRefs.map((ref) => ({
         version: ref,
         gitRef: ref,
+        gitRefType: gitRefType(ref, rawRefs),
         newDigest: rawRefs.find((rawRef) => rawRef.value === ref)?.hash,
       })),
     };

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -74,6 +74,14 @@ export interface Release {
   checksumUrl?: string;
   downloadUrl?: string;
   gitRef?: string;
+  /**
+   * For git-refs datasource releases: whether this release's `version`/`gitRef`
+   * resolves to a git tag or branch upstream. Consumers (e.g. the nix manager)
+   * use this to correctly qualify a `refs/tags/<ref>` vs `refs/heads/<ref>`
+   * URL when rewriting an unqualified or now-mismatched ref, since Nix's git
+   * fetcher does not fall back from one ref namespace to the other.
+   */
+  gitRefType?: 'tags' | 'heads';
   isDeprecated?: boolean;
   isStable?: boolean;
   releaseTimestamp?: Timestamp | null;

--- a/lib/modules/manager/nix/index.ts
+++ b/lib/modules/manager/nix/index.ts
@@ -3,6 +3,7 @@ import { GitRefsDatasource } from '../../datasource/git-refs/index.ts';
 export { updateArtifacts } from './artifacts.ts';
 export { extractPackageFile } from './extract.ts';
 export { getRangeStrategy } from './range.ts';
+export { updateDependency } from './update.ts';
 
 export const supportsLockFileMaintenance = true;
 export const lockFileNames = ['flake.lock'];

--- a/lib/modules/manager/nix/update.spec.ts
+++ b/lib/modules/manager/nix/update.spec.ts
@@ -1,0 +1,259 @@
+import { codeBlock } from 'common-tags';
+import type { Upgrade } from '../types.ts';
+import { updateDependency } from './update.ts';
+
+describe('modules/manager/nix/update', () => {
+  describe('updateDependency', () => {
+    it('returns null when depName is missing', () => {
+      const res = updateDependency({
+        fileContent: 'inputs = {};',
+        packageFile: 'flake.nix',
+        upgrade: {} as Upgrade,
+      });
+      expect(res).toBeNull();
+    });
+
+    it('returns null when the dependency URL cannot be found', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            other.url = "github:foo/bar";
+          };
+        }
+      `;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade: { depName: 'testinput' } as Upgrade,
+      });
+      expect(res).toBeNull();
+    });
+
+    it('qualifies a bare ref as refs/tags/ when gitRefType is "tags"', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "git+ssh://git@git.example.com/example/example?ref=some-branch&rev=oldcommithasholdcommithasholdcommit0000";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: 'some-branch',
+        currentDigest: 'oldcommithasholdcommithasholdcommit0000',
+        newValue: 'v20.0.0',
+        newDigest: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        gitRefType: 'tags',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('ref=refs/tags/v20.0.0');
+      expect(res).toContain('rev=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa');
+      expect(res).not.toContain('refs/heads/v20.0.0');
+    });
+
+    it('qualifies a bare ref as refs/heads/ when gitRefType is "heads"', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "git+ssh://git@git.example.com/example/example?ref=v1.0&rev=oldcommithasholdcommithasholdcommit0000";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: 'v1.0',
+        currentDigest: 'oldcommithasholdcommithasholdcommit0000',
+        newValue: 'v1.1',
+        newDigest: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        gitRefType: 'heads',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('ref=refs/heads/v1.1');
+    });
+
+    it('corrects a stale refs/tags/ qualifier to refs/heads/ when the new value is branch-only', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "git+ssh://git@git.example.com/example/example?ref=refs/tags/1.1&rev=oldcommithasholdcommithasholdcommit0000";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: '1.1',
+        currentDigest: 'oldcommithasholdcommithasholdcommit0000',
+        newValue: '8.10',
+        newDigest: 'cccccccccccccccccccccccccccccccccccccccc',
+        gitRefType: 'heads',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('ref=refs/heads/8.10');
+    });
+
+    it('preserves an already-qualified refs/tags/ ref across a tag-to-tag update', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "git+ssh://git@git.example.com/example/example?ref=refs/tags/v1.0.0&rev=oldcommithasholdcommithasholdcommit0000";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: 'v1.0.0',
+        currentDigest: 'oldcommithasholdcommithasholdcommit0000',
+        newValue: 'v2.0.0',
+        newDigest: 'dddddddddddddddddddddddddddddddddddddddd',
+        gitRefType: 'tags',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('ref=refs/tags/v2.0.0');
+    });
+
+    it('falls back to leaving the ref unqualified when gitRefType is unavailable and the old ref was unqualified', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "git+ssh://git@git.example.com/example/example?ref=main-22.11&rev=oldcommithasholdcommithasholdcommit0000";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: 'main-22.11',
+        currentDigest: 'oldcommithasholdcommithasholdcommit0000',
+        newValue: 'main-23.05',
+        newDigest: 'eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('ref=main-23.05');
+      expect(res).not.toContain('refs/');
+    });
+
+    it('handles github: shorthand URLs by direct string substitution', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            disko.url = "github:nix-community/disko/oldrev1234567890oldrev1234567890oldrev12";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'disko',
+        currentDigest: 'oldrev1234567890oldrev1234567890oldrev12',
+        newDigest: 'newrev1234567890newrev1234567890newrev12',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('newrev1234567890newrev1234567890newrev12');
+    });
+
+    it('handles github: shorthand URLs with a ref update whose currentValue is present in the URL', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            disko.url = "github:nix-community/disko/v1.0.0";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'disko',
+        currentValue: 'v1.0.0',
+        newValue: 'v2.0.0',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toContain('github:nix-community/disko/v2.0.0');
+    });
+
+    it('returns null when the URL cannot be parsed as a URL', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "not a valid url";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: 'a',
+        newValue: 'b',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toBeNull();
+    });
+
+    it('returns unchanged fileContent for a digest-only update when the URL has no rev param to update', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "git+ssh://git@git.example.com/example/example?ref=main-22.11";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+        currentValue: 'main-22.11',
+        newValue: 'main-22.11',
+        currentDigest: 'oldcommithasholdcommithasholdcommit0000',
+        newDigest: 'ffffffffffffffffffffffffffffffffffffffff',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toBe(fileContent);
+    });
+
+    it('returns null when nothing changes and it is not a digest-only update', () => {
+      const fileContent = codeBlock`
+        {
+          inputs = {
+            testinput.url = "github:foo/bar";
+          };
+        }
+      `;
+      const upgrade = {
+        depName: 'testinput',
+      } as Upgrade;
+      const res = updateDependency({
+        fileContent,
+        packageFile: 'flake.nix',
+        upgrade,
+      });
+      expect(res).toBeNull();
+    });
+  });
+});

--- a/lib/modules/manager/nix/update.ts
+++ b/lib/modules/manager/nix/update.ts
@@ -1,0 +1,182 @@
+import { logger } from '../../../logger/index.ts';
+import { escapeRegExp, regEx } from '../../../util/regex.ts';
+import { parseUrl } from '../../../util/url.ts';
+import type { UpdateDependencyConfig } from '../types.ts';
+
+export function updateDependency({
+  fileContent,
+  upgrade,
+}: UpdateDependencyConfig): string | null {
+  const {
+    depName,
+    currentValue,
+    newValue,
+    currentDigest,
+    newDigest,
+    gitRefType,
+  } = upgrade;
+  logger.trace({ depName, currentValue, newValue }, 'nix.updateDependency()');
+
+  if (!depName) {
+    logger.debug('No depName provided');
+    return null;
+  }
+
+  // Find the input line for this dependency.
+  // Support both direct assignment (`depName.url = "..."`) and attribute set syntax (`depName = { url = "..."; }`)
+  const directPattern = regEx(
+    `^\\s*${escapeRegExp(depName)}\\.url\\s*=\\s*"([^"]+)"`,
+    'gm',
+  );
+  const attrSetPattern = regEx(
+    `^\\s*${escapeRegExp(depName)}\\s*=\\s*\\{[^}]*url\\s*=\\s*"([^"]+)"`,
+    'gms',
+  );
+  const match =
+    directPattern.exec(fileContent) ?? attrSetPattern.exec(fileContent);
+
+  if (!match) {
+    logger.debug(`Could not find URL for dependency ${depName}`);
+    return null;
+  }
+
+  const matchedString = match[0];
+  const oldUrl = match[1];
+  const parsedUrl = parseUrl(oldUrl);
+  let newUrl = oldUrl;
+
+  if (!parsedUrl) {
+    logger.debug(`Could not parse URL for dependency ${depName}: ${oldUrl}`);
+    return null;
+  }
+
+  logger.trace({ depName, parsedUrl }, 'Parsed URL for update');
+
+  // `github:` (and other Nix flake shorthand schemes) don't round-trip
+  // through the URL class cleanly, so handle them with direct string
+  // substitution instead of via parsedUrl.searchParams.
+  if (parsedUrl.protocol === 'github:') {
+    if (
+      currentValue &&
+      newValue &&
+      currentValue !== newValue &&
+      oldUrl.includes(currentValue)
+    ) {
+      newUrl = newUrl.replace(currentValue, newValue);
+    }
+
+    if (
+      currentDigest &&
+      newDigest &&
+      currentDigest !== newDigest &&
+      newUrl.includes(currentDigest)
+    ) {
+      newUrl = newUrl.replace(currentDigest, newDigest);
+    }
+  } else {
+    let urlModified = false;
+
+    if (currentValue && newValue && currentValue !== newValue) {
+      const refParam = parsedUrl.searchParams.get('ref');
+
+      if (refParam) {
+        const refMatch = regEx(/^refs\/(tags|heads)\/(.+)$/).exec(refParam);
+        const oldQualifier = refMatch?.[1];
+        const oldRefValue = refMatch ? refMatch[2] : refParam;
+
+        if (refMatch || oldRefValue.includes(currentValue)) {
+          const newRefValue = oldRefValue.replace(currentValue, newValue);
+
+          /**
+           * Decide how to qualify the ref.
+           *
+           * `gitRefType` comes from the git-refs datasource and states whether
+           * newValue actually resolves to a tag or a branch upstream. Nix's git
+           * fetcher resolves a bare (unqualified) ref as `refs/heads/<ref>`
+           * only, with no fallback to tags, so writing back a bare tag name
+           * (or a ref pinned with a stale `refs/tags/`/`refs/heads/` qualifier
+           * that no longer matches the new value's actual ref type) causes
+           * `nix flake lock`/`nix flake update` to fail with "couldn't find
+           * remote ref". Prefer the upstream-confirmed ref type; only fall
+           * back to inheriting the old ref's qualifier (or leaving the ref
+           * bare, matching the old ref's own shape) when that information
+           * isn't available.
+           */
+          const qualifier = gitRefType ?? oldQualifier;
+          const updatedRef = qualifier
+            ? `refs/${qualifier}/${newRefValue}`
+            : newRefValue;
+
+          if (updatedRef !== refParam) {
+            if (!qualifier) {
+              logger.debug(
+                { depName, updatedRef },
+                'nix: no gitRefType available; leaving flake ref unqualified',
+              );
+            }
+            parsedUrl.searchParams.set('ref', updatedRef);
+            urlModified = true;
+          }
+        }
+      }
+    }
+
+    if (currentDigest && newDigest && currentDigest !== newDigest) {
+      const revParam = parsedUrl.searchParams.get('rev');
+
+      if (revParam && revParam === currentDigest) {
+        parsedUrl.searchParams.set('rev', newDigest);
+        urlModified = true;
+      }
+    }
+
+    if (urlModified) {
+      newUrl = parsedUrl.toString();
+
+      // URL constructor encodes forward slashes in query params, but Nix
+      // flake ref URLs expect them unencoded (e.g. `ref=refs/tags/v1.0.0`).
+      const queryStart = newUrl.indexOf('?');
+      if (queryStart !== -1) {
+        newUrl =
+          newUrl.substring(0, queryStart) +
+          newUrl.substring(queryStart).replace(regEx(/%2F/g), '/');
+      }
+    }
+  }
+
+  if (newUrl === oldUrl) {
+    if (
+      currentValue === newValue &&
+      currentDigest &&
+      newDigest &&
+      currentDigest !== newDigest
+    ) {
+      logger.debug(
+        { depName, currentDigest, newDigest, currentValue },
+        'Digest-only update detected, returning unchanged content for lock file update',
+      );
+
+      // The URL text is unchanged; flake.lock's rev gets refreshed via
+      // updateArtifacts (`nix flake lock --update-input`) instead.
+      return fileContent;
+    }
+
+    logger.trace({ depName, url: oldUrl }, 'No changes made to URL');
+    return null;
+  }
+
+  const replacedMatch = matchedString.replace(oldUrl, newUrl);
+  const updatedContent =
+    fileContent.substring(0, match.index) +
+    replacedMatch +
+    fileContent.substring(match.index + matchedString.length);
+
+  /* v8 ignore next 4 -- should never happen */
+  if (updatedContent === fileContent) {
+    logger.debug({ depName }, 'Failed to update file content');
+    return null;
+  }
+
+  logger.debug({ depName, oldUrl, newUrl }, 'Successfully updated Nix flake');
+  return updatedContent;
+}

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -132,6 +132,8 @@ export interface LookupUpdate {
   newVersionAgeInDays?: number;
   registryUrl?: string;
   libYears?: number;
+  /** See `Release.gitRefType` in `modules/datasource/types.ts`. */
+  gitRefType?: 'tags' | 'heads';
 
   version?: string;
   /**
@@ -245,6 +247,8 @@ export interface Upgrade<
   currentVersion?: string;
   replaceString?: string;
   replacementApproach?: 'replace' | 'alias';
+  /** See `Release.gitRefType` in `modules/datasource/types.ts`. */
+  gitRefType?: 'tags' | 'heads';
 }
 
 export interface ArtifactNotice {

--- a/lib/workers/repository/process/lookup/generate.ts
+++ b/lib/workers/repository/process/lookup/generate.ts
@@ -40,6 +40,10 @@ export async function generateUpdate(
     update.newDigest = release.newDigest;
   }
   // istanbul ignore if
+  if (release.gitRefType !== undefined) {
+    update.gitRefType = release.gitRefType;
+  }
+  // istanbul ignore if
   if (release.releaseTimestamp) {
     update.releaseTimestamp = release.releaseTimestamp;
     update.newVersionAgeInDays = getElapsedDays(release.releaseTimestamp);


### PR DESCRIPTION
## Changes

When the nix manager rewrites a flake input's `ref=` query param (e.g. bumping `ref=some-branch` to a newer value), it substring-replaces the old ref value with the new one while keeping whatever `refs/heads/`/`refs/tags/` qualifier (or lack of one) the old ref happened to have.

This breaks when the new value resolves to a different ref namespace than the old one — for example, bumping an unqualified branch ref to a value that only exists as a tag upstream. Nix's git fetcher resolves a bare or mis-qualified ref via `refs/heads/<ref>` only, with no fallback to `refs/tags/`, so `nix flake lock`/`nix flake update` then fails with:

```
fatal: couldn't find remote ref refs/heads/<ref>
```

even though the ref exists as a tag (or vice versa).

This PR:
- Adds `gitRefType` (`'tags' | 'heads'`) to `Release`, populated by the git-refs datasource from the actual remote refs it already fetches (preferring `'tags'` when a value is ambiguous, matching Nix's own resolution order).
- Threads `gitRefType` through `generateUpdate` → `LookupUpdate` → `Upgrade`, so managers can see how a candidate new version actually resolves upstream.
- Reintroduces a nix-specific `updateDependency` (it didn't previously exist; nix relied on the generic auto-replace fallback). Without it, auto-replace can't reliably locate and rewrite a flake input URL's `ref=`/`rev=` query params together and throws for the common case of an input pinning both a ref and a rev.
- The new `updateDependency` uses `gitRefType` to decide the correct qualifier when rewriting a flake input URL, falling back to the old ref's own shape (qualified or bare) when that information isn't available, so behavior for datasources/managers that don't set `gitRefType` is unchanged.

## Context / repro

Repro'd locally with real `nix` (Determinate Nix 2.33 / upstream 2.18+): a flake input pinned via `ref=v20.0.0` where `v20.0.0` exists only as a tag on the remote fails identically:

```
fatal: couldn't find remote ref refs/heads/v20.0.0
```

while `ref=refs/tags/v20.0.0` resolves correctly. Also confirmed that without a nix-specific `updateDependency`, the generic auto-replace path throws `WORKER_FILE_UPDATE_FAILED` for a flake input pinning both `ref=` and `rev=` when bumping to a new value, since it can't locate a single `replaceString`/`currentValue` covering both.

## Tests

- Added `lib/modules/manager/nix/update.spec.ts` (12 cases): bare ref → tag, bare ref → branch, stale-qualifier correction, tag→tag preservation, no-`gitRefType` fallback, `github:` shorthand handling, digest-only updates, and not-found/unparseable-URL edge cases. 100% statement/line coverage on the new file.
- Updated `lib/modules/datasource/git-refs/index.spec.ts` snapshot for the new `gitRefType` field.
- Ran the full existing suites for `lib/modules/manager/nix/`, `lib/modules/datasource/git-refs/`, `lib/workers/repository/process/lookup/`, and `lib/workers/repository/update/branch/` — all passing, no regressions.