### PR TITLE
fix(presets/monorepo): add new datatables.net source repos

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -163,6 +163,7 @@
     "datadog-browser-sdk": "https://github.com/DataDog/browser-sdk",
     "datafusion": "https://github.com/apache/datafusion",
     "datatables-net": [
+      "https://github.com/DataTables/DataTablesSrc",
       "https://github.com/DataTables/Dist-DataTables",
       "https://github.com/DataTables/Dist-DataTables-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-Bootstrap4",
@@ -174,6 +175,7 @@
       "https://github.com/DataTables/Dist-DataTables-jQueryUI"
     ],
     "datatables-net-autofill": [
+      "https://github.com/DataTables/AutoFill",
       "https://github.com/DataTables/Dist-DataTables-AutoFill",
       "https://github.com/DataTables/Dist-DataTables-AutoFill-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-AutoFill-Bootstrap4",
@@ -185,6 +187,7 @@
       "https://github.com/DataTables/Dist-DataTables-AutoFill-jQueryUI"
     ],
     "datatables-net-buttons": [
+      "https://github.com/DataTables/Buttons",
       "https://github.com/DataTables/Dist-DataTables-Buttons",
       "https://github.com/DataTables/Dist-DataTables-Buttons-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-Buttons-Bootstrap4",
@@ -196,6 +199,7 @@
       "https://github.com/DataTables/Dist-DataTables-Buttons-jQueryUI"
     ],
     "datatables-net-colreorder": [
+      "https://github.com/DataTables/ColReorder",
       "https://github.com/DataTables/Dist-DataTables-ColReorder",
       "https://github.com/DataTables/Dist-DataTables-ColReorder-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-ColReorder-Bootstrap4",
@@ -207,6 +211,7 @@
       "https://github.com/DataTables/Dist-DataTables-ColReorder-jQueryUI"
     ],
     "datatables-net-fixedcolumns": [
+      "https://github.com/DataTables/FixedColumns",
       "https://github.com/DataTables/Dist-DataTables-FixedColumns",
       "https://github.com/DataTables/Dist-DataTables-FixedColumns-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-FixedColumns-Bootstrap4",
@@ -218,6 +223,7 @@
       "https://github.com/DataTables/Dist-DataTables-FixedColumns-jQueryUI"
     ],
     "datatables-net-fixedheader": [
+      "https://github.com/DataTables/FixedHeader",
       "https://github.com/DataTables/Dist-DataTables-FixedHeader",
       "https://github.com/DataTables/Dist-DataTables-FixedHeader-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-FixedHeader-Bootstrap4",
@@ -229,6 +235,7 @@
       "https://github.com/DataTables/Dist-DataTables-FixedHeader-jQueryUI"
     ],
     "datatables-net-keytable": [
+      "https://github.com/DataTables/KeyTable",
       "https://github.com/DataTables/Dist-DataTables-KeyTable",
       "https://github.com/DataTables/Dist-DataTables-KeyTable-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-KeyTable-Bootstrap4",
@@ -240,6 +247,7 @@
       "https://github.com/DataTables/Dist-DataTables-KeyTable-jQueryUI"
     ],
     "datatables-net-responsive": [
+      "https://github.com/DataTables/Responsive",
       "https://github.com/DataTables/Dist-DataTables-Responsive",
       "https://github.com/DataTables/Dist-DataTables-Responsive-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-Responsive-Bootstrap4",
@@ -251,6 +259,7 @@
       "https://github.com/DataTables/Dist-DataTables-Responsive-jQueryUI"
     ],
     "datatables-net-rowgroup": [
+      "https://github.com/DataTables/RowGroup",
       "https://github.com/DataTables/Dist-DataTables-RowGroup",
       "https://github.com/DataTables/Dist-DataTables-RowGroup-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-RowGroup-Bootstrap4",
@@ -262,6 +271,7 @@
       "https://github.com/DataTables/Dist-DataTables-RowGroup-jQueryUI"
     ],
     "datatables-net-rowreorder": [
+      "https://github.com/DataTables/RowReorder",
       "https://github.com/DataTables/Dist-DataTables-RowReorder",
       "https://github.com/DataTables/Dist-DataTables-RowReorder-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-RowReorder-Bootstrap4",
@@ -273,6 +283,7 @@
       "https://github.com/DataTables/Dist-DataTables-RowReorder-jQueryUI"
     ],
     "datatables-net-scroller": [
+      "https://github.com/DataTables/Scroller",
       "https://github.com/DataTables/Dist-DataTables-Scroller",
       "https://github.com/DataTables/Dist-DataTables-Scroller-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-Scroller-Bootstrap4",
@@ -284,6 +295,7 @@
       "https://github.com/DataTables/Dist-DataTables-Scroller-jQueryUI"
     ],
     "datatables-net-searchbuilder": [
+      "https://github.com/DataTables/SearchBuilder",
       "https://github.com/DataTables/Dist-DataTables-SearchBuilder",
       "https://github.com/DataTables/Dist-DataTables-SearchBuilder-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-SearchBuilder-Bootstrap4",
@@ -295,6 +307,7 @@
       "https://github.com/DataTables/Dist-DataTables-SearchBuilder-jQueryUI"
     ],
     "datatables-net-searchpanes": [
+      "https://github.com/DataTables/SearchPanes",
       "https://github.com/DataTables/Dist-DataTables-SearchPanes",
       "https://github.com/DataTables/Dist-DataTables-SearchPanes-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-SearchPanes-Bootstrap4",
@@ -306,6 +319,7 @@
       "https://github.com/DataTables/Dist-DataTables-SearchPanes-jQueryUI"
     ],
     "datatables-net-select": [
+      "https://github.com/DataTables/Select",
       "https://github.com/DataTables/Dist-DataTables-Select",
       "https://github.com/DataTables/Dist-DataTables-Select-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-Select-Bootstrap4",
@@ -317,6 +331,7 @@
       "https://github.com/DataTables/Dist-DataTables-Select-jQueryUI"
     ],
     "datatables-net-staterestore": [
+      "https://github.com/DataTables/StateRestore",
       "https://github.com/DataTables/Dist-DataTables-StateRestore",
       "https://github.com/DataTables/Dist-DataTables-StateRestore-Bootstrap",
       "https://github.com/DataTables/Dist-DataTables-StateRestore-Bootstrap4",


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

The recent datatables.net update to v3 has changed the source urls in npm packages (almost*) across the board. As such, the current monorepo presets do not work correctly.

This adds the new source urls (as defined in npm) to the presets.

<sub>*SearchPanes and StateRestore have _not_ been updated yet and still point to "Dist" repos, although the corresponding "Source" repos do exist. I put them in anyways in case this was an oversight on datatables' part.</sub>

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @benmelz will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
