### PR TITLE
feat(onboarding): improve wording of concurrency limits with PRs opened

### DIFF
--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -269,6 +269,190 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       expect(res).toContain('commitHourlyLimit');
       expect(res).not.toContain('prHourlyLimit');
     });
+
+    it('shows the branchConcurrentLimit message when it restricts the PR count', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.branchConcurrentLimit = 1;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'Renovate will create 1 Pull Request, up to a maximum of 3 over time',
+      );
+      expect(res).toContain('branchConcurrentLimit');
+    });
+
+    it('shows the prConcurrentLimit message when branchConcurrentLimit does not restrict the count', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 2;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'Renovate will create 2 Pull Requests, up to a maximum of 3 over time',
+      );
+      expect(res).toContain('prConcurrentLimit');
+    });
+
+    it('does not show a concurrent limit message when the limit is not restrictive', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 10;
+      const res = getExpectedPrList(config, branches);
+      expect(res).not.toContain('up to a maximum of');
+      expect(res).not.toContain('prConcurrentLimit');
+    });
+
+    it('prioritizes branchConcurrentLimit over prConcurrentLimit when both restrict the count', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.branchConcurrentLimit = 1;
+      config.prConcurrentLimit = 2;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'Renovate will create 1 Pull Request, up to a maximum of 3 over time',
+      );
+      expect(res).toContain('branchConcurrentLimit');
+      expect(res).not.toContain('prConcurrentLimit');
+    });
   });
 
   describe('getExpectedPrListSummary()', () => {
@@ -1549,6 +1733,244 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       config.commitHourlyLimit = 0;
       const res = getExpectedPrListSummary(config, branches);
       expect(res).toContain('(with no configured maximum of PRs per hour)');
+    });
+
+    it('shows the branchConcurrentLimit message when it restricts the PR count', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.branchConcurrentLimit = 1;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain('at a maximum of 1 branch open at a time');
+      expect(res).toContain(
+        'Renovate will only work on 1 branch at a time, so not all Pull Requests will be opened straight away',
+      );
+      expect(res).toContain('branchConcurrentLimit');
+    });
+
+    it('shows the branchConcurrentLimit message with plurals when limit is greater than 1', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.branchConcurrentLimit = 2;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain('at a maximum of 2 branches open at a time');
+      expect(res).toContain(
+        'Renovate will only work on 2 branches at a time, so not all Pull Requests will be opened straight away',
+      );
+    });
+
+    it('shows the prConcurrentLimit message when branchConcurrentLimit does not restrict the count', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 2;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain('at a maximum of 2 Pull Requests open at a time');
+      expect(res).toContain(
+        'Renovate will only keep 2 Pull Requests open at a time, so not all of the above will be opened straight away',
+      );
+      expect(res).toContain('prConcurrentLimit');
+      expect(res).not.toContain('branchConcurrentLimit');
+    });
+
+    it('does not show a concurrent limit message when the limit is not restrictive', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 10;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).not.toContain('open at a time');
+      expect(res).not.toContain('prConcurrentLimit');
+    });
+
+    it('combines the concurrent limit and hourly limit messages when both restrict the count', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 1;
+      config.prHourlyLimit = 1;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        '(at a maximum of 1 Pull Request open at a time and a maximum of 1 PR per hour)',
+      );
     });
   });
 });

--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -3,6 +3,23 @@ import { partial } from '~test/util.ts';
 import type { BranchConfig } from '../../../types.ts';
 import { getExpectedPrList, getExpectedPrListSummary } from './pr-list.ts';
 
+function createBranch(letter: string): BranchConfig {
+  return {
+    prTitle: `Update ${letter} to v1`,
+    branchName: `renovate/${letter}-1.x`,
+    baseBranch: 'base',
+    manager: 'some-manager',
+    upgrades: [
+      {
+        manager: 'some-manager',
+        depName: letter,
+        newValue: '1.0.0',
+        branchName: 'some-branch',
+      },
+    ],
+  };
+}
+
 describe('workers/repository/onboarding/pr/pr-list', () => {
   describe('getExpectedPrList()', () => {
     let config: RenovateConfig;
@@ -272,48 +289,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('shows the branchConcurrentLimit message when it restricts the PR count', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.branchConcurrentLimit = 1;
       const res = getExpectedPrList(config, branches);
@@ -325,48 +303,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('shows the prConcurrentLimit message when branchConcurrentLimit does not restrict the count', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.prConcurrentLimit = 2;
       const res = getExpectedPrList(config, branches);
@@ -377,22 +316,7 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
     });
 
     it('does not show a concurrent limit message when the limit is not restrictive', () => {
-      const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-      ];
+      const branches: BranchConfig[] = [createBranch('a')];
       config.prConcurrentLimit = 10;
       const res = getExpectedPrList(config, branches);
       expect(res).not.toContain('up to a maximum of');
@@ -401,48 +325,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('prioritizes branchConcurrentLimit over prConcurrentLimit when both restrict the count', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'some-branch',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.branchConcurrentLimit = 1;
       config.prConcurrentLimit = 2;
@@ -1737,48 +1622,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('shows the branchConcurrentLimit message when it restricts the PR count', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.branchConcurrentLimit = 1;
       const res = getExpectedPrListSummary(config, branches);
@@ -1791,48 +1637,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('shows the branchConcurrentLimit message with plurals when limit is greater than 1', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.branchConcurrentLimit = 2;
       const res = getExpectedPrListSummary(config, branches);
@@ -1844,48 +1651,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('shows the prConcurrentLimit message when branchConcurrentLimit does not restrict the count', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.prConcurrentLimit = 2;
       const res = getExpectedPrListSummary(config, branches);
@@ -1898,22 +1666,7 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
     });
 
     it('does not show a concurrent limit message when the limit is not restrictive', () => {
-      const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-      ];
+      const branches: BranchConfig[] = [createBranch('a')];
       config.prConcurrentLimit = 10;
       const res = getExpectedPrListSummary(config, branches);
       expect(res).not.toContain('open at a time');
@@ -1922,48 +1675,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
 
     it('combines the concurrent limit and hourly limit messages when both restrict the count', () => {
       const branches: BranchConfig[] = [
-        {
-          prTitle: 'Update a to v1',
-          branchName: 'renovate/a-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'a',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update b to v1',
-          branchName: 'renovate/b-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'b',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
-        {
-          prTitle: 'Update c to v1',
-          branchName: 'renovate/c-1.x',
-          baseBranch: 'base',
-          manager: 'some-manager',
-          upgrades: [
-            {
-              manager: 'some-manager',
-              depName: 'c',
-              newValue: '1.0.0',
-              branchName: 'ignored',
-            },
-          ],
-        },
+        createBranch('a'),
+        createBranch('b'),
+        createBranch('c'),
       ];
       config.prConcurrentLimit = 1;
       config.prHourlyLimit = 1;

--- a/lib/workers/repository/onboarding/pr/pr-list.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.ts
@@ -8,7 +8,8 @@ import { logger } from '../../../../logger/index.ts';
 import { emojify } from '../../../../util/emoji.ts';
 import { coerceNumber } from '../../../../util/number.ts';
 import { regEx } from '../../../../util/regex.ts';
-import type { BranchConfig } from '../../../types.ts';
+import { calcLimit } from '../../../global/limits.ts';
+import type { BranchConfig, BranchUpgradeConfig } from '../../../types.ts';
 
 /**
  * The different categories of dependency updates to output, when providing the summary view.
@@ -30,6 +31,46 @@ const SUMMARY_CATEGORY_PRIORITY_ORDER: readonly SummaryCategory[] = [
   // ... anything else
 ];
 
+interface ConcurrentLimit {
+  limit: number;
+  key: 'prConcurrentLimit' | 'branchConcurrentLimit';
+}
+
+/**
+ * Resolves the concurrent limit that governs how many of the expected Pull Requests can be open at once,
+ * reusing the same `calcLimit()` used to enforce these limits (see `lib/workers/global/limits.ts`).
+ *
+ * `branchConcurrentLimit` only takes priority when it's been explicitly configured (it's `null` by default,
+ * in which case `calcLimit()` silently inherits the value of `prConcurrentLimit`) and is actually more
+ * restrictive - otherwise we'd misattribute the limit to a setting the user never touched.
+ */
+function resolveConcurrentLimit(config: RenovateConfig): ConcurrentLimit {
+  const configAsUpgrade: BranchUpgradeConfig = {
+    branchName: '',
+    manager: '',
+    prConcurrentLimit: config.prConcurrentLimit,
+    branchConcurrentLimit: config.branchConcurrentLimit,
+  };
+  const prConcurrentLimit = calcLimit([configAsUpgrade], 'prConcurrentLimit');
+  const branchConcurrentLimit = calcLimit(
+    [configAsUpgrade],
+    'branchConcurrentLimit',
+  );
+
+  if (
+    typeof config.branchConcurrentLimit === 'number' &&
+    branchConcurrentLimit > 0 &&
+    (prConcurrentLimit === 0 || branchConcurrentLimit < prConcurrentLimit)
+  ) {
+    return {
+      limit: branchConcurrentLimit,
+      key: 'branchConcurrentLimit',
+    };
+  }
+
+  return { limit: prConcurrentLimit, key: 'prConcurrentLimit' };
+}
+
 export function getExpectedPrList(
   config: RenovateConfig,
   branches: BranchConfig[],
@@ -40,8 +81,14 @@ export function getExpectedPrList(
   if (!branches.length) {
     return `${prDesc}It looks like your repository dependencies are already up-to-date and no Pull Requests will be necessary right away.\n`;
   }
-  prDesc += `With your current configuration, Renovate will create ${branches.length} Pull Request`;
-  prDesc += branches.length > 1 ? `s:\n\n` : `:\n\n`;
+  const { limit: concurrentLimit, key: concurrentLimitKey } =
+    resolveConcurrentLimit(config);
+  if (concurrentLimit > 0 && concurrentLimit < branches.length) {
+    prDesc += `With your current configuration, Renovate will create ${concurrentLimit} Pull Request${concurrentLimit > 1 ? 's' : ''}, up to a maximum of ${branches.length} over time (see [docs for \`${concurrentLimitKey}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#${concurrentLimitKey.toLowerCase()})):\n\n`;
+  } else {
+    prDesc += `With your current configuration, Renovate will create ${branches.length} Pull Request`;
+    prDesc += branches.length > 1 ? `s:\n\n` : `:\n\n`;
+  }
 
   for (const branch of branches) {
     const prTitleRe = regEx(/@([a-z]+\/[a-z]+)/);
@@ -321,6 +368,7 @@ export function getExpectedPrListSummary(
 
   const prHourlyLimit = coerceNumber(config.prHourlyLimit);
   const commitHourlyLimit = coerceNumber(config.commitHourlyLimit);
+  const concurrentLimit = resolveConcurrentLimit(config);
 
   if (hasMultipleBaseBranches) {
     let total = 0;
@@ -330,19 +378,21 @@ export function getExpectedPrListSummary(
       const label = base ? `the \`${base}\` branch` : 'the default branch';
       return `${count} Pull Request${count > 1 ? 's' : ''} to ${label}`;
     });
-    const hourlyLimitsNotice = determineHourlyLimitsNotice(
+    const limitsNotice = determineLimitsNotice(
+      concurrentLimit,
       prHourlyLimit,
       commitHourlyLimit,
       total,
     );
-    prDesc += `With your current configuration, Renovate will create ${parts.join(' and ')}${hourlyLimitsNotice}:\n\n`;
+    prDesc += `With your current configuration, Renovate will create ${parts.join(' and ')}${limitsNotice}:\n\n`;
   } else {
-    const hourlyLimitsNotice = determineHourlyLimitsNotice(
+    const limitsNotice = determineLimitsNotice(
+      concurrentLimit,
       prHourlyLimit,
       commitHourlyLimit,
       stats.prCount,
     );
-    prDesc += `With your current configuration, Renovate will create ${stats.prCount} Pull Request${stats.prCount > 1 ? 's' : ''}${hourlyLimitsNotice}:\n\n`;
+    prDesc += `With your current configuration, Renovate will create ${stats.prCount} Pull Request${stats.prCount > 1 ? 's' : ''}${limitsNotice}:\n\n`;
   }
 
   const categoryColumns = getCategoryColumns(stats.presentCategories);
@@ -387,6 +437,16 @@ export function getExpectedPrListSummary(
     }
   }
 
+  if (concurrentLimit.limit > 0 && concurrentLimit.limit < stats.prCount) {
+    const notice =
+      concurrentLimit.key === 'branchConcurrentLimit'
+        ? `Renovate will only work on ${concurrentLimit.limit} branch${concurrentLimit.limit > 1 ? 'es' : ''} at a time, so not all Pull Requests will be opened straight away`
+        : `Renovate will only keep ${concurrentLimit.limit} Pull Request${concurrentLimit.limit > 1 ? 's' : ''} open at a time, so not all of the above will be opened straight away`;
+    prDesc += emojify(
+      `\n\n:children_crossing: ${notice}. See [docs for \`${concurrentLimit.key}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#${concurrentLimit.key.toLowerCase()}) for details.\n\n`,
+    );
+  }
+
   if (
     commitHourlyLimit > 0 &&
     commitHourlyLimit < 5 &&
@@ -407,13 +467,20 @@ export function getExpectedPrListSummary(
   return prDesc;
 }
 
-function determineHourlyLimitsNotice(
+function determineLimitsNotice(
+  concurrentLimit: ConcurrentLimit,
   prHourlyLimit: number,
   commitHourlyLimit: number,
   prCount: number,
 ): string {
-  if (commitHourlyLimit === 0 && prHourlyLimit === 0) {
-    return ' (with no configured maximum of PRs per hour)';
+  const clauses: string[] = [];
+
+  if (concurrentLimit.limit > 0 && concurrentLimit.limit < prCount) {
+    clauses.push(
+      concurrentLimit.key === 'branchConcurrentLimit'
+        ? `a maximum of ${concurrentLimit.limit} branch${concurrentLimit.limit > 1 ? 'es' : ''} open at a time`
+        : `a maximum of ${concurrentLimit.limit} Pull Request${concurrentLimit.limit > 1 ? 's' : ''} open at a time`,
+    );
   }
 
   if (
@@ -421,15 +488,25 @@ function determineHourlyLimitsNotice(
     commitHourlyLimit < 5 &&
     commitHourlyLimit < prCount
   ) {
-    return emojify(
-      ` (at a maximum of ${commitHourlyLimit} PR${commitHourlyLimit > 1 ? 's' : ''}/rebase${commitHourlyLimit > 1 ? 's' : ''} per hour)`,
+    clauses.push(
+      `a maximum of ${commitHourlyLimit} PR${commitHourlyLimit > 1 ? 's' : ''}/rebase${commitHourlyLimit > 1 ? 's' : ''} per hour`,
+    );
+  } else if (
+    prHourlyLimit > 0 &&
+    prHourlyLimit < 5 &&
+    prHourlyLimit < prCount
+  ) {
+    clauses.push(
+      `a maximum of ${prHourlyLimit} PR${prHourlyLimit > 1 ? 's' : ''} per hour`,
     );
   }
 
-  if (prHourlyLimit > 0 && prHourlyLimit < 5 && prHourlyLimit < prCount) {
-    return emojify(
-      ` (at a maximum of ${prHourlyLimit} PR${prHourlyLimit > 1 ? 's' : ''} per hour)`,
-    );
+  if (clauses.length) {
+    return emojify(` (at ${clauses.join(' and ')})`);
+  }
+
+  if (commitHourlyLimit === 0 && prHourlyLimit === 0) {
+    return ' (with no configured maximum of PRs per hour)';
   }
 
   return '';


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When receiving an onboarding PR while using `prConcurrentLimit`,
`branchConcurrentLimit` or `prHourlyLimit` concurrency controls, users
may still receive a note such as:

> will create 189 Pull Requests

This isn't true, and can be surprising and/or worrying for a user who
may believe they're going to be swamped by PRs.

We can therefore improve this, to make it clearer how many will be
immediately raised, and how many will be raised over time.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
