### PR TITLE
fix(manager/npm/yarn): detect corepack from package.json when managerData flag is missing

### DIFF
--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -63,9 +63,9 @@ describe('modules/manager/npm/post-update/yarn', () => {
 
   it.each([
     ['1.22.0', '^1.10.0', 2],
-    ['2.1.0', '>= 2.0.0', 1],
-    ['2.2.0', '2.2.0', 1],
-    ['3.0.0', '3.0.0', 1],
+    ['2.1.0', '>= 2.0.0', 2],
+    ['2.2.0', '2.2.0', 2],
+    ['3.0.0', '3.0.0', 2],
   ])(
     'generates lock files using yarn v%s',
     async (yarnVersion, yarnCompatibility, expectedFsCalls) => {
@@ -375,8 +375,8 @@ describe('modules/manager/npm/post-update/yarn', () => {
 
   it.each([
     ['1.22.0', '^1.10.0', 2],
-    ['2.1.0', '>= 2.0.0', 1],
-    ['2.2.0', '2.2.0', 1],
+    ['2.1.0', '>= 2.0.0', 2],
+    ['2.2.0', '2.2.0', 2],
   ])(
     'performs lock file maintenance using yarn v%s',
     async (yarnVersion, yarnCompatibility, expectedFsCalls) => {
@@ -411,9 +411,9 @@ describe('modules/manager/npm/post-update/yarn', () => {
 
   it.each([
     ['1.22.0', '^1.10.0', 2],
-    ['2.1.0', '>= 2.0.0', 1],
-    ['2.2.0', '2.2.0', 1],
-    ['3.0.0', '3.0.0', 1],
+    ['2.1.0', '>= 2.0.0', 2],
+    ['2.2.0', '2.2.0', 2],
+    ['3.0.0', '3.0.0', 2],
   ])(
     'performs lock file maintenance in subdirectory independent workspaces using yarn v%s',
     async (yarnVersion, yarnCompatibility, expectedFsReadCalls) => {
@@ -529,6 +529,50 @@ describe('modules/manager/npm/post-update/yarn', () => {
       constraints: {
         yarn: '^3.0.0',
       },
+    });
+    const res = await yarnHelper.generateLockFile('some-dir', {}, config);
+    expect(execSnapshots).toMatchObject([
+      { cmd: 'install-tool node 16.16.0', options: { cwd: 'some-dir' } },
+      { cmd: 'install-tool corepack 0.10.0', options: { cwd: 'some-dir' } },
+      {
+        cmd: 'yarn install --mode=update-lockfile',
+        options: {
+          cwd: 'some-dir',
+          env: {
+            YARN_ENABLE_GLOBAL_CACHE: '1',
+            YARN_ENABLE_IMMUTABLE_INSTALLS: 'false',
+            YARN_HTTP_TIMEOUT: '100000',
+          },
+        },
+      },
+    ]);
+    expect(res.lockFile).toBe('package-lock-contents');
+  });
+
+  it('supports corepack even if managerData is missing the hasPackageManager flag', async () => {
+    // nested resolutions clobber the managerData flag, see #25853
+    process.env.CONTAINERBASE = 'true';
+    GlobalConfig.set({
+      localDir: '.',
+      binarySource: 'install',
+      cacheDir: '/tmp/cache',
+    });
+    Fixtures.mock(
+      {
+        'package.json': '{ "packageManager": "yarn@3.0.0" }',
+        'yarn.lock': 'package-lock-contents',
+      },
+      'some-dir',
+    );
+    vi.mocked(getPkgReleases).mockResolvedValueOnce({
+      releases: [{ version: '0.10.0' }],
+    });
+    const execSnapshots = mockExecAll({
+      stdout: '2.1.0',
+      stderr: '',
+    });
+    const config = util.partial<PostUpdateConfig<NpmManagerData>>({
+      managerData: { key: 'some-dep/some-transitive-dep' },
     });
     const res = await yarnHelper.generateLockFile('some-dir', {}, config);
     expect(execSnapshots).toMatchObject([

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -131,9 +131,16 @@ export async function generateLockFile(
     };
 
     // check first upgrade, see #17786
-    const hasPackageManager =
+    let hasPackageManager =
       !!config.managerData?.hasPackageManager ||
       !!upgrades[0]?.managerData?.hasPackageManager;
+    // the flag can be clobbered by dep-level managerData, e.g. for nested
+    // resolutions, so fall back to package.json itself, see #25853
+    if (!isYarn1 && !hasPackageManager) {
+      const pkgJson = await lazyPgkJson.getValue();
+      hasPackageManager =
+        !!pkgJson.packageManager || !!pkgJson.devEngines?.packageManager;
+    }
 
     if (!isYarn1 && hasPackageManager) {
       toolConstraints.push({


### PR DESCRIPTION
## Changes

`generateLockFile` for yarn decides between corepack and the yarn v1 fallback via `managerData.hasPackageManager`. When the update targets a nested `resolutions` entry (e.g. `"lerna/js-yaml"`), the dep-level `managerData` (which only carries `key`) shadows the package-file-level one, so the flag is lost. Renovate then installs yarn 1.x, which refuses to run in a repo with `packageManager: yarn@4.x`:

```
error This project's package.json defines "packageManager": "yarn@4.18.0". However the current global version of Yarn is 1.22.22.
```

When the flag is missing and the target yarn is not v1, this change falls back to checking `package.json` itself (already lazily loaded in scope) for `packageManager`/`devEngines.packageManager`, which is what the pnpm implementation already reads.

Read-count expectations in existing berry specs without the `managerData` flag were bumped by one, since the fallback now reads `package.json` there.

Real-world occurrence: mikro-orm/mikro-orm#8130 (artifact update failure on a `resolutions` security update).

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #25853
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code and tests were drafted by Claude Code (Claude Fable 5), directed and reviewed by @B4nan.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @B4nan will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
