### PR TITLE
fix(datasource): don't follow `Link` headers with different hosts for Docker or Nuget Datasources

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -76,6 +76,7 @@
     "renovate/no-new-url": "error",
     "renovate/no-stateful-global-regex": "error",
     "renovate/no-tools-import": "error",
+    "renovate/no-unvalidated-pagination-url": "error",
     "renovate/prefer-fs-util": "error",
     "renovate/prefer-json-pipe": "error",
     "renovate/prefer-luxon": "error",

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -110,6 +110,16 @@ Skip initializing `RE2` for regular expressions and instead use Node-native `Reg
 
 If set to any value, Renovate will download `nupkg` files for determining package metadata.
 
+## `RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN`
+
+!!! warning
+  This is an explicit opt-out of a security control.
+
+If set to any value, the `nuget` datasource will follow paginated `next` links pointing to a different origin than the feed it is querying.
+
+By default Renovate drops such cross-origin pagination links, so a malicious or compromised feed cannot redirect an authenticated request to an attacker-controlled host and exfiltrate credentials.
+Set this only if you trust the feed and it legitimately paginates across hosts (for example, an absolute `next` link pointing at a backend host).
+
 ## `RENOVATE_X_PGP_RUNTIME`
 
 Specify which PGP runtime to use for decrypting Renovate config.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -39,6 +39,16 @@ This includes the following:
 
 If set to any value, Renovate will stop using the Docker Hub API (`https://hub.docker.com`) to fetch tags and instead use the normal Docker API for images pulled from `https://index.docker.io`.
 
+## `RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN`
+
+!!! warning
+  This is an explicit opt-out of a security control.
+
+If set to any value, the `docker` datasource will follow paginated `next` links pointing to a different origin than the registry it is querying.
+
+By default Renovate drops such cross-origin pagination links, so a malicious or compromised registry cannot redirect an authenticated request to an attacker-controlled host and exfiltrate credentials.
+Set this only if you trust the registry and it legitimately paginates across hosts (for example, an absolute `next` link pointing at a CDN or backend host).
+
 ## `RENOVATE_X_ENCRYPTED_STRICT`
 
 If set to `"true"`, a config error Issue will be raised in case repository config contains `encrypted` objects without any `privateKey` defined.

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -171,6 +171,8 @@ describe('modules/datasource/docker/index', () => {
     });
     delete process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE;
     delete process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP;
+    delete process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN;
+    delete process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN;
   });
 
   describe('getDigest', () => {
@@ -1756,27 +1758,112 @@ describe('modules/datasource/docker/index', () => {
         .get('/node/tags/list?n=10000')
         .reply(200, '', {})
         .get('/node/tags/list?n=10000')
-        .reply(
-          200,
-          { tags },
-          {
-            link: '<https://api.github.com/user/9287/repos?page=3&per_page=1000>; rel="next", ',
-          },
-        )
+        .reply(200, { tags }, {})
         .get('/')
         .reply(200)
-        .get('/node/manifests/latest')
+        .get('/node/manifests/1.0.0')
         .reply(200);
-      httpMock
-        .scope('https://api.github.com')
-        .get('/user/9287/repos?page=3&per_page=1000')
-        .reply(200, { tags: ['latest'] }, {});
       const config = {
         datasource: DockerDatasource.id,
         packageName: 'node',
         registryUrls: ['https://registry.company.com'],
       };
       const res = await getPkgReleases(config);
+      expect(res?.releases).toHaveLength(1);
+    });
+
+    // as this could lead to a Server-Side Request Forgery (SSRF), but could also be misconfiguration
+    it('does not follow pagination links to a different origin', async () => {
+      const tags = ['1.0.0'];
+      httpMock
+        .scope('https://registry.company.com/v2')
+        .get('/node/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/node/tags/list?n=10000')
+        .reply(
+          200,
+          { tags },
+          {
+            link: '<https://attacker.example.com/v2/steal/tags/list?n=10000>; rel="next", ',
+          },
+        )
+        .get('/')
+        .reply(200)
+        .get('/node/manifests/1.0.0')
+        .reply(200);
+      const config = {
+        datasource: DockerDatasource.id,
+        packageName: 'node',
+        registryUrls: ['https://registry.company.com'],
+      };
+      const res = await getPkgReleases(config);
+      expect(res?.releases).toHaveLength(1);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          registryHost: 'https://registry.company.com',
+          nextUrl: 'https://attacker.example.com/v2/steal/tags/list?n=10000',
+        },
+        'Ignoring cross-origin or invalid Docker registry tags pagination link',
+      );
+    });
+
+    it('follows cross-origin tags pagination when the datasource is opted in', async () => {
+      process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      httpMock
+        .scope('https://registry.company.com/v2')
+        .get('/node/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/node/tags/list?n=10000')
+        .reply(
+          200,
+          { tags: ['1.0.0'] },
+          {
+            link: '<https://mirror.example.com/v2/node/tags/list?n=10000&last=1.0.0>; rel="next", ',
+          },
+        )
+        .get('/')
+        .reply(200)
+        .get('/node/manifests/2.0.0')
+        .reply(200);
+      httpMock
+        .scope('https://mirror.example.com/v2')
+        .get('/node/tags/list?n=10000&last=1.0.0')
+        .reply(200, { tags: ['2.0.0'] }, {});
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'node',
+        registryUrls: ['https://registry.company.com'],
+      });
+      expect(res?.releases).toMatchObject([
+        { version: '1.0.0' },
+        { version: '2.0.0' },
+      ]);
+      expect(logger.logger.once.warn).toHaveBeenCalledOnce();
+    });
+
+    it('does not opt docker in when only another datasource is opted in', async () => {
+      process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      httpMock
+        .scope('https://registry.company.com/v2')
+        .get('/node/tags/list?n=10000')
+        .reply(200, '', {})
+        .get('/node/tags/list?n=10000')
+        .reply(
+          200,
+          { tags: ['1.0.0'] },
+          {
+            link: '<https://attacker.example.com/v2/steal/tags/list?n=10000>; rel="next", ',
+          },
+        )
+        .get('/')
+        .reply(200)
+        .get('/node/manifests/1.0.0')
+        .reply(200);
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'node',
+        registryUrls: ['https://registry.company.com'],
+      });
       expect(res?.releases).toHaveLength(1);
     });
 
@@ -2502,6 +2589,93 @@ describe('modules/datasource/docker/index', () => {
           },
         ],
       });
+    });
+
+    // as this could lead to a Server-Side Request Forgery (SSRF), but could also be misconfiguration
+    it('does not follow Docker Hub tags pagination to a different origin', async () => {
+      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      httpMock
+        .scope(dockerHubUrl)
+        .get('/library/node/tags?page_size=1000&ordering=last_updated')
+        .reply(200, {
+          count: 5,
+          next: 'https://attacker.example.com/v2/repositories/library/node/tags?page=2&page_size=1000&ordering=last_updated',
+          results: [
+            {
+              id: 5,
+              last_updated: '2021-01-01T00:00:00.000Z',
+              name: '1.0.0',
+              tag_last_pushed: '2021-01-01T00:00:00.000Z',
+              digest: 'aaa',
+            },
+          ],
+        });
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'registry-1.docker.io/library/node',
+      });
+      expect(res).toMatchObject({
+        releases: [
+          {
+            version: '1.0.0',
+            releaseTimestamp: '2021-01-01T00:00:00.000Z',
+          },
+        ],
+      });
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          dockerRepository: 'library/node',
+          nextUrl:
+            'https://attacker.example.com/v2/repositories/library/node/tags?page=2&page_size=1000&ordering=last_updated',
+        },
+        'Ignoring cross-origin or invalid Docker Hub tags pagination link',
+      );
+    });
+
+    it('follows cross-origin Docker Hub pagination when the datasource is opted in', async () => {
+      process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      httpMock
+        .scope(dockerHubUrl)
+        .get('/library/node/tags?page_size=1000&ordering=last_updated')
+        .reply(200, {
+          count: 2,
+          next: 'https://mirror.example.com/v2/repositories/library/node/tags?page=2&page_size=1000&ordering=last_updated',
+          results: [
+            {
+              id: 1,
+              last_updated: '2021-01-01T00:00:00.000Z',
+              name: '1.0.0',
+              tag_last_pushed: '2021-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      httpMock
+        .scope('https://mirror.example.com')
+        .get(
+          '/v2/repositories/library/node/tags?page=2&page_size=1000&ordering=last_updated',
+        )
+        .reply(200, {
+          count: 2,
+          next: null,
+          results: [
+            {
+              id: 2,
+              last_updated: '2022-01-01T00:00:00.000Z',
+              name: '2.0.0',
+              tag_last_pushed: '2022-01-01T00:00:00.000Z',
+            },
+          ],
+        });
+      const res = await getPkgReleases({
+        datasource: DockerDatasource.id,
+        packageName: 'registry-1.docker.io/library/node',
+      });
+      expect(res?.releases).toMatchObject([
+        { version: '1.0.0' },
+        { version: '2.0.0' },
+      ]);
+      expect(logger.logger.once.warn).toHaveBeenCalledOnce();
     });
 
     it('adds library/ prefix for Docker Hub (implicit)', async () => {

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -26,7 +26,11 @@ import type {
   Release,
   ReleaseResult,
 } from '../types.ts';
-import { isArtifactoryServer } from '../util.ts';
+import {
+  isArtifactoryServer,
+  isCrossOriginPaginationAllowed,
+  resolvePaginationUrl,
+} from '../util.ts';
 import {
   DOCKER_HUB,
   dockerDatasourceId,
@@ -760,6 +764,7 @@ export class DockerDatasource extends Datasource {
       ? 1000
       : GlobalConfig.get('dockerMaxPages');
     logger.trace({ registryHost, dockerRepository, pages }, 'docker.getTags');
+    const allowCrossOrigin = isCrossOriginPaginationAllowed(dockerDatasourceId);
     let foundMaxResultsError = false;
     do {
       let res: HttpResponse<RegistryTagsList>;
@@ -802,8 +807,20 @@ export class DockerDatasource extends Datasource {
           url = null;
         }
       } else if (linkHeader?.next?.url) {
-        // for the normal case we can still use URL to resolve relative-next
-        url = new URL(linkHeader.next.url, url).href;
+        // Resolve the relative-or-absolute next link, not following cross-origin requests unless explicitly opted in
+        const nextUrl = resolvePaginationUrl(
+          url,
+          linkHeader.next.url,
+          allowCrossOrigin,
+        );
+        if (!nextUrl) {
+          // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
+          logger.once.warn(
+            { registryHost, nextUrl: linkHeader.next.url },
+            'Ignoring cross-origin or invalid Docker registry tags pagination link',
+          );
+        }
+        url = nextUrl;
       } else {
         url = null;
       }
@@ -1125,6 +1142,7 @@ export class DockerDatasource extends Datasource {
 
     const cache = await DockerHubCache.init(dockerRepository);
     const maxPages = GlobalConfig.get('dockerMaxPages');
+    const allowCrossOrigin = isCrossOriginPaginationAllowed(dockerDatasourceId);
     let page = 0,
       needNextPage = true;
     while (needNextPage && page < maxPages) {
@@ -1145,7 +1163,17 @@ export class DockerDatasource extends Datasource {
         break;
       }
 
-      url = next;
+      // Only follow the `next` link when it's on the same origin, unless explicitly opted in
+      const nextUrl = resolvePaginationUrl(url, next, allowCrossOrigin);
+      if (!nextUrl) {
+        logger.once.warn(
+          { dockerRepository, nextUrl: next },
+          'Ignoring cross-origin or invalid Docker Hub tags pagination link',
+        );
+        break;
+      }
+
+      url = nextUrl;
     }
 
     await cache.save();

--- a/lib/modules/datasource/nuget/__fixtures__/nunit/v2_paginated_cross_origin.xml
+++ b/lib/modules/datasource/nuget/__fixtures__/nunit/v2_paginated_cross_origin.xml
@@ -2,11 +2,11 @@
 <feed xml:base="https://www.nuget.org/api/v2" xmlns="http://www.w3.org/2005/Atom" xmlns:d="http://schemas.microsoft.com/ado/2007/08/dataservices" xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata" xmlns:georss="http://www.georss.org/georss" xmlns:gml="http://www.opengis.net/gml">
   <id>http://schemas.datacontract.org/2004/07/</id>
   <link rel="self" href="https://www.nuget.org/api/v2/Packages"/>
-  <link rel="next" href="https://www.nuget.org/api/v2/PageTwo"/>
+  <link rel="next" href="https://attacker.example.com/api/v2/steal"/>
   <entry>
     <m:properties>
       <d:Version>1.0.0</d:Version>
-      <d:IsLatestVersion>false</d:IsLatestVersion>
+      <d:IsLatestVersion>true</d:IsLatestVersion>
     </m:properties>
   </entry>
 </feed>

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -121,6 +121,7 @@ const configV3Deprecated = {
 describe('modules/datasource/nuget/index', () => {
   beforeEach(() => {
     GlobalConfig.reset();
+    delete process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN;
   });
 
   describe('parseRegistryUrl', () => {
@@ -946,16 +947,57 @@ describe('modules/datasource/nuget/index', () => {
         .get(
           '/api/v2/FindPackagesById()?id=%27nunit%27&$select=Version,IsLatestVersion,ProjectUrl,Published',
         )
-        .reply(200, pkgListV2Page1of2);
-      httpMock
-        .scope('https://example.org')
-        .get('/')
+        .reply(200, pkgListV2Page1of2)
+        .get('/api/v2/PageTwo')
         .reply(200, pkgListV2Page2of2);
       const res = await getPkgReleases({
         ...configV2,
       });
       expect(res).not.toBeNull();
       expect(res).toMatchSnapshot();
+    });
+
+    // as this could lead to a Server-Side Request Forgery (SSRF), but could also be misconfiguration
+    it('does not follow pagination to a different origin (v2)', async () => {
+      httpMock
+        .scope('https://www.nuget.org')
+        .get(
+          '/api/v2/FindPackagesById()?id=%27nunit%27&$select=Version,IsLatestVersion,ProjectUrl,Published',
+        )
+        .reply(200, Fixtures.get('nunit/v2_paginated_cross_origin.xml'));
+      const res = await getPkgReleases({
+        ...configV2,
+      });
+      expect(res?.releases).toEqual([{ version: '1.0.0' }]);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          feedUrl: 'https://www.nuget.org/api/v2',
+          nextUrl: 'https://attacker.example.com/api/v2/steal',
+        },
+        'Ignoring cross-origin or invalid NuGet feed pagination link',
+      );
+    });
+
+    it('follows cross-origin pagination when the datasource is opted in (v2)', async () => {
+      process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      httpMock
+        .scope('https://www.nuget.org')
+        .get(
+          '/api/v2/FindPackagesById()?id=%27nunit%27&$select=Version,IsLatestVersion,ProjectUrl,Published',
+        )
+        .reply(200, Fixtures.get('nunit/v2_paginated_cross_origin.xml'));
+      httpMock
+        .scope('https://attacker.example.com')
+        .get('/api/v2/steal')
+        .reply(200, pkgListV2Page2of2);
+      const res = await getPkgReleases({
+        ...configV2,
+      });
+      expect(res?.releases).toEqual([
+        { version: '1.0.0' },
+        { version: '2.0.0' },
+      ]);
+      expect(logger.logger.once.warn).toHaveBeenCalledOnce();
     });
 
     it('should return deprecated', async () => {

--- a/lib/modules/datasource/nuget/index.ts
+++ b/lib/modules/datasource/nuget/index.ts
@@ -2,6 +2,7 @@ import { logger } from '../../../logger/index.ts';
 import * as nugetVersioning from '../../versioning/nuget/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
+import { isCrossOriginPaginationAllowed } from '../util.ts';
 import { parseRegistryUrl } from './common.ts';
 import { NugetV2Api } from './v2.ts';
 import { NugetV3Api } from './v3.ts';
@@ -44,7 +45,12 @@ export class NugetDatasource extends Datasource {
     }
     const { feedUrl, protocolVersion } = parseRegistryUrl(registryUrl);
     if (protocolVersion === 2) {
-      return this.v2Api.getReleases(this.http, feedUrl, packageName);
+      return this.v2Api.getReleases(
+        this.http,
+        feedUrl,
+        packageName,
+        isCrossOriginPaginationAllowed(NugetDatasource.id),
+      );
     }
     if (protocolVersion === 3) {
       const queryUrl = await this.v3Api.getResourceUrl(this.http, feedUrl);

--- a/lib/modules/datasource/nuget/v2.ts
+++ b/lib/modules/datasource/nuget/v2.ts
@@ -5,6 +5,7 @@ import type { Http } from '../../../util/http/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import type { ReleaseResult } from '../types.ts';
+import { resolvePaginationUrl } from '../util.ts';
 import { massageUrl, removeBuildMeta } from './common.ts';
 
 export class NugetV2Api {
@@ -16,6 +17,7 @@ export class NugetV2Api {
     http: Http,
     feedUrl: string,
     pkgName: string,
+    allowCrossOrigin: boolean,
   ): Promise<ReleaseResult | null> {
     const dep: ReleaseResult = {
       releases: [],
@@ -65,7 +67,19 @@ export class NugetV2Api {
         .childrenNamed('link')
         .find((node) => node.attr.rel === 'next');
 
-      pkgUrlList = nextPkgUrlListLink ? nextPkgUrlListLink.attr.href : null;
+      // Resolve the relative-or-absolute next link, but only follow it when it stays on the same origin, or if the user has opted in via `RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN`
+      const nextHref = nextPkgUrlListLink?.attr.href;
+      const nextUrl: string | null = nextHref
+        ? resolvePaginationUrl(pkgUrlList, nextHref, allowCrossOrigin)
+        : null;
+      if (nextHref && !nextUrl) {
+        // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
+        logger.once.warn(
+          { feedUrl, nextUrl: nextHref },
+          'Ignoring cross-origin or invalid NuGet feed pagination link',
+        );
+      }
+      pkgUrlList = nextUrl;
     }
 
     // dep not found if no release, so we can try next registry

--- a/lib/modules/datasource/util.spec.ts
+++ b/lib/modules/datasource/util.spec.ts
@@ -8,15 +8,25 @@ describe('modules/datasource/util', () => {
   describe('isCrossOriginPaginationAllowed', () => {
     afterEach(() => {
       delete process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN;
+      delete process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN;
     });
 
     it('returns false when the flag is unset', () => {
       expect(isCrossOriginPaginationAllowed('docker')).toBe(false);
+      expect(isCrossOriginPaginationAllowed('nuget')).toBe(false);
     });
 
-    it('returns true for the opted-in datasource', () => {
+    it('returns true only for the opted-in datasource', () => {
       process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
       expect(isCrossOriginPaginationAllowed('docker')).toBe(true);
+      // per-datasource: docker's flag must not opt nuget in
+      expect(isCrossOriginPaginationAllowed('nuget')).toBe(false);
+    });
+
+    it('reads a separate flag for nuget', () => {
+      process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      expect(isCrossOriginPaginationAllowed('nuget')).toBe(true);
+      expect(isCrossOriginPaginationAllowed('docker')).toBe(false);
     });
 
     it('returns false for a datasource without a flag', () => {

--- a/lib/modules/datasource/util.spec.ts
+++ b/lib/modules/datasource/util.spec.ts
@@ -1,0 +1,90 @@
+import { logger } from '~test/util.ts';
+import {
+  isCrossOriginPaginationAllowed,
+  resolvePaginationUrl,
+} from './util.ts';
+
+describe('modules/datasource/util', () => {
+  describe('isCrossOriginPaginationAllowed', () => {
+    afterEach(() => {
+      delete process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN;
+    });
+
+    it('returns false when the flag is unset', () => {
+      expect(isCrossOriginPaginationAllowed('docker')).toBe(false);
+    });
+
+    it('returns true for the opted-in datasource', () => {
+      process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      expect(isCrossOriginPaginationAllowed('docker')).toBe(true);
+    });
+
+    it('returns false for a datasource without a flag', () => {
+      expect(isCrossOriginPaginationAllowed('npm')).toBe(false);
+    });
+  });
+
+  describe('resolvePaginationUrl', () => {
+    it('resolves a same-origin link when cross-origin is not allowed', () => {
+      expect(
+        resolvePaginationUrl(
+          'https://reg.example.com/v2/foo?n=10',
+          'https://reg.example.com/v2/foo?n=10&last=z',
+          false,
+        ),
+      ).toBe('https://reg.example.com/v2/foo?n=10&last=z');
+    });
+
+    it('drops a cross-origin link when cross-origin is not allowed', () => {
+      expect(
+        resolvePaginationUrl(
+          'https://reg.example.com/v2/foo',
+          'https://attacker.example.com/v2/foo',
+          false,
+        ),
+      ).toBeNull();
+    });
+
+    it('follows a cross-origin link when allowed', () => {
+      expect(
+        resolvePaginationUrl(
+          'https://reg.example.com/v2/foo',
+          'https://cdn.example.com/v2/foo?page=2',
+          true,
+        ),
+      ).toBe('https://cdn.example.com/v2/foo?page=2');
+    });
+
+    it('logs a warning when following a cross-origin link when allowed', () => {
+      resolvePaginationUrl(
+        'https://reg.example.com/v2/foo',
+        'https://cdn.example.com/v2/foo?page=2',
+        true,
+      );
+
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          baseUrl: 'https://reg.example.com/v2/foo',
+          nextUrl: 'https://cdn.example.com/v2/foo?page=2',
+        },
+        'Following cross-origin pagination link',
+      );
+    });
+
+    it('resolves a relative link when cross-origin is allowed', () => {
+      expect(
+        resolvePaginationUrl(
+          'https://reg.example.com/v2/foo',
+          '/v2/foo?page=2',
+          true,
+        ),
+      ).toBe('https://reg.example.com/v2/foo?page=2');
+    });
+
+    it('returns null for an invalid link when cross-origin is allowed', () => {
+      expect(
+        resolvePaginationUrl('https://reg.example.com/v2/', 'http://', true),
+      ).toBeNull();
+    });
+  });
+});

--- a/lib/modules/datasource/util.ts
+++ b/lib/modules/datasource/util.ts
@@ -2,10 +2,64 @@ import { isString } from '@sindresorhus/is';
 import { GoogleAuth } from 'google-auth-library';
 import { logger } from '../../logger/index.ts';
 import type { HostRule } from '../../types/index.ts';
+import { getEnv } from '../../util/env.ts';
 import type { HttpResponse } from '../../util/http/types.ts';
 import { addSecretForSanitizing } from '../../util/sanitize.ts';
+import { parseUrl, resolveSameOriginUrl } from '../../util/url.ts';
 
 const JFROG_ARTIFACTORY_RES_HEADER = 'x-jfrog-version';
+
+/**
+ * Experimental, per-datasource env var that opts a datasource into following
+ * server-provided pagination links across origins. Each datasource has its own
+ * flag so relaxing the restriction for one registry cannot weaken the others.
+ */
+const crossOriginPaginationEnv: Record<string, string> = {
+  docker: 'RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN',
+};
+
+/**
+ * Whether a datasource is opted in to following server-provided pagination
+ * links across origins, via its experimental `RENOVATE_X_<DATASOURCE>_PAGINATION_ALLOW_CROSS_ORIGIN`
+ * env var.
+ *
+ * By default such links are restricted to the same origin as the request so a
+ * malicious or compromised registry cannot attempt to redirect our requests in an attempt for Server Side Request Forgery.
+ */
+export function isCrossOriginPaginationAllowed(datasource: string): boolean {
+  const envVar = crossOriginPaginationEnv[datasource];
+  return envVar ? !!getEnv()[envVar] : false;
+}
+
+/**
+ * Resolves a server-provided pagination `next` URL against `baseUrl`, returning
+ * the URL to follow or `null` if it must not be followed.
+ *
+ * When `allowCrossOrigin` is false (the default; see
+ * {@link isCrossOriginPaginationAllowed}) the link is dropped unless it stays on
+ * the same origin. When true, the link is followed regardless of origin.
+ */
+export function resolvePaginationUrl(
+  baseUrl: string,
+  nextUrl: string,
+  allowCrossOrigin: boolean,
+): string | null {
+  if (!allowCrossOrigin) {
+    return resolveSameOriginUrl(baseUrl, nextUrl);
+  }
+  try {
+    const resolved = new URL(nextUrl, baseUrl).href;
+    if (parseUrl(baseUrl)?.origin !== parseUrl(resolved)?.origin) {
+      logger.once.warn(
+        { baseUrl, nextUrl },
+        'Following cross-origin pagination link',
+      );
+    }
+    return resolved;
+  } catch {
+    return null;
+  }
+}
 
 export function isArtifactoryServer<T = unknown>(
   res: HttpResponse<T> | undefined,

--- a/lib/modules/datasource/util.ts
+++ b/lib/modules/datasource/util.ts
@@ -16,6 +16,7 @@ const JFROG_ARTIFACTORY_RES_HEADER = 'x-jfrog-version';
  */
 const crossOriginPaginationEnv: Record<string, string> = {
   docker: 'RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN',
+  nuget: 'RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN',
 };
 
 /**

--- a/lib/util/url.spec.ts
+++ b/lib/util/url.spec.ts
@@ -10,6 +10,7 @@ import {
   parseUrl,
   replaceUrlPath,
   resolveBaseUrl,
+  resolveSameOriginUrl,
   trimSlashes,
   trimTrailingSlash,
 } from './url.ts';
@@ -225,5 +226,55 @@ describe('util/url', () => {
       'https://domain.com/some/path',
     );
     expect(massageHostUrl('https://domain.com')).toBe('https://domain.com');
+  });
+
+  describe('resolveSameOriginUrl', () => {
+    it('resolves a same-origin absolute URL', () => {
+      expect(
+        resolveSameOriginUrl(
+          'https://registry.example.com/v2/foo/tags/list?n=10',
+          'https://registry.example.com/v2/foo/tags/list?n=10&last=z',
+        ),
+      ).toBe('https://registry.example.com/v2/foo/tags/list?n=10&last=z');
+    });
+
+    it('resolves a relative next URL against the base', () => {
+      expect(
+        resolveSameOriginUrl(
+          'https://registry.example.com/v2/foo/tags/list?n=10',
+          '/v2/foo/tags/list?n=10&last=z',
+        ),
+      ).toBe('https://registry.example.com/v2/foo/tags/list?n=10&last=z');
+    });
+
+    it('rejects a cross-origin next URL', () => {
+      expect(
+        resolveSameOriginUrl(
+          'https://registry.example.com/v2/foo/tags/list?n=10',
+          'https://attacker.example.com/v2/steal/tags/list',
+        ),
+      ).toBeNull();
+    });
+
+    it('rejects when the base URL is invalid', () => {
+      expect(
+        resolveSameOriginUrl('not a url', 'https://registry.example.com/next'),
+      ).toBeNull();
+    });
+
+    it('rejects when the next URL is invalid', () => {
+      expect(
+        resolveSameOriginUrl('https://registry.example.com/v2/', 'http://'),
+      ).toBeNull();
+    });
+
+    it('accepts a URL instance as the base', () => {
+      expect(
+        resolveSameOriginUrl(
+          parseUrl('https://registry.example.com/v2/foo?n=10')!,
+          'https://registry.example.com/v2/foo?n=10&page=2',
+        ),
+      ).toBe('https://registry.example.com/v2/foo?n=10&page=2');
+    });
   });
 });

--- a/lib/util/url.ts
+++ b/lib/util/url.ts
@@ -74,6 +74,38 @@ export function replaceUrlPath(baseUrl: string | URL, path: string): string {
   return urlJoin(origin, path);
 }
 
+/**
+ * Resolves a server-provided pagination "next" URL against the current request
+ * URL, returning it only when it stays on the same origin.
+ *
+ * Registries paginate by returning a `Link` header (or Atom `<link rel="next">`)
+ * pointing at the next page.
+ *
+ * However, if we were to follow that URL without validating it, this could lead to us being redirected to a different host, which could lead to Server-Side Request Forgery (SSRF).
+ *
+ * This guard drops any `next` URL that resolves to a different origin.
+ *
+ * @param baseUrl - the URL of the request that produced `nextUrl`
+ * @param nextUrl - the remote-server-provided pagination target (may be relative, and may be malicious)
+ * @returns the resolved absolute URL if same-origin, otherwise `null`
+ */
+export function resolveSameOriginUrl(
+  baseUrl: string | URL,
+  nextUrl: string | URL,
+): string | null {
+  const base = parseUrl(baseUrl);
+  if (!base) {
+    return null;
+  }
+  let resolved: URL;
+  try {
+    resolved = new URL(nextUrl.toString(), base);
+  } catch {
+    return null;
+  }
+  return resolved.origin === base.origin ? resolved.href : null;
+}
+
 export function getQueryString(params: Record<string, any>): string {
   const usp = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -7,6 +7,7 @@ import noNewUrl from './rules/no-new-url.js';
 import noRedundantMockReset from './rules/no-redundant-mock-reset.js';
 import noStatefulGlobalRegex from './rules/no-stateful-global-regex.js';
 import noToolsImport from './rules/no-tools-import.js';
+import noUnvalidatedPaginationUrl from './rules/no-unvalidated-pagination-url.js';
 import preferFakeShaInSpecs from './rules/prefer-fake-sha-in-specs.js';
 import preferFsUtil from './rules/prefer-fs-util.js';
 import preferJsonPipe from './rules/prefer-json-pipe.js';
@@ -32,6 +33,7 @@ export default {
     'no-redundant-mock-reset': noRedundantMockReset,
     'no-stateful-global-regex': noStatefulGlobalRegex,
     'no-tools-import': noToolsImport,
+    'no-unvalidated-pagination-url': noUnvalidatedPaginationUrl,
     'prefer-fake-sha-in-specs': preferFakeShaInSpecs,
     'prefer-fs-util': preferFsUtil,
     'prefer-json-pipe': preferJsonPipe,

--- a/tools/lint/rules/no-unvalidated-pagination-url.js
+++ b/tools/lint/rules/no-unvalidated-pagination-url.js
@@ -1,0 +1,98 @@
+/**
+ * Strips wrappers that don't change the accessed property so the same matcher
+ * handles `a.next.url`, `a?.next?.url` (ChainExpression) and `a!.next!.url`
+ * (TSNonNullExpression).
+ *
+ * @param {any} node
+ */
+function unwrap(node) {
+  let current = node;
+  while (
+    current?.type === 'ChainExpression' ||
+    current?.type === 'TSNonNullExpression'
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/**
+ * Matches a member access ending in `.next.url` or `.next.href`, i.e. the URL of
+ * a pagination "next" link parsed from a `Link` header (`parseLinkHeader`).
+ *
+ * @param {any} input
+ */
+function isNextUrlNode(input) {
+  const node = unwrap(input);
+  if (node?.type !== 'MemberExpression') {
+    return false;
+  }
+  const { property } = node;
+  if (
+    property?.type !== 'Identifier' ||
+    (property.name !== 'url' && property.name !== 'href')
+  ) {
+    return false;
+  }
+  const inner = unwrap(node.object);
+  return (
+    inner?.type === 'MemberExpression' &&
+    inner.property?.type === 'Identifier' &&
+    inner.property.name === 'next'
+  );
+}
+
+/**
+ * Flags following a paginated `next` URL (from a `Link` header) via `new URL()`
+ * or `parseUrl()` without validating its origin.
+ *
+ * This could lead to Server Side Request Forgery if a malicious/compromised registry has modified their returned `next` URL,
+ * but could also be a sign of misconfiguration - either way, we should not allow it.
+ *
+ * Datasources have no legitimate reason to paginate across origins, so resolve
+ * such URLs with `resolveSameOriginUrl()` from `lib/util/url.ts`, which drops
+ * cross-origin targets.
+ *
+ * This focusses on Datasource-driven pagination, as Platform-driven pagination is allowed to run across origins (via Self-Hosted Experimental con fig)
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export default {
+  meta: {
+    type: 'problem',
+    messages: {
+      noUnvalidatedPaginationUrl:
+        "Do not follow a pagination `next` URL directly. Resolve it with resolveSameOriginUrl() from 'lib/util/url.ts' so a malicious registry cannot redirect the authenticated request to another host.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.physicalFilename ?? '';
+    // Only enforce in datasources, where cross-origin pagination is never valid.
+    if (
+      !filename.includes('/lib/modules/datasource/') ||
+      filename.endsWith('.spec.ts')
+    ) {
+      return {};
+    }
+    return {
+      NewExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'URL' &&
+          node.arguments.some(isNextUrlNode)
+        ) {
+          context.report({ node, messageId: 'noUnvalidatedPaginationUrl' });
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'parseUrl' &&
+          node.arguments.some(isNextUrlNode)
+        ) {
+          context.report({ node, messageId: 'noUnvalidatedPaginationUrl' });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

To prevent cases where we follow a `Link` header's `next` URL to a new domain, we can explicitly block this behaviour, and instead require a global self-hosted configuration option to opt-in to this behaviour.
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
