### PR TITLE
fix(versioning/cargo): convert ranges to semver in subset and intersects

### DIFF
--- a/lib/modules/versioning/cargo/index.spec.ts
+++ b/lib/modules/versioning/cargo/index.spec.ts
@@ -161,6 +161,37 @@ describe('modules/versioning/cargo/index', () => {
   );
 
   it.each`
+    subRange           | superRange       | expected
+    ${'1.70'}          | ${'1.63'}        | ${true}
+    ${'1.63'}          | ${'1.70'}        | ${false}
+    ${'1.2.3'}         | ${'1.2'}         | ${true}
+    ${'0.4'}           | ${'0.4.1'}       | ${false}
+    ${'^1.5'}          | ${'^1.0'}        | ${true}
+    ${'>=1.5'}         | ${'>=1.0'}       | ${true}
+    ${'>=1.0, <1.5'}   | ${'>=1.0, <2.0'} | ${true}
+    ${'>=1.0, <2.0'}   | ${'>=1.0, <1.5'} | ${false}
+    ${'not-a-version'} | ${'1.0'}         | ${false}
+  `(
+    'subset("$subRange", "$superRange") === $expected',
+    ({ subRange, superRange, expected }) => {
+      expect(semver.subset?.(subRange, superRange)).toBe(expected);
+    },
+  );
+
+  it.each`
+    subRange           | superRange | expected
+    ${'1.70'}          | ${'1.63'}  | ${true}
+    ${'1.63'}          | ${'1.70'}  | ${true}
+    ${'1.0'}           | ${'3.0'}   | ${false}
+    ${'not-a-version'} | ${'1.0'}   | ${false}
+  `(
+    'intersects("$subRange", "$superRange") === $expected',
+    ({ subRange, superRange, expected }) => {
+      expect(semver.intersects?.(subRange, superRange)).toBe(expected);
+    },
+  );
+
+  it.each`
     currentVersion     | newVersion         | expected
     ${'0.0.1'}         | ${'0.0.1'}         | ${false}
     ${'0.0.1'}         | ${'0.0.2'}         | ${true}

--- a/lib/modules/versioning/cargo/index.ts
+++ b/lib/modules/versioning/cargo/index.ts
@@ -159,6 +159,24 @@ function getNewValue({
   return newCargo;
 }
 
+function subset(subRange: string, superRange: string): boolean | undefined {
+  try {
+    return npm.subset!(cargo2npm(subRange), cargo2npm(superRange));
+  } catch (err) {
+    logger.debug({ err }, 'cargo.subset error');
+    return false;
+  }
+}
+
+function intersects(subRange: string, superRange: string): boolean {
+  try {
+    return npm.intersects!(cargo2npm(subRange), cargo2npm(superRange));
+  } catch (err) {
+    logger.debug({ err }, 'cargo.intersects error');
+    return false;
+  }
+}
+
 function isBreaking(current: string, version: string): boolean {
   // The change may be breaking if either version is unstable
   if (!semver.is(version) || !semver.is(current)) {
@@ -188,5 +206,7 @@ export const api: VersioningApi = {
   matches,
   getSatisfyingVersion,
   minSatisfyingVersion,
+  subset,
+  intersects,
 };
 export default api;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

I have looked into constraint filtering for cargo and stumbled across this. 

## Changes

`subset` is called by `applyConstraintsFiltering`, so repositories using `constraintsFiltering: 'strict'` had crate releases dropped whenever the release constraint differed from the configured one. `intersects` has no caller in this repository today, but it is part of `VersioningApi` and was wrong in the same way.

Both are now wrapped the way `composer` does it, including the `try`/`catch`, because the underlying semver calls throw on ranges they cannot parse.

The module had no tests for either function, which is why this was not caught. Both are now covered, including the throwing path.

## Context

`cargo2npm` exists because a bare `1.2.3` in Cargo means `^1.2.3` and `0.4` means `^0.4`, since caret requirements are the default. Every range-consuming function in this module converts through it: `isValid`, `matches`, `isLessThanRange`, `getSatisfyingVersion`, `minSatisfyingVersion` and `getNewValue`.

`subset` and `intersects` did not. The exported `api` is built from a `...npm` spread and never overrode them, so they received Cargo syntax and interpreted it as semver syntax. Read that way, `1.70` means `1.70.x` rather than `^1.70`:

    subset('1.70', '1.63')      was false, is now true
    intersects('1.70', '1.63')  was false, is now true
    intersects('1.63', '1.70')  was false, is now true


Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor  will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
