### PR TITLE
fix(datasource): use release-level registryUrl in postprocessRelease

### DIFF
--- a/lib/modules/datasource/postprocess-release.spec.ts
+++ b/lib/modules/datasource/postprocess-release.spec.ts
@@ -128,6 +128,36 @@ describe('modules/datasource/postprocess-release', () => {
     expect(release).toBeNull();
   });
 
+  it('uses release-level `registryUrl` over the config-level one', async () => {
+    const releaseOrig: Release = {
+      version: '1.2.3',
+      registryUrl: 'https://release-registry.example.com',
+    };
+    let usedRegistryUrl: string | null = null;
+
+    class SomeDatasource extends DummyDatasource {
+      override postprocessRelease(
+        config: PostprocessReleaseConfig,
+        release: Release,
+      ): Promise<PostprocessReleaseResult> {
+        usedRegistryUrl = config.registryUrl;
+        return Promise.resolve(release);
+      }
+    }
+    getDatasourceFor.mockReturnValueOnce(new SomeDatasource());
+
+    await postprocessRelease(
+      {
+        datasource: 'some-datasource',
+        packageName: 'some-package',
+        registryUrl: 'https://config-registry.example.com',
+      },
+      releaseOrig,
+    );
+
+    expect(usedRegistryUrl).toBe('https://release-registry.example.com');
+  });
+
   it('falls back when error was thrown', async () => {
     const releaseOrig: Release = { version: '1.2.3' };
 

--- a/lib/modules/datasource/postprocess-release.ts
+++ b/lib/modules/datasource/postprocess-release.ts
@@ -40,7 +40,14 @@ export async function postprocessRelease(
     return release;
   }
 
-  const registryUrl = config.registryUrl ?? config.registryUrls?.at(0) ?? null;
+  // Prefer the registry that actually reported this release (set by `mergeRegistries`
+  // for the `merge` registryStrategy) over the configured/default registry, otherwise
+  // we may probe a registry that never had this artifact and wrongly reject it.
+  const registryUrl =
+    release.registryUrl ??
+    config.registryUrl ??
+    config.registryUrls?.at(0) ??
+    null;
 
   try {
     const result = await ds.postprocessRelease(


### PR DESCRIPTION
## Changes

Datasources using the `merge` registryStrategy (e.g. Maven) query all configured registries and merge the resulting releases, tagging each release with the URL of the repo that actually reported it (`mergeRegistries` in `lib/modules/datasource/index.ts`).

`postprocessRelease()` ignored this per-release `registryUrl` and always fell back to `config.registryUrl` (or the first configured registry), so the datasource's `postprocessRelease` (used by Maven to verify the artifact POM actually exists, and to fetch release timestamps) probed the wrong repository. When the artifact didn't exist in that first repo, the release was rejected as not-found and no update was proposed — even though the artifact existed in another configured repository.

Fix: prefer `release.registryUrl` when set, falling back to the existing config-level resolution otherwise.

## Context

Please select one of the following:

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @tnovo will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
