### PR TITLE
feat(presets): support relative paths inside a preset repo

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -282,33 +282,15 @@ Some more things to know about relative references:
 
 - You can not add a `#tag` to a relative reference, because the tag is always inherited from the referencing preset
 - A relative reference always points to a preset _file_, you can not reference a sub-preset key inside a file with a relative reference, this is the same limitation as for the `//path` syntax
-- A reference must stay inside the preset repository, so `../` may not escape the repository root
 - Relative references are supported for `github`, `gitlab`, `gitea`, `forgejo` and `local` presets
-- Relative references inside a preset which is hosted on an HTTP server are _not_ supported, because Renovate only resolves them for presets which are hosted in a Git repository
 - Parameters are supported, for example `./group(eslint)`, and the parameters may contain a Handlebars template like `./group({{ env.TEAM }})`
 - References whose _path_ contains a Handlebars template, like `./{{ env.SOME_VAR }}/base`, are not rewritten, so they fail to resolve
 - The `ignorePresets` entries of a preset may also use the relative form, Renovate resolves them in the same way as the `extends` entries of that preset
-- A relative reference must not have a source prefix, so strings like `local>./x` or `github>../x` are invalid
 - A reference which resolves to the `default` preset at the root of the repository, like `/default`, is resolved to the plain repository form such as `github>org/repo#v2.0.0`
-
-!!! note
-  Renovate deduplicates presets by their exact string.
-  A preset which is referenced under two different spellings, for example `github>org/repo#v2.0.0` and `github>org/repo//default#v2.0.0`, is therefore fetched and merged twice.
-  This is how preset resolution has always worked, and is not specific to relative references.
-
-!!! note
-  A preset can only ignore its own nested presets when the repository which extends it does not set `ignorePresets` itself.
-  Renovate uses the `ignorePresets` of the repository config when there is one, and falls back to the `ignorePresets` of the preset otherwise.
-  This is how preset resolution has always worked, and is not specific to relative references, so do not rely on a preset ignoring its own references.
 
 !!! note
   Relative references inside an `onboardingConfig` are canonicalized as well, including the inherited tag.
   This means an onboarded repository gets an absolute preset string like `github>org/repo//system/registries#v2.0.0`, which resolves from that repository.
-
-!!! warning
-  Any `extends` string which starts with `./`, `../` or `/`, like `./group/repo` or `/group/repo`, is now read as a relative preset reference.
-  Before this feature such a string was treated as a local repository name, which in rare cases could accidentally resolve to a real preset because the platform API normalized the dot segments in the request URL.
-  For the same reason a source-prefixed relative-looking string, like `local>/org/repo`, `github>./x` or `npm>./x`, is now rejected as an invalid preset.
 
 To ignore a relatively-referenced preset with `ignorePresets`, use the absolute preset string which Renovate resolved, including the inherited tag:
 
@@ -318,9 +300,6 @@ To ignore a relatively-referenced preset with `ignorePresets`, use the absolute 
   "ignorePresets": ["github>org/repo//system/registries#v2.0.0"]
 }
 ```
-
-If the reference itself is broken, for example because it escapes the repository root, then Renovate keeps the raw reference.
-In that case put the raw relative string like `../oops` in `ignorePresets`.
 
 !!! warning
   A relative reference which cannot be resolved causes a configuration error in every repository which extends the preset.

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -292,12 +292,55 @@ Some more things to know about relative references:
   Relative references inside an `onboardingConfig` are canonicalized as well, including the inherited tag.
   This means an onboarded repository gets an absolute preset string like `github>org/repo//system/registries#v2.0.0`, which resolves from that repository.
 
-To ignore a relatively-referenced preset with `ignorePresets`, use the absolute preset string which Renovate resolved, including the inherited tag:
+### Ignoring relative references
+
+Renovate matches `ignorePresets` entries against the preset string which it resolved, and not against the relative reference which is written inside the preset.
+This means you must always use the absolute form, including the inherited tag.
+
+Take the repository from above.
+A repository which extends that catalog can skip `security/base.json` like this:
 
 ```json
 {
   "extends": ["github>org/repo#v2.0.0"],
-  "ignorePresets": ["github>org/repo//system/registries#v2.0.0"]
+  "ignorePresets": ["github>org/repo//security/base#v2.0.0"]
+}
+```
+
+This works at any depth, so a preset which is only reached through another preset, for example a `/security/base` reference inside `system/registries.json`, is skipped in the same way.
+
+Using the relative form does _not_ work, because the references are already resolved when the `ignorePresets` entries are matched:
+
+```json
+{
+  "extends": ["github>org/repo#v2.0.0"],
+  "ignorePresets": ["/security/base"]
+}
+```
+
+To find the absolute string of a preset, run Renovate with `LOG_LEVEL=debug` and read the `visitedPresets` field of the `Resolved shallow config, without merging internal presets` message.
+It lists every merged preset in its absolute form.
+
+A preset may also ignore the presets which it pulls in itself, and may use the relative form for that:
+
+```json
+{
+  "extends": ["./system/registries"],
+  "ignorePresets": ["/security/base"]
+}
+```
+
+!!! note
+  Renovate uses the `ignorePresets` of the repository config when there is one, and only falls back to the `ignorePresets` of a preset otherwise.
+  A preset can therefore only ignore its own references when the repository which extends it does not set `ignorePresets`.
+
+If a relative reference can not be resolved, for example because it escapes the repository root, then Renovate keeps the raw reference.
+Use that raw string to neutralize it:
+
+```json
+{
+  "extends": ["github>org/repo#v2.0.0"],
+  "ignorePresets": ["../oops"]
 }
 ```
 

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -346,7 +346,7 @@ Use that raw string to neutralize it:
 
 !!! warning
   A relative reference which cannot be resolved causes a configuration error in every repository which extends the preset.
-  Preset authors should therefore validate their preset repository in CI, for example with the `renovate-config-validator`.
+  Preset authors should therefore validate their preset repository in CI, for example with the `renovate-config-validator` CLI.
 
 ## Fetching presets from an HTTP server
 

--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -242,6 +242,90 @@ This is especially helpful in self-hosted scenarios where public presets cannot 
 Local presets are specified either by leaving out any prefix, e.g. `owner/name`, or explicitly by adding a `local>` prefix, e.g. `local>owner/name`.
 Renovate will determine the current platform and look up the preset from there.
 
+## Relative preset references
+
+Presets can reference other presets from the same repository with a relative path.
+Renovate resolves the relative reference to the source, repository and tag of the preset which contains the reference.
+This means you can move or fork a preset repository, or pin it to a tag, without editing the references inside the presets.
+
+| Syntax | Resolves relative to                                       |
+| ------ | ---------------------------------------------------------- |
+| `./x`  | the directory of the preset file with the reference        |
+| `../x` | the parent directory of the preset file with the reference |
+| `/x`   | the root of the preset repository                          |
+
+For example, take a preset repository with this layout:
+
+```
+default.json
+system/registries.json
+security/base.json
+```
+
+The `default.json` file can reference the other presets like this:
+
+```json
+{
+  "extends": ["./system/registries", "/security/base"]
+}
+```
+
+If a repository extends `github>org/repo#v2.0.0`, then Renovate resolves the two references to `github>org/repo//system/registries#v2.0.0` and `github>org/repo//security/base#v2.0.0`.
+The tag `v2.0.0` is inherited, so all presets are read from the same tag.
+
+!!! note
+  Relative references only work inside presets.
+  Renovate does not accept them in a repository's own `renovate.json`, in an inherited config, or in `globalExtends`.
+  The `renovate-config-validator` accepts relative references in any file, so a relative reference in a repository's own config only fails when Renovate runs, and not during validation.
+
+Some more things to know about relative references:
+
+- You can not add a `#tag` to a relative reference, because the tag is always inherited from the referencing preset
+- A relative reference always points to a preset _file_, you can not reference a sub-preset key inside a file with a relative reference, this is the same limitation as for the `//path` syntax
+- A reference must stay inside the preset repository, so `../` may not escape the repository root
+- Relative references are supported for `github`, `gitlab`, `gitea`, `forgejo` and `local` presets
+- Relative references inside a preset which is hosted on an HTTP server are _not_ supported, because Renovate only resolves them for presets which are hosted in a Git repository
+- Parameters are supported, for example `./group(eslint)`, and the parameters may contain a Handlebars template like `./group({{ env.TEAM }})`
+- References whose _path_ contains a Handlebars template, like `./{{ env.SOME_VAR }}/base`, are not rewritten, so they fail to resolve
+- The `ignorePresets` entries of a preset may also use the relative form, Renovate resolves them in the same way as the `extends` entries of that preset
+- A relative reference must not have a source prefix, so strings like `local>./x` or `github>../x` are invalid
+- A reference which resolves to the `default` preset at the root of the repository, like `/default`, is resolved to the plain repository form such as `github>org/repo#v2.0.0`
+
+!!! note
+  Renovate deduplicates presets by their exact string.
+  A preset which is referenced under two different spellings, for example `github>org/repo#v2.0.0` and `github>org/repo//default#v2.0.0`, is therefore fetched and merged twice.
+  This is how preset resolution has always worked, and is not specific to relative references.
+
+!!! note
+  A preset can only ignore its own nested presets when the repository which extends it does not set `ignorePresets` itself.
+  Renovate uses the `ignorePresets` of the repository config when there is one, and falls back to the `ignorePresets` of the preset otherwise.
+  This is how preset resolution has always worked, and is not specific to relative references, so do not rely on a preset ignoring its own references.
+
+!!! note
+  Relative references inside an `onboardingConfig` are canonicalized as well, including the inherited tag.
+  This means an onboarded repository gets an absolute preset string like `github>org/repo//system/registries#v2.0.0`, which resolves from that repository.
+
+!!! warning
+  Any `extends` string which starts with `./`, `../` or `/`, like `./group/repo` or `/group/repo`, is now read as a relative preset reference.
+  Before this feature such a string was treated as a local repository name, which in rare cases could accidentally resolve to a real preset because the platform API normalized the dot segments in the request URL.
+  For the same reason a source-prefixed relative-looking string, like `local>/org/repo`, `github>./x` or `npm>./x`, is now rejected as an invalid preset.
+
+To ignore a relatively-referenced preset with `ignorePresets`, use the absolute preset string which Renovate resolved, including the inherited tag:
+
+```json
+{
+  "extends": ["github>org/repo#v2.0.0"],
+  "ignorePresets": ["github>org/repo//system/registries#v2.0.0"]
+}
+```
+
+If the reference itself is broken, for example because it escapes the repository root, then Renovate keeps the raw reference.
+In that case put the raw relative string like `../oops` in `ignorePresets`.
+
+!!! warning
+  A relative reference which cannot be resolved causes a configuration error in every repository which extends the preset.
+  Preset authors should therefore validate their preset repository in CI, for example with the `renovate-config-validator`.
+
 ## Fetching presets from an HTTP server
 
 If your desired platform is not yet supported, or if you want presets to work when you run Renovate with `--platform=local`, you can specify presets using HTTP URLs:

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -1,7 +1,10 @@
 import { mockDeep } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
 import { logger } from '~test/util.ts';
-import { PLATFORM_RATE_LIMIT_EXCEEDED } from '../../constants/error-messages.ts';
+import {
+  CONFIG_VALIDATION,
+  PLATFORM_RATE_LIMIT_EXCEEDED,
+} from '../../constants/error-messages.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
 import * as memCache from '../../util/cache/memory/index.ts';
 import * as _packageCache from '../../util/cache/package/index.ts';
@@ -627,6 +630,148 @@ describe('config/presets/index', () => {
       );
     });
 
+    describe('relative presets', () => {
+      it('resolves a relative preset against its parent', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        gitHub.getPreset.mockResolvedValueOnce({
+          extends: ['./system/registries'],
+        });
+        gitHub.getPreset.mockResolvedValueOnce({ prCreation: 'not-pending' });
+
+        const { config: res } = await presets.resolveConfigPresets(config);
+
+        expect(res).toEqual({ prCreation: 'not-pending' });
+        expect(gitHub.getPreset).toHaveBeenCalledWith({
+          repo: 'some/repo',
+          presetPath: 'system',
+          presetName: 'registries',
+          tag: 'v1.0.0',
+        });
+      });
+
+      it('terminates on self-referencing relative presets', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        gitHub.getPreset.mockResolvedValue({
+          extends: ['./default'],
+          prCreation: 'not-pending',
+        });
+
+        const { config: res } = await presets.resolveConfigPresets(config);
+
+        expect(res).toEqual({ prCreation: 'not-pending' });
+        expect(gitHub.getPreset).toHaveBeenCalledTimes(1);
+      });
+
+      it('fetches the root default preset only once', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        gitHub.getPreset.mockImplementation(({ presetPath, presetName }) => {
+          if (presetPath === 'group' && presetName === 'a') {
+            return Promise.resolve({ extends: ['/default'] });
+          }
+          return Promise.resolve({
+            extends: ['./group/a'],
+            packageRules: [{ matchManagers: ['npm'], automerge: true }],
+          });
+        });
+
+        const { config: res } = await presets.resolveConfigPresets(config);
+
+        expect(res).toEqual({
+          packageRules: [{ matchManagers: ['npm'], automerge: true }],
+        });
+        expect(gitHub.getPreset).toHaveBeenCalledTimes(2);
+      });
+
+      it('resolves relative presets which use params', async () => {
+        config.extends = ['github>some/repo#v1.0.0(argA)'];
+        gitHub.getPreset.mockResolvedValueOnce({
+          extends: ['./{{arg0}}'],
+        });
+        gitHub.getPreset.mockResolvedValueOnce({ prCreation: 'not-pending' });
+
+        const { config: res } = await presets.resolveConfigPresets(config);
+
+        expect(res).toEqual({ prCreation: 'not-pending' });
+        expect(gitHub.getPreset).toHaveBeenCalledWith({
+          repo: 'some/repo',
+          presetPath: undefined,
+          presetName: 'argA',
+          tag: 'v1.0.0',
+        });
+      });
+
+      it('throws if a relative preset has no parent preset', async () => {
+        config.extends = ['./x'];
+
+        await expect(presets.resolveConfigPresets(config)).rejects.toThrow(
+          expect.objectContaining({
+            message: CONFIG_VALIDATION,
+            validationError:
+              'Relative preset reference cannot be resolved (./x). Relative presets can only be used within presets from a supported source, must stay inside their repository, and cannot be templated or used outside of a preset (for example in the repository config, inherited config, or globalExtends)',
+          }),
+        );
+      });
+
+      it('throws if a relative preset resolves outside of its repository', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        gitHub.getPreset.mockResolvedValueOnce({
+          extends: ['github>other/repo#v2.0.0'],
+        });
+        gitHub.getPreset.mockResolvedValueOnce({ extends: ['../x'] });
+
+        await expect(presets.resolveConfigPresets(config)).rejects.toThrow(
+          expect.objectContaining({
+            message: CONFIG_VALIDATION,
+            validationError:
+              'Relative preset reference cannot be resolved (../x). Relative presets can only be used within presets from a supported source, must stay inside their repository, and cannot be templated or used outside of a preset (for example in the repository config, inherited config, or globalExtends). Note: this is a *nested* preset so please contact the preset author if you are unable to fix it yourself.',
+          }),
+        );
+      });
+
+      it('throws if a relative preset is used by an unsupported preset source', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        gitHub.getPreset.mockResolvedValueOnce({
+          extends: ['somepackage:webapp'],
+        });
+        npm.getPreset.mockResolvedValueOnce({ extends: ['./x'] });
+
+        await expect(presets.resolveConfigPresets(config)).rejects.toThrow(
+          expect.objectContaining({
+            message: CONFIG_VALIDATION,
+            validationError:
+              'Relative preset reference cannot be resolved (./x). Relative presets can only be used within presets from a supported source, must stay inside their repository, and cannot be templated or used outside of a preset (for example in the repository config, inherited config, or globalExtends). Note: this is a *nested* preset so please contact the preset author if you are unable to fix it yourself.',
+          }),
+        );
+      });
+
+      it('resolves relative ignorePresets of a preset', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        gitHub.getPreset.mockResolvedValueOnce({
+          extends: ['./optional'],
+          ignorePresets: ['./optional'],
+          prCreation: 'not-pending',
+        });
+
+        const { config: res } = await presets.resolveConfigPresets(config);
+
+        expect(res).toEqual({ prCreation: 'not-pending' });
+        expect(gitHub.getPreset).toHaveBeenCalledTimes(1);
+      });
+
+      it('allows ignorePresets to neutralize a broken relative preset', async () => {
+        config.extends = ['github>some/repo#v1.0.0'];
+        config.ignorePresets = ['../oops'];
+        gitHub.getPreset.mockResolvedValueOnce({
+          extends: ['../oops'],
+          prCreation: 'not-pending',
+        });
+
+        const { config: res } = await presets.resolveConfigPresets(config);
+
+        expect(res).toEqual({ prCreation: 'not-pending' });
+      });
+    });
+
     describe('when using mergeInternalPresets=true', () => {
       describe('when resolving an internal preset', () => {
         it('merges `extends`', async () => {
@@ -1235,6 +1380,10 @@ describe('config/presets/index', () => {
   });
 
   describe('getPreset', () => {
+    beforeEach(() => {
+      memCache.init();
+    });
+
     it('does not use cache for internal presets', async () => {
       const memCacheGetSpy = vi.spyOn(memCache, 'get');
       expect(await presets.getPreset(':dependencyDashboard', {})).toBeDefined();
@@ -1428,6 +1577,37 @@ describe('config/presets/index', () => {
       expect(e!.validationSource).toBeUndefined();
       expect(e!.validationError).toBeUndefined();
       expect(e!.validationMessage).toBeUndefined();
+    });
+
+    it('canonicalizes relative presets', async () => {
+      gitHub.getPreset.mockResolvedValueOnce({
+        extends: ['./system/registries', 'github>other/repo'],
+        packageRules: [{ extends: ['./rules/docker'] }],
+      });
+
+      const res = await presets.getPreset('github>some/repo#v1.0.0', {});
+
+      expect(res).toEqual({
+        extends: [
+          'github>some/repo//system/registries#v1.0.0',
+          'github>other/repo',
+        ],
+        packageRules: [{ extends: ['github>some/repo//rules/docker#v1.0.0'] }],
+      });
+    });
+
+    it('leaves relative presets of npm presets unchanged', async () => {
+      npm.getPreset.mockResolvedValueOnce({
+        extends: ['./system/registries'],
+        ignorePresets: ['./optional'],
+      });
+
+      const res = await presets.getPreset('somepackage:webapp', {});
+
+      expect(res).toEqual({
+        extends: ['./system/registries'],
+        ignorePresets: ['./optional'],
+      });
     });
 
     it('handles preset not found', async () => {

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -22,6 +22,7 @@ import { mergeChildConfig } from '../utils.ts';
 import { removedPresets } from './common.ts';
 import * as internal from './internal/index.ts';
 import { parsePreset } from './parse.ts';
+import { canonicalizeRelativePresets } from './relative.ts';
 import type { Preset, PresetApi } from './types.ts';
 import {
   PRESET_DEP_NOT_FOUND,
@@ -29,7 +30,9 @@ import {
   PRESET_INVALID_JSON,
   PRESET_NOT_FOUND,
   PRESET_PROHIBITED_SUBPRESET,
+  PRESET_RELATIVE_NO_PARENT,
   PRESET_RENOVATE_CONFIG_NOT_FOUND,
+  REPO_HOSTED_PRESET_SOURCES,
 } from './util.ts';
 
 const presetSourceLoaders: Record<string, () => Promise<PresetApi>> = {
@@ -109,8 +112,13 @@ export async function getPreset(
   if (newPreset === null) {
     return {};
   }
+  const parsedPreset = parsePreset(preset);
   const { presetSource, repo, presetPath, presetName, tag, params, rawParams } =
-    parsePreset(preset);
+    parsedPreset;
+
+  if (presetSource === 'relative') {
+    throw new Error(PRESET_RELATIVE_NO_PARENT);
+  }
 
   let presetConfig: Preset | null | undefined;
 
@@ -185,7 +193,14 @@ export async function getPreset(
     delete presetConfig.description;
   }
   const { migratedConfig } = migration.migrateConfig(presetConfig);
-  return massage.massageConfig(migratedConfig);
+  const massagedConfig = massage.massageConfig(migratedConfig);
+  if (REPO_HOSTED_PRESET_SOURCES.includes(parsedPreset.presetSource)) {
+    // only presets which are hosted in a repository can contain relative
+    // references, in all other presets they are left as they are and fail
+    // when they are resolved
+    canonicalizeRelativePresets(massagedConfig, parsedPreset);
+  }
+  return massagedConfig;
 }
 
 export interface ResolveConfigPresetsResult {
@@ -383,6 +398,8 @@ async function fetchPreset(
       error.validationError = `Sub-presets cannot be combined with a custom path (${preset})`;
     } else if (err.message === PRESET_INVALID_JSON) {
       error.validationError = `Preset is invalid JSON (${preset})`;
+    } else if (err.message === PRESET_RELATIVE_NO_PARENT) {
+      error.validationError = `Relative preset reference cannot be resolved (${preset}). Relative presets can only be used within presets from a supported source, must stay inside their repository, and cannot be templated or used outside of a preset (for example in the repository config, inherited config, or globalExtends)`;
     } else {
       error.validationError = `Preset caused unexpected error (${preset})`;
     }

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -32,17 +32,26 @@ import {
   PRESET_PROHIBITED_SUBPRESET,
   PRESET_RELATIVE_NO_PARENT,
   PRESET_RENOVATE_CONFIG_NOT_FOUND,
-  REPO_HOSTED_PRESET_SOURCES,
 } from './util.ts';
 
-const presetSourceLoaders: Record<string, () => Promise<PresetApi>> = {
-  forgejo: () => import('./forgejo/index.ts'),
-  gitea: () => import('./gitea/index.ts'),
-  github: () => import('./github/index.ts'),
-  gitlab: () => import('./gitlab/index.ts'),
-  http: () => import('./http/index.ts'),
-  local: () => import('./local/index.ts'),
-  npm: () => import('./npm/index.ts'),
+interface PresetSource {
+  load: () => Promise<PresetApi>;
+
+  /**
+   * Whether presets from this source are hosted in a repository, which is what
+   * allows them to reference other presets relatively.
+   */
+  repoHosted: boolean;
+}
+
+const presetSources: Record<string, PresetSource> = {
+  forgejo: { load: () => import('./forgejo/index.ts'), repoHosted: true },
+  gitea: { load: () => import('./gitea/index.ts'), repoHosted: true },
+  github: { load: () => import('./github/index.ts'), repoHosted: true },
+  gitlab: { load: () => import('./gitlab/index.ts'), repoHosted: true },
+  http: { load: () => import('./http/index.ts'), repoHosted: false },
+  local: { load: () => import('./local/index.ts'), repoHosted: true },
+  npm: { load: () => import('./npm/index.ts'), repoHosted: false },
 };
 
 const presetCacheNamespace = 'preset';
@@ -144,7 +153,7 @@ export async function getPreset(
     }
 
     if (isNullOrUndefined(presetConfig)) {
-      const source = await presetSourceLoaders[presetSource]();
+      const source = await presetSources[presetSource].load();
       presetConfig = await source.getPreset({
         repo,
         presetPath,
@@ -194,7 +203,7 @@ export async function getPreset(
   }
   const { migratedConfig } = migration.migrateConfig(presetConfig);
   const massagedConfig = massage.massageConfig(migratedConfig);
-  if (REPO_HOSTED_PRESET_SOURCES.includes(parsedPreset.presetSource)) {
+  if (presetSources[parsedPreset.presetSource]?.repoHosted) {
     // only presets which are hosted in a repository can contain relative
     // references, in all other presets they are left as they are and fail
     // when they are resolved

--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -698,6 +698,18 @@ describe('config/presets/parse', () => {
       });
     });
 
+    it('parses scoped npm preset with explicit `npm>` prefix', () => {
+      expect(parsePreset('npm>@myorg/renovate-config')).toEqual({
+        repo: '@myorg/renovate-config',
+        params: undefined,
+        rawParams: undefined,
+        presetName: 'default',
+        presetPath: undefined,
+        presetSource: 'npm',
+        tag: undefined,
+      });
+    });
+
     it.each`
       input               | presetSource | repo
       ${'npm>owner/repo'} | ${'local'}   | ${'owner/repo'}

--- a/lib/config/presets/parse.spec.ts
+++ b/lib/config/presets/parse.spec.ts
@@ -1,4 +1,5 @@
-import { parsePreset } from './parse.ts';
+import { isRelativePresetReference, parsePreset } from './parse.ts';
+import { PRESET_INVALID } from './util.ts';
 
 describe('config/presets/parse', () => {
   describe('parsePreset', () => {
@@ -563,6 +564,186 @@ describe('config/presets/parse', () => {
         presetPath: undefined,
         presetSource: 'http',
       });
+    });
+
+    it.each`
+      input                | presetName
+      ${'./foo'}           | ${'./foo'}
+      ${'./foo/bar'}       | ${'./foo/bar'}
+      ${'./foo.json5'}     | ${'./foo.json5'}
+      ${'../foo'}          | ${'../foo'}
+      ${'../../foo/bar'}   | ${'../../foo/bar'}
+      ${'./foo/../bar'}    | ${'./foo/../bar'}
+      ${'./a/../b'}        | ${'./a/../b'}
+      ${'/foo'}            | ${'/foo'}
+      ${'/foo/bar-baz.js'} | ${'/foo/bar-baz.js'}
+    `('parses relative preset $input', ({ input, presetName }) => {
+      expect(parsePreset(input as string)).toEqual({
+        repo: '',
+        params: undefined,
+        rawParams: undefined,
+        presetName,
+        presetPath: undefined,
+        presetSource: 'relative',
+        tag: undefined,
+      });
+    });
+
+    it('parses relative preset with params', () => {
+      expect(parsePreset('./foo/bar(param1, param2)')).toEqual({
+        repo: '',
+        params: ['param1', 'param2'],
+        rawParams: 'param1, param2',
+        presetName: './foo/bar',
+        presetPath: undefined,
+        presetSource: 'relative',
+        tag: undefined,
+      });
+    });
+
+    it('parses relative preset with params which contain a hash', () => {
+      expect(parsePreset('./foo(p#1)')).toEqual({
+        repo: '',
+        params: ['p#1'],
+        rawParams: 'p#1',
+        presetName: './foo',
+        presetPath: undefined,
+        presetSource: 'relative',
+        tag: undefined,
+      });
+    });
+
+    it('parses relative preset with params which contain a sub-expression', () => {
+      expect(parsePreset('./group({{ lower (env.TEAM) }})')).toEqual({
+        repo: '',
+        params: ['{{ lower (env.TEAM) }}'],
+        rawParams: '{{ lower (env.TEAM) }}',
+        presetName: './group',
+        presetPath: undefined,
+        presetSource: 'relative',
+        tag: undefined,
+      });
+    });
+
+    it('parses relative preset with empty params', () => {
+      expect(parsePreset('./foo()')).toEqual({
+        repo: '',
+        params: [''],
+        rawParams: '',
+        presetName: './foo',
+        presetPath: undefined,
+        presetSource: 'relative',
+        tag: undefined,
+      });
+    });
+
+    it.each`
+      input                 | reason
+      ${'./foo#v1'}         | ${'tag'}
+      ${'./foo(p1)#v1'}     | ${'tag after params'}
+      ${'./foo(p1'}         | ${'unclosed params'}
+      ${'./foo//bar'}       | ${'double slash'}
+      ${'./'}               | ${'no path'}
+      ${'/'}                | ${'no path'}
+      ${'./foo/'}           | ${'trailing slash'}
+      ${'../'}              | ${'no path'}
+      ${'/foo bar'}         | ${'space'}
+      ${'./.'}              | ${'final segment names a directory'}
+      ${'./..'}             | ${'final segment names a directory'}
+      ${'./a/..'}           | ${'final segment names a directory'}
+      ${'../a/..'}          | ${'final segment names a directory'}
+      ${'.././.'}           | ${'final segment names a directory'}
+      ${'/a/..'}            | ${'final segment names a directory'}
+      ${'./foo:bar'}        | ${'sub-preset'}
+      ${'./group(eslint))'} | ${'stray closing parenthesis in params'}
+      ${'./foo(a)(b)'}      | ${'two parameter lists'}
+      ${'./foo((a)'}        | ${'unclosed parenthesis in params'}
+      ${'local>./x'}        | ${'local source prefix'}
+      ${'github>../x'}      | ${'github source prefix'}
+      ${'npm>./x'}          | ${'npm source prefix'}
+      ${'local>npm>./x'}    | ${'chained source prefixes'}
+    `('throws for invalid relative preset $input ($reason)', ({ input }) => {
+      expect(() => parsePreset(input as string)).toThrow(PRESET_INVALID);
+    });
+
+    it.each`
+      input   | repo
+      ${'.'}  | ${'renovate-config-.'}
+      ${'..'} | ${'renovate-config-..'}
+    `('keeps npm fallback for $input', ({ input, repo }) => {
+      expect(parsePreset(input as string)).toEqual({
+        repo,
+        params: undefined,
+        rawParams: undefined,
+        presetName: 'default',
+        presetPath: undefined,
+        presetSource: 'npm',
+        tag: undefined,
+      });
+    });
+
+    it.each`
+      input           | repo
+      ${'npm>foo'}    | ${'renovate-config-foo'}
+      ${'npm>@myorg'} | ${'@myorg/renovate-config'}
+    `('parses npm preset $input', ({ input, repo }) => {
+      expect(parsePreset(input as string)).toEqual({
+        repo,
+        params: undefined,
+        rawParams: undefined,
+        presetName: 'default',
+        presetPath: undefined,
+        presetSource: 'npm',
+        tag: undefined,
+      });
+    });
+
+    it.each`
+      input               | presetSource | repo
+      ${'npm>owner/repo'} | ${'local'}   | ${'owner/repo'}
+      ${'local>npm>foo'}  | ${'local'}   | ${'foo'}
+      ${'github>npm>foo'} | ${'github'}  | ${'foo'}
+    `(
+      'keeps legacy handling of $input',
+      ({ input, presetSource, repo }: Record<string, string>) => {
+        expect(parsePreset(input)).toEqual({
+          repo,
+          params: undefined,
+          rawParams: undefined,
+          presetName: 'default',
+          presetPath: undefined,
+          presetSource,
+          tag: undefined,
+        });
+      },
+    );
+
+    it('keeps legacy handling of `npm>` presets with a path', () => {
+      expect(parsePreset('npm>owner/repo//path/name')).toEqual({
+        repo: 'owner/repo',
+        params: undefined,
+        rawParams: undefined,
+        presetName: 'name',
+        presetPath: 'path',
+        presetSource: 'local',
+        tag: undefined,
+      });
+    });
+  });
+
+  describe('isRelativePresetReference', () => {
+    it.each`
+      input                      | expected
+      ${'./foo'}                 | ${true}
+      ${'../foo'}                | ${true}
+      ${'/foo'}                  | ${true}
+      ${'.'}                     | ${false}
+      ${'..'}                    | ${false}
+      ${'github>a/b'}            | ${false}
+      ${'config:best-practices'} | ${false}
+      ${'a/b'}                   | ${false}
+    `('returns $expected for $input', ({ input, expected }) => {
+      expect(isRelativePresetReference(input as string)).toBe(expected);
     });
   });
 });

--- a/lib/config/presets/parse.ts
+++ b/lib/config/presets/parse.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '@sindresorhus/is';
+import { isNonEmptyString, isString } from '@sindresorhus/is';
 import { regEx } from '../../util/regex.ts';
 import { isHttpUrl } from '../../util/url.ts';
 import type { ParsedPreset } from './types.ts';
@@ -10,6 +10,62 @@ const nonScopedPresetWithSubdirRegex = regEx(
 const gitPresetRegex = regEx(
   /^(?<repo>~?[\w\-. /%]+)(?::(?<presetName>[\w\-.+/]+))?(?:#(?<tag>[\w\-./]+?))?$/,
 );
+const relativePresetRegex = regEx(
+  /^(?:\/|(?:\.\.?\/)+)[\w\-.]+(?:\/[\w\-.]+)*$/,
+);
+
+/**
+ * Returns true if the given `extends` entry is a relative preset reference,
+ * e.g. `./foo`, `../foo` or `/foo`.
+ */
+export function isRelativePresetReference(input: string): boolean {
+  return (
+    input.startsWith('./') || input.startsWith('../') || input.startsWith('/')
+  );
+}
+
+/**
+ * Splits the trailing `(...)` parameter list off the given preset reference.
+ *
+ * The parameters are opaque, so they may contain any character and are split
+ * off before the reference itself is validated.
+ */
+function splitPresetParams(input: string): {
+  str: string;
+  params: string[] | undefined;
+  rawParams: string | undefined;
+} {
+  if (!input.includes('(')) {
+    return { str: input, params: undefined, rawParams: undefined };
+  }
+
+  const rawParams = input.slice(input.indexOf('(') + 1, -1);
+  return {
+    str: input.slice(0, input.indexOf('(')),
+    params: rawParams.split(',').map((elem) => elem.trim()),
+    rawParams,
+  };
+}
+
+/**
+ * Returns true if every parenthesis in the given preset parameters is closed in
+ * order, which allows Handlebars sub-expressions like `{{ lower (env.TEAM) }}`
+ * while still rejecting malformed parameter lists.
+ */
+function hasBalancedParens(rawParams: string): boolean {
+  let depth = 0;
+  for (const char of rawParams) {
+    if (char === '(') {
+      depth += 1;
+    } else if (char === ')') {
+      depth -= 1;
+      if (depth < 0) {
+        return false;
+      }
+    }
+  }
+  return depth === 0;
+}
 
 export function parsePreset(input: string): ParsedPreset {
   let str = input;
@@ -35,6 +91,8 @@ export function parsePreset(input: string): ParsedPreset {
   } else if (str.startsWith('local>')) {
     presetSource = 'local';
     str = str.substring('local>'.length);
+  } else if (isRelativePresetReference(str)) {
+    presetSource = 'relative';
   } else if (isHttpUrl(str)) {
     presetSource = 'http';
   } else if (
@@ -45,12 +103,36 @@ export function parsePreset(input: string): ParsedPreset {
     presetSource = 'local';
   }
   str = str.replace(regEx(/^npm>/), '');
-  presetSource = presetSource ?? 'npm';
-  if (str.includes('(')) {
-    rawParams = str.slice(str.indexOf('(') + 1, -1);
-    params = rawParams.split(',').map((elem) => elem.trim());
-    str = str.slice(0, str.indexOf('('));
+  if (
+    presetSource &&
+    presetSource !== 'relative' &&
+    isRelativePresetReference(str)
+  ) {
+    // relative references must not carry a source prefix, because they always
+    // inherit the source of the preset which references them
+    throw new Error(PRESET_INVALID);
   }
+  presetSource = presetSource ?? 'npm';
+  if (presetSource === 'relative') {
+    if (str.includes('(') && !str.endsWith(')')) {
+      throw new Error(PRESET_INVALID);
+    }
+    ({ str, params, rawParams } = splitPresetParams(str));
+    if (isString(rawParams) && !hasBalancedParens(rawParams)) {
+      throw new Error(PRESET_INVALID);
+    }
+    if (!relativePresetRegex.test(str)) {
+      throw new Error(PRESET_INVALID);
+    }
+    const finalSegment = str.split('/').pop();
+    if (finalSegment === '.' || finalSegment === '..') {
+      // references like `./.`, `./..` or `../a/..` name a directory instead of
+      // a preset file
+      throw new Error(PRESET_INVALID);
+    }
+    return { presetSource, repo: '', presetName: str, params, rawParams };
+  }
+  ({ str, params, rawParams } = splitPresetParams(str));
   if (presetSource === 'http') {
     return { presetSource, repo: str, presetName: '', params, rawParams };
   }

--- a/lib/config/presets/parse.ts
+++ b/lib/config/presets/parse.ts
@@ -91,6 +91,11 @@ export function parsePreset(input: string): ParsedPreset {
   } else if (str.startsWith('local>')) {
     presetSource = 'local';
     str = str.substring('local>'.length);
+  } else if (str.startsWith('npm>@')) {
+    // only scoped packages are unambiguous, all other `npm>` references are
+    // handled by the legacy strip below to stay backwards compatible
+    presetSource = 'npm';
+    str = str.substring('npm>'.length);
   } else if (isRelativePresetReference(str)) {
     presetSource = 'relative';
   } else if (isHttpUrl(str)) {

--- a/lib/config/presets/relative.spec.ts
+++ b/lib/config/presets/relative.spec.ts
@@ -161,7 +161,7 @@ describe('config/presets/relative', () => {
           list: [[{ extends: ['./deep'] }]],
           inner: { extends: ['./inner'] },
         },
-      } as RenovateConfig;
+      };
 
       canonicalizeRelativePresets(config, parent);
 
@@ -202,7 +202,7 @@ describe('config/presets/relative', () => {
           './{{ env.X }}/base',
           42,
         ],
-      } as RenovateConfig;
+      };
 
       canonicalizeRelativePresets(config, parent);
 
@@ -222,7 +222,7 @@ describe('config/presets/relative', () => {
     });
 
     it('ignores non-array extends', () => {
-      const config = { extends: './single' } as unknown as RenovateConfig;
+      const config = { extends: './single' };
 
       canonicalizeRelativePresets(config, parent);
 

--- a/lib/config/presets/relative.spec.ts
+++ b/lib/config/presets/relative.spec.ts
@@ -1,0 +1,232 @@
+import { logger } from '~test/util.ts';
+import type { RenovateConfig } from '../types.ts';
+import { parsePreset } from './parse.ts';
+import { canonicalizeRelativePresets } from './relative.ts';
+
+describe('config/presets/relative', () => {
+  describe('canonicalizeRelativePresets', () => {
+    it.each`
+      parent                                          | input                    | expected
+      ${'github>Stedi/renovate-config#v2.0.0'}        | ${'./system/registries'} | ${'github>Stedi/renovate-config//system/registries#v2.0.0'}
+      ${'github>some/repo'}                           | ${'./x'}                 | ${'github>some/repo//x'}
+      ${'github>some/repo//system/registries#v2.0.0'} | ${'./cache'}             | ${'github>some/repo//system/cache#v2.0.0'}
+      ${'github>some/repo//a/b/c#v1'}                 | ${'../shared/x'}         | ${'github>some/repo//a/shared/x#v1'}
+      ${'github>some/repo//a/b/c#v1'}                 | ${'/x'}                  | ${'github>some/repo//x#v1'}
+      ${'github>some/repo//a/c.json5#v1'}             | ${'./sibling.json5'}     | ${'github>some/repo//a/sibling.json5#v1'}
+      ${'github>some/repo:file/sub#v1'}               | ${'./x'}                 | ${'github>some/repo//x#v1'}
+      ${'github>some/repo#v1'}                        | ${'./x(p1, p2)'}         | ${'github>some/repo//x#v1(p1, p2)'}
+      ${'github>some/repo#v1'}                        | ${'./x()'}               | ${'github>some/repo//x#v1()'}
+      ${'github>some/repo//sub/f#v1'}                 | ${'../default'}          | ${'github>some/repo#v1'}
+      ${'github>some/repo#v1'}                        | ${'/default'}            | ${'github>some/repo#v1'}
+      ${'github>some/repo#v1'}                        | ${'./default'}           | ${'github>some/repo#v1'}
+      ${'github>some/repo#v1'}                        | ${'./default(p1)'}       | ${'github>some/repo#v1(p1)'}
+      ${'github>some/repo//dir/f#v1'}                 | ${'./default'}           | ${'github>some/repo//dir/default#v1'}
+      ${'github>some/repo//sub/f'}                    | ${'./a/../b'}            | ${'github>some/repo//sub/b'}
+      ${'github>some/repo//a/b/c#v1'}                 | ${'/nested/dir/x'}       | ${'github>some/repo//nested/dir/x#v1'}
+      ${'github>o/r//dir/base#v1'}                    | ${'./g({{ env.T }})'}    | ${'github>o/r//dir/g#v1({{ env.T }})'}
+      ${'local>group/repo//presets/base'}             | ${'./extra'}             | ${'local>group/repo//presets/extra'}
+      ${'some/repo'}                                  | ${'./x'}                 | ${'local>some/repo//x'}
+      ${'gitlab>some/repo#v1'}                        | ${'./x'}                 | ${'gitlab>some/repo//x#v1'}
+      ${'gitea>some/repo#v1'}                         | ${'./x'}                 | ${'gitea>some/repo//x#v1'}
+      ${'forgejo>some/repo#v1'}                       | ${'./x'}                 | ${'forgejo>some/repo//x#v1'}
+    `(
+      'resolves $input inside $parent',
+      ({ parent, input, expected }: Record<string, string>) => {
+        const config: RenovateConfig = { extends: [input] };
+
+        canonicalizeRelativePresets(config, parsePreset(parent));
+
+        expect(config).toEqual({ extends: [expected] });
+      },
+    );
+
+    it.each`
+      parent                        | input          | reason
+      ${'github>some/repo#v1'}      | ${'../x'}      | ${'escapes the repository'}
+      ${'github>some/repo//a/f#v1'} | ${'../../x'}   | ${'escapes the repository'}
+      ${'github>some/repo//a/f#v1'} | ${'./../../x'} | ${'escapes the repository'}
+      ${'github>some/repo#v1'}      | ${'./x#v3'}    | ${'invalid tag'}
+      ${'github>some/repo#v1'}      | ${'./x:sub'}   | ${'sub-preset'}
+      ${'github>some/repo#v1'}      | ${'./.'}       | ${'names a directory'}
+      ${'github>some/repo//a/f#v1'} | ${'./..'}      | ${'names a directory'}
+    `(
+      'leaves $input unchanged inside $parent ($reason)',
+      ({ parent, input }: Record<string, string>) => {
+        const parsedParent = parsePreset(parent);
+        const config: RenovateConfig = { extends: [input] };
+
+        canonicalizeRelativePresets(config, parsedParent);
+
+        expect(config).toEqual({ extends: [input] });
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          {
+            preset: input,
+            parentPreset: parsedParent,
+            err: expect.any(Error),
+          },
+          'Could not resolve relative preset reference',
+        );
+      },
+    );
+
+    const parent = parsePreset('github>some/repo//dir/base#v1.0.0');
+
+    it('rewrites top-level extends', () => {
+      const config: RenovateConfig = {
+        extends: ['./sibling', '/root/base', '../parent/base'],
+      };
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        extends: [
+          'github>some/repo//dir/sibling#v1.0.0',
+          'github>some/repo//root/base#v1.0.0',
+          'github>some/repo//parent/base#v1.0.0',
+        ],
+      });
+    });
+
+    it('rewrites ignorePresets', () => {
+      const config: RenovateConfig = {
+        ignorePresets: ['./sibling', 'github>other/repo'],
+      };
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        ignorePresets: [
+          'github>some/repo//dir/sibling#v1.0.0',
+          'github>other/repo',
+        ],
+      });
+    });
+
+    it('warns about broken ignorePresets entries', () => {
+      const parsedParent = parsePreset('github>some/repo#v1');
+      const config: RenovateConfig = { ignorePresets: ['../oops'] };
+
+      canonicalizeRelativePresets(config, parsedParent);
+
+      expect(config).toEqual({ ignorePresets: ['../oops'] });
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        {
+          preset: '../oops',
+          parentPreset: parsedParent,
+          err: expect.any(Error),
+        },
+        'Could not resolve relative preset reference',
+      );
+    });
+
+    it('rewrites extends and ignorePresets of the same object', () => {
+      const config: RenovateConfig = {
+        extends: ['./optional'],
+        ignorePresets: ['./optional'],
+      };
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        extends: ['github>some/repo//dir/optional#v1.0.0'],
+        ignorePresets: ['github>some/repo//dir/optional#v1.0.0'],
+      });
+    });
+
+    it('rewrites nested extends inside packageRules', () => {
+      const config: RenovateConfig = {
+        packageRules: [
+          {
+            matchManagers: ['npm'],
+            extends: ['./rules/npm'],
+          },
+        ],
+      };
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        packageRules: [
+          {
+            matchManagers: ['npm'],
+            extends: ['github>some/repo//dir/rules/npm#v1.0.0'],
+          },
+        ],
+      });
+    });
+
+    it('rewrites deeply nested extends', () => {
+      const config = {
+        outer: {
+          list: [[{ extends: ['./deep'] }]],
+          inner: { extends: ['./inner'] },
+        },
+      } as RenovateConfig;
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        outer: {
+          list: [[{ extends: ['github>some/repo//dir/deep#v1.0.0'] }]],
+          inner: { extends: ['github>some/repo//dir/inner#v1.0.0'] },
+        },
+      });
+    });
+
+    it('rewrites onboardingConfig extends', () => {
+      const config: RenovateConfig = {
+        onboardingConfig: {
+          extends: ['./onboarding'],
+        },
+      };
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        onboardingConfig: {
+          extends: ['github>some/repo//dir/onboarding#v1.0.0'],
+        },
+      });
+    });
+
+    it('leaves other entries untouched', () => {
+      const config = {
+        labels: ['dependencies'],
+        enabled: true,
+        nothing: null,
+        extends: [
+          'config:recommended',
+          'github>other/repo',
+          './{{arg0}}',
+          './with/{{arg0}}',
+          './{{ env.X }}/base',
+          42,
+        ],
+      } as RenovateConfig;
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({
+        labels: ['dependencies'],
+        enabled: true,
+        nothing: null,
+        extends: [
+          'config:recommended',
+          'github>other/repo',
+          './{{arg0}}',
+          './with/{{arg0}}',
+          './{{ env.X }}/base',
+          42,
+        ],
+      });
+    });
+
+    it('ignores non-array extends', () => {
+      const config = { extends: './single' } as unknown as RenovateConfig;
+
+      canonicalizeRelativePresets(config, parent);
+
+      expect(config).toEqual({ extends: './single' });
+    });
+  });
+});

--- a/lib/config/presets/relative.ts
+++ b/lib/config/presets/relative.ts
@@ -1,0 +1,106 @@
+import { isArray, isPlainObject, isString } from '@sindresorhus/is';
+import upath from 'upath';
+import { logger } from '../../logger/index.ts';
+import { isRelativePresetReference, parsePreset } from './parse.ts';
+import type { ParsedPreset } from './types.ts';
+import { PRESET_RELATIVE_OUTSIDE_REPO } from './util.ts';
+
+/**
+ * Keys whose array entries may contain relative preset references.
+ */
+const presetReferenceKeys = ['extends', 'ignorePresets'];
+
+/**
+ * Converts a relative preset reference into an absolute preset string, by
+ * inheriting the source, repository and tag of the preset which references it.
+ *
+ * For example `./system/registries` found inside `github>some/repo#v2.0.0`
+ * resolves to `github>some/repo//system/registries#v2.0.0`.
+ */
+function resolveRelativePreset(input: string, parent: ParsedPreset): string {
+  const parsed = parsePreset(input);
+
+  let resolved: string;
+  if (parsed.presetName.startsWith('/')) {
+    // relative to the root of the repository
+    resolved = upath.normalize(parsed.presetName.slice(1));
+  } else {
+    // relative to the directory of the preset file which references it
+    resolved = upath.normalize(
+      upath.join(parent.presetPath ?? '', parsed.presetName),
+    );
+  }
+
+  if (resolved === '..' || resolved.startsWith('../')) {
+    throw new Error(PRESET_RELATIVE_OUTSIDE_REPO);
+  }
+
+  const tag = parent.tag ? `#${parent.tag}` : '';
+  const params = isString(parsed.rawParams) ? `(${parsed.rawParams})` : '';
+
+  if (resolved === 'default') {
+    // the default preset at the root of the repository is spelled without a
+    // path, so emitting `//default` here would break deduplication against the
+    // way consumers reference the very same preset
+    return `${parent.presetSource}>${parent.repo}${tag}${params}`;
+  }
+
+  return `${parent.presetSource}>${parent.repo}//${resolved}${tag}${params}`;
+}
+
+/**
+ * Rewrites every relative preset reference found in any `extends` or
+ * `ignorePresets` array of the given value into an absolute preset string.
+ * The value is mutated in place.
+ */
+export function canonicalizeRelativePresets(
+  value: unknown,
+  parent: ParsedPreset,
+): void {
+  if (isArray(value)) {
+    for (const element of value) {
+      canonicalizeRelativePresets(element, parent);
+    }
+    return;
+  }
+
+  if (!isPlainObject(value)) {
+    return;
+  }
+
+  for (const [key, val] of Object.entries(value)) {
+    if (presetReferenceKeys.includes(key) && isArray(val)) {
+      value[key] = val.map((entry) => rewritePresetEntry(entry, parent));
+      continue;
+    }
+
+    canonicalizeRelativePresets(val, parent);
+  }
+}
+
+function rewritePresetEntry(entry: unknown, parent: ParsedPreset): unknown {
+  if (!isString(entry) || !isRelativePresetReference(entry)) {
+    return entry;
+  }
+
+  // only the path may not be templated, because it has to be resolved here,
+  // while the parameters are compiled later on
+  const pathPortion = entry.includes('(')
+    ? entry.slice(0, entry.indexOf('('))
+    : entry;
+  if (pathPortion.includes('{{')) {
+    return entry;
+  }
+
+  try {
+    return resolveRelativePreset(entry, parent);
+  } catch (err) {
+    // the unchanged entry is reported when it is resolved as a preset, which
+    // allows consumers to neutralize it using `ignorePresets`
+    logger.warn(
+      { preset: entry, parentPreset: parent, err },
+      'Could not resolve relative preset reference',
+    );
+    return entry;
+  }
+}

--- a/lib/config/presets/relative.ts
+++ b/lib/config/presets/relative.ts
@@ -1,6 +1,7 @@
 import { isArray, isPlainObject, isString } from '@sindresorhus/is';
 import upath from 'upath';
 import { logger } from '../../logger/index.ts';
+import { coerceString } from '../../util/string.ts';
 import { isRelativePresetReference, parsePreset } from './parse.ts';
 import type { ParsedPreset } from './types.ts';
 import { PRESET_RELATIVE_OUTSIDE_REPO } from './util.ts';
@@ -27,7 +28,7 @@ function resolveRelativePreset(input: string, parent: ParsedPreset): string {
   } else {
     // relative to the directory of the preset file which references it
     resolved = upath.normalize(
-      upath.join(parent.presetPath ?? '', parsed.presetName),
+      upath.join(coerceString(parent.presetPath), parsed.presetName),
     );
   }
 

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -15,21 +15,6 @@ export const PRESET_RELATIVE_OUTSIDE_REPO = 'relative preset outside repo';
 export const PRESET_RENOVATE_CONFIG_NOT_FOUND =
   'preset renovate-config not found';
 
-/**
- * Preset sources which are hosted in a repository, so presets from them can
- * reference other presets relatively.
- *
- * Must stay in sync with the repository hosted subset of `presetSourceLoaders`
- * in `index.ts`.
- */
-export const REPO_HOSTED_PRESET_SOURCES = [
-  'forgejo',
-  'gitea',
-  'github',
-  'gitlab',
-  'local',
-];
-
 export async function fetchPreset({
   repo,
   filePreset,

--- a/lib/config/presets/util.ts
+++ b/lib/config/presets/util.ts
@@ -10,8 +10,25 @@ export const PRESET_INVALID = 'invalid preset';
 export const PRESET_INVALID_JSON = 'invalid preset JSON';
 export const PRESET_NOT_FOUND = 'preset not found';
 export const PRESET_PROHIBITED_SUBPRESET = 'prohibited sub-preset';
+export const PRESET_RELATIVE_NO_PARENT = 'relative preset has no parent';
+export const PRESET_RELATIVE_OUTSIDE_REPO = 'relative preset outside repo';
 export const PRESET_RENOVATE_CONFIG_NOT_FOUND =
   'preset renovate-config not found';
+
+/**
+ * Preset sources which are hosted in a repository, so presets from them can
+ * reference other presets relatively.
+ *
+ * Must stay in sync with the repository hosted subset of `presetSourceLoaders`
+ * in `index.ts`.
+ */
+export const REPO_HOSTED_PRESET_SOURCES = [
+  'forgejo',
+  'gitea',
+  'github',
+  'gitlab',
+  'local',
+];
 
 export async function fetchPreset({
   repo,

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1766,6 +1766,212 @@ describe('config/validation', () => {
       ]);
     });
 
+    it('accepts relative preset references', async () => {
+      const config = {
+        extends: ['./foo', '../foo/bar', '/foo'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts relative preset references inside packageRules', async () => {
+      const config = {
+        packageRules: [
+          {
+            matchManagers: ['npm'],
+            extends: ['./rules/npm'],
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts relative preset references nested inside packageRules', async () => {
+      const config = {
+        packageRules: [
+          {
+            matchManagers: ['npm'],
+            minor: {
+              extends: ['./minor-rules'],
+            },
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+
+    it('accepts selectors-only packageRules which contain a relative preset', async () => {
+      const config = {
+        packageRules: [
+          {
+            matchManagers: ['npm'],
+            extends: ['./x'],
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+
+    it('warns about selectors-only packageRules which contain a non-relative preset', async () => {
+      const config = {
+        packageRules: [
+          {
+            extends: ['packages:eslint'],
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([
+        {
+          topic: 'Configuration Error',
+          message:
+            'packageRules[0]: Each packageRule must contain at least one non-match* or non-exclude* field. Rule: {"extends":["packages:eslint"]}',
+        },
+      ]);
+      expect(errors).toEqual([]);
+    });
+
+    it('warns about packageRules whose selectors may come from a relative preset', async () => {
+      const config = {
+        packageRules: [
+          {
+            extends: ['./selectors'],
+            automerge: true,
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([
+        {
+          topic: 'Configuration Error',
+          message:
+            'packageRules[0]: this rule extends a relative preset that cannot be resolved during validation, so its selectors could not be checked. Rule: {"extends":["./selectors"],"automerge":true}',
+        },
+      ]);
+      expect(errors).toEqual([]);
+    });
+
+    it('warns instead of erroring on packageRules which only contain a relative preset', async () => {
+      const config = {
+        packageRules: [
+          {
+            extends: ['./automerge'],
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([
+        {
+          topic: 'Configuration Error',
+          message:
+            'packageRules[0]: this rule extends a relative preset that cannot be resolved during validation, so its selectors could not be checked. Rule: {"extends":["./automerge"]}',
+        },
+      ]);
+      expect(errors).toEqual([]);
+    });
+
+    it('errors on packageRules without selectors and without relative presets', async () => {
+      const config = {
+        packageRules: [
+          {
+            automerge: true,
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([
+        {
+          topic: 'Configuration Error',
+          message:
+            'packageRules[0]: Each packageRule must contain at least one match* or exclude* selector. Rule: {"automerge":true}',
+        },
+      ]);
+    });
+
+    it('resolves absolute preset references inside packageRules which also contain relative ones', async () => {
+      const config = {
+        packageRules: [
+          {
+            matchManagers: ['npm'],
+            extends: ['./rel', ':pinVersions'],
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([]);
+    });
+
+    it('errors on invalid relative preset references', async () => {
+      const config = {
+        extends: ['./foo#v1', './foo:bar', './a//b'],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toEqual([]);
+      expect(errors).toEqual([
+        {
+          topic: 'Configuration Error',
+          message: 'extends: preset "./a//b" is not valid',
+        },
+        {
+          topic: 'Configuration Error',
+          message: 'extends: preset "./foo#v1" is not valid',
+        },
+        {
+          topic: 'Configuration Error',
+          message: 'extends: preset "./foo:bar" is not valid',
+        },
+      ]);
+    });
+
     it('skips preset syntax validation for templates', async () => {
       const config = {
         extends: ['local>{{ env.PRESET_REPO }}:python-312'],

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -20,6 +20,7 @@ import { isCustomManager } from '../modules/manager/custom/index.ts';
 import type { CustomManager } from '../modules/manager/custom/types.ts';
 import type { HostRule } from '../types/index.ts';
 import { packageCacheNamespaces } from '../util/cache/package/namespaces.ts';
+import { clone } from '../util/clone.ts';
 import { getToolConfig } from '../util/exec/containerbase.ts';
 import { isConstraintName, isToolName } from '../util/exec/types.ts';
 import { isValidCommitTrailer } from '../util/git/commit-trailers.ts';
@@ -47,10 +48,11 @@ import { migrateConfig } from './migration.ts';
 import { getOptions } from './options/index.ts';
 import { resolveConfigPresets } from './presets/index.ts';
 import { supportedDatasources } from './presets/internal/merge-confidence.preset.ts';
-import { parsePreset } from './presets/parse.ts';
+import { isRelativePresetReference, parsePreset } from './presets/parse.ts';
 import type {
   AllConfig,
   AllowedParents,
+  RenovateConfig,
   RenovateOptions,
   StatusCheckKey,
   ValidationMessage,
@@ -194,6 +196,54 @@ function initOptions(): void {
   }
 
   optionsInitialized = true;
+}
+
+/**
+ * Removes every relative preset reference from a deep copy of the given
+ * `packageRules` entry, at any nesting depth.
+ *
+ * Relative references are only resolvable while the preset which contains them
+ * is fetched, so they must not be passed to `resolveConfigPresets()` during
+ * validation. They are still syntax checked by the `extends` validation.
+ */
+function stripRelativePresets(packageRule: RenovateConfig): {
+  rule: RenovateConfig;
+  hasRelativePresets: boolean;
+} {
+  const rule = clone(packageRule);
+  const hasRelativePresets = stripRelativePresetsFromValue(rule);
+  return { rule, hasRelativePresets };
+}
+
+function stripRelativePresetsFromValue(value: unknown): boolean {
+  if (isArray(value)) {
+    let stripped = false;
+    for (const element of value) {
+      stripped = stripRelativePresetsFromValue(element) || stripped;
+    }
+    return stripped;
+  }
+
+  if (!isPlainObject(value)) {
+    return false;
+  }
+
+  let stripped = false;
+  for (const [key, val] of Object.entries(value)) {
+    if (key === 'extends' && isArray(val)) {
+      const remaining = val.filter(
+        (preset) => !(isString(preset) && isRelativePresetReference(preset)),
+      );
+      if (remaining.length !== val.length) {
+        value[key] = remaining;
+        stripped = true;
+      }
+      continue;
+    }
+
+    stripped = stripRelativePresetsFromValue(val) || stripped;
+  }
+  return stripped;
 }
 
 export async function validateConfig(
@@ -493,8 +543,10 @@ export async function validateConfig(
                 if (key === 'packageRules') {
                   for (const [subIndex, packageRule] of val.entries()) {
                     if (isObject(packageRule)) {
+                      const { rule, hasRelativePresets } =
+                        stripRelativePresets(packageRule);
                       const { config: resolved } = await resolveConfigPresets(
-                        packageRule,
+                        rule,
                         config,
                       );
                       const resolvedRule = migrateConfig({
@@ -511,15 +563,32 @@ export async function validateConfig(
                         (ruleKey) => selectors.includes(ruleKey),
                       ).length;
                       if (!selectorLength) {
-                        const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one match* or exclude* selector. Rule: ${JSON.stringify(
-                          packageRule,
-                        )}`;
-                        errors.push({
-                          topic: 'Configuration Error',
-                          message,
-                        });
+                        if (hasRelativePresets) {
+                          // the stripped relative preset may still provide the
+                          // missing selectors, so this cannot be an error
+                          const message = `${currentPath}[${subIndex}]: this rule extends a relative preset that cannot be resolved during validation, so its selectors could not be checked. Rule: ${JSON.stringify(
+                            packageRule,
+                          )}`;
+                          warnings.push({
+                            topic: 'Configuration Error',
+                            message,
+                          });
+                        } else {
+                          const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one match* or exclude* selector. Rule: ${JSON.stringify(
+                            packageRule,
+                          )}`;
+                          errors.push({
+                            topic: 'Configuration Error',
+                            message,
+                          });
+                        }
                       }
-                      if (selectorLength === Object.keys(resolvedRule).length) {
+                      if (
+                        // the stripped relative preset legitimately provides
+                        // the non-selector field
+                        !hasRelativePresets &&
+                        selectorLength === Object.keys(resolvedRule).length
+                      ) {
                         const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one non-match* or non-exclude* field. Rule: ${JSON.stringify(
                           packageRule,
                         )}`;

--- a/lib/modules/manager/renovate-config/extract.spec.ts
+++ b/lib/modules/manager/renovate-config/extract.spec.ts
@@ -85,6 +85,85 @@ describe('modules/manager/renovate-config/extract', () => {
         });
       });
 
+      it('provides skipReason for relative presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "extends": ["./system/registries", "../shared", "/security/base"]
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              depName: './system/registries',
+              skipReason: 'unsupported-datasource',
+            },
+            {
+              depName: '../shared',
+              skipReason: 'unsupported-datasource',
+            },
+            {
+              depName: '/security/base',
+              skipReason: 'unsupported-datasource',
+            },
+          ],
+        });
+      });
+
+      it('provides skipReason for malformed presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "extends": ["./foo#1.2.3", "github>abc/foo#1.2.3"]
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              depName: './foo#1.2.3',
+              skipReason: 'invalid-value',
+            },
+            {
+              datasource: 'github-tags',
+              depName: 'abc/foo',
+              currentValue: '1.2.3',
+            },
+          ],
+        });
+
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          { preset: './foo#1.2.3', err: expect.any(Error) },
+          'Failed to parse preset',
+        );
+      });
+
+      it('ignores templated presets', () => {
+        expect(
+          extractPackageFile(
+            codeBlock`
+            {
+              "extends": ["local>{{ env.PRESET_REPO }}:python-312", "github>abc/foo#1.2.3"]
+            }
+          `,
+            'renovate.json',
+          ),
+        ).toEqual({
+          deps: [
+            {
+              datasource: 'github-tags',
+              depName: 'abc/foo',
+              currentValue: '1.2.3',
+            },
+          ],
+        });
+      });
+
       it('provides skipReason for presets without versions', () => {
         expect(
           extractPackageFile(

--- a/lib/modules/manager/renovate-config/extract.ts
+++ b/lib/modules/manager/renovate-config/extract.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyArray, isNullOrUndefined } from '@sindresorhus/is';
 import { parsePreset } from '../../../config/presets/parse.ts';
+import type { ParsedPreset } from '../../../config/presets/types.ts';
 import { logger } from '../../../logger/index.ts';
 import { getToolConfig } from '../../../util/exec/containerbase.ts';
 import { isToolName } from '../../../util/exec/types.ts';
@@ -29,13 +30,32 @@ export function extractPackageFile(
   const deps: PackageDependency[] = [];
 
   for (const preset of config.data.extends ?? []) {
-    const parsedPreset = parsePreset(preset);
+    if (preset.includes('{{')) {
+      // templated presets are only resolvable at runtime
+      continue;
+    }
+
+    let parsedPreset: ParsedPreset;
+    try {
+      parsedPreset = parsePreset(preset);
+    } catch (err) {
+      logger.debug({ preset, err }, 'Failed to parse preset');
+      deps.push({
+        depName: preset,
+        skipReason: 'invalid-value',
+      });
+      continue;
+    }
     const datasource = supportedPresetSources[parsedPreset.presetSource];
 
     if (isNullOrUndefined(datasource)) {
       if (parsedPreset.presetSource !== 'internal') {
         deps.push({
-          depName: parsedPreset.repo,
+          // relative references have no repository of their own
+          depName:
+            parsedPreset.presetSource === 'relative'
+              ? preset
+              : parsedPreset.repo,
           skipReason: 'unsupported-datasource',
         });
       }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds support for parsing relative paths and translate them to the fullpath including parent tags. 

```jsonc
// consumer renovate.json
{ "extends": ["github>secustor/relative-presets-demo#v1.0.0"] }
```

```jsonc
// default.json — in the monorepo
{
  "extends": ["./system/registries", "/groups/aws", "./automerge/non-breaking"]
}
```

The example from changes will no translated to: 

```
github>secustor/relative-presets-demo//system/registries#v1.0.0
github>secustor/relative-presets-demo//groups/aws#v1.0.0
github>secustor/relative-presets-demo//automerge/non-breaking#v1.0.0
```

## Context

A preset repository that splits its config across many files has to spell out the full address of every internal reference:

```jsonc
// default.json — the old way
{
  "extends": [
    "github>secustor/relative-presets-demo//system/registries",
    "github>secustor/relative-presets-demo//groups/aws"
  ]
}
```

Those references carry no tag, so they always resolve from the default branch. A consumer who pins the catalog to a release:

```jsonc
{ "extends": ["github>secustor/relative-presets-demo#v1.0.0"] }
```

gets `default.json` at `v1.0.0` and **every nested preset from `main`**. Pinning properly means writing `#v1.0.0` into every internal reference in every file, and rewriting all of them on every release.

Another nice byproduct of this is that preset repos can now be forked with this setup. 

Discussions: 
 - https://github.com/renovatebot/renovate/discussions/24753
 - https://github.com/renovatebot/renovate/discussions/16983

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/secustor/relative-presets-demo

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
