### PR TITLE
fix(workers/repository): don't bump versions when `rangeStrategy=pin` and `pinDigests` on pinned digests

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4,6 +4,7 @@ import * as httpMock from '~test/http-mock.ts';
 import { fakeSha, logger, partial } from '~test/util.ts';
 import * as hostRules from '../../../../../lib/util/host-rules.ts';
 import { getConfig } from '../../../../config/defaults.ts';
+import { resolveConfigPresets } from '../../../../config/presets/index.ts';
 import { supportedDatasources as presetSupportedDatasources } from '../../../../config/presets/internal/merge-confidence.preset.ts';
 import type { AllConfig } from '../../../../config/types.ts';
 import { CONFIG_VALIDATION } from '../../../../constants/error-messages.ts';
@@ -35,6 +36,7 @@ import {
   initConfig,
   resetConfig,
 } from '../../../../util/merge-confidence/index.ts';
+import { applyPackageRules } from '../../../../util/package-rules/index.ts';
 import { Result } from '../../../../util/result.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
 import * as lookup from './index.ts';
@@ -4466,6 +4468,55 @@ describe('workers/repository/process/lookup/index', () => {
         },
       ]);
     });
+
+    it.each([
+      {
+        name: 'digest is already pinned',
+        config: { currentDigest: fakeSha('current') },
+        expectedUpdate: {
+          updateType: 'digest',
+          newValue: 'v8',
+          newDigest: fakeSha('new'),
+        },
+      },
+      {
+        name: 'digest is not yet pinned',
+        config: { pinDigests: true },
+        expectedUpdate: {
+          updateType: 'pinDigest',
+          newValue: 'v8',
+          newDigest: fakeSha('new'),
+          isPinDigest: true,
+        },
+      },
+    ])(
+      'does not bump a floating major tag to an exact version for any config that requests digest pinning ($name), regardless of a global `rangeStrategy=pin` and independent of any preset',
+      async ({ config: extraConfig, expectedUpdate }) => {
+        config = {
+          ...config,
+          ...extraConfig,
+          currentValue: 'v8',
+          packageName: 'actions/checkout',
+          rangeStrategy: 'pin',
+          versioning: githubActionsVersioningId,
+          datasource: GithubTagsDatasource.id,
+        };
+
+        getGithubTags.mockResolvedValueOnce({
+          releases: [{ version: 'v8.0.1' }, { version: 'v8' }],
+        });
+        vi.spyOn(
+          GithubTagsDatasource.prototype,
+          'getDigest',
+        ).mockResolvedValueOnce(fakeSha('new'));
+
+        const { updates } = await Result.wrap(
+          lookup.lookupUpdates(config),
+        ).unwrapOrThrow();
+
+        expect(updates).toEqual([expectedUpdate]);
+      },
+    );
 
     it('marks a too-new GitHub Actions major-tag digest update as pending when using `internalChecksFilter=strict`', async () => {
       config.currentValue = 'v7';

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -4428,6 +4428,45 @@ describe('workers/repository/process/lookup/index', () => {
       });
     });
 
+    it('does not bump a floating major tag to an exact version when a global `rangeStrategy=pin` is combined with `helpers:pinGitHubActionDigests`', async () => {
+      const { config: presetConfig } = await resolveConfigPresets({
+        extends: ['helpers:pinGitHubActionDigests'],
+      });
+
+      config = await applyPackageRules({
+        ...config,
+        ...presetConfig,
+        abandonmentThreshold: presetConfig.abandonmentThreshold ?? undefined,
+        currentValue: 'v8',
+        currentDigest: fakeSha('current'),
+        packageName: 'actions/checkout',
+        depType: 'action',
+        rangeStrategy: 'pin',
+        versioning: githubActionsVersioningId,
+        datasource: GithubTagsDatasource.id,
+      });
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v8.0.1' }, { version: 'v8' }],
+      });
+      vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      ).mockResolvedValueOnce(fakeSha('new'));
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          updateType: 'digest',
+          newValue: 'v8',
+          newDigest: fakeSha('new'),
+        },
+      ]);
+    });
+
     it('marks a too-new GitHub Actions major-tag digest update as pending when using `internalChecksFilter=strict`', async () => {
       config.currentValue = 'v7';
       config.currentDigest = fakeSha('current');

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -530,6 +530,8 @@ export async function lookupUpdates(
         compareValue &&
         currentVersion &&
         rangeStrategy === 'pin' &&
+        !config.currentDigest &&
+        !config.pinDigests &&
         !versioningApi.isSingleVersion(compareValue)
       ) {
         const newValue =


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

If a repository has `rangeStrategy=pin` as their top-level config, and
i.e.

```
- name: Setup Allure TestOps
  uses: allure-framework/setup-allurectl@6878686fce27aeb6f49009173b2947a400e282b5 # v1
```

Previously, when generating a `renovate/pin-dependencies` branch, this
could also include the dependency bumps for a given `rangeStrategy=pin`
dependencies, which would result in the "pin dependencies" branch
including updates that can make it a little less safe.

Instead, we shouldn't attempt to perform `rangeStrategy=pin` when there
is already a digest pinned.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. 
- [ ] An agent will draft replies and @username will read them before they are posted. 
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

i.e. before this change: https://github.com/JamieTanna-Mend-testing/pindigest-no-bump/pull/4

After this change, no longer raised

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
