### PR TITLE
chore(manager/flux): don't use shell execution to `flux install`

### DIFF
--- a/lib/modules/manager/flux/artifacts.spec.ts
+++ b/lib/modules/manager/flux/artifacts.spec.ts
@@ -14,9 +14,8 @@ describe('modules/manager/flux/artifacts', () => {
   });
 
   it('replaces existing value', async () => {
-    const snapshots = mockExecAll({ stdout: '', stderr: '' });
+    const snapshots = mockExecAll({ stdout: 'test', stderr: '' });
     fs.readLocalFile.mockResolvedValueOnce('old');
-    fs.readLocalFile.mockResolvedValueOnce('test');
 
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
@@ -42,20 +41,28 @@ describe('modules/manager/flux/artifacts', () => {
         },
       },
     ]);
+    expect(fs.writeLocalFile).toHaveBeenCalledWith(
+      'clusters/my-cluster/flux-system/gotk-components.yaml',
+      'test',
+    );
     expect(snapshots).toMatchObject([
       {
-        cmd: 'flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > clusters/my-cluster/flux-system/gotk-components.yaml',
-        options: {
-          shell: true,
+        cmd: {
+          command: [
+            'flux',
+            'install',
+            '--export',
+            '--components',
+            'source-controller,kustomize-controller,helm-controller,notification-controller',
+          ],
         },
       },
     ]);
   });
 
   it('detects system manifests in subdirectories', async () => {
-    const snapshots = mockExecAll({ stdout: '', stderr: '' });
+    const snapshots = mockExecAll({ stdout: 'test', stderr: '' });
     fs.readLocalFile.mockResolvedValueOnce('old');
-    fs.readLocalFile.mockResolvedValueOnce('test');
 
     const res = await updateArtifacts({
       packageFileName:
@@ -84,7 +91,15 @@ describe('modules/manager/flux/artifacts', () => {
     ]);
     expect(snapshots).toMatchObject([
       {
-        cmd: 'flux install --export --components source-controller,kustomize-controller,helm-controller,notification-controller > clusters/my-cluster/flux-system/gitops-toolkit/gotk-components.yaml',
+        cmd: {
+          command: [
+            'flux',
+            'install',
+            '--export',
+            '--components',
+            'source-controller,kustomize-controller,helm-controller,notification-controller',
+          ],
+        },
       },
     ]);
   });
@@ -101,8 +116,7 @@ describe('modules/manager/flux/artifacts', () => {
   });
 
   it('ignores unchanged system manifests', async () => {
-    const execSnapshots = mockExecAll({ stdout: '', stderr: '' });
-    fs.readLocalFile.mockResolvedValueOnce('old');
+    const execSnapshots = mockExecAll({ stdout: 'old', stderr: '' });
     fs.readLocalFile.mockResolvedValueOnce('old');
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
@@ -114,7 +128,7 @@ describe('modules/manager/flux/artifacts', () => {
     expect(res).toBeNull();
     expect(execSnapshots).toMatchObject([
       {
-        cmd: 'flux install --export > clusters/my-cluster/flux-system/gotk-components.yaml',
+        cmd: { command: ['flux', 'install', '--export'] },
       },
     ]);
   });
@@ -152,7 +166,6 @@ describe('modules/manager/flux/artifacts', () => {
   it('failed to read system manifest', async () => {
     mockExecAll({ stdout: '', stderr: 'Error' });
     fs.readLocalFile.mockResolvedValueOnce('old');
-    fs.readLocalFile.mockResolvedValueOnce('');
     const res = await updateArtifacts({
       packageFileName: 'clusters/my-cluster/flux-system/gotk-components.yaml',
       updatedDeps: [{ newVersion: '1.0.1' }],

--- a/lib/modules/manager/flux/artifacts.ts
+++ b/lib/modules/manager/flux/artifacts.ts
@@ -1,8 +1,7 @@
-import { quote } from 'shlex';
 import { logger } from '../../../logger/index.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
-import { readLocalFile } from '../../../util/fs/index.ts';
+import { readLocalFile, writeLocalFile } from '../../../util/fs/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { isSystemManifest } from './common.ts';
 import type { FluxManagerData } from './types.ts';
@@ -15,16 +14,15 @@ export async function updateArtifacts({
   if (!isSystemManifest(packageFileName) || !systemDep?.newVersion) {
     return null;
   }
-  const existingFileContent = await readLocalFile(packageFileName);
+  const existingFileContent = await readLocalFile(packageFileName, 'utf8');
   try {
     logger.debug(`Updating Flux system manifests`);
     const args: string[] = ['--export'];
     if (systemDep.managerData?.components) {
-      args.push('--components', quote(systemDep.managerData.components));
+      args.push('--components', systemDep.managerData.components);
     }
-    const cmd = `flux install ${args.join(' ')} > ${quote(packageFileName)}`;
+    const cmd = [{ command: ['flux', 'install', ...args] }];
     const execOptions: ExecOptions = {
-      shell: true,
       docker: {},
       toolConstraints: [
         {
@@ -35,8 +33,7 @@ export async function updateArtifacts({
     };
     const result = await exec(cmd, execOptions);
 
-    const newFileContent = await readLocalFile(packageFileName);
-    if (!newFileContent) {
+    if (!result.stdout) {
       logger.debug('Cannot read new flux file content');
       return [
         {
@@ -47,6 +44,8 @@ export async function updateArtifacts({
         },
       ];
     }
+    await writeLocalFile(packageFileName, result.stdout);
+    const newFileContent = result.stdout;
     if (newFileContent === existingFileContent) {
       logger.debug('Flux contents are unchanged');
       return null;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As this is the only place in the codebase we're currently doing this, we
should remove the usage of `shell` semantics for file redirection, which
isn't needed.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
