### PR TITLE
feat(instrumentation): pass instrumentation variables to child processes

### DIFF
--- a/docs/usage/environment-variable-handling.md
+++ b/docs/usage/environment-variable-handling.md
@@ -34,6 +34,13 @@ By default, Renovate will **always** pass the following environment variables to
   <br>
   This is not currently documented in full - you will need to review Renovate's code to see the full list.
 
+!!! note
+  When [OpenTelemetry tracing is enabled](./opentelemetry.md), Renovate also passes any `OTEL_*` environment variables, plus `TRACEPARENT` and `TRACESTATE` (containing the current trace context), to child processes.
+  <br>
+  This lets a child process with its own OpenTelemetry support export to the same collector, and join the same trace as the Renovate command that spawned it.
+  <br>
+  See [Child process propagation](./opentelemetry.md#child-process-propagation) for more details.
+
 As a self-hosted administrator, you can make it possible to specify other environment variables that repository owners can set, using:
 
 - [`allowedEnv`](./self-hosted-configuration.md#allowedenv): allows users to specify values for allowlisted environment variables in their repository configuration using [`env`](./configuration-options.md#env)
@@ -66,6 +73,7 @@ flowchart TD
     processEnvConfig["<strong><code>processEnv</code></strong><br/><small></small>"]
     processEnv["<strong><code>process.env</code></strong><br/><small>The original process' <code>process.env</code> and <code>processEnv</code></small>"]
     allowedEnv["<strong><code>allowedEnv</code></strong><br/><small>Admin-controlled allowlist gates which environment variables repo owners may set</small>"]
+    otelEnv["<strong><code>OTEL_*</code>, <code>TRACEPARENT</code>, <code>TRACESTATE</code></strong><br/><small>Only added when <a href='./opentelemetry.md'>tracing</a> is enabled<sup>2</sup></small>"]
 
     extraEnv -->|"overridden by"| parentEnv
     parentEnv -->|"overridden by"| globalConfigEnv
@@ -77,10 +85,13 @@ flowchart TD
     processEnvConfig -.->|"merged into"| processEnv
     processEnv -.->|"filtered with <code>basicEnvVars</code>"| parentEnv
     allowedEnv -.->|"restricts"| userConfiguredEnv
+    otelEnv -.->|"merged into"| parentEnv
 
 ```
 
 <sup>1</sup>: the list of environment variables [noted above](#with-child-processes) that are always passed to child processes
+<br/>
+<sup>2</sup>: see [Child process propagation](./opentelemetry.md#child-process-propagation)
 
 ## Templating
 

--- a/docs/usage/opentelemetry.md
+++ b/docs/usage/opentelemetry.md
@@ -96,6 +96,14 @@ Renovate provides instrumentation through traces for (non-exhaustively):
 
 As well as following [OpenTelemetry's semantic conventions](https://opentelemetry.io/docs/specs/semconv/) where possible, Renovate defines several Custom Attributes, which can be found in [`lib/instrumentation/types.ts`](https://github.com/renovatebot/renovate/blob/main/lib/instrumentation/types.ts).
 
+#### Child process propagation
+
+When tracing is enabled, Renovate forwards its current trace context to any child process it spawns (for example `git`, `npm`, or a package manager run via Docker), using the `TRACEPARENT` and `TRACESTATE` environment variables from the [W3C Trace Context](https://www.w3.org/TR/trace-context/) specification.
+Renovate also forwards any `OTEL_*` environment variables it was started with, so that a child process with its own OpenTelemetry SDK can export to the same collector.
+
+This only has an effect on tools which read these environment variables themselves.
+Renovate does not modify third-party tools to add OpenTelemetry support.
+
 ### Metrics
 
 Renovate does not currently support metrics in an OTLP format.

--- a/lib/instrumentation/utils.spec.ts
+++ b/lib/instrumentation/utils.spec.ts
@@ -1,4 +1,10 @@
-import { massageThrowable } from './utils.ts';
+import * as api from '@opentelemetry/api';
+import type { DirectoryResult } from 'tmp-promise';
+import { dir } from 'tmp-promise';
+import upath from 'upath';
+import { partial } from '~test/util.ts';
+import { disableInstrumentations, init, instrument } from './index.ts';
+import { getTraceContextEnv, massageThrowable } from './utils.ts';
 
 describe('instrumentation/utils', () => {
   describe('massageThrowable', () => {
@@ -11,6 +17,82 @@ describe('instrumentation/utils', () => {
       ${123}               | ${'123'}
     `('should return $expected for $input', ({ input, expected }) => {
       expect(massageThrowable(input)).toEqual(expected);
+    });
+  });
+
+  describe('getTraceContextEnv', () => {
+    const oldEnv = process.env;
+    let tmpDir: DirectoryResult;
+
+    beforeEach(async () => {
+      tmpDir = await dir({ unsafeCleanup: true });
+
+      api.trace.disable();
+      process.env = { ...oldEnv };
+      for (const key of Object.keys(process.env)) {
+        if (key.startsWith('OTEL_')) {
+          delete process.env[key];
+        }
+      }
+      delete process.env.RENOVATE_TRACING_CONSOLE_EXPORTER;
+      delete process.env.RENOVATE_TRACING_FILE_EXPORTER_PATH;
+      process.env.RENOVATE_USE_CLOUD_METADATA_SERVICES = 'false';
+    });
+
+    afterEach(async () => {
+      disableInstrumentations();
+      await tmpDir.cleanup();
+    });
+
+    afterAll(() => {
+      process.env = oldEnv;
+    });
+
+    function enableFileTracing(): void {
+      process.env.RENOVATE_TRACING_FILE_EXPORTER_PATH = upath.join(
+        tmpDir.path,
+        'test-traces.jsonl',
+      );
+      init();
+    }
+
+    it('returns an empty object when tracing is disabled', () => {
+      expect(getTraceContextEnv()).toEqual({});
+    });
+
+    it('returns an empty object when tracing is enabled but there is no active span', () => {
+      enableFileTracing();
+
+      expect(getTraceContextEnv()).toEqual({});
+    });
+
+    it('injects the active trace context as TRACEPARENT when tracing is enabled', () => {
+      enableFileTracing();
+
+      let env: NodeJS.ProcessEnv = {};
+      instrument('test', () => {
+        env = getTraceContextEnv();
+      });
+
+      expect(env.TRACEPARENT).toMatch(/^00-[0-9a-f]{32}-[0-9a-f]{16}-0[01]$/);
+    });
+
+    it('injects TRACESTATE when the active span context has a traceState', () => {
+      enableFileTracing();
+
+      const spanContext: api.SpanContext = {
+        traceId: '0af7651916cd43dd8448eb211c80319c',
+        spanId: 'b7ad6b7169203331',
+        traceFlags: api.TraceFlags.SAMPLED,
+        traceState: partial<api.TraceState>({
+          serialize: () => 'vendor=value',
+        }),
+      };
+      const ctx = api.trace.setSpanContext(api.context.active(), spanContext);
+
+      const env = api.context.with(ctx, getTraceContextEnv);
+
+      expect(env.TRACESTATE).toBe('vendor=value');
     });
   });
 });

--- a/lib/instrumentation/utils.ts
+++ b/lib/instrumentation/utils.ts
@@ -1,3 +1,4 @@
+import { context, propagation } from '@opentelemetry/api';
 import { isNullOrUndefined } from '@sindresorhus/is';
 import { getEnv } from '../util/env.ts';
 
@@ -23,6 +24,30 @@ export function isFileExporterEnabled(): boolean {
 
 export function getFileExporterPath(): string {
   return getEnv().RENOVATE_TRACING_FILE_EXPORTER_PATH!;
+}
+
+/**
+ * Builds the env vars needed to hand the current trace context to a child
+ * process, using the W3C Trace Context format (https://www.w3.org/TR/trace-context/).
+ * Tools which have native OpenTelemetry support can pick these up to join the
+ * same trace as the `rawExec` span that spawned them.
+ */
+export function getTraceContextEnv(): NodeJS.ProcessEnv {
+  if (!isTracingEnabled()) {
+    return {};
+  }
+
+  const carrier: Record<string, string> = {};
+  propagation.inject(context.active(), carrier);
+
+  const env: NodeJS.ProcessEnv = {};
+  if (carrier.traceparent) {
+    env.TRACEPARENT = carrier.traceparent;
+  }
+  if (carrier.tracestate) {
+    env.TRACESTATE = carrier.tracestate;
+  }
+  return env;
 }
 
 export function massageThrowable(e: unknown): string | undefined {

--- a/lib/util/exec/env.spec.ts
+++ b/lib/util/exec/env.spec.ts
@@ -1,4 +1,5 @@
 import { GlobalConfig } from '../../config/global.ts';
+import * as instrumentationUtils from '../../instrumentation/utils.ts';
 import { getChildProcessEnv } from './env.ts';
 
 describe('util/exec/env', () => {
@@ -76,9 +77,48 @@ describe('util/exec/env', () => {
   });
 
   describe('getChildProcessEnv when exposeAllEnv=true', () => {
+    afterEach(() => {
+      GlobalConfig.reset();
+    });
+
     it('returns process.env if exposeAllEnv=true', () => {
       GlobalConfig.set({ exposeAllEnv: true });
       expect(getChildProcessEnv()).toMatchObject(process.env);
     });
+  });
+
+  describe('getChildProcessEnv when tracing is enabled', () => {
+    beforeEach(() => {
+      process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'http://localhost:4318';
+      process.env.OTEL_SERVICE_NAME = 'renovate-test';
+    });
+
+    afterEach(() => {
+      delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+      delete process.env.OTEL_SERVICE_NAME;
+    });
+
+    it('forwards OTEL_* environment variables to the child process', () => {
+      expect(getChildProcessEnv()).toMatchObject({
+        OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        OTEL_SERVICE_NAME: 'renovate-test',
+      });
+    });
+
+    it('merges the current trace context into the child environment', () => {
+      vi.spyOn(instrumentationUtils, 'getTraceContextEnv').mockReturnValue({
+        TRACEPARENT: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+      });
+
+      expect(getChildProcessEnv()).toMatchObject({
+        TRACEPARENT: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
+      });
+    });
+  });
+
+  it('does not forward OTEL_* environment variables when tracing is disabled', () => {
+    process.env.OTEL_SERVICE_NAME = 'renovate-test';
+    expect(getChildProcessEnv()).not.toHaveProperty('OTEL_SERVICE_NAME');
+    delete process.env.OTEL_SERVICE_NAME;
   });
 });

--- a/lib/util/exec/env.spec.ts
+++ b/lib/util/exec/env.spec.ts
@@ -114,11 +114,25 @@ describe('util/exec/env', () => {
         TRACEPARENT: '00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01',
       });
     });
+
+    it('overrides OTEL_SERVICE_NAME with a name derived from the command, when given', () => {
+      expect(getChildProcessEnv([], 'git')).toMatchObject({
+        OTEL_SERVICE_NAME: 'renovate-git',
+      });
+    });
+
+    it('does not set OTEL_SERVICE_NAME when no command name is given', () => {
+      expect(getChildProcessEnv()).toMatchObject({
+        OTEL_SERVICE_NAME: 'renovate-test',
+      });
+    });
   });
 
   it('does not forward OTEL_* environment variables when tracing is disabled', () => {
     process.env.OTEL_SERVICE_NAME = 'renovate-test';
-    expect(getChildProcessEnv()).not.toHaveProperty('OTEL_SERVICE_NAME');
+    expect(getChildProcessEnv([], 'git')).not.toHaveProperty(
+      'OTEL_SERVICE_NAME',
+    );
     delete process.env.OTEL_SERVICE_NAME;
   });
 });

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -1,4 +1,8 @@
 import { GlobalConfig } from '../../config/global.ts';
+import {
+  getTraceContextEnv,
+  isTracingEnabled,
+} from '../../instrumentation/utils.ts';
 
 export const basicEnvVars = [
   'CI',
@@ -68,5 +72,18 @@ export function getChildProcessEnv(
       env[key] = process.env[key];
     }
   }
+
+  if (isTracingEnabled()) {
+    // Forward the OpenTelemetry SDK configuration so that tools with native
+    // OTEL support export to the same collector, and propagate the current
+    // trace context so they can join the same trace.
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith('OTEL_')) {
+        env[key] = process.env[key];
+      }
+    }
+    Object.assign(env, getTraceContextEnv());
+  }
+
   return env;
 }

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -54,6 +54,7 @@ export const basicEnvVars = [
 
 export function getChildProcessEnv(
   customEnvVars: string[] = [],
+  commandName?: string,
 ): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {};
   if (GlobalConfig.get('exposeAllEnv')) {
@@ -83,6 +84,13 @@ export function getChildProcessEnv(
       }
     }
     Object.assign(env, getTraceContextEnv());
+
+    // Give the child its own service name, distinct from Renovate's, so its
+    // spans don't get grouped under Renovate's own service in tools which
+    // read OTEL_SERVICE_NAME natively.
+    if (commandName) {
+      env.OTEL_SERVICE_NAME = `renovate-${commandName}`;
+    }
   }
 
   return env;

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -281,7 +281,7 @@ describe('util/exec/index', () => {
         outCmd: [
           dockerPullCmd,
           dockerRemoveCmd,
-          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -e OTEL_EXPORTER_OTLP_ENDPOINT ${defaultCwd} ${fullImage} bash -l -c '${inCmd}'`,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -e OTEL_EXPORTER_OTLP_ENDPOINT -e OTEL_SERVICE_NAME ${defaultCwd} ${fullImage} bash -l -c '${inCmd}'`,
         ],
         outOpts: [
           dockerPullOpts,
@@ -291,6 +291,7 @@ describe('util/exec/index', () => {
             env: {
               ...containerbaseEnv,
               OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+              OTEL_SERVICE_NAME: 'renovate-echo',
             },
             timeout: 900000,
             maxBuffer: 10485760,

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -270,6 +270,40 @@ describe('util/exec/index', () => {
     ],
 
     [
+      'Docker with tracing enabled',
+      {
+        processEnv: {
+          ...processEnv,
+          OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+        },
+        inCmd,
+        inOpts: { docker, cwd },
+        outCmd: [
+          dockerPullCmd,
+          dockerRemoveCmd,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e CONTAINERBASE_CACHE_DIR -e OTEL_EXPORTER_OTLP_ENDPOINT ${defaultCwd} ${fullImage} bash -l -c '${inCmd}'`,
+        ],
+        outOpts: [
+          dockerPullOpts,
+          dockerRemoveOpts,
+          {
+            cwd,
+            env: {
+              ...containerbaseEnv,
+              OTEL_EXPORTER_OTLP_ENDPOINT: 'http://localhost:4318',
+            },
+            timeout: 900000,
+            maxBuffer: 10485760,
+            stdin: 'pipe',
+            stdout: 'pipe',
+            stderr: 'pipe',
+          },
+        ],
+        adminConfig: { binarySource: 'docker' },
+      },
+    ],
+
+    [
       'Extra env vars',
       {
         processEnv,

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -22,7 +22,7 @@ import type {
   Opt,
   RawExecOptions,
 } from './types.ts';
-import { getChildEnv } from './utils.ts';
+import { getChildEnv, getExecutableName } from './utils.ts';
 
 function dockerEnvVars(extraEnv: ExtraEnv, childEnv: ExtraEnv): string[] {
   const extraEnvKeys = Object.keys(extraEnv);
@@ -38,9 +38,12 @@ function getCwd({ cwd, cwdFile }: ExecOptions): string | undefined {
   return paramCwd ?? defaultCwd;
 }
 
-function getRawExecOptions(opts: ExecOptions): RawExecOptions {
+function getRawExecOptions(
+  opts: ExecOptions,
+  commandName?: string,
+): RawExecOptions {
   const defaultExecutionTimeout = GlobalConfig.get('executionTimeout');
-  const childEnv = getChildEnv(opts);
+  const childEnv = getChildEnv(opts, commandName);
   const cwd = getCwd(opts);
   let timeout = opts.timeout;
   timeout ??= defaultExecutionTimeout * 60 * 1000;
@@ -90,9 +93,10 @@ async function prepareRawExec(
     opts.env.CONTAINERBASE_CACHE_DIR = containerbaseDir;
   }
 
-  let rawOptions = getRawExecOptions(opts);
-
   let rawCommands = typeof cmd === 'string' ? [cmd] : cmd;
+  const commandName = getExecutableName(rawCommands);
+
+  let rawOptions = getRawExecOptions(opts, commandName);
 
   if (isDocker(docker)) {
     logger.debug({ image: sideCarImage }, 'Using docker to execute');
@@ -101,7 +105,7 @@ async function prepareRawExec(
       ...customEnvVariables,
       ...userConfiguredEnv,
     };
-    const childEnv = getChildEnv(opts);
+    const childEnv = getChildEnv(opts, commandName);
     const otelEnvVars = Object.keys(childEnv).filter(
       (key) =>
         key.startsWith('OTEL_') ||

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -102,9 +102,16 @@ async function prepareRawExec(
       ...userConfiguredEnv,
     };
     const childEnv = getChildEnv(opts);
+    const otelEnvVars = Object.keys(childEnv).filter(
+      (key) =>
+        key.startsWith('OTEL_') ||
+        key === 'TRACEPARENT' ||
+        key === 'TRACESTATE',
+    );
     const envVars = [
       ...dockerEnvVars(extraEnv, childEnv),
       'CONTAINERBASE_CACHE_DIR',
+      ...otelEnvVars,
     ];
     const cwd = getCwd(opts);
     const dockerOptions: DockerOptions = { ...docker, cwd, envVars };

--- a/lib/util/exec/utils.spec.ts
+++ b/lib/util/exec/utils.spec.ts
@@ -1,5 +1,9 @@
 import type { CommandWithOptions } from './types.ts';
-import { asRawCommands, isCommandWithOptions } from './utils.ts';
+import {
+  asRawCommands,
+  getExecutableName,
+  isCommandWithOptions,
+} from './utils.ts';
 
 describe('util/exec/utils', () => {
   describe('isCommandWithOptions', () => {
@@ -231,6 +235,38 @@ describe('util/exec/utils', () => {
         expect(res).toBeArrayOfSize(2);
         expect(res).toEqual(['ls', 'go mod tidy']);
       });
+    });
+  });
+
+  describe('getExecutableName', () => {
+    it('returns the executable name from a string command', () => {
+      expect(getExecutableName('git status')).toBe('git');
+    });
+
+    it('strips any path from the executable', () => {
+      expect(getExecutableName('/usr/bin/git status')).toBe('git');
+    });
+
+    it('returns the executable name from the first of an array of commands', () => {
+      expect(getExecutableName(['npm install', 'npm run build'])).toBe('npm');
+    });
+
+    it('returns the executable name from `CommandWithOptions`', () => {
+      expect(getExecutableName([{ command: ['go', 'mod', 'tidy'] }])).toBe(
+        'go',
+      );
+    });
+
+    it('returns undefined for an empty array', () => {
+      expect(getExecutableName([])).toBeUndefined();
+    });
+
+    it('returns undefined for an empty string', () => {
+      expect(getExecutableName('')).toBeUndefined();
+    });
+
+    it('returns undefined for a whitespace-only string', () => {
+      expect(getExecutableName('   ')).toBeUndefined();
     });
   });
 });

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -3,15 +3,16 @@ import {
   isNonEmptyStringAndNotWhitespace,
   isString,
 } from '@sindresorhus/is';
-import { join } from 'shlex';
+import { join, split } from 'shlex';
+import upath from 'upath';
 import { getCustomEnv, getUserEnv } from '../env.ts';
 import { getChildProcessEnv } from './env.ts';
 import type { CommandWithOptions, ExecOptions } from './types.ts';
 
-export function getChildEnv({
-  extraEnv,
-  env: forcedEnv = {},
-}: Pick<ExecOptions, 'env' | 'extraEnv'> = {}): Record<string, string> {
+export function getChildEnv(
+  { extraEnv, env: forcedEnv = {} }: Pick<ExecOptions, 'env' | 'extraEnv'> = {},
+  commandName?: string,
+): Record<string, string> {
   const globalConfigEnv = getCustomEnv();
   const userConfiguredEnv = getUserEnv();
 
@@ -22,7 +23,7 @@ export function getChildEnv({
     }
   }
 
-  const parentEnv = getChildProcessEnv(inheritedKeys);
+  const parentEnv = getChildProcessEnv(inheritedKeys, commandName);
   const combinedEnv = {
     ...extraEnv,
     ...parentEnv,
@@ -87,4 +88,21 @@ export function asRawCommands(
     return [cmds];
   }
   return cmds.map((cmd) => asRawCommand(cmd));
+}
+
+/**
+ * Derives the name of the executable being run, from the first of the given
+ * commands, stripped of any path and arguments, e.g. `/usr/bin/git status` ->
+ * `git`. Used to give the child process its own OpenTelemetry `service.name`,
+ * distinct from Renovate's.
+ */
+export function getExecutableName(
+  cmds: string | (string | CommandWithOptions)[],
+): string | undefined {
+  const [firstCommand] = asRawCommands(cmds);
+  if (!firstCommand) {
+    return undefined;
+  }
+  const [executable] = split(firstCommand);
+  return executable ? upath.basename(executable) : undefined;
 }


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

<img width="443" height="393" alt="Screenshot 2026-08-07 at 16 54 51" src="https://github.com/user-attachments/assets/42489d7c-c0bd-4c9f-99f2-6d103b482189" />


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
