### PR TITLE
fix(proxy): sanitise password components in `HTTP_PROXY` variable(s) in logs

### DIFF
--- a/lib/proxy.spec.ts
+++ b/lib/proxy.spec.ts
@@ -1,4 +1,7 @@
 import { bootstrap, hasProxy } from './proxy.ts';
+import * as sanitize from './util/sanitize.ts';
+
+const addSecretForSanitizing = vi.spyOn(sanitize, 'addSecretForSanitizing');
 
 describe('proxy', () => {
   const httpProxy = 'http://example.org/http-proxy';
@@ -56,5 +59,35 @@ describe('proxy', () => {
     process.env.no_proxy = noProxy;
     bootstrap();
     expect(hasProxy()).toBeFalse();
+  });
+
+  it('sanitizes password from HTTP_PROXY credentials', () => {
+    process.env.HTTP_PROXY = 'http://user:s3cr3t@example.org';
+    bootstrap();
+    expect(addSecretForSanitizing).toHaveBeenCalledWith('s3cr3t', 'global');
+  });
+
+  it('sanitizes password from HTTPS_PROXY credentials', () => {
+    process.env.HTTPS_PROXY = 'http://user:s3cr3t@example.org';
+    bootstrap();
+    expect(addSecretForSanitizing).toHaveBeenCalledWith('s3cr3t', 'global');
+  });
+
+  it('does not sanitize username-only proxy credentials', () => {
+    process.env.HTTP_PROXY = 'http://user@example.org';
+    bootstrap();
+    expect(addSecretForSanitizing).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes password-only proxy credentials', () => {
+    process.env.HTTP_PROXY = 'http://:s3cr3t@example.org';
+    bootstrap();
+    expect(addSecretForSanitizing).toHaveBeenCalledWith('s3cr3t', 'global');
+  });
+
+  it('does not sanitize when proxy has no credentials', () => {
+    process.env.HTTP_PROXY = httpProxy;
+    bootstrap();
+    expect(addSecretForSanitizing).not.toHaveBeenCalled();
   });
 });

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,10 +1,20 @@
 import { isNonEmptyString } from '@sindresorhus/is';
 import { createGlobalProxyAgent } from 'global-agent';
 import { logger } from './logger/index.ts';
+import { addSecretForSanitizing } from './util/sanitize.ts';
+import { parseUrl } from './util/url.ts';
 
 const envVars = ['HTTP_PROXY', 'HTTPS_PROXY', 'NO_PROXY'];
+const proxyEnvVarsWithCredentials = ['HTTP_PROXY', 'HTTPS_PROXY'];
 
 let agent = false;
+
+function sanitizeProxyCredentials(envVar: string): void {
+  const uri = parseUrl(process.env[envVar]);
+  if (uri?.password) {
+    addSecretForSanitizing(uri.password, 'global');
+  }
+}
 
 export function bootstrap(): void {
   envVars.forEach((envVar) => {
@@ -21,6 +31,8 @@ export function bootstrap(): void {
       process.env[envVar.toLowerCase()] = process.env[envVar];
     }
   });
+
+  proxyEnvVarsWithCredentials.forEach(sanitizeProxyCredentials);
 
   if (
     isNonEmptyString(process.env.HTTP_PROXY) ||


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

If a proxy URL appears to have a password component in it, we should
make sure that this is sanitised.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
