### PR TITLE
fix(platform): don't follow `Link` headers with different hosts on GitHub or GitLab

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -308,6 +308,24 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
     });
 
+    it('does not follow pagination links to a different origin', async () => {
+      // If a misconfigured/malicious host suggests pagination links across origins, ignore them by default
+      // In this case, only the first page of results is fetched, and a warning message is logged
+      const url = '/some-url?per_page=2';
+      httpMock.scope(githubApiHost).get(url).reply(200, ['a', 'b'], {
+        link: `<https://attacker.example.com/some-url?per_page=2&page=2>; rel="next", <https://attacker.example.com/some-url?per_page=2&page=3>; rel="last"`,
+      });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: true });
+      expect(res.body).toEqual(['a', 'b']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          requestHost: 'api.github.com',
+          paginationHost: 'attacker.example.com',
+        },
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+      );
+    });
+
     describe('handleGotError', () => {
       it('should log a once warning for github.com 401', async () => {
         await expect(

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -439,42 +439,54 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
         const firstPageUrl = rebasePagination
           ? replaceUrlBase(parsedUrl, baseUrl)
           : parsedUrl;
-        const queue = [...range(2, lastPage)].map(
-          (pageNumber) => (): Promise<HttpResponse<T>> => {
-            // copy before modifying searchParams
-            const nextUrl = parseUrl(firstPageUrl.toString())!;
-            nextUrl.searchParams.set('page', String(pageNumber));
-            return super.requestJsonUnsafe<T>(method, {
-              ...opts,
-              url: nextUrl,
-            });
-          },
-        );
-        const pages = await p.all(queue);
-        // v8 ignore else -- TODO: add test #40625
-        if (httpOptions.paginationField && isPlainObject(result.body)) {
-          const paginatedResult = result.body[httpOptions.paginationField];
+        // Don't follow a cross-origin request, unless we've been explicitly requested to do so with `RENOVATE_X_REBASE_PAGINATION_LINKS`
+        if (firstPageUrl.origin === resolvedUrl.origin) {
+          const queue = [...range(2, lastPage)].map(
+            (pageNumber) => (): Promise<HttpResponse<T>> => {
+              // copy before modifying searchParams
+              const nextUrl = parseUrl(firstPageUrl.toString())!;
+              nextUrl.searchParams.set('page', String(pageNumber));
+              return super.requestJsonUnsafe<T>(method, {
+                ...opts,
+                url: nextUrl,
+              });
+            },
+          );
+          const pages = await p.all(queue);
           // v8 ignore else -- TODO: add test #40625
-          if (isArray<T>(paginatedResult)) {
-            for (const nextPage of pages) {
-              // v8 ignore else -- TODO: add test #40625
-              if (isPlainObject(nextPage.body)) {
-                const nextPageResults =
-                  nextPage.body[httpOptions.paginationField];
+          if (httpOptions.paginationField && isPlainObject(result.body)) {
+            const paginatedResult = result.body[httpOptions.paginationField];
+            // v8 ignore else -- TODO: add test #40625
+            if (isArray<T>(paginatedResult)) {
+              for (const nextPage of pages) {
                 // v8 ignore else -- TODO: add test #40625
-                if (isArray<T>(nextPageResults)) {
-                  paginatedResult.push(...nextPageResults);
+                if (isPlainObject(nextPage.body)) {
+                  const nextPageResults =
+                    nextPage.body[httpOptions.paginationField];
+                  // v8 ignore else -- TODO: add test #40625
+                  if (isArray<T>(nextPageResults)) {
+                    paginatedResult.push(...nextPageResults);
+                  }
                 }
               }
             }
-          }
-        } else if (isArray<T>(result.body)) {
-          for (const nextPage of pages) {
-            // v8 ignore else -- TODO: add test #40625
-            if (isArray<T>(nextPage.body)) {
-              result.body.push(...nextPage.body);
+          } else if (isArray<T>(result.body)) {
+            for (const nextPage of pages) {
+              // v8 ignore else -- TODO: add test #40625
+              if (isArray<T>(nextPage.body)) {
+                result.body.push(...nextPage.body);
+              }
             }
           }
+        } else {
+          // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
+          logger.once.warn(
+            {
+              requestHost: resolvedUrl.host,
+              paginationHost: firstPageUrl.host,
+            },
+            'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+          );
         }
       }
     }

--- a/lib/util/http/gitlab.spec.ts
+++ b/lib/util/http/gitlab.spec.ts
@@ -82,6 +82,25 @@ describe('util/http/gitlab', () => {
     expect(res.body).toHaveLength(4);
   });
 
+  it('does not follow pagination links to a different origin', async () => {
+    // If a misconfigured/malicious host suggests pagination links across origins, ignore them by default
+    // In this case, only the first page of results is fetched, and a warning message is logged
+    httpMock.scope(gitlabApiHost).get('/api/v4/some-url').reply(200, ['a'], {
+      link: '<https://other.host.com/api/v4/some-url&page=2>; rel="next", <https://other.host.com/api/v4/some-url&page=3>; rel="last"',
+    });
+    const res = await gitlabApi.getJsonUnchecked('some-url', {
+      paginate: true,
+    });
+    expect(res.body).toHaveLength(1);
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      {
+        requestHost: 'gitlab.com',
+        paginationHost: 'other.host.com',
+      },
+      'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different host in pagination links.',
+    );
+  });
+
   it('supports different datasources', async () => {
     const gitlabApiDatasource = new GitlabHttp(GitlabReleasesDatasource.id);
     hostRules.add({ hostType: 'gitlab', token: 'abc' });

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -60,12 +60,21 @@ export class GitlabHttp extends HttpBase<GitlabHttpOptions> {
             nextUrl.host = defaultEndpoint.host;
           }
 
-          opts.url = nextUrl;
+          // Don't follow a cross-origin request, unless we've been explicitly requested to do so with `RENOVATE_X_REBASE_PAGINATION_LINKS`
+          if (nextUrl.origin === resolvedUrl.origin) {
+            opts.url = nextUrl;
 
-          const nextResult = await this.requestJsonUnsafe<T>(method, opts);
-          // v8 ignore else -- TODO: add test #40625
-          if (isArray(nextResult.body)) {
-            result.body.push(...nextResult.body);
+            const nextResult = await this.requestJsonUnsafe<T>(method, opts);
+            // v8 ignore else -- TODO: add test #40625
+            if (isArray(nextResult.body)) {
+              result.body.push(...nextResult.body);
+            }
+          } else {
+            // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
+            logger.once.warn(
+              { requestHost: resolvedUrl.host, paginationHost: nextUrl.host },
+              'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different host in pagination links.',
+            );
           }
         }
       } catch (err) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
