### PR TITLE
refactor(git): extract runtime config appending

### DIFF
--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -7,6 +7,8 @@ import {
 describe('util/git/auth', () => {
   afterEach(() => {
     delete process.env.GIT_CONFIG_COUNT;
+    delete process.env.GIT_CONFIG_KEY_0;
+    delete process.env.GIT_CONFIG_VALUE_0;
   });
 
   describe('getGitAuthenticatedEnvironmentVariables()', () => {
@@ -118,13 +120,19 @@ describe('util/git/auth', () => {
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { GIT_CONFIG_COUNT: '1' },
+          {
+            GIT_CONFIG_COUNT: '1',
+            GIT_CONFIG_KEY_0: 'existing-key',
+            GIT_CONFIG_VALUE_0: 'existing-value',
+          },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -141,13 +149,19 @@ describe('util/git/auth', () => {
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { GIT_CONFIG_COUNT: '1' },
+          {
+            GIT_CONFIG_COUNT: '1',
+            GIT_CONFIG_KEY_0: 'existing-key',
+            GIT_CONFIG_VALUE_0: 'existing-value',
+          },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -156,6 +170,8 @@ describe('util/git/auth', () => {
 
     it('returns url with token and already existing GIT_CONFIG_COUNT from environment', () => {
       process.env.GIT_CONFIG_COUNT = '1';
+      process.env.GIT_CONFIG_KEY_0 = 'existing-key';
+      process.env.GIT_CONFIG_VALUE_0 = 'existing-value';
       expect(
         getGitAuthenticatedEnvironmentVariables('https://github.com/', {
           token: 'token1234',
@@ -164,9 +180,11 @@ describe('util/git/auth', () => {
         }),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -7,8 +7,6 @@ import {
 describe('util/git/auth', () => {
   afterEach(() => {
     delete process.env.GIT_CONFIG_COUNT;
-    delete process.env.GIT_CONFIG_KEY_0;
-    delete process.env.GIT_CONFIG_VALUE_0;
   });
 
   describe('getGitAuthenticatedEnvironmentVariables()', () => {
@@ -124,11 +122,9 @@ describe('util/git/auth', () => {
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -149,11 +145,9 @@ describe('util/git/auth', () => {
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_0: 'existing-key',
         GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
         GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: 'existing-value',
         GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_2: 'git@github.com:',
         GIT_CONFIG_VALUE_3: 'https://github.com/',
@@ -162,8 +156,6 @@ describe('util/git/auth', () => {
 
     it('does not inherit GIT_CONFIG_COUNT from the process environment', () => {
       process.env.GIT_CONFIG_COUNT = '1';
-      process.env.GIT_CONFIG_KEY_0 = 'existing-key';
-      process.env.GIT_CONFIG_VALUE_0 = 'existing-value';
       expect(
         getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/', {
           token: 'token1234',

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -3,10 +3,10 @@ import { PLATFORM_HOST_TYPES } from '../../constants/platforms.ts';
 import { logger } from '../../logger/index.ts';
 import type { HostRule } from '../../types/index.ts';
 import { detectPlatform } from '../common.ts';
-import { getEnv } from '../env.ts';
 import { find, getAll } from '../host-rules.ts';
 import { regEx } from '../regex.ts';
 import { createURLFromHostOrURL, isHttpUrl } from '../url.ts';
+import { addGitConfigEnvironmentVariables } from './config.ts';
 import type { AuthenticationRule } from './types.ts';
 import { parseGitUrl } from './url.ts';
 
@@ -34,24 +34,6 @@ export function getGitAuthenticatedEnvironmentVariables(
     return { ...environmentVariables };
   }
 
-  const env = getEnv();
-  // check if the environmentVariables already contain a GIT_CONFIG_COUNT or if the process has one
-  const gitConfigCountEnvVariable =
-    environmentVariables?.GIT_CONFIG_COUNT ?? env.GIT_CONFIG_COUNT;
-  let gitConfigCount = 0;
-  if (gitConfigCountEnvVariable) {
-    // passthrough the gitConfigCountEnvVariable environment variable as start value of the index count
-    gitConfigCount = parseInt(gitConfigCountEnvVariable, 10);
-    if (Number.isNaN(gitConfigCount)) {
-      logger.warn(
-        {
-          GIT_CONFIG_COUNT: env.GIT_CONFIG_COUNT,
-        },
-        `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
-      );
-      gitConfigCount = 0;
-    }
-  }
   let authenticationRules: AuthenticationRule[];
   if (token) {
     authenticationRules = getAuthenticationRulesWithToken(
@@ -70,22 +52,13 @@ export function getGitAuthenticatedEnvironmentVariables(
     );
   }
 
-  // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
-  // add the two new config key and value to the returnEnvironmentVariables object
-  // increase the CONFIG_COUNT by one for each rule and add it to the object
-  const newEnvironmentVariables = {
-    ...environmentVariables,
-  };
-  for (const rule of authenticationRules) {
-    newEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] =
-      `url.${rule.url}.insteadOf`;
-    newEnvironmentVariables[`GIT_CONFIG_VALUE_${gitConfigCount}`] =
-      rule.insteadOf;
-    gitConfigCount++;
-  }
-  newEnvironmentVariables.GIT_CONFIG_COUNT = gitConfigCount.toString();
-
-  return newEnvironmentVariables;
+  return addGitConfigEnvironmentVariables(
+    authenticationRules.map((rule) => ({
+      key: `url.${rule.url}.insteadOf`,
+      value: rule.insteadOf,
+    })),
+    environmentVariables,
+  );
 }
 
 function getAuthenticationRulesWithToken(

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -7,6 +7,7 @@ import type { ResolvedChildEnv } from '../exec/utils.ts';
 import { find, getAll } from '../host-rules.ts';
 import { regEx } from '../regex.ts';
 import { createURLFromHostOrURL, isHttpUrl } from '../url.ts';
+import { addGitConfigEnvironmentVariables } from './config.ts';
 import type { AuthenticationRule } from './types.ts';
 import { parseGitUrl } from './url.ts';
 
@@ -34,21 +35,6 @@ export function getGitAuthenticatedEnvironmentVariables(
     return { ...environmentVariables };
   }
 
-  const gitConfigCountEnvVariable = environmentVariables.GIT_CONFIG_COUNT;
-  let gitConfigCount = 0;
-  if (gitConfigCountEnvVariable) {
-    // passthrough the gitConfigCountEnvVariable environment variable as start value of the index count
-    gitConfigCount = parseInt(gitConfigCountEnvVariable, 10);
-    if (Number.isNaN(gitConfigCount)) {
-      logger.warn(
-        {
-          GIT_CONFIG_COUNT: gitConfigCountEnvVariable,
-        },
-        `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
-      );
-      gitConfigCount = 0;
-    }
-  }
   let authenticationRules: AuthenticationRule[];
   if (token) {
     authenticationRules = getAuthenticationRulesWithToken(
@@ -67,22 +53,13 @@ export function getGitAuthenticatedEnvironmentVariables(
     );
   }
 
-  // create a shallow copy of the environmentVariables as base so we don't modify the input parameter object
-  // add the two new config key and value to the returnEnvironmentVariables object
-  // increase the CONFIG_COUNT by one for each rule and add it to the object
-  const newEnvironmentVariables = {
-    ...environmentVariables,
-  };
-  for (const rule of authenticationRules) {
-    newEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] =
-      `url.${rule.url}.insteadOf`;
-    newEnvironmentVariables[`GIT_CONFIG_VALUE_${gitConfigCount}`] =
-      rule.insteadOf;
-    gitConfigCount++;
-  }
-  newEnvironmentVariables.GIT_CONFIG_COUNT = gitConfigCount.toString();
-
-  return newEnvironmentVariables;
+  return addGitConfigEnvironmentVariables(
+    environmentVariables,
+    authenticationRules.map((rule) => ({
+      key: `url.${rule.url}.insteadOf`,
+      value: rule.insteadOf,
+    })),
+  );
 }
 
 function getAuthenticationRulesWithToken(

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -1,9 +1,26 @@
+import { logger } from '~test/util.ts';
 import { GlobalConfig } from '../../config/global.ts';
-import { setNoVerify, simpleGitConfig } from './config.ts';
+import { setCustomEnv } from '../env.ts';
+import {
+  addGitConfigEnvironmentVariables,
+  getNoVerify,
+  setNoVerify,
+  simpleGitConfig,
+} from './config.ts';
 
 describe('util/git/config', () => {
   beforeEach(() => {
     GlobalConfig.reset();
+    setCustomEnv({});
+    setNoVerify(['push', 'commit']);
+  });
+
+  afterEach(() => {
+    delete process.env.GIT_CONFIG_COUNT;
+    delete process.env.GIT_CONFIG_KEY_0;
+    delete process.env.GIT_CONFIG_KEY_1;
+    delete process.env.GIT_CONFIG_VALUE_0;
+    delete process.env.GIT_CONFIG_VALUE_1;
   });
 
   it('uses "close" events, ignores "exit" events from child processes', () => {
@@ -34,10 +51,167 @@ describe('util/git/config', () => {
     });
   });
 
+  it('allows clearing Git hooks from the environment', () => {
+    setCustomEnv({ RENOVATE_X_CLEAR_HOOKS: 'true' });
+
+    expect(simpleGitConfig()).toMatchObject({
+      unsafe: { allowUnsafeHooksPath: true },
+    });
+  });
+
+  it('sets the commands that skip Git hooks', () => {
+    setNoVerify(['commit']);
+
+    expect(getNoVerify()).toEqual(['commit']);
+  });
+
   it('throws', () => {
     // @ts-expect-error -- testing invalid input
     expect(() => setNoVerify(1)).toThrow(
       'config error: gitNoVerify should be an array of strings',
+    );
+  });
+
+  it('adds runtime Git configuration without modifying the input', () => {
+    const environmentVariables = { RANDOM_VARIABLE: 'random' };
+
+    expect(
+      addGitConfigEnvironmentVariables(
+        [
+          { key: 'first-key', value: 'first-value' },
+          { key: 'second-key', value: 'second-value' },
+        ],
+        environmentVariables,
+      ),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'first-key',
+      GIT_CONFIG_KEY_1: 'second-key',
+      GIT_CONFIG_VALUE_0: 'first-value',
+      GIT_CONFIG_VALUE_1: 'second-value',
+      RANDOM_VARIABLE: 'random',
+    });
+    expect(environmentVariables).toStrictEqual({ RANDOM_VARIABLE: 'random' });
+  });
+
+  it('preserves existing entries supplied by the caller', () => {
+    expect(
+      addGitConfigEnvironmentVariables(
+        [{ key: 'new-key', value: 'new-value' }],
+        {
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'existing-key',
+          GIT_CONFIG_VALUE_0: 'existing-value',
+        },
+      ),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_KEY_1: 'new-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+      GIT_CONFIG_VALUE_1: 'new-value',
+    });
+  });
+
+  it('preserves existing entries inherited from the process', () => {
+    process.env.GIT_CONFIG_COUNT = '1';
+    process.env.GIT_CONFIG_KEY_0 = 'existing-key';
+    process.env.GIT_CONFIG_VALUE_0 = 'existing-value';
+
+    expect(
+      addGitConfigEnvironmentVariables([
+        { key: 'new-key', value: 'new-value' },
+      ]),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_KEY_1: 'new-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+      GIT_CONFIG_VALUE_1: 'new-value',
+    });
+  });
+
+  it('prefers the supplied environment over the process environment', () => {
+    process.env.GIT_CONFIG_COUNT = '1';
+    process.env.GIT_CONFIG_KEY_0 = 'process-key';
+    process.env.GIT_CONFIG_VALUE_0 = 'process-value';
+
+    expect(
+      addGitConfigEnvironmentVariables(
+        [{ key: 'new-key', value: 'new-value' }],
+        {
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'supplied-key',
+          GIT_CONFIG_VALUE_0: 'supplied-value',
+        },
+      ),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'supplied-key',
+      GIT_CONFIG_KEY_1: 'new-key',
+      GIT_CONFIG_VALUE_0: 'supplied-value',
+      GIT_CONFIG_VALUE_1: 'new-value',
+    });
+  });
+
+  it('supports repeated additions without copying inherited entries again', () => {
+    process.env.GIT_CONFIG_COUNT = '1';
+    process.env.GIT_CONFIG_KEY_0 = 'existing-key';
+    process.env.GIT_CONFIG_VALUE_0 = 'existing-value';
+
+    const firstEnvironment = addGitConfigEnvironmentVariables([
+      { key: 'first-key', value: 'first-value' },
+    ]);
+
+    expect(
+      addGitConfigEnvironmentVariables(
+        [{ key: 'second-key', value: 'second-value' }],
+        firstEnvironment,
+      ),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '3',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_KEY_1: 'first-key',
+      GIT_CONFIG_KEY_2: 'second-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+      GIT_CONFIG_VALUE_1: 'first-value',
+      GIT_CONFIG_VALUE_2: 'second-value',
+    });
+  });
+
+  it('defaults missing inherited entries to empty strings', () => {
+    process.env.GIT_CONFIG_COUNT = '1';
+
+    expect(addGitConfigEnvironmentVariables([])).toStrictEqual({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: '',
+      GIT_CONFIG_VALUE_0: '',
+    });
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      { gitConfigCount: 1, index: 0, kind: 'key' },
+      'Missing runtime Git configuration entry; setting it to an empty string',
+    );
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      { gitConfigCount: 1, index: 0, kind: 'value' },
+      'Missing runtime Git configuration entry; setting it to an empty string',
+    );
+  });
+
+  it('ignores an invalid Git configuration count', () => {
+    process.env.GIT_CONFIG_COUNT = 'invalid';
+
+    expect(
+      addGitConfigEnvironmentVariables([
+        { key: 'new-key', value: 'new-value' },
+      ]),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'new-key',
+      GIT_CONFIG_VALUE_0: 'new-value',
+    });
+    expect(logger.logger.warn).toHaveBeenCalledWith(
+      { GIT_CONFIG_COUNT: 'invalid' },
+      `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
     );
   });
 });

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -9,16 +9,6 @@ import {
 describe('util/git/config', () => {
   beforeEach(() => {
     GlobalConfig.reset();
-    setCustomEnv({});
-    setNoVerify(['push', 'commit']);
-  });
-
-  afterEach(() => {
-    delete process.env.GIT_CONFIG_COUNT;
-    delete process.env.GIT_CONFIG_KEY_0;
-    delete process.env.GIT_CONFIG_KEY_1;
-    delete process.env.GIT_CONFIG_VALUE_0;
-    delete process.env.GIT_CONFIG_VALUE_1;
   });
 
   it('uses "close" events, ignores "exit" events from child processes', () => {
@@ -47,20 +37,6 @@ describe('util/git/config', () => {
         allowUnsafeConfigEnvCount: true,
       },
     });
-  });
-
-  it('allows clearing Git hooks from the environment', () => {
-    setCustomEnv({ RENOVATE_X_CLEAR_HOOKS: 'true' });
-
-    expect(simpleGitConfig()).toMatchObject({
-      unsafe: { allowUnsafeHooksPath: true },
-    });
-  });
-
-  it('sets the commands that skip Git hooks', () => {
-    setNoVerify(['commit']);
-
-    expect(getNoVerify()).toEqual(['commit']);
   });
 
   it('throws', () => {

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -1,5 +1,10 @@
+import { logger } from '~test/util.ts';
 import { GlobalConfig } from '../../config/global.ts';
-import { setNoVerify, simpleGitConfig } from './config.ts';
+import {
+  addGitConfigEnvironmentVariables,
+  setNoVerify,
+  simpleGitConfig,
+} from './config.ts';
 
 describe('util/git/config', () => {
   beforeEach(() => {
@@ -38,6 +43,72 @@ describe('util/git/config', () => {
     // @ts-expect-error -- testing invalid input
     expect(() => setNoVerify(1)).toThrow(
       'config error: gitNoVerify should be an array of strings',
+    );
+  });
+
+  it('appends entries without modifying the supplied environment', () => {
+    const environmentVariables = {
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+      RANDOM_VARIABLE: 'random',
+    };
+
+    expect(
+      addGitConfigEnvironmentVariables(environmentVariables, [
+        { key: 'first-key', value: 'first-value' },
+        { key: 'second-key', value: 'second-value' },
+      ]),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '3',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_KEY_1: 'first-key',
+      GIT_CONFIG_KEY_2: 'second-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+      GIT_CONFIG_VALUE_1: 'first-value',
+      GIT_CONFIG_VALUE_2: 'second-value',
+      RANDOM_VARIABLE: 'random',
+    });
+    expect(environmentVariables).toStrictEqual({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+      RANDOM_VARIABLE: 'random',
+    });
+  });
+
+  it('supports repeated additions', () => {
+    const firstEnvironment = addGitConfigEnvironmentVariables({}, [
+      { key: 'first-key', value: 'first-value' },
+    ]);
+
+    expect(
+      addGitConfigEnvironmentVariables(firstEnvironment, [
+        { key: 'second-key', value: 'second-value' },
+      ]),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '2',
+      GIT_CONFIG_KEY_0: 'first-key',
+      GIT_CONFIG_KEY_1: 'second-key',
+      GIT_CONFIG_VALUE_0: 'first-value',
+      GIT_CONFIG_VALUE_1: 'second-value',
+    });
+  });
+
+  it('ignores an invalid Git configuration count', () => {
+    expect(
+      addGitConfigEnvironmentVariables(
+        { GIT_CONFIG_COUNT: 'invalid' },
+        [{ key: 'new-key', value: 'new-value' }],
+      ),
+    ).toStrictEqual({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'new-key',
+      GIT_CONFIG_VALUE_0: 'new-value',
+    });
+    expect(logger.logger.warn).toHaveBeenCalledWith(
+      { GIT_CONFIG_COUNT: 'invalid' },
+      `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
     );
   });
 });

--- a/lib/util/git/config.spec.ts
+++ b/lib/util/git/config.spec.ts
@@ -97,10 +97,9 @@ describe('util/git/config', () => {
 
   it('ignores an invalid Git configuration count', () => {
     expect(
-      addGitConfigEnvironmentVariables(
-        { GIT_CONFIG_COUNT: 'invalid' },
-        [{ key: 'new-key', value: 'new-value' }],
-      ),
+      addGitConfigEnvironmentVariables({ GIT_CONFIG_COUNT: 'invalid' }, [
+        { key: 'new-key', value: 'new-value' },
+      ]),
     ).toStrictEqual({
       GIT_CONFIG_COUNT: '1',
       GIT_CONFIG_KEY_0: 'new-key',

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -77,7 +77,7 @@ function getGitConfigCount(value: string | undefined): number {
   if (Number.isNaN(gitConfigCount)) {
     logger.warn(
       { GIT_CONFIG_COUNT: value },
-      `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
+      `Found GIT_CONFIG_COUNT env variable, but could not parse the value to an integer. Ignoring it.`,
     );
     return 0;
   }

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -1,7 +1,9 @@
 import { isArray, isNumber, isString } from '@sindresorhus/is';
 import type { SimpleGitOptions } from 'simple-git';
 import { GlobalConfig } from '../../config/global.ts';
+import { logger } from '../../logger/index.ts';
 import { getEnv } from '../env.ts';
+import type { ResolvedChildEnv } from '../exec/utils.ts';
 import type { GitNoVerifyOption } from './types.ts';
 
 let noVerify: GitNoVerifyOption[] = ['push', 'commit'];
@@ -42,4 +44,43 @@ export function simpleGitConfig(): Partial<SimpleGitOptions> {
     config.timeout = { block: gitTimeout };
   }
   return config;
+}
+
+export interface GitConfigEntry {
+  key: string;
+  value: string;
+}
+
+export function addGitConfigEnvironmentVariables(
+  environment: Readonly<ResolvedChildEnv>,
+  entries: readonly GitConfigEntry[],
+): ResolvedChildEnv {
+  let gitConfigCount = getGitConfigCount(environment.GIT_CONFIG_COUNT);
+  const newEnvironment = { ...environment };
+
+  for (const entry of entries) {
+    newEnvironment[`GIT_CONFIG_KEY_${gitConfigCount}`] = entry.key;
+    newEnvironment[`GIT_CONFIG_VALUE_${gitConfigCount}`] = entry.value;
+    gitConfigCount++;
+  }
+  newEnvironment.GIT_CONFIG_COUNT = gitConfigCount.toString();
+
+  return newEnvironment;
+}
+
+function getGitConfigCount(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const gitConfigCount = parseInt(value, 10);
+  if (Number.isNaN(gitConfigCount)) {
+    logger.warn(
+      { GIT_CONFIG_COUNT: value },
+      `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
+    );
+    return 0;
+  }
+
+  return gitConfigCount;
 }

--- a/lib/util/git/config.ts
+++ b/lib/util/git/config.ts
@@ -1,6 +1,7 @@
 import { isArray, isNumber, isString } from '@sindresorhus/is';
 import type { SimpleGitOptions } from 'simple-git';
 import { GlobalConfig } from '../../config/global.ts';
+import { logger } from '../../logger/index.ts';
 import { getEnv } from '../env.ts';
 import type { GitNoVerifyOption } from './types.ts';
 
@@ -42,4 +43,99 @@ export function simpleGitConfig(): Partial<SimpleGitOptions> {
     config.timeout = { block: gitTimeout };
   }
   return config;
+}
+
+export interface GitConfigEntry {
+  key: string;
+  value: string;
+}
+
+/**
+ * Add runtime Git configuration entries to an environment without modifying
+ * the supplied environment or losing entries inherited from the process.
+ */
+export function addGitConfigEnvironmentVariables(
+  entries: readonly GitConfigEntry[],
+  environmentVariables?: NodeJS.ProcessEnv,
+): NodeJS.ProcessEnv {
+  const sourceEnvironment =
+    environmentVariables?.GIT_CONFIG_COUNT === undefined
+      ? getEnv()
+      : environmentVariables;
+  let gitConfigCount = getGitConfigCount(sourceEnvironment.GIT_CONFIG_COUNT);
+  const newEnvironmentVariables = { ...environmentVariables };
+
+  for (let index = 0; index < gitConfigCount; index++) {
+    copyExistingGitConfigEntry(
+      sourceEnvironment,
+      newEnvironmentVariables,
+      gitConfigCount,
+      index,
+    );
+  }
+
+  for (const entry of entries) {
+    newEnvironmentVariables[`GIT_CONFIG_KEY_${gitConfigCount}`] = entry.key;
+    newEnvironmentVariables[`GIT_CONFIG_VALUE_${gitConfigCount}`] = entry.value;
+    gitConfigCount++;
+  }
+  newEnvironmentVariables.GIT_CONFIG_COUNT = gitConfigCount.toString();
+
+  return newEnvironmentVariables;
+}
+
+function getGitConfigCount(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+
+  const gitConfigCount = parseInt(value, 10);
+  if (Number.isNaN(gitConfigCount)) {
+    logger.warn(
+      { GIT_CONFIG_COUNT: value },
+      `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
+    );
+    return 0;
+  }
+
+  return gitConfigCount;
+}
+
+function copyExistingGitConfigEntry(
+  sourceEnvironment: NodeJS.ProcessEnv,
+  targetEnvironment: NodeJS.ProcessEnv,
+  gitConfigCount: number,
+  index: number,
+): void {
+  const keyVariable = `GIT_CONFIG_KEY_${index}`;
+  const valueVariable = `GIT_CONFIG_VALUE_${index}`;
+  targetEnvironment[keyVariable] = getExistingGitConfigVariable(
+    sourceEnvironment[keyVariable],
+    gitConfigCount,
+    index,
+    'key',
+  );
+  targetEnvironment[valueVariable] = getExistingGitConfigVariable(
+    sourceEnvironment[valueVariable],
+    gitConfigCount,
+    index,
+    'value',
+  );
+}
+
+function getExistingGitConfigVariable(
+  value: string | undefined,
+  gitConfigCount: number,
+  index: number,
+  kind: 'key' | 'value',
+): string {
+  if (value !== undefined) {
+    return value;
+  }
+
+  logger.once.warn(
+    { gitConfigCount, index, kind },
+    'Missing runtime Git configuration entry; setting it to an empty string',
+  );
+  return '';
 }


### PR DESCRIPTION
## Changes

- Extract indexed `GIT_CONFIG_*` appending from the authentication helper into the Git config module.
- Require a resolved child environment as the first argument and never read `process.env` or `getEnv()`.
- Clone the supplied environment and append entries after its existing `GIT_CONFIG_COUNT`.
- Preserve append order and repeated additions while retaining the existing invalid-count behavior.
- Keep authentication behavior unchanged by routing its existing entries through the extracted helper.

#45184 now owns child-environment resolution, inherited runtime Git configuration, and the fix for #40580. This PR is the smaller behavior-preserving extraction requested in the review and no longer claims to close that issue.

## Stack

1. #45165 - extract runtime Git configuration appending (this PR)
1. #45166 - accept a scoped environment in `git.initRepo()`
1. #45167 - keep shared Git authentication rewrite URLs credential-free
1. #45168 - keep GitHub working and upstream URLs credential-free

The stack is replayed on top of #45184. The dependent layers remain drafts while this layer is reviewed.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No - I did not use AI for this contribution.
- [ ] Yes - minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes - substantive assistance. OpenAI Codex (GPT-5) produced non-trivial code and test changes under operator direction.
- [ ] Yes - other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted. Name the account.
- [x] Nobody has explicitly committed to replying.

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The helper and authentication tests pass. The complete rebased stack also passes the targeted fixer and lint checks, all 13 affected test files, and the TypeScript type-check.
