### PR TITLE
fix(manager/rust-toolchain): report skipReason instead of dropping deps

### DIFF
--- a/lib/modules/manager/rust-toolchain/extract.spec.ts
+++ b/lib/modules/manager/rust-toolchain/extract.spec.ts
@@ -1,4 +1,5 @@
 import { codeBlock } from 'common-tags';
+import { logger } from '~test/util.ts';
 import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import { extractPackageFile } from './extract.ts';
 
@@ -44,6 +45,27 @@ describe('modules/manager/rust-toolchain/extract', () => {
       });
     });
 
+    it('extracts stable channel', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          [toolchain]
+          channel = "stable"
+        `,
+        'rust-toolchain.toml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            currentValue: 'stable',
+            datasource: RustVersionDatasource.id,
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+
     it('extracts beta channel', () => {
       const result = extractPackageFile(
         codeBlock`
@@ -62,6 +84,7 @@ describe('modules/manager/rust-toolchain/extract', () => {
           },
         ],
       });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('extracts nightly channel', () => {
@@ -110,6 +133,7 @@ describe('modules/manager/rust-toolchain/extract', () => {
         'rust-toolchain.toml',
       );
       expect(result).toBeNull();
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('returns null when [toolchain] section is absent', () => {
@@ -118,9 +142,10 @@ describe('modules/manager/rust-toolchain/extract', () => {
         'rust-toolchain.toml',
       );
       expect(result).toBeNull();
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
-    it('returns null when channel is absent', () => {
+    it('returns dep with unspecified-version skipReason when channel is absent', () => {
       const result = extractPackageFile(
         codeBlock`
           [toolchain]
@@ -128,10 +153,84 @@ describe('modules/manager/rust-toolchain/extract', () => {
         `,
         'rust-toolchain.toml',
       );
-      expect(result).toBeNull();
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            datasource: RustVersionDatasource.id,
+            skipReason: 'unspecified-version',
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
-    it('returns null for unparseable channel value', () => {
+    it('returns dep with unspecified-version skipReason for empty channel', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          [toolchain]
+          channel = ""
+        `,
+        'rust-toolchain.toml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            datasource: RustVersionDatasource.id,
+            skipReason: 'unspecified-version',
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns dep with path-dependency skipReason when only path is set', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          [toolchain]
+          path = "/path/to/toolchain"
+        `,
+        'rust-toolchain.toml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            datasource: RustVersionDatasource.id,
+            skipReason: 'path-dependency',
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('prefers channel over path when both are set', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          [toolchain]
+          channel = "1.89.1"
+          path = "/path/to/toolchain"
+        `,
+        'rust-toolchain.toml',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            currentValue: '1.89.1',
+            datasource: RustVersionDatasource.id,
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns dep with invalid-version skipReason for unparseable channel value', () => {
       const result = extractPackageFile(
         codeBlock`
           [toolchain]
@@ -139,7 +238,18 @@ describe('modules/manager/rust-toolchain/extract', () => {
         `,
         'rust-toolchain.toml',
       );
-      expect(result).toBeNull();
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            currentValue: 'not-a-rust-channel',
+            datasource: RustVersionDatasource.id,
+            skipReason: 'invalid-version',
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('can handle additional fields', () => {
@@ -162,6 +272,7 @@ describe('modules/manager/rust-toolchain/extract', () => {
           },
         ],
       });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('can read from legacy filename', () => {
@@ -182,11 +293,13 @@ describe('modules/manager/rust-toolchain/extract', () => {
           },
         ],
       });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('returns null for empty legacy file', () => {
       const result = extractPackageFile('', 'rust-toolchain');
       expect(result).toBeNull();
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('extracts from legacy format', () => {
@@ -201,6 +314,26 @@ describe('modules/manager/rust-toolchain/extract', () => {
           },
         ],
       });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('returns dep with invalid-version skipReason for legacy file with a single garbage line', () => {
+      const result = extractPackageFile(
+        'not-a-rust-channel\n',
+        'rust-toolchain',
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            depName: 'rust',
+            depType: 'toolchain',
+            currentValue: 'not-a-rust-channel',
+            datasource: RustVersionDatasource.id,
+            skipReason: 'invalid-version',
+          },
+        ],
+      });
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
 
     it('returns null for multiline legacy files', () => {
@@ -213,6 +346,7 @@ describe('modules/manager/rust-toolchain/extract', () => {
         'rust-toolchain',
       );
       expect(result).toBeNull();
+      expect(logger.logger.warn).not.toHaveBeenCalled();
     });
   });
 });

--- a/lib/modules/manager/rust-toolchain/extract.ts
+++ b/lib/modules/manager/rust-toolchain/extract.ts
@@ -1,7 +1,9 @@
+import { isNonEmptyString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { newlineRegex } from '../../../util/regex.ts';
 import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as rustVersioning from '../../versioning/rust-release-channel/index.ts';
-import type { PackageFileContent } from '../types.ts';
+import type { PackageDependency, PackageFileContent } from '../types.ts';
 import { RustToolchain } from './schema.ts';
 
 export function extractPackageFile(
@@ -13,13 +15,29 @@ export function extractPackageFile(
   // Try TOML parsing first
   const parsedResult = RustToolchain.safeParse(content);
   if (parsedResult.success) {
-    const { channel } = parsedResult.data.toolchain;
-    return createDependency(channel, packageFile);
+    const { channel, path } = parsedResult.data.toolchain;
+    if (isNonEmptyString(channel)) {
+      return { deps: [createDependency(channel)] };
+    }
+    if (isNonEmptyString(path)) {
+      logger.debug(
+        `rust-toolchain.toml file at ${packageFile} uses a local path toolchain, which cannot be updated`,
+      );
+      return {
+        deps: [{ ...baseDependency(), skipReason: 'path-dependency' }],
+      };
+    }
+    logger.debug(
+      `rust-toolchain.toml file at ${packageFile} has no toolchain channel or path specified`,
+    );
+    return {
+      deps: [{ ...baseDependency(), skipReason: 'unspecified-version' }],
+    };
   }
 
   // For .toml files, TOML parsing must succeed
   if (packageFile.endsWith('.toml')) {
-    logger.warn(
+    logger.debug(
       { err: parsedResult.error, packageFile },
       'Failed to parse rust-toolchain.toml file',
     );
@@ -30,41 +48,39 @@ export function extractPackageFile(
   logger.trace({ packageFile }, 'TOML parsing failed, trying legacy format');
 
   const lines = content
-    .split('\n')
+    .split(newlineRegex)
     .map((l) => l.trim())
     .filter((l) => l.length > 0);
 
-  if (lines.length === 0) {
-    logger.warn({ packageFile }, 'rust-toolchain file is empty');
-    return null;
-  }
-
-  if (lines.length > 1) {
-    logger.warn({ packageFile }, 'rust-toolchain file contains multiple lines');
-    return null;
-  }
-
-  return createDependency(lines[0], packageFile);
-}
-
-function createDependency(
-  channel: string,
-  packageFile: string,
-): PackageFileContent | null {
-  if (!rustVersioning.api.isValid(channel)) {
-    logger.warn(
-      { channel, packageFile },
-      'Unsupported rust-toolchain channel value',
+  if (lines.length !== 1) {
+    logger.debug(
+      { packageFile },
+      'rust-toolchain file is empty or contains multiple lines',
     );
     return null;
   }
 
-  const dep = {
+  return { deps: [createDependency(lines[0])] };
+}
+
+function baseDependency(): PackageDependency {
+  return {
     depName: 'rust',
     depType: 'toolchain',
-    currentValue: channel,
     datasource: RustVersionDatasource.id,
   };
+}
 
-  return { deps: [dep] };
+function createDependency(channel: string): PackageDependency {
+  const dep: PackageDependency = {
+    ...baseDependency(),
+    currentValue: channel,
+  };
+
+  if (!rustVersioning.api.isValid(channel)) {
+    logger.debug(`Unsupported rust-toolchain channel value "${channel}"`);
+    dep.skipReason = 'invalid-version';
+  }
+
+  return dep;
 }

--- a/lib/modules/manager/rust-toolchain/schema.spec.ts
+++ b/lib/modules/manager/rust-toolchain/schema.spec.ts
@@ -52,15 +52,17 @@ describe('modules/manager/rust-toolchain/schema', () => {
       );
     });
 
-    it('throws error for missing channel field', () => {
+    it('parses successfully when channel field is missing', () => {
       const toml = codeBlock`
         [toolchain]
         components = ["rustfmt"]
       `;
 
-      expect(() => RustToolchain.parse(toml)).toThrow(
-        'Invalid input: expected string, received undefined',
-      );
+      const result = RustToolchain.parse(toml);
+
+      expect(result).toEqual({
+        toolchain: {},
+      });
     });
 
     it('throws error for non-string channel', () => {
@@ -74,15 +76,51 @@ describe('modules/manager/rust-toolchain/schema', () => {
       );
     });
 
-    it('throws error for empty channel', () => {
+    it('parses successfully for empty channel', () => {
       const toml = codeBlock`
         [toolchain]
         channel = ""
       `;
 
-      expect(() => RustToolchain.parse(toml)).toThrow(
-        'Too small: expected string to have >=1 characters',
-      );
+      const result = RustToolchain.parse(toml);
+
+      expect(result).toEqual({
+        toolchain: {
+          channel: '',
+        },
+      });
+    });
+
+    it('parses TOML with path', () => {
+      const toml = codeBlock`
+        [toolchain]
+        path = "/path/to/toolchain"
+      `;
+
+      const result = RustToolchain.parse(toml);
+
+      expect(result).toEqual({
+        toolchain: {
+          path: '/path/to/toolchain',
+        },
+      });
+    });
+
+    it('parses TOML with both channel and path', () => {
+      const toml = codeBlock`
+        [toolchain]
+        channel = "1.89.1"
+        path = "/path/to/toolchain"
+      `;
+
+      const result = RustToolchain.parse(toml);
+
+      expect(result).toEqual({
+        toolchain: {
+          channel: '1.89.1',
+          path: '/path/to/toolchain',
+        },
+      });
     });
 
     it('parses nightly channel', () => {

--- a/lib/modules/manager/rust-toolchain/schema.ts
+++ b/lib/modules/manager/rust-toolchain/schema.ts
@@ -4,7 +4,8 @@ import { Toml } from '../../../util/schema-utils/index.ts';
 export const RustToolchain = Toml.pipe(
   z.object({
     toolchain: z.object({
-      channel: z.string().min(1),
+      channel: z.string().optional(),
+      path: z.string().optional(),
     }),
   }),
 );


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

The schema now accepts an optional `channel` and an optional `path`, and extraction reports:

- `invalid-version` when a channel cannot be parsed
- `path-dependency` when the file points at a local toolchain
- `unspecified-version` when neither field is set


## Context

The manager emitted `logger.warn` four times during extraction and returned `null` for content that is valid but not updatable. A `rust-toolchain.toml` using `path` instead of `channel` is a legitimate file, yet it failed schema validation and produced a maintainer-facing warning.

Per the logging guidance in `docs/development/best-practices.md`, WARN is consumed by metrics and error catching services, so it should not fire for user content Renovate simply cannot update. The manager guide also asks for a `skipReason` rather than silently dropping a dependency.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
