### PR TITLE
fix(cargo): support fetching crates from git monorepo

### DIFF
--- a/lib/modules/manager/cargo/extract.spec.ts
+++ b/lib/modules/manager/cargo/extract.spec.ts
@@ -546,6 +546,54 @@ replace-with = "mcorbin"
       expect(res?.deps[0].packageName).toBe('boolector');
     });
 
+    it('keeps the git source as packageName for renamed git dependencies', async () => {
+      const cargotoml = codeBlock`
+        [dependencies]
+        github-tag = { package = "real-crate", git = "https://github.com/foo/bar", tag = "v1.2.3" }
+        gitlab-tag = { package = "real-crate", git = "https://gitlab.com/foo/bar", tag = "v1.2.3" }
+        other-tag = { package = "real-crate", git = "https://gitea.example.com/foo/bar", tag = "v1.2.3" }
+        rev = { package = "real-crate", git = "https://github.com/foo/bar", rev = "abcdef0" }
+        crates-io = { package = "real-crate", version = "0.4.0" }
+        `;
+
+      const res = await extractPackageFile(cargotoml, 'Cargo.toml', config);
+
+      expect(res?.deps).toMatchObject([
+        {
+          depName: 'github-tag',
+          datasource: 'github-tags',
+          packageName: 'foo/bar',
+          registryUrls: ['https://github.com'],
+          currentValue: 'v1.2.3',
+        },
+        {
+          depName: 'gitlab-tag',
+          datasource: 'gitlab-tags',
+          packageName: 'foo/bar',
+          registryUrls: ['https://gitlab.com'],
+          currentValue: 'v1.2.3',
+        },
+        {
+          depName: 'other-tag',
+          datasource: 'git-tags',
+          packageName: 'https://gitea.example.com/foo/bar',
+          currentValue: 'v1.2.3',
+        },
+        {
+          depName: 'rev',
+          datasource: 'git-refs',
+          packageName: 'https://github.com/foo/bar',
+          currentDigest: 'abcdef0',
+        },
+        {
+          depName: 'crates-io',
+          datasource: 'crate',
+          packageName: 'real-crate',
+          currentValue: '0.4.0',
+        },
+      ]);
+    });
+
     it('extracts locked versions', async () => {
       const cargolock = Fixtures.get('lockfile-update/Cargo.3.lock');
       mockReadLocalFile({ 'Cargo.lock': cargolock });

--- a/lib/modules/manager/cargo/schema.ts
+++ b/lib/modules/manager/cargo/schema.ts
@@ -70,7 +70,7 @@ const CargoDep = z.union([
         if (skipReason) {
           dep.skipReason = skipReason;
         }
-        if (pkg) {
+        if (pkg && !git) {
           dep.packageName = pkg;
         }
         if (registry) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Fixes parsing of Cargo references such as 
```
lambda-extensions-smithy = { package = "lambda-extensions-smithy-v1", git = "https://github.com/stedi/crates", tag = "v0.1062.0" }
```

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor  will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
