### PR TITLE
fix: Support resolving registry aliases in replacements

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -5931,6 +5931,47 @@ describe('workers/repository/process/lookup/index', () => {
       );
     });
 
+    it('handles replacements - resolves registryAliases when looking up new digest', async () => {
+      config.packageName = 'path/to/old-image';
+      config.currentDigest = 'sha256:fedcba0987654321';
+      config.currentValue = '3.0.26';
+      config.datasource = DockerDatasource.id;
+      config.versioning = dockerVersioningId;
+      config.registryAliases = {
+        $CI_REGISTRY: 'registry.internal-gitlab.tld',
+      };
+      config.replacementName = '$CI_REGISTRY/path/to/my/image-name';
+      config.replacementVersion = '4.0.0';
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.0.26' }],
+      });
+      getDockerDigest.mockResolvedValueOnce('sha256:abcdef1234567890');
+      // Digest for the unrelated (non-replacement) digest-pin check on the current value; unchanged so it's filtered out of the result.
+      getDockerDigest.mockResolvedValueOnce('sha256:fedcba0987654321');
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          newDigest: 'sha256:abcdef1234567890',
+          newName: '$CI_REGISTRY/path/to/my/image-name',
+          newValue: '4.0.0',
+          newVersion: undefined,
+          updateType: 'replacement',
+        },
+      ]);
+
+      expect(getDockerDigest).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          packageName: 'registry.internal-gitlab.tld/path/to/my/image-name',
+        }),
+        '4.0.0',
+      );
+    });
+
     it('handles replacements - skips if package and replacement names match', async () => {
       config.packageName = 'openjdk';
       config.currentValue = undefined;

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -5972,6 +5972,48 @@ describe('workers/repository/process/lookup/index', () => {
       );
     });
 
+    it('handles replacements - does not resolve registryAliases for non-docker datasources', async () => {
+      config.packageName = 'old-org/old-repo';
+      config.currentValue = 'v1.0.0';
+      config.currentDigest = 'digestOld';
+      config.datasource = GithubTagsDatasource.id;
+      config.registryAliases = {
+        'old-org': 'new-org',
+      };
+      config.replacementName = 'old-org/new-repo';
+      config.replacementVersion = 'v2.0.0';
+      getGithubTags.mockResolvedValueOnce({
+        releases: [{ version: 'v1.0.0' }],
+      });
+      const getGithubTagsDigest = vi.spyOn(
+        GithubTagsDatasource.prototype,
+        'getDigest',
+      );
+      getGithubTagsDigest.mockResolvedValueOnce('digest1234');
+      // Digest for the unrelated (non-replacement) digest-pin check on the current value; unchanged so it's filtered out of the result.
+      getGithubTagsDigest.mockResolvedValueOnce('digestOld');
+
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(updates).toEqual([
+        {
+          newDigest: 'digest1234',
+          newName: 'old-org/new-repo',
+          newValue: 'v2.0.0',
+          newVersion: undefined,
+          updateType: 'replacement',
+        },
+      ]);
+
+      expect(getGithubTagsDigest).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ packageName: 'old-org/new-repo' }),
+        'v2.0.0',
+      );
+    });
+
     it('handles replacements - skips if package and replacement names match', async () => {
       config.packageName = 'openjdk';
       config.currentValue = undefined;

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -7,6 +7,7 @@ import {
   getDatasourceFor,
   getDefaultVersioning,
 } from '../../../../modules/datasource/common.ts';
+import { DockerDatasource } from '../../../../modules/datasource/docker/index.ts';
 import type {
   GetDigestInputConfig,
   Release,
@@ -870,13 +871,20 @@ export async function lookupUpdates(
           ) {
             delete getDigestConfig.lookupName;
             delete getDigestConfig.currentDigest;
+            getDigestConfig.replacementName = update.newName;
+
             // `update.newName` may itself start with a configured registryAlias (e.g. when set via
             // `replacementName`/`replacementNameTemplate`), so resolve it before using it for the digest
             // lookup. The unresolved alias form is still used everywhere else (e.g. the replaced string).
-            getDigestConfig.replacementName = resolveReplacementNameForAliases(
-              update.newName,
-              config.registryAliases,
-            );
+            // `registryAliases` is repo-level config and its prefix-matching semantics are specific to
+            // registry-prefixed package names, so only apply it for the docker datasource
+            if (config.datasource === DockerDatasource.id) {
+              getDigestConfig.replacementName =
+                resolveReplacementNameForAliases(
+                  update.newName,
+                  config.registryAliases,
+                );
+            }
           }
 
           // Don't use current releases if replacement changes name, otherwise we use the wrong new digest.

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -44,6 +44,7 @@ import type { LookupUpdateConfig, UpdateResult } from './types.ts';
 import {
   addReplacementUpdateIfValid,
   isReplacementRulesConfigured,
+  resolveReplacementNameForAliases,
 } from './utils.ts';
 
 async function getTimestamp(
@@ -869,7 +870,13 @@ export async function lookupUpdates(
           ) {
             delete getDigestConfig.lookupName;
             delete getDigestConfig.currentDigest;
-            getDigestConfig.replacementName = update.newName;
+            // `update.newName` may itself start with a configured registryAlias (e.g. when set via
+            // `replacementName`/`replacementNameTemplate`), so resolve it before using it for the digest
+            // lookup. The unresolved alias form is still used everywhere else (e.g. the replaced string).
+            getDigestConfig.replacementName = resolveReplacementNameForAliases(
+              update.newName,
+              config.registryAliases,
+            );
           }
 
           // Don't use current releases if replacement changes name, otherwise we use the wrong new digest.

--- a/lib/workers/repository/process/lookup/utils.spec.ts
+++ b/lib/workers/repository/process/lookup/utils.spec.ts
@@ -1,5 +1,8 @@
 import type { LookupUpdateConfig } from './types.ts';
-import { determineNewReplacementName } from './utils.ts';
+import {
+  determineNewReplacementName,
+  resolveReplacementNameForAliases,
+} from './utils.ts';
 
 const lookupConfig: LookupUpdateConfig = {
   datasource: 'npm',
@@ -31,6 +34,63 @@ describe('workers/repository/process/lookup/utils', () => {
 
     it('returns the package name if defined', () => {
       expect(determineNewReplacementName(lookupConfig)).toBe('b');
+    });
+  });
+
+  describe('resolveReplacementNameForAliases()', () => {
+    it('returns undefined unchanged', () => {
+      expect(
+        resolveReplacementNameForAliases(undefined, {
+          jfrogecosystem: 'some.jfrog.mirror',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('returns the replacement name unchanged when no registryAliases are configured', () => {
+      expect(
+        resolveReplacementNameForAliases('$CI_REGISTRY/foo/bar', undefined),
+      ).toBe('$CI_REGISTRY/foo/bar');
+    });
+
+    it('returns the replacement name unchanged when no alias matches', () => {
+      expect(
+        resolveReplacementNameForAliases('foo/bar', {
+          jfrogecosystem: 'some.jfrog.mirror',
+        }),
+      ).toBe('foo/bar');
+    });
+
+    it('resolves a matching prefix alias', () => {
+      expect(
+        resolveReplacementNameForAliases('$CI_REGISTRY/foo/bar', {
+          $CI_REGISTRY: 'registry.example.com',
+        }),
+      ).toBe('registry.example.com/foo/bar');
+    });
+
+    it('resolves an exact alias match with no trailing path', () => {
+      expect(
+        resolveReplacementNameForAliases('jfrogecosystem', {
+          jfrogecosystem: 'some.jfrog.mirror',
+        }),
+      ).toBe('some.jfrog.mirror');
+    });
+
+    it('does not partially match an alias that is a substring of another segment', () => {
+      expect(
+        resolveReplacementNameForAliases('jfrogecosystem2/foo', {
+          jfrogecosystem: 'some.jfrog.mirror',
+        }),
+      ).toBe('jfrogecosystem2/foo');
+    });
+
+    it('uses the first matching alias when multiple are configured', () => {
+      expect(
+        resolveReplacementNameForAliases('docker.io/library/redis', {
+          'docker.io': 'harbor.example.com/docker.io',
+          'docker.io/library': 'harbor.example.com/library-mirror',
+        }),
+      ).toBe('harbor.example.com/docker.io/library/redis');
     });
   });
 });

--- a/lib/workers/repository/process/lookup/utils.spec.ts
+++ b/lib/workers/repository/process/lookup/utils.spec.ts
@@ -68,12 +68,12 @@ describe('workers/repository/process/lookup/utils', () => {
       ).toBe('registry.example.com/foo/bar');
     });
 
-    it('resolves an exact alias match with no trailing path', () => {
+    it('does not resolve a bare alias with no trailing path', () => {
       expect(
         resolveReplacementNameForAliases('jfrogecosystem', {
           jfrogecosystem: 'some.jfrog.mirror',
         }),
-      ).toBe('some.jfrog.mirror');
+      ).toBe('jfrogecosystem');
     });
 
     it('does not partially match an alias that is a substring of another segment', () => {

--- a/lib/workers/repository/process/lookup/utils.ts
+++ b/lib/workers/repository/process/lookup/utils.ts
@@ -6,6 +6,21 @@ import * as allVersioning from '../../../../modules/versioning/index.ts';
 import * as template from '../../../../util/template/index.ts';
 import type { LookupUpdateConfig } from './types.ts';
 
+export function resolveReplacementNameForAliases(
+  replacementName: string | undefined,
+  registryAliases: Record<string, string> | undefined,
+): string | undefined {
+  if (!replacementName) {
+    return replacementName;
+  }
+  for (const [alias, value] of Object.entries(registryAliases ?? {})) {
+    if (replacementName === alias || replacementName.startsWith(`${alias}/`)) {
+      return value + replacementName.slice(alias.length);
+    }
+  }
+  return replacementName;
+}
+
 export function addReplacementUpdateIfValid(
   updates: LookupUpdate[],
   config: LookupUpdateConfig,

--- a/lib/workers/repository/process/lookup/utils.ts
+++ b/lib/workers/repository/process/lookup/utils.ts
@@ -14,7 +14,7 @@ export function resolveReplacementNameForAliases(
     return replacementName;
   }
   for (const [alias, value] of Object.entries(registryAliases ?? {})) {
-    if (replacementName === alias || replacementName.startsWith(`${alias}/`)) {
+    if (replacementName.startsWith(`${alias}/`)) {
       return value + replacementName.slice(alias.length);
     }
   }

--- a/lib/workers/repository/process/lookup/utils.ts
+++ b/lib/workers/repository/process/lookup/utils.ts
@@ -3,6 +3,7 @@ import { isNonEmptyString, isNullOrUndefined } from '@sindresorhus/is';
 import { getRangeStrategy } from '../../../../modules/manager/index.ts';
 import type { LookupUpdate } from '../../../../modules/manager/types.ts';
 import * as allVersioning from '../../../../modules/versioning/index.ts';
+import { coerceObject } from '../../../../util/object.ts';
 import * as template from '../../../../util/template/index.ts';
 import type { LookupUpdateConfig } from './types.ts';
 
@@ -13,7 +14,7 @@ export function resolveReplacementNameForAliases(
   if (!replacementName) {
     return replacementName;
   }
-  for (const [alias, value] of Object.entries(registryAliases ?? {})) {
+  for (const [alias, value] of Object.entries(coerceObject(registryAliases))) {
     if (replacementName.startsWith(`${alias}/`)) {
       return value + replacementName.slice(alias.length);
     }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Attempts to resolve replacement names against the registry aliases configured in a config.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Fixes this discussion, also ran into this issue: https://github.com/renovatebot/renovate/discussions/42878

Our replacements were failing with the following auth errors when we were trying to switch to using a pull through ECR cache which shouldn't be required as we had configured a registry alias to point back to the public ECR.

```
DEBUG: getDigest(https://111111111111.dkr.ecr.ap-southeast-2.amazonaws.com, public.ecr.aws/docker/library/node, 22-alpine)
DEBUG: getManifestResponse(https://111111111111.dkr.ecr.ap-southeast-2.amazonaws.com, public.ecr.aws/docker/library/node, 22-alpine, head)
DEBUG: Using queue: host=111111111111.dkr.ecr.ap-southeast-2.amazonaws.com, concurrency=16
DEBUG: Using queue: host=registry.npmjs.org, concurrency=999
DEBUG: hostRules: ecr auth for https://111111111111.dkr.ecr.ap-southeast-2.amazonaws.com
DEBUG: hostRules: testing direct auth for https://111111111111.dkr.ecr.ap-southeast-2.amazonaws.com
DEBUG: HEAD https://111111111111.dkr.ecr.ap-southeast-2.amazonaws.com/v2/public.ecr.aws/docker/library/node/manifests/22-alpine = (code=ERR_NON_2XX_3XX_RESPONSE, statusCode=403 retryCount=0, duration=257)
DEBUG: Unknown Error looking up docker manifest
```

```json
    "registryAliases": {
      "111111111111.dkr.ecr.ap-southeast-2.amazonaws.com/public.ecr.aws": "public.ecr.aws"
    }
```

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/samchungy/renovate-registry-aliases/pull/1

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
