### PR TITLE
fix(github-actions): support ratchet comments for nested actions

### DIFF
--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -558,6 +558,27 @@ describe('modules/manager/github-actions/extract', () => {
       });
     });
 
+    it('extracts ratchet pinned action in subdirectory', async () => {
+      const res = await extractPackageFile(
+        `
+        jobs:
+          build:
+            steps:
+              - uses: actions/cache/restore@b7e8d49f17405cc70c1c120101943203c98d3a4b # ratchet:actions/cache/restore@v4
+        `,
+        'workflow.yml',
+      );
+      expect(res?.deps[0]).toMatchObject({
+        depName: 'actions/cache',
+        currentValue: 'v4',
+        currentDigest: 'b7e8d49f17405cc70c1c120101943203c98d3a4b',
+        datasource: 'github-tags',
+        versioning: 'github-actions',
+        replaceString:
+          'actions/cache/restore@b7e8d49f17405cc70c1c120101943203c98d3a4b # ratchet:actions/cache/restore@v4',
+      });
+    });
+
     it('disables naked SHA pins without version comment', async () => {
       const res = await extractPackageFile(
         codeBlock`

--- a/lib/modules/manager/github-actions/parse.spec.ts
+++ b/lib/modules/manager/github-actions/parse.spec.ts
@@ -219,6 +219,15 @@ describe('modules/manager/github-actions/parse', () => {
       });
     });
 
+    it('parses ratchet pinned version for action in subdirectory', () => {
+      const result = parseComment('ratchet:actions/cache/restore@v4');
+      expect(result).toEqual({
+        index: 0,
+        matchedString: 'ratchet:actions/cache/restore@v4',
+        pinnedVersion: 'v4',
+      });
+    });
+
     it('parses version without v prefix', () => {
       const result = parseComment('1.2.3');
       expect(result).toEqual({

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -201,7 +201,7 @@ export interface CommentData {
 }
 
 const pinTokenRe = regEx(
-  /^\s*(?:(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+))?@?(?<version>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?(?:-[a-zA-Z0-9.]+)?)/,
+  /^\s*(?:(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+(?:\/[.\w-]+)*))?@?(?<version>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?(?:-[a-zA-Z0-9.]+)?)/,
 );
 
 export const versionLikeRe = regEx(/^v?\d+/);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

The `ratchet:` alternative in the pin-comment regex only allowed `owner/repo`, so a ratchet marker for an action in a subdirectory (`owner/repo/path@ref`) never matched. Such comments fell through to the bare-token branch, which made `currentValue` the entire marker string, e.g. `ratchet:actions/cache/restore@v4`. That is not version-like, so the dep was switched to the `github-digest` datasource, which cannot resolve the marker as a tag or branch and logs "Could not determine new digest for update". The dep then gets no updates at all.

Allow further path segments after `owner/repo` so that nested actions are extracted the same way as their top-level counterparts, with `currentValue: v4` and the `github-tags` datasource.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I have reviewed the changed myself, and they are correct from what I can tell.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @garazdawi will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/garazdawi/renovate

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
