### PR TITLE
feat(manager/gomod): allow pointing to a fork of `marwan-at-work/mod`

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -5000,7 +5000,7 @@ This option can be used on the repository level and in the [Renovate configurati
 !!! note
   The JVM memory settings are considered for the `gradle` and `gradle-wrapper` manager.
 
-### `toolSettings.gomodModPackage`
+### `toolSettings.gomodModInstallPath`
 
 Used to specify the path to [the `mod` binary](https://github.com/marwan-at-work/mod) used to perform updates of import paths on major updates, when using [`postupdateoptions=["gomodUpdateImportPaths"]`](#postupdateoptions).
 
@@ -5008,7 +5008,7 @@ Will be used verbatim as part of a `go install` command such as:
 
 ```sh
 # i.e.
-go install ${toolSettings.gomodModPackage}@latest
+go install ${toolSettings.gomodModInstallPath}@latest
 ```
 
 Use this if you're pointing Renovate to a fork of [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -5000,6 +5000,19 @@ This option can be used on the repository level and in the [Renovate configurati
 !!! note
   The JVM memory settings are considered for the `gradle` and `gradle-wrapper` manager.
 
+### `toolSettings.gomodModPackage`
+
+Used to specify the path to [the `mod` binary](https://github.com/marwan-at-work/mod) used to perform updates of import paths on major updates, when using [`postupdateoptions=["gomodUpdateImportPaths"]`](#postupdateoptions).
+
+Will be used verbatim as part of a `go install` command such as:
+
+```sh
+# i.e.
+go install ${toolSettings.gomodModPackage}@latest
+```
+
+Use this if you're pointing Renovate to a fork of [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).
+
 ### `toolSettings.jvmMaxMemory`
 
 Maximum heap size in MB for Java VMs.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -5013,6 +5013,9 @@ go install ${toolSettings.gomodModPackage}@latest
 
 Use this if you're pointing Renovate to a fork of [`github.com/marwan-at-work/mod`](https://github.com/marwan-at-work/mod).
 
+The binary that's invoked is named after the last element of the module path.
+For example, setting this to `github.com/some-fork/mod/cmd/new-mod` installs and runs a binary named `new-mod`.
+
 ### `toolSettings.jvmMaxMemory`
 
 Maximum heap size in MB for Java VMs.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3612,6 +3612,17 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
   },
   {
+    name: 'gomodModPackage',
+    description:
+      'The full path to `go install` a `mod` binary, for updating import paths on major updates.',
+    type: 'string',
+    default: 'github.com/marwan-at-work/mod/cmd/mod',
+    parents: ['toolSettings'],
+    supportedManagers: ['gomod'],
+    cli: false,
+    env: false,
+  },
+  {
     name: 'constraintsVersioning',
     description:
       'Override the versioning scheme used when filtering releases by specific constraint names. Does not apply to tools.',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3612,7 +3612,7 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
   },
   {
-    name: 'gomodModPackage',
+    name: 'gomodModInstallPath',
     description:
       'The full path to `go install` a `mod` binary, for updating import paths on major updates.',
     type: 'string',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -526,6 +526,10 @@ export interface AllConfig
   password?: string;
   token?: string;
   username?: string;
+  // `RenovateConfig` and `RepoGlobalConfig` declare `toolSettings` with
+  // different (repo-only vs global-only) shapes; this combines both since
+  // `AllConfig` is a superset of both.
+  toolSettings?: GlobalToolSettingsOptions & RepoToolSettingsOptions;
 }
 
 export interface AssigneesAndReviewersConfig {
@@ -874,4 +878,5 @@ export interface RepoToolSettingsOptions {
   jvmMemory?: number;
   /** The maximum memory child Node.JS processes can use. If greater than the Global Self-Hosted configuration setting, it will be set to that limit **/
   nodeMaxMemory?: number;
+  gomodModPackage?: string;
 }

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -878,5 +878,5 @@ export interface RepoToolSettingsOptions {
   jvmMemory?: number;
   /** The maximum memory child Node.JS processes can use. If greater than the Global Self-Hosted configuration setting, it will be set to that limit **/
   nodeMaxMemory?: number;
-  gomodModPackage?: string;
+  gomodModInstallPath?: string;
 }

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -2185,6 +2185,65 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
   });
 
+  it('updates import paths using a configured fork of the mod tool', async () => {
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('vendor');
+    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
+    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({
+        modified: ['go.sum', 'main.go'],
+      }),
+    );
+    fs.readLocalFile
+      .mockResolvedValueOnce('New go.sum')
+      .mockResolvedValueOnce('New main.go')
+      .mockResolvedValueOnce('New go.mod');
+    expect(
+      await gomod.updateArtifacts({
+        packageFileName: 'go.mod',
+        updatedDeps: [
+          { depName: 'github.com/google/go-github/v24', newVersion: 'v28.0.0' },
+        ],
+        newPackageFileContent: gomod1,
+        config: {
+          ...config,
+          updateType: 'major',
+          postUpdateOptions: ['gomodUpdateImportPaths'],
+          toolSettings: {
+            gomodModPackage: 'github.com/some-fork/mod/cmd/mod',
+          },
+        },
+      }),
+    ).toEqual([
+      { file: { type: 'addition', path: 'go.sum', contents: 'New go.sum' } },
+      { file: { type: 'addition', path: 'main.go', contents: 'New main.go' } },
+      { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'go get -d -t ./...',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go install github.com/some-fork/mod/cmd/mod@latest',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'mod upgrade --mod-name=github.com/google/go-github/v24 -t=28',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+    ]);
+  });
+
   it('updates import paths with latest tool version on invalid version constraint', async () => {
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('vendor');
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -2185,7 +2185,7 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
   });
 
-  it('updates import paths using a configured fork of the mod tool', async () => {
+  it('updates import paths using a configured fork of the mod tool with the same binary name', async () => {
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('vendor');
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
     fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
@@ -2231,6 +2231,65 @@ describe('modules/manager/gomod/artifacts', () => {
       },
       {
         cmd: 'mod upgrade --mod-name=github.com/google/go-github/v24 -t=28',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+    ]);
+  });
+
+  it('invokes the binary named after the last path element of a configured fork', async () => {
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('vendor');
+    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
+    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({
+        modified: ['go.sum', 'main.go'],
+      }),
+    );
+    fs.readLocalFile
+      .mockResolvedValueOnce('New go.sum')
+      .mockResolvedValueOnce('New main.go')
+      .mockResolvedValueOnce('New go.mod');
+    expect(
+      await gomod.updateArtifacts({
+        packageFileName: 'go.mod',
+        updatedDeps: [
+          { depName: 'github.com/google/go-github/v24', newVersion: 'v28.0.0' },
+        ],
+        newPackageFileContent: gomod1,
+        config: {
+          ...config,
+          updateType: 'major',
+          postUpdateOptions: ['gomodUpdateImportPaths'],
+          toolSettings: {
+            gomodModPackage: 'github.com/some-fork/mod/cmd/new-mod',
+          },
+        },
+      }),
+    ).toEqual([
+      { file: { type: 'addition', path: 'go.sum', contents: 'New go.sum' } },
+      { file: { type: 'addition', path: 'main.go', contents: 'New main.go' } },
+      { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'go get -d -t ./...',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go install github.com/some-fork/mod/cmd/new-mod@latest',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'new-mod upgrade --mod-name=github.com/google/go-github/v24 -t=28',
         options: { cwd: '/tmp/github/some/repo' },
       },
       {

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -2244,6 +2244,66 @@ describe('modules/manager/gomod/artifacts', () => {
     ]);
   });
 
+  it('quotes the derived binary name', async () => {
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('vendor');
+    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
+    fs.readLocalFile.mockResolvedValueOnce(null); // vendor modules filename
+    const execSnapshots = mockExecAll();
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({
+        modified: ['go.sum', 'main.go'],
+      }),
+    );
+    fs.readLocalFile
+      .mockResolvedValueOnce('New go.sum')
+      .mockResolvedValueOnce('New main.go')
+      .mockResolvedValueOnce('New go.mod');
+    expect(
+      await gomod.updateArtifacts({
+        packageFileName: 'go.mod',
+        updatedDeps: [
+          { depName: 'github.com/google/go-github/v24', newVersion: 'v28.0.0' },
+        ],
+        newPackageFileContent: gomod1,
+        config: {
+          ...config,
+          updateType: 'major',
+          postUpdateOptions: ['gomodUpdateImportPaths'],
+          toolSettings: {
+            gomodModInstallPath:
+              'github.com/some-fork/mod/cmd/new-mod; echo "Sorry, $HOME has been hacked"',
+          },
+        },
+      }),
+    ).toEqual([
+      { file: { type: 'addition', path: 'go.sum', contents: 'New go.sum' } },
+      { file: { type: 'addition', path: 'main.go', contents: 'New main.go' } },
+      { file: { type: 'addition', path: 'go.mod', contents: 'New go.mod' } },
+    ]);
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'go get -d -t ./...',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go install \'github.com/some-fork/mod/cmd/new-mod; echo "Sorry, $HOME has been hacked"\'@latest',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: '\'new-mod; echo "Sorry, $HOME has been hacked"\' upgrade --mod-name=github.com/google/go-github/v24 -t=28',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+      {
+        cmd: 'go mod tidy',
+        options: { cwd: '/tmp/github/some/repo' },
+      },
+    ]);
+  });
+
   it('invokes the binary named after the last path element of a configured fork', async () => {
     fs.findLocalSiblingOrParent.mockResolvedValueOnce('vendor');
     fs.readLocalFile.mockResolvedValueOnce('Current go.sum');

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -2211,7 +2211,7 @@ describe('modules/manager/gomod/artifacts', () => {
           updateType: 'major',
           postUpdateOptions: ['gomodUpdateImportPaths'],
           toolSettings: {
-            gomodModPackage: 'github.com/some-fork/mod/cmd/mod',
+            gomodModInstallPath: 'github.com/some-fork/mod/cmd/mod',
           },
         },
       }),
@@ -2270,7 +2270,7 @@ describe('modules/manager/gomod/artifacts', () => {
           updateType: 'major',
           postUpdateOptions: ['gomodUpdateImportPaths'],
           toolSettings: {
-            gomodModPackage: 'github.com/some-fork/mod/cmd/new-mod',
+            gomodModInstallPath: 'github.com/some-fork/mod/cmd/new-mod',
           },
         },
       }),

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -48,8 +48,8 @@ function getUpdateImportPathCmds(
     );
   }
 
-  const { gomodModPackage } = getToolSettingsOptions(toolSettings);
-  const modBinaryName = gomodModPackage.split('/').pop()!;
+  const { gomodModInstallPath } = getToolSettingsOptions(toolSettings);
+  const modBinaryName = gomodModInstallPath.split('/').pop()!;
 
   const updateImportCommands = updatedDeps
     .filter(
@@ -72,7 +72,7 @@ function getUpdateImportPathCmds(
     );
 
   if (updateImportCommands.length > 0) {
-    let installMarwanModArgs = `install ${gomodModPackage}@latest`;
+    let installMarwanModArgs = `install ${gomodModInstallPath}@latest`;
     const gomodModCompatibility = constraints?.gomodMod;
     if (gomodModCompatibility) {
       if (

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -49,7 +49,7 @@ function getUpdateImportPathCmds(
   }
 
   const { gomodModInstallPath } = getToolSettingsOptions(toolSettings);
-  const modBinaryName = gomodModInstallPath.split('/').pop()!;
+  const modBinaryName = quote(gomodModInstallPath.split('/').pop()!);
 
   const updateImportCommands = updatedDeps
     .filter(
@@ -72,7 +72,7 @@ function getUpdateImportPathCmds(
     );
 
   if (updateImportCommands.length > 0) {
-    let installMarwanModArgs = `install ${gomodModInstallPath}@latest`;
+    let installMarwanModArgs = `install ${quote(gomodModInstallPath)}@latest`;
     const gomodModCompatibility = constraints?.gomodMod;
     if (gomodModCompatibility) {
       if (

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -7,7 +7,7 @@ import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getEnv } from '../../../util/env.ts';
-import { exec } from '../../../util/exec/index.ts';
+import { exec, getToolSettingsOptions } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import { filterMap } from '../../../util/filter-map.ts';
 import {
@@ -33,7 +33,7 @@ const { major, valid } = semver;
 
 function getUpdateImportPathCmds(
   updatedDeps: PackageDependency[],
-  { constraints }: UpdateArtifactsConfig,
+  { constraints, toolSettings }: UpdateArtifactsConfig,
 ): string[] {
   // Check if we fail to parse any major versions and log that they're skipped
   const invalidMajorDeps = updatedDeps.filter(
@@ -69,8 +69,8 @@ function getUpdateImportPathCmds(
     );
 
   if (updateImportCommands.length > 0) {
-    let installMarwanModArgs =
-      'install github.com/marwan-at-work/mod/cmd/mod@latest';
+    const { gomodModPackage } = getToolSettingsOptions(toolSettings);
+    let installMarwanModArgs = `install ${gomodModPackage}@latest`;
     const gomodModCompatibility = constraints?.gomodMod;
     if (gomodModCompatibility) {
       if (

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -48,6 +48,9 @@ function getUpdateImportPathCmds(
     );
   }
 
+  const { gomodModPackage } = getToolSettingsOptions(toolSettings);
+  const modBinaryName = gomodModPackage.split('/').pop()!;
+
   const updateImportCommands = updatedDeps
     .filter(
       ({ newVersion }) =>
@@ -65,11 +68,10 @@ function getUpdateImportPathCmds(
 
     .map(
       ({ depName, newMajor }) =>
-        `mod upgrade --mod-name=${quote(depName)} -t=${newMajor}`,
+        `${modBinaryName} upgrade --mod-name=${quote(depName)} -t=${newMajor}`,
     );
 
   if (updateImportCommands.length > 0) {
-    const { gomodModPackage } = getToolSettingsOptions(toolSettings);
     let installMarwanModArgs = `install ${gomodModPackage}@latest`;
     const gomodModCompatibility = constraints?.gomodMod;
     if (gomodModCompatibility) {

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -1589,32 +1589,32 @@ describe('util/exec/index', () => {
         const res = getToolSettingsOptions(undefined);
 
         expect(res).toMatchObject({
-          gomodModPackage: 'github.com/marwan-at-work/mod/cmd/mod',
+          gomodModInstallPath: 'github.com/marwan-at-work/mod/cmd/mod',
         });
       });
 
       it('has no global config override - it is only settable at the repo config level', () => {
         GlobalConfig.set({
-          // no `gomodModPackage` field exists on `GlobalToolSettingsOptions`
+          // no `gomodModInstallPath` field exists on `GlobalToolSettingsOptions`
           toolSettings: { jvmMaxMemory: 1024 },
         });
 
         const res = getToolSettingsOptions(undefined);
 
         expect(res).toMatchObject({
-          gomodModPackage: 'github.com/marwan-at-work/mod/cmd/mod',
+          gomodModInstallPath: 'github.com/marwan-at-work/mod/cmd/mod',
         });
       });
 
       it('uses the repo config override if set', () => {
         config.toolSettings = {
-          gomodModPackage: 'github.com/some-fork/mod/cmd/mod',
+          gomodModInstallPath: 'github.com/some-fork/mod/cmd/mod',
         };
 
         const res = getToolSettingsOptions(config.toolSettings);
 
         expect(res).toMatchObject({
-          gomodModPackage: 'github.com/some-fork/mod/cmd/mod',
+          gomodModInstallPath: 'github.com/some-fork/mod/cmd/mod',
         });
       });
     });

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -1576,6 +1576,48 @@ describe('util/exec/index', () => {
         });
       });
     });
+
+    describe('for gomod mod package settings', () => {
+      beforeEach(() => {
+        GlobalConfig.set({});
+
+        // remove any test-specific overrides
+        delete config.toolSettings;
+      });
+
+      it('returns the default package if no repo config', () => {
+        const res = getToolSettingsOptions(undefined);
+
+        expect(res).toMatchObject({
+          gomodModPackage: 'github.com/marwan-at-work/mod/cmd/mod',
+        });
+      });
+
+      it('has no global config override - it is only settable at the repo config level', () => {
+        GlobalConfig.set({
+          // no `gomodModPackage` field exists on `GlobalToolSettingsOptions`
+          toolSettings: { jvmMaxMemory: 1024 },
+        });
+
+        const res = getToolSettingsOptions(undefined);
+
+        expect(res).toMatchObject({
+          gomodModPackage: 'github.com/marwan-at-work/mod/cmd/mod',
+        });
+      });
+
+      it('uses the repo config override if set', () => {
+        config.toolSettings = {
+          gomodModPackage: 'github.com/some-fork/mod/cmd/mod',
+        };
+
+        const res = getToolSettingsOptions(config.toolSettings);
+
+        expect(res).toMatchObject({
+          gomodModPackage: 'github.com/some-fork/mod/cmd/mod',
+        });
+      });
+    });
   });
 
   describe('gradleJvmArg()', () => {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -246,12 +246,12 @@ export function getToolSettingsOptions(
     jvmMemory: defaults?.jvmMemory ?? jvmMaxMemory,
     nodeMaxMemory: defaults?.nodeMaxMemory,
     // doesn't have a global override, only a default
-    gomodModPackage: 'github.com/marwan-at-work/mod/cmd/mod',
+    gomodModInstallPath: 'github.com/marwan-at-work/mod/cmd/mod',
   };
 
   if (repoConfig !== undefined) {
-    if (repoConfig.gomodModPackage) {
-      options.gomodModPackage = repoConfig.gomodModPackage;
+    if (repoConfig.gomodModInstallPath) {
+      options.gomodModInstallPath = repoConfig.gomodModInstallPath;
     }
 
     if (repoConfig.jvmMaxMemory) {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -245,9 +245,15 @@ export function getToolSettingsOptions(
     jvmMaxMemory,
     jvmMemory: defaults?.jvmMemory ?? jvmMaxMemory,
     nodeMaxMemory: defaults?.nodeMaxMemory,
+    // doesn't have a global override, only a default
+    gomodModPackage: 'github.com/marwan-at-work/mod/cmd/mod',
   };
 
   if (repoConfig !== undefined) {
+    if (repoConfig.gomodModPackage) {
+      options.gomodModPackage = repoConfig.gomodModPackage;
+    }
+
     if (repoConfig.jvmMaxMemory) {
       if (repoConfig.jvmMaxMemory > options.jvmMaxMemory) {
         logger.once.debug(

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -221,20 +221,31 @@ export async function exec(
   return res;
 }
 
+/**
+ * When we resolve `toolSettings` in `getToolSettingsOptions`, we provide a stronger type than our input types, because we set defaults on config options.
+ *
+ * We do not have a default that is set for `nodeMaxMemory`, so it must remain as optional.
+ */
+type ResolvedToolSettingsOptions = Required<
+  Omit<RepoToolSettingsOptions, 'nodeMaxMemory'>
+> &
+  Pick<RepoToolSettingsOptions, 'nodeMaxMemory'>;
+
 export function getToolSettingsOptions(
   repoConfig?: RepoToolSettingsOptions,
-): RepoToolSettingsOptions {
+): ResolvedToolSettingsOptions {
   let defaults = GlobalConfig.get('toolSettings');
   defaults ??= {
     jvmMaxMemory: 512,
     jvmMemory: 512,
   };
 
-  const options: RepoToolSettingsOptions = {};
-
-  options.jvmMaxMemory = defaults?.jvmMaxMemory ?? 512;
-  options.jvmMemory = defaults?.jvmMemory ?? options.jvmMaxMemory;
-  options.nodeMaxMemory ??= defaults?.nodeMaxMemory;
+  const jvmMaxMemory = defaults?.jvmMaxMemory ?? 512;
+  const options: ResolvedToolSettingsOptions = {
+    jvmMaxMemory,
+    jvmMemory: defaults?.jvmMemory ?? jvmMaxMemory,
+    nodeMaxMemory: defaults?.nodeMaxMemory,
+  };
 
   if (repoConfig !== undefined) {
     if (repoConfig.jvmMaxMemory) {

--- a/lib/workers/repository/init/types.ts
+++ b/lib/workers/repository/init/types.ts
@@ -1,6 +1,8 @@
 import type {
+  GlobalToolSettingsOptions,
   RenovateConfig,
   RepoGlobalConfig,
+  RepoToolSettingsOptions,
 } from '../../../config/types.ts';
 
 /**
@@ -14,6 +16,10 @@ import type {
 export interface RepositoryWorkerConfig
   extends RenovateConfig, RepoGlobalConfig {
   repositoryEntryConfig?: RenovateConfig;
+  // `RenovateConfig` and `RepoGlobalConfig` declare `toolSettings` with
+  // different (repo-only vs global-only) shapes; this combines both since
+  // this handoff config can carry either.
+  toolSettings?: GlobalToolSettingsOptions & RepoToolSettingsOptions;
 }
 
 export interface RepoConfigError {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes


As part of changes in #41817, we're considering forking
`marwan-at-work/mod` and maintaining a version under `renovatebot`.

In the meantime, we can start by making it possible to override the
location of `mod`.
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
