### PR TITLE
fix(pnpm): skip minimumReleaseAgeExclude when security update is past age gate

### DIFF
--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../../config/types.ts';
 import * as docker from '../../../util/exec/docker/index.ts';
 import type { FileAddition } from '../../../util/git/types.ts';
+import type { Timestamp } from '../../../util/timestamp.ts';
 import type { UpdateArtifactsConfig, Upgrade } from '../types.ts';
 import { updateArtifacts } from './index.ts';
 import * as rules from './post-update/rules.ts';
@@ -409,6 +410,93 @@ minimumReleaseAgeExclude:
             path: 'pnpm-workspace.yaml',
             contents:
               'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  # Renovate security update: pnpm@8.15.6\n  - pnpm@8.15.6\n',
+          },
+        },
+      ]);
+    });
+
+    it('returns null if security update is past the minimumReleaseAge gate', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 1440`,
+      ); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            currentValue: '8.15.5',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+            releaseTimestamp: '2020-01-01T00:00:00Z' as Timestamp,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+
+      expect(res).toBeNull();
+      expect(fs.writeLocalFile).not.toHaveBeenCalled();
+    });
+
+    it('writes minimumReleaseAgeExclude when security update is within the gate', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(
+        codeBlock`minimumReleaseAge: 10080`,
+      ); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            currentValue: '8.15.5',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+            newVersionAgeInDays: 1,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents:
+              'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  # Renovate security update: pnpm@8.15.6\n  - pnpm@8.15.6\n',
+          },
+        },
+      ]);
+    });
+
+    it('writes minimumReleaseAgeExclude when minimumReleaseAge is non-numeric (duration string)', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
+      fs.localPathExists.mockResolvedValueOnce(true);
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`minimumReleaseAge: 7d`); // for pnpm-workspace.yaml
+      const res = await updateArtifacts({
+        packageFileName: 'package.json',
+        updatedDeps: [
+          {
+            ...validDepUpdate,
+            currentValue: '8.15.5',
+            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
+            isVulnerabilityAlert: true,
+            newVersionAgeInDays: 1,
+          },
+        ],
+        newPackageFileContent: 'some new content',
+        config,
+      });
+      expect(res).toStrictEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'pnpm-workspace.yaml',
+            contents:
+              'minimumReleaseAge: 7d\nminimumReleaseAgeExclude:\n  # Renovate security update: pnpm@8.15.6\n  - pnpm@8.15.6\n',
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.spec.ts
+++ b/lib/modules/manager/npm/artifacts.spec.ts
@@ -454,7 +454,7 @@ minimumReleaseAgeExclude:
             currentValue: '8.15.5',
             managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
             isVulnerabilityAlert: true,
-            newVersionAgeInDays: 1,
+            releaseTimestamp: new Date().toISOString() as Timestamp,
           },
         ],
         newPackageFileContent: 'some new content',
@@ -467,36 +467,6 @@ minimumReleaseAgeExclude:
             path: 'pnpm-workspace.yaml',
             contents:
               'minimumReleaseAge: 10080\nminimumReleaseAgeExclude:\n  # Renovate security update: pnpm@8.15.6\n  - pnpm@8.15.6\n',
-          },
-        },
-      ]);
-    });
-
-    it('writes minimumReleaseAgeExclude when minimumReleaseAge is non-numeric (duration string)', async () => {
-      fs.getSiblingFileName.mockReturnValueOnce('pnpm-workspace.yaml');
-      fs.localPathExists.mockResolvedValueOnce(true);
-      fs.readLocalFile.mockResolvedValueOnce(codeBlock`minimumReleaseAge: 7d`); // for pnpm-workspace.yaml
-      const res = await updateArtifacts({
-        packageFileName: 'package.json',
-        updatedDeps: [
-          {
-            ...validDepUpdate,
-            currentValue: '8.15.5',
-            managerData: { pnpmShrinkwrap: 'pnpm-lock.yaml' },
-            isVulnerabilityAlert: true,
-            newVersionAgeInDays: 1,
-          },
-        ],
-        newPackageFileContent: 'some new content',
-        config,
-      });
-      expect(res).toStrictEqual([
-        {
-          file: {
-            type: 'addition',
-            path: 'pnpm-workspace.yaml',
-            contents:
-              'minimumReleaseAge: 7d\nminimumReleaseAgeExclude:\n  # Renovate security update: pnpm@8.15.6\n  - pnpm@8.15.6\n',
           },
         },
       ]);

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -4,6 +4,7 @@ import upath from 'upath';
 import type { Scalar, YAMLSeq } from 'yaml';
 import { isScalar, isSeq, parseDocument } from 'yaml';
 import { logger } from '../../../logger/index.ts';
+import { getElapsedDays } from '../../../util/date.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
@@ -186,6 +187,18 @@ async function updatePnpmWorkspace(
   let updated = false;
 
   for (const upgrade of upgrades) {
+    const minimumReleaseAge = doc.get('minimumReleaseAge');
+    if (
+      typeof minimumReleaseAge === 'number' &&
+      Number.isFinite(minimumReleaseAge)
+    ) {
+      const ageInDays = upgrade.releaseTimestamp
+        ? getElapsedDays(upgrade.releaseTimestamp, false)
+        : upgrade.newVersionAgeInDays;
+      if (ageInDays !== undefined && minimumReleaseAge / 1440 <= ageInDays) {
+        continue; // past the gate — pnpm won't block, exclude is a no-op
+      }
+    }
     let excludeNode = doc.getIn(['minimumReleaseAgeExclude']) as YAMLSeq | null;
     // v8 ignore next -- TODO: add test #40625
     const newVersion = upgrade.newVersion ?? upgrade.newValue;

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -4,7 +4,7 @@ import upath from 'upath';
 import type { Scalar, YAMLSeq } from 'yaml';
 import { isScalar, isSeq, parseDocument } from 'yaml';
 import { logger } from '../../../logger/index.ts';
-import { getElapsedDays } from '../../../util/date.ts';
+import { getElapsedMs } from '../../../util/date.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
@@ -180,24 +180,19 @@ async function updatePnpmWorkspace(
       : (await readLocalFile(pnpmWorkspaceFilePath, 'utf8'))!;
   const doc = parseDocument(packageFileContent);
 
-  if (!doc.get('minimumReleaseAge')) {
+  const minimumReleaseAge = doc.get('minimumReleaseAge') as number;
+  if (!minimumReleaseAge) {
     return null;
   }
 
   let updated = false;
 
   for (const upgrade of upgrades) {
-    const minimumReleaseAge = doc.get('minimumReleaseAge');
     if (
-      typeof minimumReleaseAge === 'number' &&
-      Number.isFinite(minimumReleaseAge)
+      upgrade.releaseTimestamp &&
+      getElapsedMs(upgrade.releaseTimestamp) >= minimumReleaseAge * 60_000
     ) {
-      const ageInDays = upgrade.releaseTimestamp
-        ? getElapsedDays(upgrade.releaseTimestamp, false)
-        : upgrade.newVersionAgeInDays;
-      if (ageInDays !== undefined && minimumReleaseAge / 1440 <= ageInDays) {
-        continue; // past the gate — pnpm won't block, exclude is a no-op
-      }
+      continue; // past the gate — pnpm won't block, exclude is a no-op
     }
     let excludeNode = doc.getIn(['minimumReleaseAgeExclude']) as YAMLSeq | null;
     // v8 ignore next -- TODO: add test #40625

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -247,7 +247,6 @@ export interface Upgrade<
   replaceString?: string;
   replacementApproach?: 'replace' | 'alias';
   releaseTimestamp?: Timestamp;
-  newVersionAgeInDays?: number;
 }
 
 export interface ArtifactNotice {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -246,6 +246,8 @@ export interface Upgrade<
   currentVersion?: string;
   replaceString?: string;
   replacementApproach?: 'replace' | 'alias';
+  releaseTimestamp?: Timestamp;
+  newVersionAgeInDays?: number;
 }
 
 export interface ArtifactNotice {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

`updatePnpmWorkspace` writes a `minimumReleaseAgeExclude` entry for every vulnerability alert without checking whether the fixed version is already old enough for pnpm to install. When the fixed version is past the configured `minimumReleaseAge` gate, the entry is a no-op but remains in `pnpm-workspace.yaml` as configuration that must be hand-cleaned.

This PR checks the fixed version's `releaseTimestamp` before writing the exclude. If its elapsed age meets or exceeds the numeric `minimumReleaseAge` configured in `pnpm-workspace.yaml`, the exclude is skipped. When no timestamp is available, the existing behavior is retained.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42190 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Tool: opencode (model: gpt-5.6-terra).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @aqeelat will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @aqeelat will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
