### PR TITLE
chore: add linter rule for `shell: true` usage

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -72,6 +72,7 @@
 
     "renovate/enforce-ts-extension": "error",
     "renovate/logger-static-message": "error",
+    "renovate/no-exec-shell-option": "error",
     "renovate/no-hardcoded-docs-url": "error",
     "renovate/no-new-url": "error",
     "renovate/no-stateful-global-regex": "error",

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -161,6 +161,7 @@ export async function postUpgradeCommandsExecutor(
             logger.trace({ cmd: compiledCmd }, 'Executing post-upgrade task');
 
             const execOpts: ExecOptions = {
+              // oxlint-disable-next-line renovate/no-exec-shell-option -- some self-hosted adminstrators allow their users to use shell features (pipes, globbing, sub-shells), so this is allowed for that purpose when it's opted in via allowShellExecutorForPostUpgradeCommands
               shell: GlobalConfig.get(
                 'allowShellExecutorForPostUpgradeCommands',
               ),

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -1,6 +1,7 @@
 import codeblockInSpecFixtures from './rules/codeblock-in-spec-fixtures.js';
 import enforceTsExtension from './rules/enforce-ts-extension.js';
 import loggerStaticMessage from './rules/logger-static-message.js';
+import noExecShellOption from './rules/no-exec-shell-option.js';
 import noHardcodedDocsUrl from './rules/no-hardcoded-docs-url.js';
 import noHostRulesMock from './rules/no-host-rules-mock.js';
 import noNewUrl from './rules/no-new-url.js';
@@ -28,6 +29,7 @@ export default {
     'codeblock-in-spec-fixtures': codeblockInSpecFixtures,
     'enforce-ts-extension': enforceTsExtension,
     'logger-static-message': loggerStaticMessage,
+    'no-exec-shell-option': noExecShellOption,
     'no-hardcoded-docs-url': noHardcodedDocsUrl,
     'no-host-rules-mock': noHostRulesMock,
     'no-new-url': noNewUrl,

--- a/tools/lint/rules/no-exec-shell-option.js
+++ b/tools/lint/rules/no-exec-shell-option.js
@@ -1,0 +1,50 @@
+/**
+ * Flags a `shell` property set on an object literal (e.g. `ExecOptions`,
+ * `CommandWithOptions`) passed to `lib/util/exec`. Enabling the child
+ * process's shell reintroduces the injection risk that `exec()` is designed
+ * to avoid by running commands as an argv array - see the warning on
+ * `CommandWithOptions.shell` in `lib/util/exec/types.ts`.
+ *
+ * The implementation in `lib/util/exec/` itself is exempt, since it has to
+ * accept and plumb the option through. Call sites with a genuine, reviewed
+ * need for a shell (e.g. to run user-configured commands) should disable
+ * this rule inline with a justification instead of being silently exempted.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+export default {
+  meta: {
+    type: 'problem',
+    messages: {
+      noExecShellOption:
+        "Do not set 'shell' on exec options: it re-enables shell interpretation of the command, which can lead to command injection. Build the command as an argv array instead. If a shell is genuinely required, disable this rule inline with a justification.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.physicalFilename ?? '';
+    if (
+      !filename.includes('/lib/') ||
+      filename.endsWith('.spec.ts') ||
+      filename.includes('/lib/util/exec/')
+    ) {
+      return {};
+    }
+    return {
+      Property(node) {
+        if (node.parent.type !== 'ObjectExpression') {
+          return;
+        }
+        const { key } = node;
+        let name;
+        if (key.type === 'Identifier') {
+          name = key.name;
+        } else if (key.type === 'Literal' && typeof key.value === 'string') {
+          name = key.value;
+        }
+        if (name === 'shell') {
+          context.report({ node, messageId: 'noExecShellOption' });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As we shouldn't really be using it, we should flag up usages more
clearly.

In cases where we do need to specify this - when
`allowShellExecutorForPostUpgradeCommands` is set - then we can disable
the rule.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
