### PR TITLE
fix(util/host-rules): sanitise TLS credential fields in hostRules

### DIFF
--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -1,18 +1,58 @@
 import { NugetDatasource } from '../modules/datasource/nuget/index.ts';
+import type { HostRule } from '../types/index.ts';
 import {
   add,
   clear,
+  confidentialFields,
   find,
   findAll,
   getAll,
   hostType,
   hosts,
 } from './host-rules.ts';
-import { sanitize } from './sanitize.ts';
+import { redactedFields, sanitize } from './sanitize.ts';
 
 describe('util/host-rules', () => {
   beforeEach(() => {
     clear();
+  });
+
+  it('registers every redactedFields entry that is a HostRule field for value-level sanitizing', () => {
+    // exhaustive check for fields of `HostRule`, to introduce a compile-time error when adding a new field to `HostRule`
+    const allHostRuleFields: Record<keyof HostRule, true> = {
+      authType: true,
+      token: true,
+      username: true,
+      password: true,
+      insecureRegistry: true,
+      timeout: true,
+      abortOnError: true,
+      abortIgnoreStatusCodes: true,
+      enabled: true,
+      enableHttp2: true,
+      concurrentRequestLimit: true,
+      maxRequestsPerSecond: true,
+      headers: true,
+      maxRetryAfter: true,
+      keepAlive: true,
+      artifactAuth: true,
+      httpsCertificateAuthority: true,
+      httpsPrivateKey: true,
+      httpsCertificate: true,
+      encrypted: true,
+      hostType: true,
+      matchHost: true,
+      resolvedHost: true,
+      readOnly: true,
+    };
+
+    const expectedConfidentialFields = redactedFields.filter(
+      (field) => field in allHostRuleFields,
+    );
+
+    expect([...confidentialFields].sort()).toEqual(
+      expectedConfidentialFields.sort(),
+    );
   });
 
   describe('add()', () => {

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -8,6 +8,7 @@ import {
   hostType,
   hosts,
 } from './host-rules.ts';
+import { sanitize } from './sanitize.ts';
 
 describe('util/host-rules', () => {
   beforeEach(() => {
@@ -106,6 +107,20 @@ describe('util/host-rules', () => {
         password: 'pass2',
         username: 'user2',
       });
+    });
+
+    it('sanitizes TLS credential values', () => {
+      add({
+        matchHost: 'https://some.endpoint',
+        httpsPrivateKey: 'private-key-value',
+        httpsCertificate: 'certificate-value',
+        httpsCertificateAuthority: 'certificate-authority-value',
+      });
+      expect(
+        sanitize(
+          'key=private-key-value cert=certificate-value ca=certificate-authority-value',
+        ),
+      ).toBe('key=**redacted** cert=**redacted** ca=**redacted**');
     });
   });
 

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -8,6 +8,21 @@ import { isHttpUrl, massageHostUrl, parseUrl } from './url.ts';
 
 let hostRules: HostRule[] = [];
 
+/**
+ * Fields within `HostRule`s that must have their value registered for sanitising through `sanitize.addSecretForSanitizing()`.
+ *
+ * Kept in sync with `redactedFields` through tests.
+ */
+export const confidentialFields: (keyof HostRule)[] = [
+  'password',
+  'token',
+  'httpsPrivateKey',
+  /* not actually sensitive, but redacted nonetheless */
+  'httpsCertificate',
+  /* not actually sensitive, but redacted nonetheless */
+  'httpsCertificateAuthority',
+];
+
 export interface LegacyHostRule {
   hostName?: string;
   domainName?: string;
@@ -41,15 +56,6 @@ export function migrateRule(rule: LegacyHostRule & HostRule): HostRule {
 export function add(params: HostRule): void {
   const rule = migrateRule(params);
 
-  const confidentialFields: (keyof HostRule)[] = [
-    'password',
-    'token',
-    'httpsPrivateKey',
-    /* not actually sensitive, but redacted nonetheless */
-    'httpsCertificate',
-    /* not actually sensitive, but redacted nonetheless */
-    'httpsCertificateAuthority',
-  ];
   if (rule.matchHost) {
     rule.matchHost = massageHostUrl(rule.matchHost);
     const parsedUrl = parseUrl(rule.matchHost);

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -41,7 +41,15 @@ export function migrateRule(rule: LegacyHostRule & HostRule): HostRule {
 export function add(params: HostRule): void {
   const rule = migrateRule(params);
 
-  const confidentialFields: (keyof HostRule)[] = ['password', 'token'];
+  const confidentialFields: (keyof HostRule)[] = [
+    'password',
+    'token',
+    'httpsPrivateKey',
+    /* not actually sensitive, but redacted nonetheless */
+    'httpsCertificate',
+    /* not actually sensitive, but redacted nonetheless */
+    'httpsCertificateAuthority',
+  ];
   if (rule.matchHost) {
     rule.matchHost = massageHostUrl(rule.matchHost);
     const parsedUrl = parseUrl(rule.matchHost);

--- a/lib/util/sanitize.ts
+++ b/lib/util/sanitize.ts
@@ -15,8 +15,10 @@ export const redactedFields = [
   'gitPrivateKey',
   'forkToken',
   'password',
+  /* not actually sensitive, but redacted nonetheless */
   'httpsCertificate',
   'httpsPrivateKey',
+  /* not actually sensitive, but redacted nonetheless */
   'httpsCertificateAuthority',
 ];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
