### PR TITLE
feat(presets): add replacement for deprecated password pusher images

### DIFF
--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -39,6 +39,7 @@
       "replacements:opencost-registry-move",
       "replacements:parcel-css-to-lightningcss",
       "replacements:passport-saml",
+      "replacements:pwpush-to-universal-container",
       "replacements:react-query-devtools-to-scoped",
       "replacements:react-query-to-scoped",
       "replacements:react-scripts-ts-to-react-scripts",
@@ -987,6 +988,18 @@
         "matchPackageNames": ["passport-saml"],
         "replacementName": "@node-saml/passport-saml",
         "replacementVersion": "4.0.4"
+      }
+    ]
+  },
+  "pwpush-to-universal-container": {
+    "description": "Replace deprecated Password Pusher database-specific images with its universal image.",
+    "packageRules": [
+      {
+        "matchDatasources": ["docker"],
+        "matchPackageNames": [
+          "/^(?:docker\\.io/)?pglombardo/pwpush-(?:ephemeral|mariadb|mysql|postgres)$/"
+        ],
+        "replacementName": "pglombardo/pwpush"
       }
     ]
   },

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -1000,6 +1000,9 @@
         "matchPackageNames": [
           "/^(?:docker\\.io/)?pglombardo/pwpush-(?:ephemeral|mysql|postgres)$/"
         ],
+        "prBodyNotes": [
+          "⚠️ Follow Password Pusher's [universal-container migration guide](https://docs.pwpush.com/docs/how-to-universal/) before merging. Back up the database and validate existing data after migration."
+        ],
         "replacementName": "pglombardo/pwpush"
       }
     ]

--- a/lib/data/replacements.json
+++ b/lib/data/replacements.json
@@ -995,9 +995,10 @@
     "description": "Replace deprecated Password Pusher database-specific images with its universal image.",
     "packageRules": [
       {
+        "matchCurrentVersion": "1.35.0",
         "matchDatasources": ["docker"],
         "matchPackageNames": [
-          "/^(?:docker\\.io/)?pglombardo/pwpush-(?:ephemeral|mariadb|mysql|postgres)$/"
+          "/^(?:docker\\.io/)?pglombardo/pwpush-(?:ephemeral|mysql|postgres)$/"
         ],
         "replacementName": "pglombardo/pwpush"
       }


### PR DESCRIPTION
## Changes

Adds the `replacements:pwpush-to-universal-container` preset.

It replaces the deprecated `pglombardo/pwpush-ephemeral`, `pglombardo/pwpush-mysql`, and `pglombardo/pwpush-postgres` Docker images with `pglombardo/pwpush` once they reach their final legacy release, `1.35.0`.

The replacement PR includes a link to Password Pusher's universal-container migration guide and advises users to back up and validate their data before merging.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI Codex (GPT-5) was used to research the deprecation, inspect the codebase, implement the rule, and run targeted tests.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @MindTooth will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The existing parameterized internal-preset test now validates this additional replacement. Targeted replacement-preset, data ordering, and PR-note tests passed (1,285 tests).