### PR TITLE
fix(manager/asdf,mise,proto): use rust-version datasource for rust

### DIFF
--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -704,8 +704,8 @@ dummy 1.2.3
           },
           {
             currentValue: '1.64.0',
-            datasource: 'github-tags',
-            packageName: 'rust-lang/rust',
+            datasource: 'rust-version',
+            packageName: 'rust',
             depName: 'rust',
           },
           {

--- a/lib/modules/manager/asdf/index.ts
+++ b/lib/modules/manager/asdf/index.ts
@@ -10,6 +10,7 @@ import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 
 export { extractPackageFile } from './extract.ts';
 
@@ -33,4 +34,5 @@ export const supportedDatasources = [
   NpmDatasource.id,
   PypiDatasource.id,
   RubyVersionDatasource.id,
+  RustVersionDatasource.id,
 ];

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -11,6 +11,7 @@ import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as regexVersioning from '../../versioning/regex/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
 import type { PackageDependency } from '../types.ts';
@@ -715,8 +716,8 @@ export const upgradeableTooling: Record<string, ToolingDefinition> = {
   rust: {
     asdfPluginUrl: 'https://github.com/code-lever/asdf-rust',
     config: {
-      datasource: GithubTagsDatasource.id,
-      packageName: 'rust-lang/rust',
+      datasource: RustVersionDatasource.id,
+      packageName: 'rust',
     },
   },
   sbt: {

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -468,8 +468,8 @@ describe('modules/manager/mise/extract', () => {
           {
             depName: 'asdf:rust',
             currentValue: '1.82.0',
-            packageName: 'rust-lang/rust',
-            datasource: 'github-tags',
+            packageName: 'rust',
+            datasource: 'rust-version',
           },
           {
             depName: 'vfox:scala',

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -12,6 +12,7 @@ import { NugetDatasource } from '../../datasource/nuget/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 import { RubygemsDatasource } from '../../datasource/rubygems/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import { supportedDatasources as asdfSupportedDatasources } from '../asdf/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
@@ -44,6 +45,7 @@ const backendDatasources = {
     JavaVersionDatasource.id,
     NodeVersionDatasource.id,
     RubyVersionDatasource.id,
+    RustVersionDatasource.id,
   ],
   // Re-use the asdf datasources, as mise and asdf support the same plugins.
   asdf: asdfSupportedDatasources,

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -7,6 +7,7 @@ import { JavaVersionDatasource } from '../../datasource/java-version/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as regexVersioning from '../../versioning/regex/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
 import * as semverPartialVersioning from '../../versioning/semver-partial/index.ts';
@@ -178,8 +179,8 @@ const miseCoreTooling: Record<string, ToolingDefinition> = {
   rust: {
     misePluginUrl: 'https://mise.jdx.dev/lang/rust.html',
     config: {
-      packageName: 'rust-lang/rust',
-      datasource: GithubTagsDatasource.id,
+      packageName: 'rust',
+      datasource: RustVersionDatasource.id,
     },
   },
   swift: {

--- a/lib/modules/manager/proto/index.ts
+++ b/lib/modules/manager/proto/index.ts
@@ -3,6 +3,7 @@ import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 
 export { extractPackageFile } from './extract.ts';
 
@@ -19,4 +20,5 @@ export const supportedDatasources = [
   NodeVersionDatasource.id,
   NpmDatasource.id,
   RubyVersionDatasource.id,
+  RustVersionDatasource.id,
 ];

--- a/lib/modules/manager/proto/readme.md
+++ b/lib/modules/manager/proto/readme.md
@@ -32,7 +32,7 @@ Renovate's `proto` manager supports the following built-in proto tools:
 | `yarn`   | `npm`             | `@yarnpkg/cli`         |
 | `python` | `github-tags`     | `python/cpython`       |
 | `ruby`   | `ruby-version`    | `ruby-version`         |
-| `rust`   | `github-tags`     | `rust-lang/rust`       |
+| `rust`   | `rust-version`    | `rust`                 |
 | `proto`  | `github-releases` | `moonrepo/proto`       |
 | `gh`     | `github-releases` | `cli/cli`              |
 | `poetry` | `github-releases` | `python-poetry/poetry` |

--- a/lib/modules/manager/proto/upgradeable-tooling.ts
+++ b/lib/modules/manager/proto/upgradeable-tooling.ts
@@ -3,6 +3,7 @@ import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
+import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
 import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
 
@@ -97,8 +98,8 @@ export const protoTooling: Record<string, ToolingDefinition> = {
   },
   rust: {
     config: {
-      packageName: 'rust-lang/rust',
-      datasource: GithubTagsDatasource.id,
+      packageName: 'rust',
+      datasource: RustVersionDatasource.id,
     },
   },
   uv: {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Changes the `rust` datasource used in the `asdf`, `mise` and `proto` managers to `rust-version` 

Behaviour change: `nightly-<date>` pins were previously skipped as `invalid-value` and now update. `stable`, `beta` and `nightly` are now recognised as ranges rather than flagged invalid, but still only resolve to a concrete version under `rangeStrategy: pin`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
