### PR TITLE
feat(gitlab): support custom dashboard work item types

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -360,6 +360,23 @@ Set this to a work item type that exists in your project, such as `Task`.
   To switch an existing issue to the new type, either rename the old work item (so its title no longer matches) and close it, or close and delete the old work item.
   Renovate then creates a fresh work item of the configured type on the next run.
 
+## `gitlabWorkItemType`
+
+The work item type Renovate uses when creating its issues (such as the Dependency Dashboard) on GitLab.
+
+It defaults to `Issue`.
+Set this to a project work item type that exists in GitLab, such as `Task` or a custom type like `Renovate`.
+
+GitLab configurable work item types were introduced in GitLab `19.0` and became generally available in GitLab `19.1`.
+If your GitLab instance does not provide the configured type to the project, Renovate skips creating a new dashboard item for that run.
+
+<!-- prettier-ignore -->
+!!! note
+  Renovate finds its existing issues by title, not by work item type.
+  If you change `gitlabWorkItemType` while an issue (such as the Dependency Dashboard) already exists, Renovate keeps using the existing item and does _not_ recreate it with the new type.
+  To switch an existing issue to the new type, either rename the old item so its title no longer matches and close it, or close and delete the old item.
+  Renovate then creates a fresh work item of the configured type on the next run.
+
 ## `baseBranchPatterns`
 
 This configuration option was formerly known as `baseBranches`.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -360,23 +360,6 @@ Set this to a work item type that exists in your project, such as `Task`.
   To switch an existing issue to the new type, either rename the old work item (so its title no longer matches) and close it, or close and delete the old work item.
   Renovate then creates a fresh work item of the configured type on the next run.
 
-## `gitlabWorkItemType`
-
-The work item type Renovate uses when creating its issues (such as the Dependency Dashboard) on GitLab.
-
-It defaults to `Issue`.
-Set this to a project work item type that exists in GitLab, such as `Task` or a custom type like `Renovate`.
-
-GitLab configurable work item types were introduced in GitLab `19.0` and became generally available in GitLab `19.1`.
-If your GitLab instance does not provide the configured type to the project, Renovate skips creating a new dashboard item for that run.
-
-<!-- prettier-ignore -->
-!!! note
-  Renovate finds its existing issues by title, not by work item type.
-  If you change `gitlabWorkItemType` while an issue (such as the Dependency Dashboard) already exists, Renovate keeps using the existing item and does _not_ recreate it with the new type.
-  To switch an existing issue to the new type, either rename the old item so its title no longer matches and close it, or close and delete the old item.
-  Renovate then creates a fresh work item of the configured type on the next run.
-
 ## `baseBranchPatterns`
 
 This configuration option was formerly known as `baseBranches`.
@@ -2040,6 +2023,23 @@ Ignore the default project level approval(s), so that Renovate bot can automerge
 Under the hood, it creates a MR-level approval rule where `approvals_required` is set to `0`.
 This option works only when `automerge=true` and either `automergeType=pr` or `automergeType=branch`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
+
+## `gitLabWorkItemType`
+
+The work item type Renovate uses when creating its issues (such as the Dependency Dashboard) on GitLab.
+
+It defaults to `Issue`.
+Set this to a project work item type that exists in GitLab, such as `Task` or a custom type like `Renovate`.
+
+GitLab configurable work item types were introduced in GitLab `19.0` and became generally available in GitLab `19.1`.
+If your GitLab instance does not provide the configured type to the project, Renovate skips creating a new dashboard item for that run.
+
+<!-- prettier-ignore -->
+!!! note
+  Renovate finds its existing issues by title, not by work item type.
+  If you change `gitLabWorkItemType` while an issue (such as the Dependency Dashboard) already exists, Renovate keeps using the existing item and does _not_ recreate it with the new type.
+  To switch an existing issue to the new type, either rename the old item so its title no longer matches and close it, or close and delete the old item.
+  Renovate then creates a fresh work item of the configured type on the next run.
 
 ## `goGetDirs`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1441,6 +1441,14 @@ const options: Readonly<RenovateOptions>[] = [
     supportedPlatforms: ['azure'],
   },
   {
+    name: 'gitlabWorkItemType',
+    description:
+      'The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on GitLab.',
+    type: 'string',
+    default: 'Issue',
+    supportedPlatforms: ['gitlab'],
+  },
+  {
     name: 'autoApprove',
     description: 'Set to `true` to automatically approve PRs.',
     type: 'boolean',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1441,7 +1441,7 @@ const options: Readonly<RenovateOptions>[] = [
     supportedPlatforms: ['azure'],
   },
   {
-    name: 'gitlabWorkItemType',
+    name: 'gitLabWorkItemType',
     description:
       'The work item type Renovate uses for its issues (e.g. the Dependency Dashboard) on GitLab.',
     type: 'string',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -79,7 +79,7 @@ export interface RenovateSharedConfig {
   automergeType?: AutoMergeType;
   azureWorkItemId?: number;
   azureWorkItemType?: string;
-  gitlabWorkItemType?: string;
+  gitLabWorkItemType?: string;
   branchName?: string;
   branchNameStrict?: boolean;
   branchPrefix?: string;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -79,6 +79,7 @@ export interface RenovateSharedConfig {
   automergeType?: AutoMergeType;
   azureWorkItemId?: number;
   azureWorkItemType?: string;
+  gitlabWorkItemType?: string;
   branchName?: string;
   branchNameStrict?: boolean;
   branchPrefix?: string;

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1680,6 +1680,22 @@ describe('modules/platform/gitlab/index', () => {
       await expect(gitlab.findIssue('title-2')).resolves.toBeNull();
       expect(logger.logger.warn).toHaveBeenCalledWith('Error finding issue');
     });
+
+    it('returns null when custom work item GraphQL response omits nodes', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {
+        data: {
+          project: {
+            issues: {},
+          },
+        },
+      });
+      await expect(gitlab.findIssue('title-2')).resolves.toBeNull();
+      expect(scope.isDone()).toBeTrue();
+    });
   });
 
   describe('ensureIssue()', () => {
@@ -2063,6 +2079,251 @@ describe('modules/platform/gitlab/index', () => {
         { err: new Error('GitLab GraphQL error: boom') },
         'Could not ensure issue',
       );
+    });
+
+    it('creates custom work item without metadata update', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+              },
+            },
+          },
+        });
+      const res = await gitlab.ensureIssue({
+        title: 'new-title',
+        body: 'new-content',
+      });
+      expect(res).toBe('created');
+      expect(scope.isDone()).toBeTrue();
+    });
+
+    it('creates custom work item with confidential metadata and default labels', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+              },
+            },
+          },
+        })
+        .post(
+          '/api/graphql',
+          (requestBody) =>
+            requestBody.variables?.input?.confidential === true &&
+            requestBody.variables?.input?.labels?.length === 0,
+        )
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: [],
+            },
+          },
+        });
+      const res = await gitlab.ensureIssue({
+        title: 'new-title',
+        body: 'new-content',
+        confidential: true,
+      });
+      expect(res).toBe('created');
+      expect(scope.isDone()).toBeTrue();
+    });
+
+    it('creates custom work item with label metadata and default confidentiality', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+              },
+            },
+          },
+        })
+        .post(
+          '/api/graphql',
+          (requestBody) =>
+            requestBody.variables?.input?.confidential === false &&
+            requestBody.variables?.input?.labels?.includes('Renovate'),
+        )
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: [],
+            },
+          },
+        });
+      const res = await gitlab.ensureIssue({
+        title: 'new-title',
+        body: 'new-content',
+        labels: ['Renovate'],
+      });
+      expect(res).toBe('created');
+      expect(scope.isDone()).toBeTrue();
+    });
+
+    it('reuses existing custom work item found by reuseTitle', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post(
+          '/api/graphql',
+          (requestBody) => requestBody.variables?.search === 'new-title',
+        )
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+                pageInfo: {
+                  endCursor: null,
+                  hasNextPage: false,
+                },
+              },
+            },
+          },
+        })
+        .post(
+          '/api/graphql',
+          (requestBody) => requestBody.variables?.search === 'old-title',
+        )
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'old-title',
+                    description: 'old-content',
+                    labels: {
+                      nodes: [],
+                    },
+                  },
+                ],
+                pageInfo: {
+                  endCursor: null,
+                  hasNextPage: false,
+                },
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: [],
+            },
+          },
+        });
+      const res = await gitlab.ensureIssue({
+        title: 'new-title',
+        reuseTitle: 'old-title',
+        body: 'new-content',
+      });
+      expect(res).toBe('updated');
+      expect(scope.isDone()).toBeTrue();
     });
 
     it('updates existing issue when a custom work item type is configured', async () => {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1895,7 +1895,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {
@@ -1954,7 +1954,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {
@@ -2000,7 +2000,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {
@@ -2048,7 +2048,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {
@@ -2100,7 +2100,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {
@@ -2150,7 +2150,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {
@@ -2214,7 +2214,7 @@ describe('modules/platform/gitlab/index', () => {
         .post('/api/graphql')
         .reply(200, {
           data: {
-            project: {
+            namespace: {
               workItemTypes: {
                 nodes: [
                   {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1724,6 +1724,23 @@ describe('modules/platform/gitlab/index', () => {
       expect(res).toBe('created');
     });
 
+    it('keeps default issue flow when repo context omits work item type', async () => {
+      gitlab.setRepoContext?.({});
+      httpMock
+        .scope(gitlabApiHost)
+        .get(
+          '/api/v4/projects/undefined/issues?per_page=100&scope=created_by_me&state=opened',
+        )
+        .reply(200, [])
+        .post('/api/v4/projects/undefined/issues')
+        .reply(200);
+      const res = await gitlab.ensureIssue({
+        title: 'new-title',
+        body: 'new-content',
+      });
+      expect(res).toBe('created');
+    });
+
     it('sets issue labels', async () => {
       httpMock
         .scope(gitlabApiHost)

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -54,13 +54,14 @@ describe('modules/platform/gitlab/index', () => {
     repoCache.resetCache();
   });
 
-  async function initFakePlatform(version: string) {
+  async function initFakePlatform(version: string, username?: string) {
     httpMock
       .scope(gitlabApiHost)
       .get('/api/v4/user')
       .reply(200, {
         email: 'a@b.com',
         name: 'Renovate Bot',
+        ...(username ? { username } : {}),
       })
       .get('/api/v4/version')
       .reply(200, {
@@ -1514,7 +1515,7 @@ describe('modules/platform/gitlab/index', () => {
     it('finds custom work item', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
-        gitlabWorkItemType: 'Renovate',
+        gitLabWorkItemType: 'Renovate',
       });
       scope.post('/api/graphql').reply(200, {
         data: {
@@ -1542,10 +1543,42 @@ describe('modules/platform/gitlab/index', () => {
       });
     });
 
+    it('finds custom work item with author filter and missing optional fields', async () => {
+      await initFakePlatform('13.3.6', 'renovate-bot');
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql', (requestBody) =>
+          requestBody.variables?.authorUsername === 'renovate-bot',
+        )
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'title-2',
+                  },
+                ],
+              },
+            },
+          },
+        });
+      const res = await gitlab.findIssue('title-2');
+      expect(res).toEqual({
+        body: '',
+        number: 2,
+      });
+    });
+
     it('finds custom work item on a later GraphQL page', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
-        gitlabWorkItemType: 'Renovate',
+        gitLabWorkItemType: 'Renovate',
       });
       scope
         .post('/api/graphql')
@@ -1601,6 +1634,49 @@ describe('modules/platform/gitlab/index', () => {
         body: 'new-content',
         number: 2,
       });
+    });
+
+    it('returns null when custom work item is not found', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {
+        data: {
+          project: {
+            issues: {
+              nodes: [],
+              pageInfo: {
+                endCursor: null,
+                hasNextPage: false,
+              },
+            },
+          },
+        },
+      });
+      await expect(gitlab.findIssue('title-2')).resolves.toBeNull();
+    });
+
+    it('returns null when custom work item GraphQL returns errors', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {
+        errors: [{ message: 'boom' }],
+      });
+      await expect(gitlab.findIssue('title-2')).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith('Error finding issue');
+    });
+
+    it('returns null when custom work item GraphQL returns no data', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {});
+      await expect(gitlab.findIssue('title-2')).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith('Error finding issue');
     });
   });
 
@@ -1785,7 +1861,7 @@ describe('modules/platform/gitlab/index', () => {
     it('creates custom work item', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
-        gitlabWorkItemType: 'Renovate',
+        gitLabWorkItemType: 'Renovate',
       });
       scope
         .post('/api/graphql')
@@ -1841,10 +1917,156 @@ describe('modules/platform/gitlab/index', () => {
       expect(res).toBe('created');
     });
 
+    it('skips custom work item creation when configured type does not exist', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/24',
+                    name: 'Task',
+                  },
+                ],
+              },
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        {
+          repository: 'some/repo',
+          workItemType: 'Renovate',
+        },
+        'GitLab configured work item type does not exist in project; skipping issue creation',
+      );
+    });
+
+    it('returns null when custom work item creation returns no iid', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: null,
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBeNull();
+    });
+
+    it('returns null when custom work item creation mutation returns errors', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: ['boom'],
+              workItem: null,
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: new Error('GitLab GraphQL error: boom') },
+        'Could not ensure issue',
+      );
+    });
+
     it('updates existing issue when a custom work item type is configured', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
-        gitlabWorkItemType: 'Renovate',
+        gitLabWorkItemType: 'Renovate',
       });
       scope
         .post('/api/graphql')
@@ -1885,6 +2107,84 @@ describe('modules/platform/gitlab/index', () => {
       });
       expect(res).toBe('updated');
     });
+
+    it('skips custom work item update if unchanged', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {
+        data: {
+          project: {
+            issues: {
+              nodes: [
+                {
+                  id: 'gid://gitlab/Issue/2',
+                  iid: '2',
+                  title: 'title-2',
+                  description: 'new-content',
+                  labels: {
+                    nodes: [],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'title-2',
+          body: 'new-content',
+        }),
+      ).resolves.toBeNull();
+    });
+
+    it('returns null when custom work item update mutation returns errors', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'title-2',
+                    description: 'new-content',
+                    labels: {
+                      nodes: [],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: ['boom'],
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'title-2',
+          body: 'newer-content',
+        }),
+      ).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: new Error('GitLab GraphQL error: boom') },
+        'Could not ensure issue',
+      );
+    });
   });
 
   describe('ensureIssueClosing()', () => {
@@ -1912,7 +2212,7 @@ describe('modules/platform/gitlab/index', () => {
     it('closes custom work item', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
-        gitlabWorkItemType: 'Renovate',
+        gitLabWorkItemType: 'Renovate',
       });
       scope
         .post('/api/graphql')
@@ -1944,6 +2244,62 @@ describe('modules/platform/gitlab/index', () => {
           },
         });
       await expect(gitlab.ensureIssueClosing('title-2')).toResolve();
+    });
+
+    it('does nothing when custom work item to close is not found', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {
+        data: {
+          project: {
+            issues: {
+              nodes: [],
+            },
+          },
+        },
+      });
+      await expect(gitlab.ensureIssueClosing('title-2')).toResolve();
+    });
+
+    it('throws when closing custom work item mutation returns errors', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'title-2',
+                    description: 'new-content',
+                    labels: {
+                      nodes: [],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: ['boom'],
+            },
+          },
+        });
+      await expect(gitlab.ensureIssueClosing('title-2')).rejects.toThrow(
+        'GitLab GraphQL error: boom',
+      );
     });
   });
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1550,8 +1550,10 @@ describe('modules/platform/gitlab/index', () => {
         gitLabWorkItemType: 'Renovate',
       });
       scope
-        .post('/api/graphql', (requestBody) =>
-          requestBody.variables?.authorUsername === 'renovate-bot',
+        .post(
+          '/api/graphql',
+          (requestBody) =>
+            requestBody.variables?.authorUsername === 'renovate-bot',
         )
         .reply(200, {
           data: {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1935,6 +1935,59 @@ describe('modules/platform/gitlab/index', () => {
       expect(res).toBe('created');
     });
 
+    it('creates custom work item when repo config is applied after initRepo', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+      });
+      gitlab.setRepoContext?.({
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            namespace: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+              },
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBe('created');
+      expect(scope.isDone()).toBeTrue();
+    });
+
     it('skips custom work item creation when configured type does not exist', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
@@ -1977,7 +2030,55 @@ describe('modules/platform/gitlab/index', () => {
           repository: 'some/repo',
           workItemType: 'Renovate',
         },
-        'GitLab configured work item type does not exist in project; skipping issue creation',
+        'GitLab configured work item type does not exist or is not creatable in this project; skipping issue creation',
+      );
+    });
+
+    it('skips custom work item creation when configured type is not creatable in the project', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            namespace: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                    enabled: false,
+                    canUserCreateItems: false,
+                  },
+                ],
+              },
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        {
+          repository: 'some/repo',
+          workItemType: 'Renovate',
+        },
+        'GitLab configured work item type does not exist or is not creatable in this project; skipping issue creation',
       );
     });
 
@@ -2081,6 +2182,68 @@ describe('modules/platform/gitlab/index', () => {
       );
     });
 
+    it('falls back to legacy work item types query when availability fields are unsupported', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          errors: [
+            {
+              message:
+                "Field 'canUserCreateItems' doesn't exist on type 'WorkItemType'",
+            },
+          ],
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            namespace: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+              },
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBe('created');
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'GitLab GraphQL work item availability fields unsupported; falling back to legacy work item types query',
+      );
+    });
+
     it('creates custom work item without metadata update', async () => {
       const scope = await initRepo({
         repository: 'some/repo',
@@ -2129,6 +2292,67 @@ describe('modules/platform/gitlab/index', () => {
       });
       expect(res).toBe('created');
       expect(scope.isDone()).toBeTrue();
+    });
+
+    it('warns when GitLab creates a different work item type than requested', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            namespace: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+                workItemType: {
+                  name: 'Issue',
+                },
+              },
+            },
+          },
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBe('created');
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        {
+          repository: 'some/repo',
+          requestedWorkItemType: 'Renovate',
+          createdWorkItemType: 'Issue',
+        },
+        'GitLab created a different work item type than requested',
+      );
     });
 
     it('creates custom work item with confidential metadata and default labels', async () => {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -2244,6 +2244,38 @@ describe('modules/platform/gitlab/index', () => {
       );
     });
 
+    it('returns null when work item types query returns an unrecoverable GraphQL error', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitLabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          errors: [{ message: 'boom' }],
+        });
+      await expect(
+        gitlab.ensureIssue({
+          title: 'new-title',
+          body: 'new-content',
+        }),
+      ).resolves.toBeNull();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: new Error('GitLab GraphQL error: boom') },
+        'Could not ensure issue',
+      );
+    });
+
     it('creates custom work item without metadata update', async () => {
       const scope = await initRepo({
         repository: 'some/repo',

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1510,6 +1510,98 @@ describe('modules/platform/gitlab/index', () => {
       const res = await gitlab.findIssue('title-2');
       expect(res).not.toBeNull();
     });
+
+    it('finds custom work item', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitlabWorkItemType: 'Renovate',
+      });
+      scope.post('/api/graphql').reply(200, {
+        data: {
+          project: {
+            issues: {
+              nodes: [
+                {
+                  id: 'gid://gitlab/Issue/2',
+                  iid: '2',
+                  title: 'title-2',
+                  description: 'new-content',
+                  labels: {
+                    nodes: [],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+      const res = await gitlab.findIssue('title-2');
+      expect(res).toEqual({
+        body: 'new-content',
+        number: 2,
+      });
+    });
+
+    it('finds custom work item on a later GraphQL page', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitlabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/1',
+                    iid: '1',
+                    title: 'title-2 draft',
+                    description: 'wrong-content',
+                    labels: {
+                      nodes: [],
+                    },
+                  },
+                ],
+                pageInfo: {
+                  endCursor: 'cursor-1',
+                  hasNextPage: true,
+                },
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'title-2',
+                    description: 'new-content',
+                    labels: {
+                      nodes: [],
+                    },
+                  },
+                ],
+                pageInfo: {
+                  endCursor: null,
+                  hasNextPage: false,
+                },
+              },
+            },
+          },
+        });
+      const res = await gitlab.findIssue('title-2');
+      expect(res).toEqual({
+        body: 'new-content',
+        number: 2,
+      });
+    });
   });
 
   describe('ensureIssue()', () => {
@@ -1689,6 +1781,110 @@ describe('modules/platform/gitlab/index', () => {
       });
       expect(res).toBe('updated');
     });
+
+    it('creates custom work item', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitlabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              workItemTypes: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/WorkItems::Type/42',
+                    name: 'Renovate',
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            workItemCreate: {
+              errors: [],
+              workItem: {
+                iid: '123',
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: [],
+            },
+          },
+        });
+      const res = await gitlab.ensureIssue({
+        title: 'new-title',
+        body: 'new-content',
+        labels: ['Renovate', 'Maintenance'],
+        confidential: true,
+      });
+      expect(res).toBe('created');
+    });
+
+    it('updates existing issue when a custom work item type is configured', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitlabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'title-2',
+                    description: 'new-content',
+                    labels: {
+                      nodes: [
+                        {
+                          title: 'existing-label',
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: [],
+            },
+          },
+        });
+      const res = await gitlab.ensureIssue({
+        title: 'title-2',
+        body: 'newer-content',
+      });
+      expect(res).toBe('updated');
+    });
   });
 
   describe('ensureIssueClosing()', () => {
@@ -1710,6 +1906,43 @@ describe('modules/platform/gitlab/index', () => {
         ])
         .put('/api/v4/projects/undefined/issues/2')
         .reply(200);
+      await expect(gitlab.ensureIssueClosing('title-2')).toResolve();
+    });
+
+    it('closes custom work item', async () => {
+      const scope = await initRepo({
+        repository: 'some/repo',
+        gitlabWorkItemType: 'Renovate',
+      });
+      scope
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            project: {
+              issues: {
+                nodes: [
+                  {
+                    id: 'gid://gitlab/Issue/2',
+                    iid: '2',
+                    title: 'title-2',
+                    description: 'new-content',
+                    labels: {
+                      nodes: [],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        })
+        .post('/api/graphql')
+        .reply(200, {
+          data: {
+            updateIssue: {
+              errors: [],
+            },
+          },
+        });
       await expect(gitlab.ensureIssueClosing('title-2')).toResolve();
     });
   });

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -1102,7 +1102,7 @@ async function findGraphqlIssueByTitle(
 
 async function resolveGraphqlWorkItemTypeId(): Promise<string | null> {
   const data = await requestGraphql<{
-    project?: {
+    namespace?: {
       workItemTypes?: {
         nodes?: {
           id: string;
@@ -1112,8 +1112,8 @@ async function resolveGraphqlWorkItemTypeId(): Promise<string | null> {
     } | null;
   }>(
     `
-      query ProjectWorkItemTypes($projectPath: ID!) {
-        project(fullPath: $projectPath) {
+      query NamespaceWorkItemTypes($namespacePath: ID!) {
+        namespace(fullPath: $namespacePath) {
           workItemTypes(first: 100) {
             nodes {
               id
@@ -1124,10 +1124,10 @@ async function resolveGraphqlWorkItemTypeId(): Promise<string | null> {
       }
     `,
     {
-      projectPath: config.repositoryPath,
+      namespacePath: config.repositoryPath,
     },
   );
-  const workItemType = data.project?.workItemTypes?.nodes?.find(
+  const workItemType = data.namespace?.workItemTypes?.nodes?.find(
     (item) => item.name === config.workItemType,
   );
   if (!workItemType) {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -335,7 +335,7 @@ export async function initRepo({
   cloneSubmodules,
   cloneSubmodulesFilter,
   gitUrl,
-  gitlabWorkItemType,
+  gitLabWorkItemType,
 }: RepoParams): Promise<RepoResult> {
   config = {} as any;
   config.repositoryPath = repository;
@@ -343,7 +343,7 @@ export async function initRepo({
   config.cloneSubmodules = cloneSubmodules;
   config.cloneSubmodulesFilter = cloneSubmodulesFilter;
   config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor');
-  config.workItemType = gitlabWorkItemType ?? getConfig().gitlabWorkItemType!;
+  config.workItemType = gitLabWorkItemType ?? getConfig().gitLabWorkItemType!;
 
   let res: HttpResponse<RepoResponse>;
   try {

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -51,6 +51,7 @@ import type {
   MergePRConfig,
   PlatformParams,
   PlatformPrOptions,
+  PlatformRepoConfig,
   PlatformResult,
   Pr,
   ReattemptPlatformAutomergeConfig,
@@ -123,6 +124,13 @@ interface GitlabGraphqlIssueNode {
       title: string;
     }[];
   } | null;
+}
+
+interface GitlabGraphqlWorkItemTypeNode {
+  id: string;
+  name: string;
+  enabled?: boolean | null;
+  canUserCreateItems?: boolean | null;
 }
 
 interface GitlabGraphqlPageInfo {
@@ -431,6 +439,14 @@ export async function initRepo({
     repoFingerprint: repoFingerprint(res.body.id, defaults.endpoint),
   };
   return repoConfig;
+}
+
+export function setRepoContext({
+  gitLabWorkItemType,
+}: PlatformRepoConfig): void {
+  if (isString(gitLabWorkItemType)) {
+    config.workItemType = gitLabWorkItemType;
+  }
 }
 
 export function getBranchForceRebase(): Promise<boolean> {
@@ -1100,34 +1116,87 @@ async function findGraphqlIssueByTitle(
   return null;
 }
 
+function isUnsupportedWorkItemTypeFieldError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err.message.includes("Field 'enabled' doesn't exist") ||
+      err.message.includes("Field 'canUserCreateItems' doesn't exist"))
+  );
+}
+
+function isGraphqlWorkItemTypeCreatable(
+  workItemType: GitlabGraphqlWorkItemTypeNode,
+): boolean {
+  return (
+    workItemType.enabled !== false && workItemType.canUserCreateItems !== false
+  );
+}
+
 async function resolveGraphqlWorkItemTypeId(): Promise<string | null> {
-  const data = await requestGraphql<{
-    namespace?: {
-      workItemTypes?: {
-        nodes?: {
-          id: string;
-          name: string;
-        }[];
+  let workItemTypes: GitlabGraphqlWorkItemTypeNode[] | undefined;
+  try {
+    const data = await requestGraphql<{
+      namespace?: {
+        workItemTypes?: {
+          nodes?: GitlabGraphqlWorkItemTypeNode[];
+        } | null;
       } | null;
-    } | null;
-  }>(
-    `
-      query NamespaceWorkItemTypes($namespacePath: ID!) {
-        namespace(fullPath: $namespacePath) {
-          workItemTypes(first: 100) {
-            nodes {
-              id
-              name
+    }>(
+      `
+        query NamespaceWorkItemTypes($namespacePath: ID!) {
+          namespace(fullPath: $namespacePath) {
+            workItemTypes(first: 100) {
+              nodes {
+                id
+                name
+                enabled
+                canUserCreateItems
+              }
             }
           }
         }
-      }
-    `,
-    {
-      namespacePath: config.repositoryPath,
-    },
-  );
-  const workItemType = data.namespace?.workItemTypes?.nodes?.find(
+      `,
+      {
+        namespacePath: config.repositoryPath,
+      },
+    );
+    workItemTypes = data.namespace?.workItemTypes?.nodes?.filter(
+      isGraphqlWorkItemTypeCreatable,
+    );
+  } catch (err) {
+    if (!isUnsupportedWorkItemTypeFieldError(err)) {
+      throw err;
+    }
+    logger.debug(
+      'GitLab GraphQL work item availability fields unsupported; falling back to legacy work item types query',
+    );
+    const data = await requestGraphql<{
+      namespace?: {
+        workItemTypes?: {
+          nodes?: GitlabGraphqlWorkItemTypeNode[];
+        } | null;
+      } | null;
+    }>(
+      `
+        query NamespaceWorkItemTypes($namespacePath: ID!) {
+          namespace(fullPath: $namespacePath) {
+            workItemTypes(first: 100) {
+              nodes {
+                id
+                name
+              }
+            }
+          }
+        }
+      `,
+      {
+        namespacePath: config.repositoryPath,
+      },
+    );
+    workItemTypes = data.namespace?.workItemTypes?.nodes;
+  }
+
+  const workItemType = workItemTypes?.find(
     (item) => item.name === config.workItemType,
   );
   if (!workItemType) {
@@ -1136,7 +1205,7 @@ async function resolveGraphqlWorkItemTypeId(): Promise<string | null> {
         repository: config.repositoryPath,
         workItemType: config.workItemType,
       },
-      'GitLab configured work item type does not exist in project; skipping issue creation',
+      'GitLab configured work item type does not exist or is not creatable in this project; skipping issue creation',
     );
     return null;
   }
@@ -1156,6 +1225,9 @@ async function createGraphqlWorkItem(
       errors: string[];
       workItem?: {
         iid: string;
+        workItemType?: {
+          name: string;
+        } | null;
       } | null;
     } | null;
   }>(
@@ -1165,6 +1237,9 @@ async function createGraphqlWorkItem(
           errors
           workItem {
             iid
+            workItemType {
+              name
+            }
           }
         }
       }
@@ -1188,6 +1263,17 @@ async function createGraphqlWorkItem(
   const iid = data.workItemCreate?.workItem?.iid;
   if (!iid) {
     return null;
+  }
+  const createdWorkItemType = data.workItemCreate?.workItem?.workItemType?.name;
+  if (createdWorkItemType && createdWorkItemType !== config.workItemType) {
+    logger.warn(
+      {
+        repository: config.repositoryPath,
+        requestedWorkItemType: config.workItemType,
+        createdWorkItemType,
+      },
+      'GitLab created a different work item type than requested',
+    );
   }
   return { iid: parseInteger(iid) };
 }

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -7,6 +7,7 @@ import {
 } from '@sindresorhus/is';
 import pMap from 'p-map';
 import semver from 'semver';
+import { getConfig } from '../../../config/defaults.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import {
   REPOSITORY_ACCESS_FORBIDDEN,
@@ -91,6 +92,7 @@ export { extractRulesFromCodeOwnersLines } from './code-owners.ts';
 
 let config: {
   repository: string;
+  repositoryPath: string;
   email: EmailAddress;
   issueList: GitlabIssue[] | undefined;
   mergeMethod: MergeMethod;
@@ -100,11 +102,62 @@ let config: {
   cloneSubmodulesFilter: string[] | undefined;
   ignorePrAuthor: boolean | undefined;
   squash: boolean;
+  workItemType: string;
 } = {} as any;
+
+interface GitlabGraphqlIssue {
+  id: string;
+  iid: number;
+  title: string;
+  description: string;
+  labels: string[];
+}
+
+interface GitlabGraphqlIssueNode {
+  id: string;
+  iid: string;
+  title: string;
+  description?: string | null;
+  labels?: {
+    nodes?: {
+      title: string;
+    }[];
+  } | null;
+}
+
+interface GitlabGraphqlPageInfo {
+  endCursor?: string | null;
+  hasNextPage?: boolean;
+}
+
+interface GitlabGraphqlResponse<T> {
+  data?: T;
+  errors?: {
+    message: string;
+  }[];
+}
+
+interface FindGraphqlIssueVariables {
+  projectPath: string;
+  search: string;
+  authorUsername?: string;
+  after: string | null;
+}
+
+interface FindGraphqlIssueData {
+  project?: {
+    issues?: {
+      nodes?: GitlabGraphqlIssueNode[];
+      pageInfo?: GitlabGraphqlPageInfo | null;
+    } | null;
+  } | null;
+}
 
 export function resetPlatform(): void {
   config = {} as any;
   draftPrefix = DRAFT_PREFIX;
+  botUserName = '';
+  botUsername = undefined;
   defaults.hostType = 'gitlab';
   defaults.endpoint = 'https://gitlab.com/api/v4/';
   defaults.version = '0.0.0';
@@ -115,6 +168,7 @@ export const id = 'gitlab';
 
 let draftPrefix = DRAFT_PREFIX;
 let botUserName: string;
+let botUsername: string | undefined;
 
 export async function initPlatform({
   endpoint,
@@ -144,6 +198,7 @@ export async function initPlatform({
           email: EmailAddress;
           name: string;
           id: number;
+          username?: string;
           commit_email?: EmailAddress;
         }>(`user`, { token })
       ).body;
@@ -151,6 +206,7 @@ export async function initPlatform({
         user.commit_email ?? user.email
       }>`;
       botUserName = user.name;
+      botUsername = user.username;
     }
     const env = getEnv();
     /* v8 ignore next: experimental feature */
@@ -180,6 +236,7 @@ export async function initPlatform({
     : DRAFT_PREFIX;
 
   botUserName ??= username!;
+  botUsername ??= username;
 
   return platformConfig;
 }
@@ -278,12 +335,15 @@ export async function initRepo({
   cloneSubmodules,
   cloneSubmodulesFilter,
   gitUrl,
+  gitlabWorkItemType,
 }: RepoParams): Promise<RepoResult> {
   config = {} as any;
+  config.repositoryPath = repository;
   config.repository = urlEscape(repository);
   config.cloneSubmodules = cloneSubmodules;
   config.cloneSubmodulesFilter = cloneSubmodulesFilter;
   config.ignorePrAuthor = GlobalConfig.get('ignorePrAuthor');
+  config.workItemType = gitlabWorkItemType ?? getConfig().gitlabWorkItemType!;
 
   let res: HttpResponse<RepoResponse>;
   try {
@@ -334,10 +394,17 @@ export async function initRepo({
     logger.debug(`${repository} default branch = ${config.defaultBranch}`);
     logger.debug('Enabling Git FS');
     const url = getRepoUrl(repository, gitUrl, res);
-    await git.initRepo({
-      ...config,
+    const gitStorageConfig = {
+      cloneSubmodules: config.cloneSubmodules,
+      cloneSubmodulesFilter: config.cloneSubmodulesFilter,
+      defaultBranch: config.defaultBranch,
+      ignorePrAuthor: config.ignorePrAuthor,
+      mergeMethod: config.mergeMethod,
+      mergeTrainsEnabled: config.mergeTrainsEnabled,
+      repository: config.repository,
       url,
-    });
+    };
+    await git.initRepo(gitStorageConfig);
   } catch (err) /* v8 ignore next -- initRepo error mapping needs git-level failures not mocked in specs */ {
     logger.debug({ err }, 'Caught initRepo error');
     if (err.message.includes('HEAD is not a symbolic ref')) {
@@ -898,6 +965,304 @@ export function labelCharLimit(): number {
   return 255;
 }
 
+function useCustomWorkItemType(): boolean {
+  return (config.workItemType ?? 'Issue').toLowerCase() !== 'issue';
+}
+
+function getGraphqlEndpoint(): string {
+  return new URL('../graphql', defaults.endpoint).toString();
+}
+
+async function requestGraphql<T>(query: string, variables: object): Promise<T> {
+  const res = await gitlabApi.postJson<GitlabGraphqlResponse<T>>(
+    getGraphqlEndpoint(),
+    {
+      body: { query, variables },
+    },
+  );
+  if (isNonEmptyArray(res.body.errors)) {
+    throw new Error(
+      `GitLab GraphQL error: ${res.body.errors.map((err) => err.message).join('; ')}`,
+    );
+  }
+  if (!res.body.data) {
+    throw new Error('GitLab GraphQL error: missing data');
+  }
+  return res.body.data;
+}
+
+function parseGraphqlIssue(issue: GitlabGraphqlIssueNode): GitlabGraphqlIssue {
+  return {
+    id: issue.id,
+    iid: parseInteger(issue.iid),
+    title: issue.title,
+    description: issue.description ?? '',
+    labels: issue.labels?.nodes?.map((label) => label.title) ?? [],
+  };
+}
+
+async function findGraphqlIssueByTitle(
+  title: string,
+): Promise<GitlabGraphqlIssue | null> {
+  const query =
+    botUsername && !config.ignorePrAuthor
+      ? `
+        query FindProjectIssueByTitle(
+          $projectPath: ID!
+          $search: String!
+          $authorUsername: String!
+          $after: String
+        ) {
+          project(fullPath: $projectPath) {
+            issues(
+              first: 100
+              state: opened
+              search: $search
+              authorUsername: $authorUsername
+              after: $after
+            ) {
+              nodes {
+                id
+                iid
+                title
+                description
+                labels {
+                  nodes {
+                    title
+                  }
+                }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+            }
+          }
+        }
+      `
+      : `
+        query FindProjectIssueByTitle(
+          $projectPath: ID!
+          $search: String!
+          $after: String
+        ) {
+          project(fullPath: $projectPath) {
+            issues(first: 100, state: opened, search: $search, after: $after) {
+              nodes {
+                id
+                iid
+                title
+                description
+                labels {
+                  nodes {
+                    title
+                  }
+                }
+              }
+              pageInfo {
+                endCursor
+                hasNextPage
+              }
+            }
+          }
+        }
+      `;
+  let after: string | null = null;
+  let hasNextPage = true;
+
+  while (hasNextPage) {
+    const variables: FindGraphqlIssueVariables =
+      botUsername && !config.ignorePrAuthor
+        ? {
+            projectPath: config.repositoryPath,
+            search: title,
+            authorUsername: botUsername,
+            after,
+          }
+        : {
+            projectPath: config.repositoryPath,
+            search: title,
+            after,
+          };
+    const data: FindGraphqlIssueData =
+      await requestGraphql<FindGraphqlIssueData>(query, variables);
+    const issues =
+      data.project?.issues?.nodes
+        ?.map(parseGraphqlIssue)
+        .filter((issue: GitlabGraphqlIssue) => issue.title === title) ?? [];
+    if (issues[0]) {
+      return issues[0];
+    }
+    after = data.project?.issues?.pageInfo?.endCursor ?? null;
+    hasNextPage = data.project?.issues?.pageInfo?.hasNextPage ?? false;
+  }
+
+  return null;
+}
+
+async function resolveGraphqlWorkItemTypeId(): Promise<string | null> {
+  const data = await requestGraphql<{
+    project?: {
+      workItemTypes?: {
+        nodes?: {
+          id: string;
+          name: string;
+        }[];
+      } | null;
+    } | null;
+  }>(
+    `
+      query ProjectWorkItemTypes($projectPath: ID!) {
+        project(fullPath: $projectPath) {
+          workItemTypes(first: 100) {
+            nodes {
+              id
+              name
+            }
+          }
+        }
+      }
+    `,
+    {
+      projectPath: config.repositoryPath,
+    },
+  );
+  const workItemType = data.project?.workItemTypes?.nodes?.find(
+    (item) => item.name === config.workItemType,
+  );
+  if (!workItemType) {
+    logger.warn(
+      {
+        repository: config.repositoryPath,
+        workItemType: config.workItemType,
+      },
+      'GitLab configured work item type does not exist in project; skipping issue creation',
+    );
+    return null;
+  }
+  return workItemType.id;
+}
+
+async function createGraphqlWorkItem(
+  title: string,
+  description: string,
+): Promise<{ iid: number } | null> {
+  const workItemTypeId = await resolveGraphqlWorkItemTypeId();
+  if (!workItemTypeId) {
+    return null;
+  }
+  const data = await requestGraphql<{
+    workItemCreate?: {
+      errors: string[];
+      workItem?: {
+        iid: string;
+      } | null;
+    } | null;
+  }>(
+    `
+      mutation CreateWorkItem($input: WorkItemCreateInput!) {
+        workItemCreate(input: $input) {
+          errors
+          workItem {
+            iid
+          }
+        }
+      }
+    `,
+    {
+      input: {
+        namespacePath: config.repositoryPath,
+        title,
+        workItemTypeId,
+        descriptionWidget: {
+          description,
+        },
+      },
+    },
+  );
+  if (isNonEmptyArray(data.workItemCreate?.errors)) {
+    throw new Error(
+      `GitLab GraphQL error: ${data.workItemCreate.errors.join('; ')}`,
+    );
+  }
+  const iid = data.workItemCreate?.workItem?.iid;
+  if (!iid) {
+    return null;
+  }
+  return { iid: parseInteger(iid) };
+}
+
+async function updateGraphqlIssue({
+  iid,
+  title,
+  description,
+  labels,
+  confidential,
+}: {
+  iid: number;
+  title: string;
+  description: string;
+  labels: string[];
+  confidential: boolean;
+}): Promise<void> {
+  const data = await requestGraphql<{
+    updateIssue?: {
+      errors: string[];
+    } | null;
+  }>(
+    `
+      mutation UpdateIssue($input: UpdateIssueInput!) {
+        updateIssue(input: $input) {
+          errors
+        }
+      }
+    `,
+    {
+      input: {
+        iid: String(iid),
+        projectPath: config.repositoryPath,
+        title,
+        description,
+        labels,
+        confidential,
+      },
+    },
+  );
+  if (isNonEmptyArray(data.updateIssue?.errors)) {
+    throw new Error(
+      `GitLab GraphQL error: ${data.updateIssue.errors.join('; ')}`,
+    );
+  }
+}
+
+async function closeGraphqlIssue(iid: number): Promise<void> {
+  const data = await requestGraphql<{
+    updateIssue?: {
+      errors: string[];
+    } | null;
+  }>(
+    `
+      mutation CloseIssue($input: UpdateIssueInput!) {
+        updateIssue(input: $input) {
+          errors
+        }
+      }
+    `,
+    {
+      input: {
+        iid: String(iid),
+        projectPath: config.repositoryPath,
+        stateEvent: 'CLOSE',
+      },
+    },
+  );
+  if (isNonEmptyArray(data.updateIssue?.errors)) {
+    throw new Error(
+      `GitLab GraphQL error: ${data.updateIssue.errors.join('; ')}`,
+    );
+  }
+}
+
 // Branch
 
 function matchesState(state: string, desiredState: string): boolean {
@@ -1127,6 +1492,21 @@ export async function getIssue(
 
 export async function findIssue(title: string): Promise<Issue | null> {
   logger.debug(`findIssue(${title})`);
+  if (useCustomWorkItemType()) {
+    try {
+      const issue = await findGraphqlIssueByTitle(title);
+      if (!issue) {
+        return null;
+      }
+      return {
+        number: issue.iid,
+        body: issue.description,
+      };
+    } catch /* v8 ignore next -- defensive: GraphQL issue lookup failures are logged and swallowed, not simulated in specs */ {
+      logger.warn('Error finding issue');
+      return null;
+    }
+  }
   try {
     const issueList = await getIssueList();
     const issue = issueList.find((i) => i.title === title);
@@ -1149,6 +1529,45 @@ export async function ensureIssue({
 }: EnsureIssueConfig): Promise<'updated' | 'created' | null> {
   logger.debug(`ensureIssue()`);
   const description = massageMarkdown(sanitize(body));
+  if (useCustomWorkItemType()) {
+    try {
+      let issue = await findGraphqlIssueByTitle(title);
+      issue ??= reuseTitle ? await findGraphqlIssueByTitle(reuseTitle) : null;
+      if (issue) {
+        if (issue.title !== title || issue.description !== description) {
+          logger.debug('Updating issue');
+          await updateGraphqlIssue({
+            iid: issue.iid,
+            title,
+            description,
+            labels: labels ?? issue.labels,
+            confidential: confidential ?? false,
+          });
+          return 'updated';
+        }
+      } else {
+        const createdIssue = await createGraphqlWorkItem(title, description);
+        if (!createdIssue) {
+          return null;
+        }
+        if (labels || confidential) {
+          await updateGraphqlIssue({
+            iid: createdIssue.iid,
+            title,
+            description,
+            labels: labels ?? [],
+            confidential: confidential ?? false,
+          });
+        }
+        logger.info('Issue created');
+        return 'created';
+      }
+    } catch (err) /* v8 ignore next -- GraphQL issue/work item failures are swallowed, not simulated in specs */ {
+      logger.warn({ err }, 'Could not ensure issue');
+      return null;
+    }
+    return null;
+  }
   try {
     const issueList = await getIssueList();
     let issue = issueList.find((i) => i.title === title);
@@ -1200,6 +1619,14 @@ export async function ensureIssue({
 
 export async function ensureIssueClosing(title: string): Promise<void> {
   logger.debug(`ensureIssueClosing()`);
+  if (useCustomWorkItemType()) {
+    const issue = await findGraphqlIssueByTitle(title);
+    if (issue) {
+      logger.debug({ issue }, 'Closing issue');
+      await closeGraphqlIssue(issue.iid);
+    }
+    return;
+  }
   const issueList = await getIssueList();
   for (const issue of issueList) {
     if (issue.title === title) {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -46,6 +46,8 @@ export interface RepoParams {
   cloneSubmodulesFilter?: string[];
   /** Azure only: work item type to use when creating issues. */
   azureWorkItemType?: string;
+  /** GitLab only: work item type to use when creating issues. */
+  gitlabWorkItemType?: string;
 }
 
 export interface PrDebugData {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -32,6 +32,11 @@ export interface RepoResult {
   repoFingerprint: string;
 }
 
+export interface PlatformRepoConfig {
+  azureWorkItemType?: string;
+  gitLabWorkItemType?: string;
+}
+
 export type GitUrlOption = 'default' | 'ssh' | 'endpoint';
 
 export interface RepoParams {
@@ -254,6 +259,7 @@ export interface Platform {
     branchOrTag?: string,
   ): Promise<any>;
   initRepo(config: RepoParams): Promise<RepoResult>;
+  setRepoContext?(config: PlatformRepoConfig): void;
   getPrList(): Promise<Pr[]>;
   ensureIssueClosing(title: string): Promise<void>;
   ensureIssue(

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -47,7 +47,7 @@ export interface RepoParams {
   /** Azure only: work item type to use when creating issues. */
   azureWorkItemType?: string;
   /** GitLab only: work item type to use when creating issues. */
-  gitlabWorkItemType?: string;
+  gitLabWorkItemType?: string;
 }
 
 export interface PrDebugData {

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -67,6 +67,7 @@ export async function initRepo(
   config = applySecretsAndVariablesToConfig({
     config,
   });
+  platform.setRepoContext?.(config);
   setUserRepoConfig(config);
   config = await detectVulnerabilityAlerts(config);
   // istanbul ignore if


### PR DESCRIPTION
## Changes

Adds support for configuring the GitLab work item type used for the Dependency Dashboard.

By default Renovate keeps creating the dashboard as an `Issue`, so existing behavior is unchanged. When `gitlabWorkItemType` is configured to a custom work item type, Renovate will:

- resolve the configured work item type in the target GitLab project
- create the Dependency Dashboard as that work item type
- continue finding existing dashboards by title
- update and close the dashboard through the GitLab GraphQL flow for custom work item types

This PR also adds tests for the custom work item flow and documents the new configuration option.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5) was used to implement the code changes, add tests, update docs, and prepare this pull request.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
