### PR TITLE
fix(changelog): match release notes for host-qualified names

### DIFF
--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -1556,6 +1556,270 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       });
     });
 
+    it('matches a host-qualified name on its trailing name', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'exampleChart-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some old body',
+        },
+        {
+          id: 2,
+          version: 'exampleChart-1.0.1',
+          releaseTimestamp: '2020-01-02' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'some.registry/some/charts/exampleChart',
+          depName: 'some.registry/some/charts/exampleChart',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.1',
+          gitRef: '1.0.1',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 2,
+        tag: 'exampleChart-1.0.1',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('matches a host-qualified name on its unqualified name', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'charts/podinfo-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'ghcr.io/charts/podinfo',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 1,
+        tag: 'charts/podinfo-1.0.0',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('matches a host-qualified name with a port', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'exampleChart-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'some.registry:5000/some/charts/exampleChart',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 1,
+        tag: 'exampleChart-1.0.0',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('matches a localhost-qualified name with a port', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'exampleChart-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'localhost:5000/charts/exampleChart',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 1,
+        tag: 'exampleChart-1.0.0',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('does not match an unrelated tag for a name with a trailing slash', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: '_1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'some.registry/charts/exampleChart/',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('does not match a scoped npm package on its trailing name', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'node-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: '@types/node',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('does not treat regex characters in the name as wildcards', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'depXjs-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'dep.js',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('returns null when neither packageName nor depName is set', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'dep-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
     it('fallback to extractVersion', async () => {
       githubReleasesMock.mockResolvedValueOnce([
         {

--- a/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.spec.ts
@@ -1355,6 +1355,270 @@ describe('workers/repository/update/pr/changelog/release-notes', () => {
       });
     });
 
+    it('matches a host-qualified name on its trailing name', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'exampleChart-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some old body',
+        },
+        {
+          id: 2,
+          version: 'exampleChart-1.0.1',
+          releaseTimestamp: '2020-01-02' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'some.registry/some/charts/exampleChart',
+          depName: 'some.registry/some/charts/exampleChart',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.1',
+          gitRef: '1.0.1',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 2,
+        tag: 'exampleChart-1.0.1',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('matches a host-qualified name on its unqualified name', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'charts/podinfo-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'ghcr.io/charts/podinfo',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 1,
+        tag: 'charts/podinfo-1.0.0',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('matches a host-qualified name with a port', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'exampleChart-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'some.registry:5000/some/charts/exampleChart',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 1,
+        tag: 'exampleChart-1.0.0',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('matches a localhost-qualified name with a port', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'exampleChart-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'correct/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'localhost:5000/charts/exampleChart',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toEqual({
+        url: 'correct/url/tag.com',
+        notesSourceUrl:
+          'https://api.github.com/repos/some/other-repository/releases',
+        id: 1,
+        tag: 'exampleChart-1.0.0',
+        name: 'some/dep',
+        body: 'some body\n',
+      });
+    });
+
+    it('does not match an unrelated tag for a name with a trailing slash', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: '_1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'some.registry/charts/exampleChart/',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('does not match a scoped npm package on its trailing name', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'node-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: '@types/node',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('does not treat regex characters in the name as wildcards', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'depXjs-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+          packageName: 'dep.js',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
+    it('returns null when neither packageName nor depName is set', async () => {
+      githubReleasesMock.mockResolvedValueOnce([
+        {
+          id: 1,
+          version: 'dep-1.0.0',
+          releaseTimestamp: '2020-01-01' as Timestamp,
+          url: 'wrong/url/tag.com',
+          name: 'some/dep',
+          description: 'some body',
+        },
+      ]);
+
+      const res = await getReleaseNotes(
+        {
+          ...githubProject,
+          repository: 'some/other-repository',
+        },
+        partial<ChangeLogRelease>({
+          version: '1.0.0',
+          gitRef: '1.0.0',
+        }),
+        partial<BranchUpgradeConfig>(),
+      );
+
+      expect(res).toBeNull();
+    });
+
     it('fallback to extractVersion', async () => {
       githubReleasesMock.mockResolvedValueOnce([
         {

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -1,4 +1,9 @@
-import { isDate, isTruthy, isUndefined } from '@sindresorhus/is';
+import {
+  isDate,
+  isNonEmptyString,
+  isTruthy,
+  isUndefined,
+} from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
 import { instrument } from '../../../../../instrumentation/index.ts';
@@ -35,6 +40,12 @@ const repositoriesToSkipMdFetching = [
   'facebook/react-native',
   'react/react-native',
 ];
+
+// Per the OCI distribution reference grammar a leading path segment is a host
+// when it contains a `.` or a `:`. Go module paths are qualified the same way.
+const hostQualifiedNameRegex = regEx(
+  /^(?:localhost(?::\d+)?|[^/]+[.:][^/]*)\/(?<unqualifiedName>.+)$/,
+);
 
 export async function getReleaseList(
   project: ChangeLogProject,
@@ -166,8 +177,8 @@ export async function getReleaseNotes(
     let releaseNotes: ChangeLogNotes | null = null;
 
     let matchedRelease = getExactReleaseMatch(
-      packageName!,
-      depName!,
+      packageName,
+      depName,
       version,
       releases,
     );
@@ -196,19 +207,58 @@ export async function getReleaseNotes(
 }
 
 function getExactReleaseMatch(
-  packageName: string,
-  depName: string,
+  packageName: string | undefined,
+  depName: string | undefined,
   version: string,
   releases: ChangeLogNotes[],
 ): ChangeLogNotes | undefined {
+  const namePatterns = getNamePatterns(packageName, depName);
+  if (!namePatterns.length) {
+    return undefined;
+  }
+
   const exactReleaseReg = regEx(
-    `(?:^|/)(?:${packageName}|${depName})[@_/-]v?${version}`,
+    `(?:^|/)(?:${namePatterns.join('|')})[@_/-]v?${RegExp.escape(version)}`,
   );
   const candidateReleases = releases.filter((r) => r.tag?.endsWith(version));
   const matchedRelease = candidateReleases.find((r) =>
     exactReleaseReg.test(r.tag!),
   );
   return matchedRelease;
+}
+
+/**
+ * A registry host never appears in a Git tag, so a host-qualified name such as
+ * an OCI chart `<registry>/<org>/<repo>/<chart>` can never match the tag that
+ * publishes it, which is scoped by the chart name alone: `<chart>-<version>`.
+ * For those names, also match against the name with its host stripped, and
+ * against the trailing path segment alone. Names that are not host-qualified,
+ * such as scoped npm packages, keep matching in full only, so their tag
+ * prefixes stay as specific as they are today.
+ */
+function getNamePatterns(
+  packageName: string | undefined,
+  depName: string | undefined,
+): string[] {
+  const names = new Set<string>();
+  for (const name of [packageName, depName]) {
+    if (!isNonEmptyString(name)) {
+      continue;
+    }
+    names.add(name);
+
+    const unqualifiedName =
+      hostQualifiedNameRegex.exec(name)?.groups?.unqualifiedName;
+    if (isNonEmptyString(unqualifiedName)) {
+      names.add(unqualifiedName);
+
+      const trailingName = unqualifiedName.split('/').pop();
+      if (isNonEmptyString(trailingName)) {
+        names.add(trailingName);
+      }
+    }
+  }
+  return [...names].map((name) => RegExp.escape(name));
 }
 
 async function releaseNotesResult(

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -1,4 +1,9 @@
-import { isDate, isTruthy, isUndefined } from '@sindresorhus/is';
+import {
+  isDate,
+  isNonEmptyString,
+  isTruthy,
+  isUndefined,
+} from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
 import { logger } from '../../../../../logger/index.ts';
@@ -32,6 +37,12 @@ const repositoriesToSkipMdFetching = [
   'facebook/react-native',
   'react/react-native',
 ];
+
+// Per the OCI distribution reference grammar a leading path segment is a host
+// when it contains a `.` or a `:`. Go module paths are qualified the same way.
+const hostQualifiedNameRegex = regEx(
+  /^(?:localhost(?::\d+)?|[^/]+[.:][^/]*)\/(?<unqualifiedName>.+)$/,
+);
 
 export async function getReleaseList(
   project: ChangeLogProject,
@@ -162,8 +173,8 @@ export async function getReleaseNotes(
   let releaseNotes: ChangeLogNotes | null = null;
 
   let matchedRelease = getExactReleaseMatch(
-    packageName!,
-    depName!,
+    packageName,
+    depName,
     version,
     releases,
   );
@@ -191,19 +202,58 @@ export async function getReleaseNotes(
 }
 
 function getExactReleaseMatch(
-  packageName: string,
-  depName: string,
+  packageName: string | undefined,
+  depName: string | undefined,
   version: string,
   releases: ChangeLogNotes[],
 ): ChangeLogNotes | undefined {
+  const namePatterns = getNamePatterns(packageName, depName);
+  if (!namePatterns.length) {
+    return undefined;
+  }
+
   const exactReleaseReg = regEx(
-    `(?:^|/)(?:${packageName}|${depName})[@_/-]v?${version}`,
+    `(?:^|/)(?:${namePatterns.join('|')})[@_/-]v?${RegExp.escape(version)}`,
   );
   const candidateReleases = releases.filter((r) => r.tag?.endsWith(version));
   const matchedRelease = candidateReleases.find((r) =>
     exactReleaseReg.test(r.tag!),
   );
   return matchedRelease;
+}
+
+/**
+ * A registry host never appears in a Git tag, so a host-qualified name such as
+ * an OCI chart `<registry>/<org>/<repo>/<chart>` can never match the tag that
+ * publishes it, which is scoped by the chart name alone: `<chart>-<version>`.
+ * For those names, also match against the name with its host stripped, and
+ * against the trailing path segment alone. Names that are not host-qualified,
+ * such as scoped npm packages, keep matching in full only, so their tag
+ * prefixes stay as specific as they are today.
+ */
+function getNamePatterns(
+  packageName: string | undefined,
+  depName: string | undefined,
+): string[] {
+  const names = new Set<string>();
+  for (const name of [packageName, depName]) {
+    if (!isNonEmptyString(name)) {
+      continue;
+    }
+    names.add(name);
+
+    const unqualifiedName =
+      hostQualifiedNameRegex.exec(name)?.groups?.unqualifiedName;
+    if (isNonEmptyString(unqualifiedName)) {
+      names.add(unqualifiedName);
+
+      const trailingName = unqualifiedName.split('/').pop();
+      if (isNonEmptyString(trailingName)) {
+        names.add(trailingName);
+      }
+    }
+  }
+  return [...names].map((name) => RegExp.escape(name));
 }
 
 async function releaseNotesResult(


### PR DESCRIPTION
## Changes

`getExactReleaseMatch` builds its pattern by interpolating `packageName` and `depName` directly:

```ts
const exactReleaseReg = regEx(
  `(?:^|/)(?:${packageName}|${depName})[@_/-]v?${version}`,
);
```

The `(?:^|/)` anchor allows a tag prefix, but it anchors the *entire* name. For anything distributed through a registry, that name is host-qualified (`<registry>/<org>/<repo>/<chart>`), while the Git tag is scoped by the trailing name alone (`<chart>-<version>`). The host can never appear in a tag, so the match is structurally impossible and the PR body is rendered without release notes.

This affects every OCI-distributed Helm chart in a multi-chart repository, which is an increasingly common publishing layout. Go module paths in monorepos are qualified the same way and hit the same gap (`github.com/<org>/<repo>/service/s3` vs. tag `service/s3/v1.2.3`).

There is no config workaround today. `extractVersion` is the only tag-shaping knob and it is dual-purpose: `applyExtractVersion` runs at the datasource layer and *drops* every release that does not match, before release-note matching ever sees them. Using it to describe the tag format therefore breaks version detection for the package.

### What this PR does

`getNamePatterns()` now derives the alternatives for the match:

| name | patterns tried | matches tag |
| --- | --- | --- |
| `<registry>/<org>/<repo>/<chart>` | full, host-stripped, trailing segment | `<chart>-1.2.3` |
| `<registry>/<org>/<chart>` | full, host-stripped, trailing segment | `<org>/<chart>-1.2.3` |
| `@scope/pkg` | full only (unchanged) | — |

Host detection follows the OCI distribution reference rule: the first path segment is a host when it contains a `.` or a `:` (plus `localhost`). That deliberately excludes scoped npm names, so the widening only reaches names that are registry- or module-path-qualified, and existing tag prefixes stay exactly as specific as they are today.

False-positive risk is small: `candidateReleases` is already narrowed to `tag.endsWith(version)`, so a wrong hit would need a tag shaped `*<trailing-name>[@_/-]v?<that exact version>`.

Two smaller fixes ride along:

- The interpolated names and version are now escaped with `RegExp.escape`. Previously `some.registry/dep` matched the tag `someXregistry/dep-1.0.0`, and a name containing regex metacharacters could throw out of `regEx()`.
- `getExactReleaseMatch` takes `string | undefined` and returns early when no name is available, removing two `!` assertions that contradicted `ChangeLogProject`'s optional `packageName`/`depName`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5, via Claude Code. It diagnosed the root cause from debug logs of a real Renovate run, wrote the implementation, the unit tests and this description. All of it was reviewed before submitting.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @wittdennis will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Five tests added to `release-notes.spec.ts`: trailing-name match (with a decoy release at the adjacent version, to prove the right one is picked), host-stripped-name match, scoped-npm negative, regex-metacharacter negative, and the no-name-set case. `release-notes.ts` keeps 100% statement, function and line coverage; the two remaining branch misses are pre-existing.

The originating case was found on a self-hosted Forgejo instance, so there is no public repository to link.
