### PR TITLE
fix(git): resolve child env before adding authentication

### DIFF
--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -1,7 +1,6 @@
 import { isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
 import { createSimpleGit } from '../../../util/git/index.ts';
 import { getRemoteUrlWithToken } from '../../../util/git/url.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
@@ -25,10 +24,9 @@ export abstract class GitDatasource extends Datasource {
   private async _getRawRefs({
     packageName,
   }: GetReleasesConfig): Promise<RawRefs[] | null> {
-    const gitSubmoduleAuthEnvironmentVariables = getGitEnvironmentVariables([
-      this.id,
-    ]);
-    const git = createSimpleGit({ env: gitSubmoduleAuthEnvironmentVariables });
+    const git = createSimpleGit({
+      authentication: { additionalHostTypes: [this.id] },
+    });
 
     // fetch remote tags
     const lsRemote = await git.listRemote([

--- a/lib/modules/datasource/git-refs/base.ts
+++ b/lib/modules/datasource/git-refs/base.ts
@@ -25,7 +25,7 @@ export abstract class GitDatasource extends Datasource {
     packageName,
   }: GetReleasesConfig): Promise<RawRefs[] | null> {
     const git = createSimpleGit({
-      authentication: { additionalHostTypes: [this.id] },
+      authentication: { hostTypes: [this.id] },
     });
 
     // fetch remote tags

--- a/lib/modules/datasource/git-refs/index.spec.ts
+++ b/lib/modules/datasource/git-refs/index.spec.ts
@@ -3,7 +3,6 @@ import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
 import * as git from '../../../util/git/index.ts';
-import { add, clear } from '../../../util/host-rules.ts';
 import { getPkgReleases } from '../index.ts';
 import { GitRefsDatasource } from './index.ts';
 
@@ -19,9 +18,6 @@ describe('modules/datasource/git-refs/index', () => {
   let gitMock: MockProxy<SimpleGit>;
 
   beforeEach(() => {
-    // clear host rules
-    clear();
-
     // clear environment variables
     process.env = {};
 
@@ -121,46 +117,8 @@ describe('modules/datasource/git-refs/index', () => {
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
     });
 
-    it('calls simpleGit with emptyEnv if no hostrules exist', async () => {
+    it('requests authentication for git-refs lookups', async () => {
       gitMock.listRemote.mockResolvedValue(lsRemote1);
-
-      const digest = await new GitRefsDatasource().getDigest(
-        { packageName: 'another tag to look up' },
-        undefined,
-      );
-      expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
-      expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        authentication: { additionalHostTypes: ['git-refs'] },
-      });
-    });
-
-    it('calls simpleGit with git envs if hostrules exist', async () => {
-      gitMock.listRemote.mockResolvedValue(lsRemote1);
-
-      add({
-        hostType: 'github',
-        matchHost: 'api.github.com',
-        token: 'token123',
-      });
-
-      const digest = await new GitRefsDatasource().getDigest(
-        { packageName: 'another tag to look up' },
-        undefined,
-      );
-      expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
-      expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        authentication: { additionalHostTypes: ['git-refs'] },
-      });
-    });
-
-    it('calls simpleGit with git envs if hostrules exist for datasource type git-refs', async () => {
-      gitMock.listRemote.mockResolvedValue(lsRemote1);
-
-      add({
-        hostType: 'git-refs',
-        matchHost: 'git.example.com',
-        token: 'token123',
-      });
 
       const digest = await new GitRefsDatasource().getDigest(
         { packageName: 'another tag to look up' },

--- a/lib/modules/datasource/git-refs/index.spec.ts
+++ b/lib/modules/datasource/git-refs/index.spec.ts
@@ -129,7 +129,9 @@ describe('modules/datasource/git-refs/index', () => {
         undefined,
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
-      expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({ env: {} });
+      expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
+        authentication: { additionalHostTypes: ['git-refs'] },
+      });
     });
 
     it('calls simpleGit with git envs if hostrules exist', async () => {
@@ -147,15 +149,7 @@ describe('modules/datasource/git-refs/index', () => {
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
       expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        env: {
-          GIT_CONFIG_COUNT: '3',
-          GIT_CONFIG_KEY_0: 'url.https://ssh:token123@github.com/.insteadOf',
-          GIT_CONFIG_KEY_1: 'url.https://git:token123@github.com/.insteadOf',
-          GIT_CONFIG_KEY_2: 'url.https://token123@github.com/.insteadOf',
-          GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
-          GIT_CONFIG_VALUE_1: 'git@github.com:',
-          GIT_CONFIG_VALUE_2: 'https://github.com/',
-        },
+        authentication: { additionalHostTypes: ['git-refs'] },
       });
     });
 
@@ -174,17 +168,7 @@ describe('modules/datasource/git-refs/index', () => {
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
       expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        env: {
-          GIT_CONFIG_COUNT: '3',
-          GIT_CONFIG_KEY_0:
-            'url.https://ssh:token123@git.example.com/.insteadOf',
-          GIT_CONFIG_KEY_1:
-            'url.https://git:token123@git.example.com/.insteadOf',
-          GIT_CONFIG_KEY_2: 'url.https://token123@git.example.com/.insteadOf',
-          GIT_CONFIG_VALUE_0: 'ssh://git@git.example.com/',
-          GIT_CONFIG_VALUE_1: 'git@git.example.com:',
-          GIT_CONFIG_VALUE_2: 'https://git.example.com/',
-        },
+        authentication: { additionalHostTypes: ['git-refs'] },
       });
     });
   });

--- a/lib/modules/datasource/git-refs/index.spec.ts
+++ b/lib/modules/datasource/git-refs/index.spec.ts
@@ -126,7 +126,7 @@ describe('modules/datasource/git-refs/index', () => {
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
       expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        authentication: { additionalHostTypes: ['git-refs'] },
+        authentication: { hostTypes: ['git-refs'] },
       });
     });
   });

--- a/lib/modules/datasource/git-tags/index.spec.ts
+++ b/lib/modules/datasource/git-tags/index.spec.ts
@@ -96,7 +96,7 @@ describe('modules/datasource/git-tags/index', () => {
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
       expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        authentication: { additionalHostTypes: ['git-tags'] },
+        authentication: { hostTypes: ['git-tags'] },
       });
     });
   });

--- a/lib/modules/datasource/git-tags/index.spec.ts
+++ b/lib/modules/datasource/git-tags/index.spec.ts
@@ -106,15 +106,7 @@ describe('modules/datasource/git-tags/index', () => {
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
       expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        env: {
-          GIT_CONFIG_COUNT: '3',
-          GIT_CONFIG_KEY_0: 'url.https://ssh:token123@github.com/.insteadOf',
-          GIT_CONFIG_KEY_1: 'url.https://git:token123@github.com/.insteadOf',
-          GIT_CONFIG_KEY_2: 'url.https://token123@github.com/.insteadOf',
-          GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
-          GIT_CONFIG_VALUE_1: 'git@github.com:',
-          GIT_CONFIG_VALUE_2: 'https://github.com/',
-        },
+        authentication: { additionalHostTypes: ['git-tags'] },
       });
     });
 
@@ -133,17 +125,7 @@ describe('modules/datasource/git-tags/index', () => {
       );
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
       expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        env: {
-          GIT_CONFIG_COUNT: '3',
-          GIT_CONFIG_KEY_0:
-            'url.https://ssh:token123@git.example.com/.insteadOf',
-          GIT_CONFIG_KEY_1:
-            'url.https://git:token123@git.example.com/.insteadOf',
-          GIT_CONFIG_KEY_2: 'url.https://token123@git.example.com/.insteadOf',
-          GIT_CONFIG_VALUE_0: 'ssh://git@git.example.com/',
-          GIT_CONFIG_VALUE_1: 'git@git.example.com:',
-          GIT_CONFIG_VALUE_2: 'https://git.example.com/',
-        },
+        authentication: { additionalHostTypes: ['git-tags'] },
       });
     });
   });

--- a/lib/modules/datasource/git-tags/index.spec.ts
+++ b/lib/modules/datasource/git-tags/index.spec.ts
@@ -3,7 +3,6 @@ import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
 import * as git from '../../../util/git/index.ts';
-import { add, clear } from '../../../util/host-rules.ts';
 import { getPkgReleases } from '../index.ts';
 import { GitTagsDatasource } from './index.ts';
 
@@ -20,9 +19,6 @@ describe('modules/datasource/git-tags/index', () => {
   let gitMock: MockProxy<SimpleGit>;
 
   beforeEach(() => {
-    // clear host rules
-    clear();
-
     // clear environment variables
     process.env = {};
 
@@ -91,33 +87,8 @@ describe('modules/datasource/git-tags/index', () => {
       expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
     });
 
-    it('returns digest for HEAD with authentication environment variables', async () => {
+    it('requests authentication for git-tags lookups', async () => {
       gitMock.listRemote.mockResolvedValue(lsRemote1);
-
-      add({
-        hostType: 'github',
-        matchHost: 'api.github.com',
-        token: 'token123',
-      });
-
-      const digest = await datasourceInstance.getDigest(
-        { packageName: 'another tag to look up' },
-        undefined,
-      );
-      expect(digest).toBe('a9920c014aebc28dc1b23e7efcc006d0455cc710');
-      expect(createSimpleGit).toHaveBeenCalledExactlyOnceWith({
-        authentication: { additionalHostTypes: ['git-tags'] },
-      });
-    });
-
-    it('returns digest for HEAD with authentication environment variables for datasource type git-tags', async () => {
-      gitMock.listRemote.mockResolvedValue(lsRemote1);
-
-      add({
-        hostType: 'git-tags',
-        matchHost: 'git.example.com',
-        token: 'token123',
-      });
 
       const digest = await datasourceInstance.getDigest(
         { packageName: 'another tag to look up' },

--- a/lib/modules/manager/cargo/artifacts.ts
+++ b/lib/modules/manager/cargo/artifacts.ts
@@ -2,14 +2,13 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
-import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   findLocalSiblingOrParent,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import { regEx } from '../../../util/regex.ts';
 import { CrateDatasource } from '../../datasource/crate/index.ts';
 import type {
@@ -18,6 +17,8 @@ import type {
   Upgrade,
 } from '../types.ts';
 import { extractLockFileContentVersions } from './locked-version.ts';
+
+const gitExec = withGitEnvironment(['cargo']);
 
 async function cargoUpdate(
   manifestPath: string,
@@ -34,11 +35,10 @@ async function cargoUpdate(
   }
 
   const execOptions: ExecOptions = {
-    extraEnv: { ...getGitEnvironmentVariables(['cargo']) },
     docker: {},
     toolConstraints: [{ toolName: 'rust', constraint }],
   };
-  await exec(cmd, execOptions);
+  await gitExec(cmd, execOptions);
 }
 
 async function cargoUpdatePrecise(
@@ -72,12 +72,11 @@ async function cargoUpdatePrecise(
   );
 
   const execOptions: ExecOptions = {
-    extraEnv: { ...getGitEnvironmentVariables(['cargo']) },
     docker: {},
     toolConstraints: [{ toolName: 'rust', constraint }],
   };
 
-  await exec(cmds, execOptions);
+  await gitExec(cmds, execOptions);
 }
 
 export async function updateArtifacts(

--- a/lib/modules/manager/conan/artifacts.ts
+++ b/lib/modules/manager/conan/artifacts.ts
@@ -1,15 +1,16 @@
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   findLocalSiblingOrParent,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+
+const gitExec = withGitEnvironment(['conan']);
 
 async function conanLockUpdate(
   conanFilePath: string,
@@ -20,7 +21,6 @@ async function conanLockUpdate(
   const command = `conan lock create ${quote(conanFilePath)}${isLockFileMaintenance ? ' --lockfile=""' : ''}`;
 
   const execOptions: ExecOptions = {
-    extraEnv: { ...getGitEnvironmentVariables(['conan']) },
     toolConstraints: [
       {
         toolName: 'python',
@@ -34,7 +34,7 @@ async function conanLockUpdate(
     docker: {},
   };
 
-  await exec(command, execOptions);
+  await gitExec(command, execOptions);
 }
 
 export async function updateArtifacts(

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -2,10 +2,9 @@ import { quote } from 'shlex';
 import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
-import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import type {
   UpdateArtifact,
@@ -18,6 +17,7 @@ import {
 } from './utils.ts';
 
 const DEFAULT_COMMAND_OPTIONS = ['--skip-answered', '--defaults'];
+const gitExec = withGitEnvironment(['git-tags']);
 
 function buildCommand(
   config: UpdateArtifactsConfig,
@@ -73,11 +73,9 @@ export async function updateArtifacts({
   }
 
   const command = buildCommand(config, packageFileName, newValue);
-  const gitEnv = getGitEnvironmentVariables(['git-tags']);
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
     docker: {},
-    extraEnv: gitEnv,
     toolConstraints: [
       {
         toolName: 'python',
@@ -90,7 +88,7 @@ export async function updateArtifacts({
     ],
   };
   try {
-    await exec(command, execOptions);
+    await gitExec(command, execOptions);
   } catch (err) {
     logger.debug({ err }, `Failed to update copier template: ${err.message}`);
     return artifactError(packageFileName, err.message);

--- a/lib/modules/manager/git-submodules/update.spec.ts
+++ b/lib/modules/manager/git-submodules/update.spec.ts
@@ -11,7 +11,6 @@ import type {
   RepoGlobalConfig,
 } from '../../../config/types.ts';
 import * as git from '../../../util/git/index.ts';
-import * as hostRules from '../../../util/host-rules.ts';
 import type { Upgrade } from '../types.ts';
 import { updateDependency } from './index.ts';
 
@@ -24,8 +23,6 @@ const baseDir = `${import.meta.dirname}/__fixtures__`;
 describe('modules/manager/git-submodules/update', () => {
   beforeEach(() => {
     GlobalConfig.set({ localDir: baseDir });
-    // clear host rules
-    hostRules.clear();
     // clear environment variables
     process.env = {};
 
@@ -145,31 +142,6 @@ describe('modules/manager/git-submodules/update', () => {
       });
       expect(update).toBe('');
       expect(gitMock.subModule).toHaveBeenCalledTimes(0);
-    });
-
-    it('requests authentication for git-tags and git-refs', async () => {
-      gitMock.submoduleUpdate.mockResolvedValue('');
-      gitMock.checkout.mockResolvedValue('');
-
-      const update = await updateDependency({
-        fileContent: '',
-        packageFile: '.gitmodules',
-        upgrade,
-      });
-      expect(update).toBe('');
-      expect(createSimpleGit).toHaveBeenCalledTimes(2);
-      expect(createSimpleGit).toHaveBeenNthCalledWith(1, {
-        config: { baseDir },
-        authentication: {
-          additionalHostTypes: ['git-tags', 'git-refs'],
-        },
-      });
-      expect(createSimpleGit).toHaveBeenNthCalledWith(2, {
-        config: { baseDir: upath.join(baseDir, 'renovate') },
-        authentication: {
-          additionalHostTypes: ['git-tags', 'git-refs'],
-        },
-      });
     });
   });
 });

--- a/lib/modules/manager/git-submodules/update.spec.ts
+++ b/lib/modules/manager/git-submodules/update.spec.ts
@@ -84,13 +84,13 @@ describe('modules/manager/git-submodules/update', () => {
       expect(createSimpleGit).toHaveBeenNthCalledWith(1, {
         config: { baseDir },
         authentication: {
-          additionalHostTypes: ['git-tags', 'git-refs'],
+          hostTypes: ['git-tags', 'git-refs'],
         },
       });
       expect(createSimpleGit).toHaveBeenNthCalledWith(2, {
         config: { baseDir: upath.join(baseDir, 'renovate') },
         authentication: {
-          additionalHostTypes: ['git-tags', 'git-refs'],
+          hostTypes: ['git-tags', 'git-refs'],
         },
       });
     });

--- a/lib/modules/manager/git-submodules/update.spec.ts
+++ b/lib/modules/manager/git-submodules/update.spec.ts
@@ -73,14 +73,9 @@ describe('modules/manager/git-submodules/update', () => {
       expect(update).toBe('');
     });
 
-    it('returns content on update and uses git environment variables', async () => {
+    it('requests Git authentication for submodule commands', async () => {
       gitMock.submoduleUpdate.mockResolvedValue('');
       gitMock.checkout.mockResolvedValue('');
-      hostRules.add({
-        hostType: 'github',
-        matchHost: 'github.com',
-        token: 'abc123',
-      });
 
       const update = await updateDependency({
         fileContent: '',
@@ -88,23 +83,18 @@ describe('modules/manager/git-submodules/update', () => {
         upgrade,
       });
       expect(update).toBe('');
-      const variables = {
-        GIT_CONFIG_COUNT: '3',
-        GIT_CONFIG_KEY_0: 'url.https://ssh:abc123@github.com/.insteadOf',
-        GIT_CONFIG_KEY_1: 'url.https://git:abc123@github.com/.insteadOf',
-        GIT_CONFIG_KEY_2: 'url.https://abc123@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
-        GIT_CONFIG_VALUE_1: 'git@github.com:',
-        GIT_CONFIG_VALUE_2: 'https://github.com/',
-      };
       expect(createSimpleGit).toHaveBeenCalledTimes(2);
       expect(createSimpleGit).toHaveBeenNthCalledWith(1, {
         config: { baseDir },
-        env: variables,
+        authentication: {
+          additionalHostTypes: ['git-tags', 'git-refs'],
+        },
       });
       expect(createSimpleGit).toHaveBeenNthCalledWith(2, {
         config: { baseDir: upath.join(baseDir, 'renovate') },
-        env: variables,
+        authentication: {
+          additionalHostTypes: ['git-tags', 'git-refs'],
+        },
       });
     });
 
@@ -157,21 +147,9 @@ describe('modules/manager/git-submodules/update', () => {
       expect(gitMock.subModule).toHaveBeenCalledTimes(0);
     });
 
-    it('returns content on update and uses git environment variables for git-tags/git-refs', async () => {
+    it('requests authentication for git-tags and git-refs', async () => {
       gitMock.submoduleUpdate.mockResolvedValue('');
       gitMock.checkout.mockResolvedValue('');
-      hostRules.add({
-        hostType: 'git-refs',
-        matchHost: 'gitrefs.com',
-        username: 'git-refs-user',
-        password: 'git-refs-password',
-      });
-      hostRules.add({
-        hostType: 'git-tags',
-        matchHost: 'gittags.com',
-        username: 'git-tags-user',
-        password: 'git-tags-password',
-      });
 
       const update = await updateDependency({
         fileContent: '',
@@ -179,35 +157,18 @@ describe('modules/manager/git-submodules/update', () => {
         upgrade,
       });
       expect(update).toBe('');
-      const variables = {
-        GIT_CONFIG_COUNT: '6',
-        GIT_CONFIG_KEY_0:
-          'url.https://git-refs-user:git-refs-password@gitrefs.com/.insteadOf',
-        GIT_CONFIG_KEY_1:
-          'url.https://git-refs-user:git-refs-password@gitrefs.com/.insteadOf',
-        GIT_CONFIG_KEY_2:
-          'url.https://git-refs-user:git-refs-password@gitrefs.com/.insteadOf',
-        GIT_CONFIG_KEY_3:
-          'url.https://git-tags-user:git-tags-password@gittags.com/.insteadOf',
-        GIT_CONFIG_KEY_4:
-          'url.https://git-tags-user:git-tags-password@gittags.com/.insteadOf',
-        GIT_CONFIG_KEY_5:
-          'url.https://git-tags-user:git-tags-password@gittags.com/.insteadOf',
-        GIT_CONFIG_VALUE_0: 'ssh://git@gitrefs.com/',
-        GIT_CONFIG_VALUE_1: 'git@gitrefs.com:',
-        GIT_CONFIG_VALUE_2: 'https://gitrefs.com/',
-        GIT_CONFIG_VALUE_3: 'ssh://git@gittags.com/',
-        GIT_CONFIG_VALUE_4: 'git@gittags.com:',
-        GIT_CONFIG_VALUE_5: 'https://gittags.com/',
-      };
       expect(createSimpleGit).toHaveBeenCalledTimes(2);
       expect(createSimpleGit).toHaveBeenNthCalledWith(1, {
         config: { baseDir },
-        env: variables,
+        authentication: {
+          additionalHostTypes: ['git-tags', 'git-refs'],
+        },
       });
       expect(createSimpleGit).toHaveBeenNthCalledWith(2, {
         config: { baseDir: upath.join(baseDir, 'renovate') },
-        env: variables,
+        authentication: {
+          additionalHostTypes: ['git-tags', 'git-refs'],
+        },
       });
     });
   });

--- a/lib/modules/manager/git-submodules/update.ts
+++ b/lib/modules/manager/git-submodules/update.ts
@@ -12,7 +12,7 @@ export default async function updateDependency({
   // TODO: types (#22198)
   const localDir = GlobalConfig.get('localDir');
   const authentication = {
-    additionalHostTypes: ['git-tags', 'git-refs'],
+    hostTypes: ['git-tags', 'git-refs'],
   };
 
   const git = createSimpleGit({

--- a/lib/modules/manager/git-submodules/update.ts
+++ b/lib/modules/manager/git-submodules/update.ts
@@ -2,7 +2,6 @@ import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
 import { createSimpleGit } from '../../../util/git/index.ts';
 import type { UpdateDependencyConfig } from '../types.ts';
 
@@ -12,19 +11,18 @@ export default async function updateDependency({
 }: UpdateDependencyConfig): Promise<string | null> {
   // TODO: types (#22198)
   const localDir = GlobalConfig.get('localDir');
-  const gitSubmoduleAuthEnvironmentVariables = getGitEnvironmentVariables([
-    'git-tags',
-    'git-refs',
-  ]);
+  const authentication = {
+    additionalHostTypes: ['git-tags', 'git-refs'],
+  };
 
   const git = createSimpleGit({
     config: { baseDir: localDir },
-    env: gitSubmoduleAuthEnvironmentVariables,
+    authentication,
   });
   const submoduleGit = createSimpleGit({
     // TODO: types (#22198)
     config: { baseDir: upath.join(localDir, upgrade.depName!) },
-    env: gitSubmoduleAuthEnvironmentVariables,
+    authentication,
   });
 
   try {

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -7,7 +7,6 @@ import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getEnv } from '../../../util/env.ts';
-import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import { filterMap } from '../../../util/filter-map.ts';
 import {
@@ -17,7 +16,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { isValid } from '../../versioning/semver/index.ts';
@@ -30,6 +29,7 @@ import type {
 import { getExtraDepsNotice } from './artifacts-extra.ts';
 
 const { major, valid } = semver;
+const gitExec = withGitEnvironment(['go']);
 
 function getUpdateImportPathCmds(
   updatedDeps: PackageDependency[],
@@ -213,7 +213,6 @@ export async function updateArtifacts({
         /* v8 ignore next -- TODO: add test */
         GOFLAGS: useModcacherw(goConstraints) ? '-modcacherw' : null,
         CGO_ENABLED: GlobalConfig.get('binarySource') === 'docker' ? '0' : null,
-        ...getGitEnvironmentVariables(['go']),
       },
       docker: {},
       toolConstraints: [
@@ -349,7 +348,7 @@ export async function updateArtifacts({
       }
     }
 
-    await exec(execCommands, execOptions);
+    await gitExec(execCommands, execOptions);
 
     const status = await getRepoStatus();
     if (

--- a/lib/modules/manager/hermit/artifacts.spec.ts
+++ b/lib/modules/manager/hermit/artifacts.spec.ts
@@ -318,20 +318,34 @@ describe('modules/manager/hermit/artifacts', () => {
       ]);
     });
 
-    it('should fail if uninstallation fails', async () => {
-      lstatsMock.mockResolvedValue(true);
-
-      readlinkMock.mockResolvedValue(null);
-      GlobalConfig.set({ localDir: '', binarySource: 'global' });
-
-      mockExecAll(
-        new ExecError('', {
+    it.each([
+      {
+        name: 'returns an update error when uninstallation execution fails',
+        error: new ExecError('', {
           stdout: '',
           stderr: 'error executing hermit uninstall',
           cmd: '',
           options: {},
         }),
-      );
+        artifactError: {
+          fileName: 'from: openjdk-17.0.3, to: openjdk',
+          stderr: 'error executing hermit uninstall',
+        },
+      },
+      {
+        name: 'returns a generic error when uninstallation setup fails',
+        error: new Error('unexpected environment preparation failure'),
+        artifactError: {
+          stderr: 'unexpected environment preparation failure',
+        },
+      },
+    ])('$name', async ({ error, artifactError }) => {
+      lstatsMock.mockResolvedValue(true);
+
+      readlinkMock.mockResolvedValue(null);
+      GlobalConfig.set({ localDir: '', binarySource: 'global' });
+
+      mockExecAll(error);
 
       getRepoStatusMock.mockResolvedValue(
         partial<StatusResult>({
@@ -360,10 +374,7 @@ describe('modules/manager/hermit/artifacts', () => {
 
       expect(res).toEqual([
         {
-          artifactError: {
-            fileName: 'from: openjdk-17.0.3, to: openjdk',
-            stderr: 'error executing hermit uninstall',
-          },
+          artifactError,
         },
       ]);
     });

--- a/lib/modules/manager/hermit/artifacts.spec.ts
+++ b/lib/modules/manager/hermit/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import { mockExecAll } from '~test/exec-util.ts';
+import { exec, mockExecAll } from '~test/exec-util.ts';
 import { hostRules, partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { ExecError } from '../../../util/exec/exec-error.ts';
@@ -6,7 +6,6 @@ import {
   localPathIsSymbolicLink,
   readLocalSymlink,
 } from '../../../util/fs/index.ts';
-import * as gitAuth from '../../../util/git/auth.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import type { StatusResult } from '../../../util/git/types.ts';
 import type { UpdateArtifact } from '../types.ts';
@@ -625,11 +624,7 @@ describe('modules/manager/hermit/artifacts', () => {
     });
 
     it('returns generic error when a non-UpdateHermitError propagates from updateHermitPackage', async () => {
-      vi.spyOn(gitAuth, 'getGitEnvironmentVariables').mockImplementationOnce(
-        () => {
-          throw new Error('unexpected auth failure');
-        },
-      );
+      mockExecAll(new Error('unexpected execution failure'));
 
       const res = await updateArtifacts(
         partial<UpdateArtifact>({
@@ -647,19 +642,17 @@ describe('modules/manager/hermit/artifacts', () => {
       expect(res).toStrictEqual([
         {
           artifactError: {
-            stderr: 'unexpected auth failure',
+            stderr: 'unexpected execution failure',
           },
         },
       ]);
     });
 
     it('stringifies non-Error thrown values in the generic fallback', async () => {
-      vi.spyOn(gitAuth, 'getGitEnvironmentVariables').mockImplementationOnce(
-        () => {
-          // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately testing non-Error throw path
-          throw 'raw string failure';
-        },
-      );
+      exec.mockImplementationOnce(() => {
+        // eslint-disable-next-line @typescript-eslint/only-throw-error -- deliberately testing non-Error throw path
+        throw 'raw string failure';
+      });
 
       const res = await updateArtifacts(
         partial<UpdateArtifact>({

--- a/lib/modules/manager/hermit/artifacts.ts
+++ b/lib/modules/manager/hermit/artifacts.ts
@@ -1,17 +1,19 @@
 import { quote } from 'shlex';
 import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
-import { exec } from '../../../util/exec/index.ts';
+import { ExecError } from '../../../util/exec/exec-error.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   localPathIsSymbolicLink,
   readLocalSymlink,
 } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import * as p from '../../../util/promises.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import type { ReadContentResult } from './types.ts';
+
+const gitExec = withGitEnvironment(['hermit']);
 
 /**
  * updateArtifacts runs hermit install for each updated dependencies
@@ -228,7 +230,6 @@ async function updateHermitPackage(update: UpdateArtifact): Promise<void> {
   const execOptions: ExecOptions = {
     docker: {},
     cwdFile: update.packageFileName,
-    extraEnv: getGitEnvironmentVariables(['hermit']),
   };
 
   const fromPackages = from.map(quote).join(' ');
@@ -239,13 +240,16 @@ async function updateHermitPackage(update: UpdateArtifact): Promise<void> {
     const uninstallCommands = `./hermit uninstall ${packagesToUninstall}`;
 
     try {
-      const result = await exec(uninstallCommands, execOptions);
+      const result = await gitExec(uninstallCommands, execOptions);
       logger.trace(
         { stdout: result.stdout },
         `hermit uninstall command stdout`,
       );
     } catch (e) {
       logger.warn({ err: e }, `error uninstall hermit package for replacement`);
+      if (!(e instanceof ExecError)) {
+        throw e;
+      }
       throw new UpdateHermitError(
         fromPackages,
         packagesToUninstall,
@@ -267,10 +271,13 @@ async function updateHermitPackage(update: UpdateArtifact): Promise<void> {
   );
 
   try {
-    const result = await exec(execCommands, execOptions);
+    const result = await gitExec(execCommands, execOptions);
     logger.trace({ stdout: result.stdout }, `hermit command stdout`);
   } catch (e) {
     logger.warn({ err: e }, `error updating hermit package`);
+    if (!(e instanceof ExecError)) {
+      throw e;
+    }
     throw new UpdateHermitError(
       fromPackages,
       packagesToInstall,

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -1,7 +1,6 @@
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
-import { exec } from '../../../../util/exec/index.ts';
 import type {
   ExecOptions,
   ToolConstraint,
@@ -10,7 +9,7 @@ import {
   getSiblingFileName,
   readLocalFile,
 } from '../../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../../util/git/exec.ts';
 import { Result } from '../../../../util/result.ts';
 import { PypiDatasource } from '../../../datasource/pypi/index.ts';
 import type {
@@ -25,6 +24,7 @@ import { depTypes } from '../utils.ts';
 import { BasePyProjectProcessor } from './abstract.ts';
 
 const pdmUpdateCMD = 'pdm update --no-sync --update-eager';
+const gitExec = withGitEnvironment(['pep621']);
 
 export class PdmProcessor extends BasePyProjectProcessor {
   override lockfileName = 'pdm.lock';
@@ -108,12 +108,8 @@ export class PdmProcessor extends BasePyProjectProcessor {
         constraint: config.constraints?.pdm,
       };
 
-      const extraEnv = {
-        ...getGitEnvironmentVariables(['pep621']),
-      };
       const execOptions: ExecOptions = {
         cwdFile: packageFileName,
-        extraEnv,
         docker: {},
         toolConstraints: [pythonConstraint, pdmConstraint],
       };
@@ -126,7 +122,7 @@ export class PdmProcessor extends BasePyProjectProcessor {
       } else {
         cmds.push(...generateCMDs(updatedDeps));
       }
-      await exec(cmds, execOptions);
+      await gitExec(cmds, execOptions);
 
       // check for changes
       const fileChanges: UpdateArtifactsResult[] = [];

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -3,7 +3,6 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
 import type { HostRule } from '../../../../types/index.ts';
-import { exec } from '../../../../util/exec/index.ts';
 import type {
   ExecOptions,
   ToolConstraint,
@@ -12,7 +11,7 @@ import {
   findLocalSiblingOrParent,
   readLocalFile,
 } from '../../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../../util/git/exec.ts';
 import { find } from '../../../../util/host-rules.ts';
 import { Result } from '../../../../util/result.ts';
 import { parseUrl } from '../../../../util/url.ts';
@@ -31,6 +30,7 @@ import { depTypes } from '../utils.ts';
 import { BasePyProjectProcessor } from './abstract.ts';
 
 const uvUpdateCMD = 'uv lock';
+const gitExec = withGitEnvironment(['pep621']);
 
 export class UvProcessor extends BasePyProjectProcessor {
   override lockfileName = 'uv.lock';
@@ -196,7 +196,6 @@ export class UvProcessor extends BasePyProjectProcessor {
       };
 
       const extraEnv = {
-        ...getGitEnvironmentVariables(['pep621']),
         ...(await getUvExtraIndexUrl(project, updateArtifact.updatedDeps)),
         ...(await getUvIndexCredentials(project)),
       };
@@ -215,7 +214,7 @@ export class UvProcessor extends BasePyProjectProcessor {
       } else {
         cmd = generateCMD(updatedDeps);
       }
-      await exec(cmd, execOptions);
+      await gitExec(cmd, execOptions);
 
       // check for changes
       const fileChanges: UpdateArtifactsResult[] = [];

--- a/lib/modules/manager/poetry/artifacts.spec.ts
+++ b/lib/modules/manager/poetry/artifacts.spec.ts
@@ -511,6 +511,7 @@ describe('modules/manager/poetry/artifacts', () => {
             'docker run --rm --name=renovate_sidecar --label=renovate_child ' +
             '-v "/tmp/github/some/repo":"/tmp/github/some/repo" ' +
             '-v "/tmp/cache":"/tmp/cache" ' +
+            '-e PIP_CACHE_DIR ' +
             '-e GIT_CONFIG_KEY_0 ' +
             '-e GIT_CONFIG_VALUE_0 ' +
             '-e GIT_CONFIG_KEY_1 ' +
@@ -524,7 +525,6 @@ describe('modules/manager/poetry/artifacts', () => {
             '-e GIT_CONFIG_VALUE_4 ' +
             '-e GIT_CONFIG_KEY_5 ' +
             '-e GIT_CONFIG_VALUE_5 ' +
-            '-e PIP_CACHE_DIR ' +
             '-e CONTAINERBASE_CACHE_DIR ' +
             '-w "/tmp/github/some/repo" ' +
             'ghcr.io/renovatebot/base-image ' +

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -3,7 +3,6 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { HostRule } from '../../../types/index.ts';
-import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   deleteLocalFile,
@@ -12,7 +11,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import { find } from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
 import { Result } from '../../../util/result.ts';
@@ -26,6 +25,8 @@ import { getGoogleAuthHostRule } from '../../datasource/util.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
 import { Lockfile, PoetryPyProject } from './schema.ts';
 import type { PoetryFile, PoetrySource } from './types.ts';
+
+const gitExec = withGitEnvironment(['poetry']);
 
 export function getPythonConstraint(
   pyProjectContent: string,
@@ -220,7 +221,6 @@ export async function updateArtifacts({
         newPackageFileContent,
         packageFileName,
       )),
-      ...getGitEnvironmentVariables(['poetry']),
       PIP_CACHE_DIR: await ensureCacheDir('pip'),
     };
 
@@ -233,7 +233,7 @@ export async function updateArtifacts({
         { toolName: 'poetry', constraint: poetryConstraint },
       ],
     };
-    await exec(cmd, execOptions);
+    await gitExec(cmd, execOptions);
     const newPoetryLockContent = await readLocalFile(lockFileName, 'utf8');
     if (existingLockFileContent === newPoetryLockContent) {
       logger.debug(`${lockFileName} is unchanged`);

--- a/lib/modules/manager/vendir/artifacts.ts
+++ b/lib/modules/manager/vendir/artifacts.ts
@@ -1,6 +1,5 @@
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   getParentDir,
@@ -8,9 +7,11 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../util/git/exec.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+
+const gitExec = withGitEnvironment();
 
 export async function updateArtifacts({
   packageFileName,
@@ -34,7 +35,6 @@ export async function updateArtifacts({
     await writeLocalFile(packageFileName, newPackageFileContent);
     logger.debug('Updating Vendir artifacts');
     const execOptions: ExecOptions = {
-      extraEnv: { ...getGitEnvironmentVariables([]) },
       cwdFile: packageFileName,
       docker: {},
       toolConstraints: [
@@ -43,7 +43,7 @@ export async function updateArtifacts({
       ],
     };
 
-    await exec(`vendir sync`, execOptions);
+    await gitExec(`vendir sync`, execOptions);
 
     logger.debug('Returning updated Vendir artifacts');
 

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -270,6 +270,41 @@ describe('util/exec/index', () => {
     ],
 
     [
+      'Explicit Docker env vars',
+      {
+        processEnv,
+        inCmd,
+        inOpts: {
+          docker: { envVars: ['FORCED_ENV_VAR'] },
+          env: { FORCED_ENV_VAR: 'forced' },
+          cwd,
+        },
+        outCmd: [
+          dockerPullCmd,
+          dockerRemoveCmd,
+          `docker run --rm --name=${name} --label=renovate_child ${defaultVolumes} -e FORCED_ENV_VAR -e CONTAINERBASE_CACHE_DIR ${defaultCwd} ${fullImage} bash -l -c '${inCmd}'`,
+        ],
+        outOpts: [
+          dockerPullOpts,
+          dockerRemoveOpts,
+          {
+            cwd,
+            env: {
+              ...containerbaseEnv,
+              FORCED_ENV_VAR: 'forced',
+            },
+            timeout: 900000,
+            maxBuffer: 10485760,
+            stdin: 'pipe',
+            stdout: 'pipe',
+            stderr: 'pipe',
+          },
+        ],
+        adminConfig: { binarySource: 'docker' },
+      },
+    ],
+
+    [
       'Extra env vars',
       {
         processEnv,

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -4,6 +4,7 @@ import { GlobalConfig } from '../../config/global.ts';
 import type { RepoToolSettingsOptions } from '../../config/types.ts';
 import { TEMPORARY_ERROR } from '../../constants/error-messages.ts';
 import { logger } from '../../logger/index.ts';
+import { coerceArray } from '../array.ts';
 import { getCustomEnv, getUserEnv } from '../env.ts';
 import { coerceObject } from '../object.ts';
 import { rawExec } from './common.ts';
@@ -104,7 +105,7 @@ async function prepareRawExec(
     const childEnv = getChildEnv(opts);
     const envVars = [
       ...dockerEnvVars(extraEnv, childEnv),
-      ...(docker.envVars ?? []),
+      ...coerceArray(docker.envVars),
       'CONTAINERBASE_CACHE_DIR',
     ];
     const cwd = getCwd(opts);

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -104,6 +104,7 @@ async function prepareRawExec(
     const childEnv = getChildEnv(opts);
     const envVars = [
       ...dockerEnvVars(extraEnv, childEnv),
+      ...(docker.envVars ?? []),
       'CONTAINERBASE_CACHE_DIR',
     ];
     const cwd = getCwd(opts);

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -8,10 +8,12 @@ import { getCustomEnv, getUserEnv } from '../env.ts';
 import { getChildProcessEnv } from './env.ts';
 import type { CommandWithOptions, ExecOptions } from './types.ts';
 
+export type ResolvedChildEnv = Record<string, string>;
+
 export function getChildEnv({
   extraEnv,
   env: forcedEnv = {},
-}: Pick<ExecOptions, 'env' | 'extraEnv'> = {}): Record<string, string> {
+}: Pick<ExecOptions, 'env' | 'extraEnv'> = {}): ResolvedChildEnv {
   const globalConfigEnv = getCustomEnv();
   const userConfiguredEnv = getUserEnv();
 

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -12,7 +12,7 @@ describe('util/git/auth', () => {
   describe('getGitAuthenticatedEnvironmentVariables()', () => {
     it('returns url with token', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/', {
           token: 'token1234',
           hostType: 'github',
           matchHost: 'github.com',
@@ -30,7 +30,7 @@ describe('util/git/auth', () => {
 
     it('returns url with username and password', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://example.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://example.com/', {
           username: 'username',
           password: 'password',
           hostType: 'github',
@@ -52,7 +52,7 @@ describe('util/git/auth', () => {
 
     it('prefers token over username and password', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/', {
           username: 'username',
           password: 'password',
           token: 'token1234',
@@ -72,7 +72,7 @@ describe('util/git/auth', () => {
 
     it('returns url with token for different protocols', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('foobar://github.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'foobar://github.com/', {
           token: 'token1234',
           hostType: 'github',
           matchHost: 'github.com',
@@ -90,7 +90,7 @@ describe('util/git/auth', () => {
 
     it('returns correct url if token already contains GitHub App username', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/', {
           token: 'x-access-token:token1234',
           hostType: 'github',
           matchHost: 'github.com',
@@ -112,13 +112,13 @@ describe('util/git/auth', () => {
     it('returns url with token and already existing GIT_CONFIG_COUNT from parameter', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
+          { GIT_CONFIG_COUNT: '1' },
           'https://github.com/',
           {
             token: 'token1234',
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { GIT_CONFIG_COUNT: '1' },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
@@ -135,13 +135,13 @@ describe('util/git/auth', () => {
       process.env.GIT_CONFIG_COUNT = '54';
       expect(
         getGitAuthenticatedEnvironmentVariables(
+          { GIT_CONFIG_COUNT: '1' },
           'https://github.com/',
           {
             token: 'token1234',
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { GIT_CONFIG_COUNT: '1' },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '4',
@@ -154,35 +154,35 @@ describe('util/git/auth', () => {
       });
     });
 
-    it('returns url with token and already existing GIT_CONFIG_COUNT from environment', () => {
+    it('does not inherit GIT_CONFIG_COUNT from the process environment', () => {
       process.env.GIT_CONFIG_COUNT = '1';
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/', {
           token: 'token1234',
           hostType: 'github',
           matchHost: 'github.com',
         }),
       ).toStrictEqual({
-        GIT_CONFIG_COUNT: '4',
-        GIT_CONFIG_KEY_1: 'url.https://ssh:token1234@github.com/.insteadOf',
-        GIT_CONFIG_KEY_2: 'url.https://git:token1234@github.com/.insteadOf',
-        GIT_CONFIG_KEY_3: 'url.https://token1234@github.com/.insteadOf',
-        GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
-        GIT_CONFIG_VALUE_2: 'git@github.com:',
-        GIT_CONFIG_VALUE_3: 'https://github.com/',
+        GIT_CONFIG_COUNT: '3',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token1234@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token1234@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
+        GIT_CONFIG_VALUE_1: 'git@github.com:',
+        GIT_CONFIG_VALUE_2: 'https://github.com/',
       });
     });
 
     it('returns url with token and passthrough existing variables', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
+          { RANDOM_VARIABLE: 'random' },
           'https://github.com/',
           {
             token: 'token1234',
             hostType: 'github',
             matchHost: 'github.com',
           },
-          { RANDOM_VARIABLE: 'random' },
         ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
@@ -196,14 +196,17 @@ describe('util/git/auth', () => {
       });
     });
 
-    it('return url with token with invalid GIT_CONFIG_COUNT from environment', () => {
-      process.env.GIT_CONFIG_COUNT = 'notvalid';
+    it('ignores an invalid supplied GIT_CONFIG_COUNT', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/', {
-          token: 'token1234',
-          hostType: 'github',
-          matchHost: 'github.com',
-        }),
+        getGitAuthenticatedEnvironmentVariables(
+          { GIT_CONFIG_COUNT: 'notvalid' },
+          'https://github.com/',
+          {
+            token: 'token1234',
+            hostType: 'github',
+            matchHost: 'github.com',
+          },
+        ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0: 'url.https://ssh:token1234@github.com/.insteadOf',
@@ -217,7 +220,7 @@ describe('util/git/auth', () => {
 
     it('returns url with token containing username for GitLab token', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://gitlab.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://gitlab.com/', {
           token: 'token1234',
           hostType: 'gitlab',
           matchHost: 'github.com',
@@ -238,7 +241,7 @@ describe('util/git/auth', () => {
 
     it('returns url with token containing username for GitLab token without hostType', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://gitlab.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://gitlab.com/', {
           token: 'token1234',
           matchHost: 'gitlab.com',
         }),
@@ -259,12 +262,12 @@ describe('util/git/auth', () => {
     it('returns original environment variables when no token is set', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
+          { env: 'value' },
           'https://gitlab.com/',
           {
             hostType: 'gitlab',
             matchHost: 'gitlab.com',
           },
-          { env: 'value' },
         ),
       ).toStrictEqual({
         env: 'value',
@@ -273,7 +276,7 @@ describe('util/git/auth', () => {
 
     it('returns url with token for http hosts', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('http://github.com/', {
+        getGitAuthenticatedEnvironmentVariables({}, 'http://github.com/', {
           token: 'token1234',
           hostType: 'github',
           matchHost: 'github.com',
@@ -291,7 +294,7 @@ describe('util/git/auth', () => {
 
     it('returns url with token for orgs', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/org', {
+        getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/org', {
           token: 'token1234',
           hostType: 'github',
           matchHost: 'github.com',
@@ -309,11 +312,15 @@ describe('util/git/auth', () => {
 
     it('returns url with token for orgs and projects', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://github.com/org/repo', {
-          token: 'token1234',
-          hostType: 'github',
-          matchHost: 'github.com',
-        }),
+        getGitAuthenticatedEnvironmentVariables(
+          {},
+          'https://github.com/org/repo',
+          {
+            token: 'token1234',
+            hostType: 'github',
+            matchHost: 'github.com',
+          },
+        ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
@@ -330,6 +337,7 @@ describe('util/git/auth', () => {
     it('returns url with token for orgs and projects and ports', () => {
       expect(
         getGitAuthenticatedEnvironmentVariables(
+          {},
           'https://github.com:89/org/repo.git',
           {
             token: 'token1234',
@@ -353,11 +361,15 @@ describe('util/git/auth', () => {
 
     it('returns url with token for bitbucket-server', () => {
       expect(
-        getGitAuthenticatedEnvironmentVariables('https://git.mycompany.com/', {
-          token: 'token1234',
-          hostType: 'bitbucket-server',
-          matchHost: 'git.mycompany.com',
-        }),
+        getGitAuthenticatedEnvironmentVariables(
+          {},
+          'https://git.mycompany.com/',
+          {
+            token: 'token1234',
+            hostType: 'bitbucket-server',
+            matchHost: 'git.mycompany.com',
+          },
+        ),
       ).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
@@ -379,7 +391,7 @@ describe('util/git/auth', () => {
     });
 
     it('returns empty object if no environment variables exist', () => {
-      expect(getGitEnvironmentVariables()).toStrictEqual({});
+      expect(getGitEnvironmentVariables({})).toStrictEqual({});
     });
 
     it('returns environment variables with token if hostRule for api.github.com exists', () => {
@@ -388,7 +400,7 @@ describe('util/git/auth', () => {
         matchHost: 'api.github.com',
         token: 'token123',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({
+      expect(getGitEnvironmentVariables({})).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0: 'url.https://ssh:token123@github.com/.insteadOf',
         GIT_CONFIG_KEY_1: 'url.https://git:token123@github.com/.insteadOf',
@@ -396,6 +408,31 @@ describe('util/git/auth', () => {
         GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
         GIT_CONFIG_VALUE_1: 'git@github.com:',
         GIT_CONFIG_VALUE_2: 'https://github.com/',
+      });
+    });
+
+    it('appends authentication to the supplied environment', () => {
+      add({
+        hostType: 'github',
+        matchHost: 'api.github.com',
+        token: 'token123',
+      });
+      expect(
+        getGitEnvironmentVariables({
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'existing-key',
+          GIT_CONFIG_VALUE_0: 'existing-value',
+        }),
+      ).toStrictEqual({
+        GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'existing-key',
+        GIT_CONFIG_KEY_1: 'url.https://ssh:token123@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://git:token123@github.com/.insteadOf',
+        GIT_CONFIG_KEY_3: 'url.https://token123@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'existing-value',
+        GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
+        GIT_CONFIG_VALUE_2: 'git@github.com:',
+        GIT_CONFIG_VALUE_3: 'https://github.com/',
       });
     });
 
@@ -415,7 +452,7 @@ describe('util/git/auth', () => {
         matchHost: 'https://github.example.com',
         token: 'token345',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({
+      expect(getGitEnvironmentVariables({})).toStrictEqual({
         GIT_CONFIG_COUNT: '9',
         GIT_CONFIG_KEY_0: 'url.https://ssh:token123@github.com/.insteadOf',
         GIT_CONFIG_KEY_1: 'url.https://git:token123@github.com/.insteadOf',
@@ -449,7 +486,7 @@ describe('util/git/auth', () => {
         matchHost: 'https://gitlab.example.com',
         token: 'token123',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({
+      expect(getGitEnvironmentVariables({})).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
           'url.https://gitlab-ci-token:token123@gitlab.example.com/.insteadOf',
@@ -470,7 +507,7 @@ describe('util/git/auth', () => {
         username: 'user1234',
         password: 'pass1234',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({
+      expect(getGitEnvironmentVariables({})).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
           'url.https://user1234:pass1234@gitlab.example.com/.insteadOf',
@@ -491,7 +528,7 @@ describe('util/git/auth', () => {
         username: 'user @ :$ abc',
         password: 'abc @ blub pass0:',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({
+      expect(getGitEnvironmentVariables({})).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
           'url.https://user%20%40%20%3A%24%20abc:abc%20%40%20blub%20pass0%3A@gitlab.example.com/.insteadOf',
@@ -511,7 +548,7 @@ describe('util/git/auth', () => {
         matchHost: 'https://custom.example.com',
         token: 'token123',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({});
+      expect(getGitEnvironmentVariables({})).toStrictEqual({});
     });
 
     it('returns no environment variables when only username is set', () => {
@@ -520,7 +557,7 @@ describe('util/git/auth', () => {
         matchHost: 'https://custom.example.com',
         username: 'user123',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({});
+      expect(getGitEnvironmentVariables({})).toStrictEqual({});
     });
 
     it('returns no environment variables when only password is set', () => {
@@ -529,7 +566,7 @@ describe('util/git/auth', () => {
         matchHost: 'https://custom.example.com',
         password: 'pass123',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({});
+      expect(getGitEnvironmentVariables({})).toStrictEqual({});
     });
 
     it('returns environment variables when hostType is explicitly set', () => {
@@ -538,7 +575,7 @@ describe('util/git/auth', () => {
         matchHost: 'https://custom.example.com',
         token: 'token123',
       });
-      expect(getGitEnvironmentVariables(['custom'])).toStrictEqual({
+      expect(getGitEnvironmentVariables({}, ['custom'])).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
           'url.https://ssh:token123@custom.example.com/.insteadOf',
@@ -557,7 +594,7 @@ describe('util/git/auth', () => {
         matchHost: 'invalid://*.github.example.com',
         token: 'token123',
       });
-      expect(getGitEnvironmentVariables(['custom'])).toStrictEqual({});
+      expect(getGitEnvironmentVariables({}, ['custom'])).toStrictEqual({});
     });
 
     it('returns environment variables for bitbucket-server', () => {
@@ -566,7 +603,7 @@ describe('util/git/auth', () => {
         matchHost: 'git.mycompany.com',
         token: 'token123',
       });
-      expect(getGitEnvironmentVariables()).toStrictEqual({
+      expect(getGitEnvironmentVariables({})).toStrictEqual({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0:
           'url.https://ssh:token123@git.mycompany.com/scm/.insteadOf',

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -168,7 +168,7 @@ export function getAuthenticationRules(
 
 export function getGitEnvironmentVariables(
   environmentVariables: Readonly<ResolvedChildEnv>,
-  additionalHostTypes: readonly string[] = [],
+  hostTypes: readonly string[] = [],
 ): ResolvedChildEnv {
   let gitEnvironmentVariables: ResolvedChildEnv = { ...environmentVariables };
 
@@ -186,11 +186,10 @@ export function getGitEnvironmentVariables(
     );
   }
 
-  // construct the Set of allowed hostTypes consisting of the standard Git provides
-  // plus additionalHostTypes, which are provided as parameter
+  // Manager-scoped rules are opt-in so unrelated credentials are not exposed to Git.
   const gitAllowedHostTypes = new Set<string>([
     ...PLATFORM_HOST_TYPES,
-    ...additionalHostTypes,
+    ...hostTypes,
   ]);
 
   // filter rules without `matchHost` and `token` or username and password and github api github rules

--- a/lib/util/git/auth.ts
+++ b/lib/util/git/auth.ts
@@ -3,7 +3,7 @@ import { PLATFORM_HOST_TYPES } from '../../constants/platforms.ts';
 import { logger } from '../../logger/index.ts';
 import type { HostRule } from '../../types/index.ts';
 import { detectPlatform } from '../common.ts';
-import { getEnv } from '../env.ts';
+import type { ResolvedChildEnv } from '../exec/utils.ts';
 import { find, getAll } from '../host-rules.ts';
 import { regEx } from '../regex.ts';
 import { createURLFromHostOrURL, isHttpUrl } from '../url.ts';
@@ -18,14 +18,14 @@ const githubApiUrls = new Set([
 ]);
 
 /**
- * Add authorization to a Git Url and returns a new environment variables object
- * @returns a new NodeJS.ProcessEnv object without modifying any input parameters
+ * Append Git authentication configuration to a resolved child environment.
+ * @returns a new environment without modifying the input
  */
 export function getGitAuthenticatedEnvironmentVariables(
+  environmentVariables: Readonly<ResolvedChildEnv>,
   originalGitUrl: string,
   { token, username, password, hostType, matchHost }: HostRule,
-  environmentVariables?: NodeJS.ProcessEnv,
-): NodeJS.ProcessEnv {
+): ResolvedChildEnv {
   if (!token && !(username && password)) {
     logger.warn(
       { host: matchHost },
@@ -34,10 +34,7 @@ export function getGitAuthenticatedEnvironmentVariables(
     return { ...environmentVariables };
   }
 
-  const env = getEnv();
-  // check if the environmentVariables already contain a GIT_CONFIG_COUNT or if the process has one
-  const gitConfigCountEnvVariable =
-    environmentVariables?.GIT_CONFIG_COUNT ?? env.GIT_CONFIG_COUNT;
+  const gitConfigCountEnvVariable = environmentVariables.GIT_CONFIG_COUNT;
   let gitConfigCount = 0;
   if (gitConfigCountEnvVariable) {
     // passthrough the gitConfigCountEnvVariable environment variable as start value of the index count
@@ -45,7 +42,7 @@ export function getGitAuthenticatedEnvironmentVariables(
     if (Number.isNaN(gitConfigCount)) {
       logger.warn(
         {
-          GIT_CONFIG_COUNT: env.GIT_CONFIG_COUNT,
+          GIT_CONFIG_COUNT: gitConfigCountEnvVariable,
         },
         `Found GIT_CONFIG_COUNT env variable, but couldn't parse the value to an integer. Ignoring it.`,
       );
@@ -170,9 +167,10 @@ export function getAuthenticationRules(
 }
 
 export function getGitEnvironmentVariables(
-  additionalHostTypes: string[] = [],
-): NodeJS.ProcessEnv {
-  let environmentVariables: NodeJS.ProcessEnv = {};
+  environmentVariables: Readonly<ResolvedChildEnv>,
+  additionalHostTypes: readonly string[] = [],
+): ResolvedChildEnv {
+  let gitEnvironmentVariables: ResolvedChildEnv = { ...environmentVariables };
 
   // hard-coded logic to use authentication for github.com based on the githubToken for api.github.com
   const gitHubHostRule = find({
@@ -181,7 +179,8 @@ export function getGitEnvironmentVariables(
   });
 
   if (gitHubHostRule?.token) {
-    environmentVariables = getGitAuthenticatedEnvironmentVariables(
+    gitEnvironmentVariables = getGitAuthenticatedEnvironmentVariables(
+      gitEnvironmentVariables,
       'https://github.com/',
       gitHubHostRule,
     );
@@ -203,32 +202,31 @@ export function getGitEnvironmentVariables(
   // for each hostRule with hostType we add additional authentication variables to the environmentVariables
   for (const hostRule of hostRules) {
     if (!hostRule.hostType || gitAllowedHostTypes.has(hostRule.hostType)) {
-      environmentVariables = addAuthFromHostRule(
+      gitEnvironmentVariables = addAuthFromHostRule(
         hostRule,
-        environmentVariables,
+        gitEnvironmentVariables,
       );
     }
   }
-  return environmentVariables;
+  return gitEnvironmentVariables;
 }
 
 function addAuthFromHostRule(
   hostRule: HostRule,
-  env: NodeJS.ProcessEnv,
-): NodeJS.ProcessEnv {
-  let environmentVariables = env;
+  environmentVariables: Readonly<ResolvedChildEnv>,
+): ResolvedChildEnv {
   const httpUrl = createURLFromHostOrURL(hostRule.matchHost!)?.toString();
   if (isHttpUrl(httpUrl)) {
     logger.trace(`Adding Git authentication for ${httpUrl} using token auth.`);
-    environmentVariables = getGitAuthenticatedEnvironmentVariables(
+    return getGitAuthenticatedEnvironmentVariables(
+      environmentVariables,
       httpUrl!,
       hostRule,
-      environmentVariables,
-    );
-  } else {
-    logger.debug(
-      `Could not parse registryUrl ${hostRule.matchHost!} or not using http(s). Ignoring`,
     );
   }
-  return environmentVariables;
+
+  logger.debug(
+    `Could not parse registryUrl ${hostRule.matchHost!} or not using http(s). Ignoring`,
+  );
+  return { ...environmentVariables };
 }

--- a/lib/util/git/exec.spec.ts
+++ b/lib/util/git/exec.spec.ts
@@ -1,0 +1,124 @@
+import { GlobalConfig } from '../../config/global.ts';
+import { setCustomEnv, setUserEnv } from '../env.ts';
+import { exec as _exec } from '../exec/index.ts';
+import { add, clear } from '../host-rules.ts';
+import { withGitEnvironment } from './exec.ts';
+
+vi.mock('../exec/index.ts');
+
+const exec = vi.mocked(_exec);
+
+describe('util/git/exec', () => {
+  beforeEach(() => {
+    GlobalConfig.reset();
+    setCustomEnv({});
+    setUserEnv({});
+    clear();
+  });
+
+  afterEach(() => {
+    delete process.env.GIT_CONFIG_COUNT;
+    delete process.env.GIT_CONFIG_KEY_0;
+    delete process.env.GIT_CONFIG_VALUE_0;
+  });
+
+  it('appends authentication to approved runtime Git configuration', async () => {
+    exec.mockResolvedValue({ stdout: '', stderr: '' });
+    const gitExec = withGitEnvironment();
+    setCustomEnv({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+    });
+    add({
+      hostType: 'github',
+      matchHost: 'api.github.com',
+      token: 'token123',
+    });
+
+    await gitExec('command', {
+      extraEnv: { EXTRA_VARIABLE: 'extra' },
+      env: { FORCED_VARIABLE: 'forced' },
+      docker: {
+        envVars: ['EXISTING_DOCKER_VARIABLE', 'GIT_CONFIG_COUNT'],
+      },
+    });
+
+    expect(exec).toHaveBeenCalledExactlyOnceWith('command', {
+      extraEnv: { EXTRA_VARIABLE: 'extra' },
+      env: {
+        FORCED_VARIABLE: 'forced',
+        GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'existing-key',
+        GIT_CONFIG_KEY_1: 'url.https://ssh:token123@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://git:token123@github.com/.insteadOf',
+        GIT_CONFIG_KEY_3: 'url.https://token123@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'existing-value',
+        GIT_CONFIG_VALUE_1: 'ssh://git@github.com/',
+        GIT_CONFIG_VALUE_2: 'git@github.com:',
+        GIT_CONFIG_VALUE_3: 'https://github.com/',
+      },
+      docker: {
+        envVars: [
+          'EXISTING_DOCKER_VARIABLE',
+          'GIT_CONFIG_COUNT',
+          'GIT_CONFIG_KEY_0',
+          'GIT_CONFIG_VALUE_0',
+          'GIT_CONFIG_KEY_1',
+          'GIT_CONFIG_VALUE_1',
+          'GIT_CONFIG_KEY_2',
+          'GIT_CONFIG_VALUE_2',
+          'GIT_CONFIG_KEY_3',
+          'GIT_CONFIG_VALUE_3',
+        ],
+      },
+    });
+  });
+
+  it('does not import unapproved runtime Git configuration', async () => {
+    exec.mockResolvedValue({ stdout: '', stderr: '' });
+    const gitExec = withGitEnvironment();
+    process.env.GIT_CONFIG_COUNT = '1';
+    process.env.GIT_CONFIG_KEY_0 = 'process-key';
+    process.env.GIT_CONFIG_VALUE_0 = 'process-value';
+    add({
+      hostType: 'github',
+      matchHost: 'api.github.com',
+      token: 'token123',
+    });
+
+    await gitExec('command');
+
+    expect(exec).toHaveBeenCalledExactlyOnceWith('command', {
+      env: {
+        GIT_CONFIG_COUNT: '3',
+        GIT_CONFIG_KEY_0: 'url.https://ssh:token123@github.com/.insteadOf',
+        GIT_CONFIG_KEY_1: 'url.https://git:token123@github.com/.insteadOf',
+        GIT_CONFIG_KEY_2: 'url.https://token123@github.com/.insteadOf',
+        GIT_CONFIG_VALUE_0: 'ssh://git@github.com/',
+        GIT_CONFIG_VALUE_1: 'git@github.com:',
+        GIT_CONFIG_VALUE_2: 'https://github.com/',
+      },
+    });
+  });
+
+  it('forces approved runtime Git configuration without authentication', async () => {
+    exec.mockResolvedValue({ stdout: '', stderr: '' });
+    const gitExec = withGitEnvironment();
+    setCustomEnv({
+      GIT_CONFIG_COUNT: '1',
+      GIT_CONFIG_KEY_0: 'existing-key',
+      GIT_CONFIG_VALUE_0: 'existing-value',
+    });
+
+    await gitExec('command');
+
+    expect(exec).toHaveBeenCalledExactlyOnceWith('command', {
+      env: {
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'existing-key',
+        GIT_CONFIG_VALUE_0: 'existing-value',
+      },
+    });
+  });
+});

--- a/lib/util/git/exec.ts
+++ b/lib/util/git/exec.ts
@@ -1,4 +1,4 @@
-import { deduplicateArray } from '../array.ts';
+import { coerceArray, deduplicateArray } from '../array.ts';
 import { exec } from '../exec/index.ts';
 import type { ExecOptions } from '../exec/types.ts';
 import { getChildEnv } from '../exec/utils.ts';
@@ -39,7 +39,7 @@ function getGitExecOptions(
       docker: {
         ...execOptions.docker,
         envVars: deduplicateArray([
-          ...(execOptions.docker.envVars ?? []),
+          ...coerceArray(execOptions.docker.envVars),
           ...gitConfigKeys,
         ]),
       },

--- a/lib/util/git/exec.ts
+++ b/lib/util/git/exec.ts
@@ -1,0 +1,57 @@
+import { deduplicateArray } from '../array.ts';
+import { exec } from '../exec/index.ts';
+import type { ExecOptions } from '../exec/types.ts';
+import { getChildEnv } from '../exec/utils.ts';
+import { regEx } from '../regex.ts';
+import { getGitEnvironmentVariables } from './auth.ts';
+
+const gitConfigEnvironmentVariableRegex = regEx(
+  /^GIT_CONFIG_(?:COUNT|KEY_\d+|VALUE_\d+)$/,
+);
+
+function getGitExecOptions(
+  execOptions: ExecOptions,
+  additionalHostTypes: readonly string[],
+): ExecOptions {
+  const childEnv = getChildEnv(execOptions);
+  const environmentVariables = getGitEnvironmentVariables(
+    childEnv,
+    additionalHostTypes,
+  );
+  const gitConfigEnv: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(environmentVariables)) {
+    if (gitConfigEnvironmentVariableRegex.test(key)) {
+      gitConfigEnv[key] = value;
+    }
+  }
+
+  const gitConfigKeys = Object.keys(gitConfigEnv);
+  if (!gitConfigKeys.length) {
+    return { ...execOptions };
+  }
+
+  return {
+    ...execOptions,
+    env: {
+      ...execOptions.env,
+      ...gitConfigEnv,
+    },
+    ...(execOptions.docker && {
+      docker: {
+        ...execOptions.docker,
+        envVars: deduplicateArray([
+          ...(execOptions.docker.envVars ?? []),
+          ...gitConfigKeys,
+        ]),
+      },
+    }),
+  };
+}
+
+export function withGitEnvironment(
+  additionalHostTypes: readonly string[] = [],
+): typeof exec {
+  return (command, execOptions) =>
+    exec(command, getGitExecOptions(execOptions ?? {}, additionalHostTypes));
+}

--- a/lib/util/git/exec.ts
+++ b/lib/util/git/exec.ts
@@ -11,13 +11,10 @@ const gitConfigEnvironmentVariableRegex = regEx(
 
 function getGitExecOptions(
   execOptions: ExecOptions,
-  additionalHostTypes: readonly string[],
+  hostTypes: readonly string[],
 ): ExecOptions {
   const childEnv = getChildEnv(execOptions);
-  const environmentVariables = getGitEnvironmentVariables(
-    childEnv,
-    additionalHostTypes,
-  );
+  const environmentVariables = getGitEnvironmentVariables(childEnv, hostTypes);
   const gitConfigEnv: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(environmentVariables)) {
@@ -50,8 +47,8 @@ function getGitExecOptions(
 }
 
 export function withGitEnvironment(
-  additionalHostTypes: readonly string[] = [],
+  hostTypes: readonly string[] = [],
 ): typeof exec {
   return (command, execOptions) =>
-    exec(command, getGitExecOptions(execOptions ?? {}, additionalHostTypes));
+    exec(command, getGitExecOptions(execOptions ?? {}, hostTypes));
 }

--- a/lib/util/git/exec.ts
+++ b/lib/util/git/exec.ts
@@ -2,6 +2,7 @@ import { deduplicateArray } from '../array.ts';
 import { exec } from '../exec/index.ts';
 import type { ExecOptions } from '../exec/types.ts';
 import { getChildEnv } from '../exec/utils.ts';
+import { coerceObject } from '../object.ts';
 import { regEx } from '../regex.ts';
 import { getGitEnvironmentVariables } from './auth.ts';
 
@@ -50,5 +51,5 @@ export function withGitEnvironment(
   hostTypes: readonly string[] = [],
 ): typeof exec {
   return (command, execOptions) =>
-    exec(command, getGitExecOptions(execOptions ?? {}, hostTypes));
+    exec(command, getGitExecOptions(coerceObject(execOptions), hostTypes));
 }

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -204,6 +204,37 @@ describe('util/git/index', { timeout: 30000 }, () => {
     await base?.cleanup();
   });
 
+  describe('createSimpleGit()', () => {
+    it('adds authentication to the approved child environment', () => {
+      setCustomEnv({
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'existing-key',
+        GIT_CONFIG_VALUE_0: 'existing-value',
+      });
+      const authenticatedEnv = {
+        GIT_CONFIG_COUNT: '4',
+        GIT_CONFIG_KEY_0: 'existing-key',
+        GIT_CONFIG_VALUE_0: 'existing-value',
+      };
+      auth.getGitEnvironmentVariables.mockReturnValue(authenticatedEnv);
+      const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
+
+      git.createSimpleGit({
+        authentication: { additionalHostTypes: ['git-refs'] },
+      });
+
+      expect(auth.getGitEnvironmentVariables).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          GIT_CONFIG_COUNT: '1',
+          GIT_CONFIG_KEY_0: 'existing-key',
+          GIT_CONFIG_VALUE_0: 'existing-value',
+        }),
+        ['git-refs'],
+      );
+      expect(envSpy).toHaveBeenCalledWith(authenticatedEnv);
+    });
+  });
+
   describe('gitRetry', () => {
     it('returns result if git returns successfully', async () => {
       const gitFunc = vi.fn().mockImplementation((args) => {

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -220,7 +220,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
 
       git.createSimpleGit({
-        authentication: { additionalHostTypes: ['git-refs'] },
+        authentication: { hostTypes: ['git-refs'] },
       });
 
       expect(auth.getGitEnvironmentVariables).toHaveBeenCalledExactlyOnceWith(

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -95,35 +95,43 @@ const delayFactor = 2;
 
 export const RENOVATE_FORK_UPSTREAM = 'renovate-fork-upstream';
 
+interface CreateSimpleGitOptions {
+  config?: Partial<SimpleGitOptions>;
+  env?: ExtraEnv;
+  authentication?: {
+    additionalHostTypes?: readonly string[];
+  };
+}
+
 export function createSimpleGit({
   config,
   env,
-}: {
-  config?: Partial<SimpleGitOptions>;
-  env?: ExtraEnv;
-} = {}): SimpleGit {
-  return simpleGit({ ...simpleGitConfig(), ...config }).env(
-    getChildEnv({
-      extraEnv: {
-        // Git will prompt for known hosts or passwords, unless we activate BatchMode.
-        // Set as extraEnv (lowest priority) so that process.env and
-        // customEnvVariables can override it.
-        GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
-      },
-      env: {
-        ...env,
-        // To ensure the simple-git parsers match correctly, we need
-        // to set the `LANG` and `LC_ALL` environment variables to
-        // the `C.UTF-8` locale. See the docs for more details:
-        // https://github.com/steveukx/git-js/blob/1bb14df0595794a9353d28ccdaeeb06c0b9bf2a5/docs/NON_ENGLISH_LOCALE.md
-        //
-        // Use "C.UTF-8" instead of just "C" (as specified in docs) to handle special characters:
-        // https://github.com/renovatebot/renovate/pull/18963
-        LANG: 'C.UTF-8',
-        LC_ALL: 'C.UTF-8',
-      },
-    }),
-  );
+  authentication,
+}: CreateSimpleGitOptions = {}): SimpleGit {
+  const childEnv = getChildEnv({
+    extraEnv: {
+      // Git will prompt for known hosts or passwords, unless we activate BatchMode.
+      // Set as extraEnv (lowest priority) so that process.env and
+      // customEnvVariables can override it.
+      GIT_SSH_COMMAND: 'ssh -o BatchMode=yes',
+    },
+    env: {
+      ...env,
+      // To ensure the simple-git parsers match correctly, we need
+      // to set the `LANG` and `LC_ALL` environment variables to
+      // the `C.UTF-8` locale. See the docs for more details:
+      // https://github.com/steveukx/git-js/blob/1bb14df0595794a9353d28ccdaeeb06c0b9bf2a5/docs/NON_ENGLISH_LOCALE.md
+      //
+      // Use "C.UTF-8" instead of just "C" (as specified in docs) to handle special characters:
+      // https://github.com/renovatebot/renovate/pull/18963
+      LANG: 'C.UTF-8',
+      LC_ALL: 'C.UTF-8',
+    },
+  });
+  const gitEnv = authentication
+    ? getGitEnvironmentVariables(childEnv, authentication.additionalHostTypes)
+    : childEnv;
+  return simpleGit({ ...simpleGitConfig(), ...config }).env(gitEnv);
 }
 
 // A generic wrapper for simpleGit.* calls to make them more fault-tolerant
@@ -433,7 +441,7 @@ export async function cloneSubmodules(
     return;
   }
   submodulesInitizialized = true;
-  const gitEnv = getChildEnv({ env: getGitEnvironmentVariables() });
+  const gitEnv = getGitEnvironmentVariables(getChildEnv());
   await syncGit();
   const submodules = await getSubmodules();
   for (const submodule of submodules) {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -99,7 +99,7 @@ interface CreateSimpleGitOptions {
   config?: Partial<SimpleGitOptions>;
   env?: ExtraEnv;
   authentication?: {
-    additionalHostTypes?: readonly string[];
+    hostTypes?: readonly string[];
   };
 }
 
@@ -129,7 +129,7 @@ export function createSimpleGit({
     },
   });
   const gitEnv = authentication
-    ? getGitEnvironmentVariables(childEnv, authentication.additionalHostTypes)
+    ? getGitEnvironmentVariables(childEnv, authentication.hostTypes)
     : childEnv;
   return simpleGit({ ...simpleGitConfig(), ...config }).env(gitEnv);
 }

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -29,6 +29,9 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
 
     beforeEach(async () => {
       GlobalConfig.reset();
+      gitAuth.getGitEnvironmentVariables.mockImplementation((env) => ({
+        ...env,
+      }));
 
       tmpDir = await dir({ unsafeCleanup: true });
     });
@@ -1053,7 +1056,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
         'some-command',
         expect.objectContaining({
           cwd: localDir,
-          extraEnv: gitEnvVars,
+          env: gitEnvVars,
         }),
       );
       expect(res.artifactErrors).toHaveLength(0);

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -8,7 +8,6 @@ import { mergeChildConfig } from '../../../../config/index.ts';
 import { addMeta, logger } from '../../../../logger/index.ts';
 import type { ArtifactError } from '../../../../modules/manager/types.ts';
 import { coerceArray } from '../../../../util/array.ts';
-import { exec } from '../../../../util/exec/index.ts';
 import {
   type ExecOptions,
   isConstraintName,
@@ -23,7 +22,7 @@ import {
   statLocalFile,
   writeLocalFile,
 } from '../../../../util/fs/index.ts';
-import { getGitEnvironmentVariables } from '../../../../util/git/auth.ts';
+import { withGitEnvironment } from '../../../../util/git/exec.ts';
 import {
   getRepoStatus,
   isFileModeEnabled,
@@ -41,6 +40,7 @@ export interface PostUpgradeCommandsExecutionResult {
 }
 
 const ownerExecutePermission = 0o100;
+const gitExec = withGitEnvironment();
 
 async function detectExecutable(
   relativePath: string,
@@ -167,7 +167,6 @@ export async function postUpgradeCommandsExecutor(
               ),
 
               cwd: workingDir,
-              extraEnv: getGitEnvironmentVariables(),
             };
             if (dataFilePath) {
               execOpts.env = {
@@ -200,7 +199,7 @@ export async function postUpgradeCommandsExecutor(
                 });
               }
             }
-            const execResult = await exec(compiledCmd, execOpts);
+            const execResult = await gitExec(compiledCmd, execOpts);
 
             logger.debug(
               { cmd: compiledCmd, ...execResult },

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -2494,7 +2494,6 @@ describe('workers/repository/update/branch/index', () => {
         'echo semver',
         expect.objectContaining({
           cwd: '/localDir',
-          extraEnv: {},
         }),
       );
     });
@@ -2626,7 +2625,6 @@ describe('workers/repository/update/branch/index', () => {
         'echo some-dep-name-1',
         expect.objectContaining({
           cwd: '/localDir',
-          extraEnv: {},
         }),
       );
       expect(exec.exec).toHaveBeenNthCalledWith(
@@ -2634,7 +2632,6 @@ describe('workers/repository/update/branch/index', () => {
         'echo some-dep-name-2',
         expect.objectContaining({
           cwd: '/localDir',
-          extraEnv: {},
         }),
       );
       expect(exec.exec).toHaveBeenCalledTimes(2);
@@ -2783,7 +2780,6 @@ describe('workers/repository/update/branch/index', () => {
         'echo hardcoded-string',
         expect.objectContaining({
           cwd: '/localDir',
-          extraEnv: {},
         }),
       );
       expect(exec.exec).toHaveBeenCalledTimes(1);
@@ -2992,7 +2988,6 @@ describe('workers/repository/update/branch/index', () => {
           'echo hardcoded-string',
           expect.objectContaining({
             cwd: '/localDir',
-            extraEnv: {},
           }),
         );
         expect(exec.exec).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## Changes

Git authentication now starts with the environment from `getChildEnv()`. The authentication helpers no longer read `process.env`. They append authentication entries to the environment that the caller supplies.

Renovate passes `GIT_CONFIG_COUNT` and all matching `GIT_CONFIG_KEY_<n>` and `GIT_CONFIG_VALUE_<n>` entries as one forced set. A later environment layer cannot replace the count without also replacing its indexed entries.

`createSimpleGit()` resolves the child environment before it adds authentication. Generic commands use the same order through a shared Git execution wrapper.

For Docker commands, the wrapper adds only the required Git variable names to `docker.envVars`. Their values remain in the forced environment. Renovate does not expose unrelated forced variables to the container.

The authentication helpers now require a `ResolvedChildEnv` as their first argument. `createSimpleGit()` uses an explicit authentication option. This PR migrates all current production callers.

Users do not need to change their configuration. Existing Git configuration from `customEnvVariables`, repository `env`, or forced values continues to work.

This PR is a prerequisite for #45165. It moves the current caller behavior into this change so that #45165 can rebase as a behavior-preserving helper extraction.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40580
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Codex with GPT-5.6 Sol helped write and review the code, tests, and PR description under human direction.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @zharinov will read and reply directly.
- [ ] An agent will draft replies and @zharinov will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The [public reproduction](https://github.com/renovate-testing/git-runtime-env-reproduction) runs the current `main` revision and this PR revision in both global and Docker execution modes. In the [successful matrix run](https://github.com/renovate-testing/git-runtime-env-reproduction/actions/runs/31350109850), current `main` loses the Cargo Git dependency authentication after child-environment composition. This PR preserves the authentication and updates `Cargo.lock` in both execution modes. Git submodule authentication succeeds in all four cells.
