### PR TITLE
feat(sbt): support singleton object with versions and dotted symbols

### DIFF
--- a/lib/modules/manager/sbt/extract.spec.ts
+++ b/lib/modules/manager/sbt/extract.spec.ts
@@ -135,6 +135,82 @@ describe('modules/manager/sbt/extract', () => {
       });
     });
 
+    it('extracts deps when versions are defined in a named singleton object', () => {
+      const content = codeBlock`
+        object Version {
+          val scala = "2.12.10"
+          val example = "0.0.8"
+        }
+        scalaVersion := Version.scala
+        version := "3.2.1"
+        libraryDependencies += "org.example" % "foo" % Version.example
+      `;
+      expect(extractPackageFile(content)).toEqual({
+        deps: [
+          {
+            datasource: 'maven',
+            depName: 'scala',
+            packageName: 'org.scala-lang:scala-library',
+            currentValue: '2.12.10',
+            registryUrls: [],
+            separateMinorPatch: true,
+          },
+          {
+            datasource: 'sbt-package',
+            depName: 'org.example:foo',
+            packageName: 'org.example:foo',
+            currentValue: '0.0.8',
+            registryUrls: [],
+            sharedVariableName: 'Version.example',
+            variableName: 'Version.example',
+          },
+        ],
+        packageFileVersion: '3.2.1',
+        managerData: {
+          scalaVersion: '2.12',
+        },
+      });
+    });
+
+    it('extracts deps when named singleton object is nested inside another object', () => {
+      const content = codeBlock`
+        object Dependencies {
+          object Version {
+            val scala = "2.12.10"
+            val example = "0.0.8"
+          }
+          scalaVersion := Version.scala
+          version := "3.2.1"
+          libraryDependencies += "org.example" % "foo" % Version.example
+        }
+      `;
+      expect(extractPackageFile(content)).toEqual({
+        deps: [
+          {
+            datasource: 'maven',
+            depName: 'scala',
+            packageName: 'org.scala-lang:scala-library',
+            currentValue: '2.12.10',
+            registryUrls: [],
+            separateMinorPatch: true,
+          },
+          {
+            datasource: 'sbt-package',
+            depName: 'org.example:foo',
+            packageName: 'org.example:foo',
+            currentValue: '0.0.8',
+            registryUrls: [],
+            sharedVariableName: 'Version.example',
+            variableName: 'Version.example',
+          },
+        ],
+        packageFileVersion: '3.2.1',
+        managerData: {
+          scalaVersion: '2.12',
+        },
+      });
+    });
+
     it('skips deps when dotted symbolds do not resolve to anything', () => {
       const content = codeBlock`
         scalaVersion := versions.scala

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -393,6 +393,33 @@ export function extractProxyUrls(
   return extractedProxyUrls;
 }
 
+// Finds named singleton objects of the form:
+//   object Name {
+//     val field = "version"
+//   }
+// and returns a map of `Name.field -> version` entries.
+// Uses a regex that only matches object bodies without nested braces, so
+// outer wrapper objects (e.g. `object Dependencies { ... }`) are naturally
+// skipped — only leaf-level version objects are captured.
+const namedSingletonObjectRegex = regEx(/object\s+(\w+)\s*\{([^{}]*)\}/g);
+const namedSingletonObjectFieldRegex = regEx(
+  /\bval\s+(\w+)(?:\s*:\s*String)?\s*=\s*"([^"]+)"/g,
+);
+
+function extractNamedSingletonObjectVars(content: string): Vars {
+  const vars: Vars = {};
+  namedSingletonObjectRegex.lastIndex = 0;
+  for (const objectMatch of content.matchAll(namedSingletonObjectRegex)) {
+    const objectName = objectMatch[1];
+    const body = objectMatch[2];
+    namedSingletonObjectFieldRegex.lastIndex = 0;
+    for (const fieldMatch of body.matchAll(namedSingletonObjectFieldRegex)) {
+      vars[`${objectName}.${fieldMatch[1]}`] = fieldMatch[2];
+    }
+  }
+  return vars;
+}
+
 export function extractPackageFile(
   content: string,
   packageFile: string,
@@ -435,7 +462,7 @@ function extractPackageFileInternal(
 
   try {
     parsedResult = scala.query(content, query, {
-      vars: {},
+      vars: extractNamedSingletonObjectVars(content),
       deps: [],
       registryUrls: [],
       scalaVersion: ctxScalaVersion,

--- a/lib/modules/manager/sbt/extract.ts
+++ b/lib/modules/manager/sbt/extract.ts
@@ -393,27 +393,18 @@ export function extractProxyUrls(
   return extractedProxyUrls;
 }
 
-// Finds named singleton objects of the form:
-//   object Name {
-//     val field = "version"
-//   }
-// and returns a map of `Name.field -> version` entries.
-// Uses a regex that only matches object bodies without nested braces, so
-// outer wrapper objects (e.g. `object Dependencies { ... }`) are naturally
-// skipped — only leaf-level version objects are captured.
-const namedSingletonObjectRegex = regEx(/object\s+(\w+)\s*\{([^{}]*)\}/g);
-const namedSingletonObjectFieldRegex = regEx(
-  /\bval\s+(\w+)(?:\s*:\s*String)?\s*=\s*"([^"]+)"/g,
-);
-
+// Extracts `Name.field -> version` entries from `object Name { val field = "version" }` blocks.
+// The `[^{}]*` body pattern naturally skips outer wrapper objects with nested braces.
 function extractNamedSingletonObjectVars(content: string): Vars {
   const vars: Vars = {};
-  namedSingletonObjectRegex.lastIndex = 0;
-  for (const objectMatch of content.matchAll(namedSingletonObjectRegex)) {
+  const objectRegex = regEx(/object\s+(\w+)\s*\{([^{}]*)\}/g);
+  for (const objectMatch of content.matchAll(objectRegex)) {
     const objectName = objectMatch[1];
     const body = objectMatch[2];
-    namedSingletonObjectFieldRegex.lastIndex = 0;
-    for (const fieldMatch of body.matchAll(namedSingletonObjectFieldRegex)) {
+    const fieldRegex = regEx(
+      /\bval\s+(\w+)(?:\s*:\s*String)?\s*=\s*"([^"]+)"/g,
+    );
+    for (const fieldMatch of body.matchAll(fieldRegex)) {
       vars[`${objectName}.${fieldMatch[1]}`] = fieldMatch[2];
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

PR #40699 (merged v43.113.0) added support for anonymous object assignment and dotted symbol resolution:

```scala
val versions = new {
  http4s = "0.23.35"
}
// resolved as versions.http4s
```

However, this anonymous object syntax (`new { ... }`) is not valid in sbt v2 build files — the Scala compiler rejects member access on structural types without `import scala.language.reflectiveCalls`, and sbt's build file compiler does not enable that feature. The pattern therefore cannot be used in practice in `project/*.scala` files targeting sbt v2.

A common — and compiler-safe — sbt pattern uses a named singleton object instead:

```scala
object Dependencies {
  object Version {
    val http4s    = "0.23.35"
    val circe     = "0.14.16"
    val log4cats  = "2.8.0"
  }

  val http4s = Seq(
    "org.http4s" %% "http4s-ember-server" % Version.http4s,
    ...
  )
}
```

This pattern is semantically equivalent but currently not extracted. The dotted reference resolution introduced in #40699 would handle `Version.http4s` correctly if the variable were registered — the only missing piece is extracting `object Name { val field = "..." }` into the shared variables map as `Name.field`.

**Suggested approach**

Run a regex pre-pass over the file before the main parser query, matching leaf-level named objects (bodies without nested braces):

```
/object\s+(\w+)\s*\{([^{}]*)\}/g
```

For each match, extract inner `val <field> = "<version>"` pairs and seed the parser context's `vars` map with `<ObjectName>.<field>` entries before the query runs. The existing dotted symbol resolver in `versionMatch` and `scalaVersionMatch` then resolves `Version.http4s` references without any further changes.

The regex naturally skips outer wrapper objects such as `object Dependencies { ... }` (whose bodies contain nested braces) and only captures the leaf version objects — so it does not interfere with dep extraction in the main query pass.

Two test cases cover the feature: a top-level `object Version { ... }` and one nested inside `object Dependencies { ... }`.


## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [X] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [X] @simonjscott will read and reply directly.
- [X] An agent will draft replies and @simonjscott will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [X] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
