### PR TITLE
fix(onboarding): clarify security PRs are not part of limits

### DIFF
--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -338,6 +338,271 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       expect(res).toContain('branchConcurrentLimit');
       expect(res).not.toContain('prConcurrentLimit');
     });
+
+    it('does not count security updates towards the concurrent limit, and notes they bypass it', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for d',
+          branchName: 'renovate/d-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'd',
+              newValue: '1.0.1',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 1;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'Renovate will create 1 Pull Request, up to a maximum of 4 over time',
+      );
+      expect(res).toContain(
+        'plus 1 security update Pull Request which is not subject to this limit',
+      );
+    });
+
+    it('does not count multiple security updates towards the concurrent limit, and notes they bypass it (plural)', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for d',
+          branchName: 'renovate/d-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'd',
+              newValue: '1.0.1',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for e',
+          branchName: 'renovate/e-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'e',
+              newValue: '1.0.1',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 1;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'Renovate will create 1 Pull Request, up to a maximum of 5 over time',
+      );
+      expect(res).toContain(
+        'plus 2 security update Pull Requests which are not subject to this limit',
+      );
+    });
+
+    it('does not count security updates towards the hourly limit, and notes they bypass it (plural)', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for c',
+          branchName: 'renovate/c-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.1',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for d',
+          branchName: 'renovate/d-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'd',
+              newValue: '1.0.1',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.prHourlyLimit = 1;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'PR creation will be limited to maximum 1 per hour',
+      );
+      expect(res).toContain(
+        'Security update Pull Requests are not subject to this limit and will be created straight away.',
+      );
+    });
+
+    it('does not show a security bypass note when there are no security updates', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'some-branch',
+            },
+          ],
+        },
+      ];
+      config.prHourlyLimit = 1;
+      const res = getExpectedPrList(config, branches);
+      expect(res).toContain(
+        'PR creation will be limited to maximum 1 per hour',
+      );
+      expect(res).not.toContain('security update');
+    });
   });
 
   describe('getExpectedPrListSummary()', () => {
@@ -1115,7 +1380,7 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
           "
           ### What to Expect
 
-          With your current configuration, Renovate will create 3 Pull Requests (at a maximum of 2 PRs per hour):
+          With your current configuration, Renovate will create 3 Pull Requests:
 
           | Manager | security |
           | --- | --- |
@@ -1132,10 +1397,6 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
           - \`a\`, (some-manager, patch):
             - \`packages/examples/blah.json\`
             - \`packages/examples/another.json\`
-
-
-          🚸 PR creation will be limited to maximum 2 per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](https://docs.renovatebot.com/configuration-options/#prhourlylimit) for details.
-
           "
         `);
       });
@@ -1684,6 +1945,198 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       const res = getExpectedPrListSummary(config, branches);
       expect(res).toContain(
         '(at a maximum of 1 Pull Request open at a time and a maximum of 1 PR per hour)',
+      );
+    });
+
+    it('shows the branchConcurrentLimit message with plurals when limit is greater than 1', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.branchConcurrentLimit = 2;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain('at a maximum of 2 branches open at a time');
+      expect(res).toContain('Renovate will only work on 2 branches at a time');
+    });
+
+    it('does not count a single security update towards the concurrent limit, and notes it bypasses it', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update c to v1',
+          branchName: 'renovate/c-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for d',
+          branchName: 'renovate/d-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'd',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 1;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        "plus 1 security update which isn't subject to these limits",
+      );
+      expect(res).toContain(
+        'Security update Pull Request is not subject to this limit and will be created straight away.',
+      );
+    });
+
+    it('does not count multiple security updates towards the hourly limit, and notes they bypass it (plural)', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'Update a to v1',
+          branchName: 'renovate/a-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'Update b to v1',
+          branchName: 'renovate/b-1.x',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.0',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for c',
+          branchName: 'renovate/c-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for d',
+          branchName: 'renovate/d-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'd',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prHourlyLimit = 1;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        "plus 2 security updates which aren't subject to these limits",
+      );
+      expect(res).toContain(
+        'Security update Pull Requests are not subject to this limit and will be created straight away.',
       );
     });
   });

--- a/lib/workers/repository/onboarding/pr/pr-list.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.ts
@@ -81,10 +81,20 @@ export function getExpectedPrList(
   if (!branches.length) {
     return `${prDesc}It looks like your repository dependencies are already up-to-date and no Pull Requests will be necessary right away.\n`;
   }
+  // Vulnerability alert branches bypass all rate/concurrency limits, so they shouldn't count towards them.
+  const securityBranchCount = branches.filter(
+    (b) => b.isVulnerabilityAlert,
+  ).length;
+  const throttledBranchCount = branches.length - securityBranchCount;
+
   const { limit: concurrentLimit, key: concurrentLimitKey } =
     resolveConcurrentLimit(config);
-  if (concurrentLimit > 0 && concurrentLimit < branches.length) {
-    prDesc += `With your current configuration, Renovate will create ${concurrentLimit} Pull Request${concurrentLimit > 1 ? 's' : ''}, up to a maximum of ${branches.length} over time (see [docs for \`${concurrentLimitKey}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#${concurrentLimitKey.toLowerCase()})):\n\n`;
+  if (concurrentLimit > 0 && concurrentLimit < throttledBranchCount) {
+    const securityNote =
+      securityBranchCount > 0
+        ? `, plus ${securityBranchCount} security update Pull Request${securityBranchCount > 1 ? 's' : ''} which ${securityBranchCount > 1 ? 'are' : 'is'} not subject to this limit`
+        : '';
+    prDesc += `With your current configuration, Renovate will create ${concurrentLimit} Pull Request${concurrentLimit > 1 ? 's' : ''}, up to a maximum of ${branches.length} over time (see [docs for \`${concurrentLimitKey}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#${concurrentLimitKey.toLowerCase()}))${securityNote}:\n\n`;
   } else {
     prDesc += `With your current configuration, Renovate will create ${branches.length} Pull Request`;
     prDesc += branches.length > 1 ? `s:\n\n` : `:\n\n`;
@@ -137,21 +147,25 @@ export function getExpectedPrList(
   }
   const prHourlyLimit = coerceNumber(config.prHourlyLimit);
   const commitHourlyLimit = coerceNumber(config.commitHourlyLimit);
+  const securityBypassNote =
+    securityBranchCount > 0
+      ? ` Security update Pull Request${securityBranchCount > 1 ? 's are' : ' is'} not subject to this limit and will be created straight away.`
+      : '';
   if (
     commitHourlyLimit > 0 &&
     commitHourlyLimit < 5 &&
-    commitHourlyLimit < branches.length
+    commitHourlyLimit < throttledBranchCount
   ) {
     prDesc += emojify(
-      `\n\n:children_crossing: Branch creation and rebasing will be limited to maximum ${commitHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`commitHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#commithourlylimit) for details.\n\n`,
+      `\n\n:children_crossing: Branch creation and rebasing will be limited to maximum ${commitHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`commitHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#commithourlylimit) for details.${securityBypassNote}\n\n`,
     );
   } else if (
     prHourlyLimit > 0 &&
     prHourlyLimit < 5 &&
-    prHourlyLimit < branches.length
+    prHourlyLimit < throttledBranchCount
   ) {
     prDesc += emojify(
-      `\n\n:children_crossing: PR creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#prhourlylimit) for details.\n\n`,
+      `\n\n:children_crossing: PR creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#prhourlylimit) for details.${securityBypassNote}\n\n`,
     );
   }
   return prDesc;
@@ -369,6 +383,8 @@ export function getExpectedPrListSummary(
   const prHourlyLimit = coerceNumber(config.prHourlyLimit);
   const commitHourlyLimit = coerceNumber(config.commitHourlyLimit);
   const concurrentLimit = resolveConcurrentLimit(config);
+  // Vulnerability alert branches bypass all rate/concurrency limits, so they shouldn't count towards them.
+  const securityCount = Object.keys(stats.securityGroups).length;
 
   if (hasMultipleBaseBranches) {
     let total = 0;
@@ -382,7 +398,8 @@ export function getExpectedPrListSummary(
       concurrentLimit,
       prHourlyLimit,
       commitHourlyLimit,
-      total,
+      total - securityCount,
+      securityCount,
     );
     prDesc += `With your current configuration, Renovate will create ${parts.join(' and ')}${limitsNotice}:\n\n`;
   } else {
@@ -390,7 +407,8 @@ export function getExpectedPrListSummary(
       concurrentLimit,
       prHourlyLimit,
       commitHourlyLimit,
-      stats.prCount,
+      stats.prCount - securityCount,
+      securityCount,
     );
     prDesc += `With your current configuration, Renovate will create ${stats.prCount} Pull Request${stats.prCount > 1 ? 's' : ''}${limitsNotice}:\n\n`;
   }
@@ -437,31 +455,37 @@ export function getExpectedPrListSummary(
     }
   }
 
-  if (concurrentLimit.limit > 0 && concurrentLimit.limit < stats.prCount) {
+  const throttledPrCount = stats.prCount - securityCount;
+  const securityBypassNote =
+    securityCount > 0
+      ? ` Security update Pull Request${securityCount > 1 ? 's are' : ' is'} not subject to this limit and will be created straight away.`
+      : '';
+
+  if (concurrentLimit.limit > 0 && concurrentLimit.limit < throttledPrCount) {
     const notice =
       concurrentLimit.key === 'branchConcurrentLimit'
         ? `Renovate will only work on ${concurrentLimit.limit} branch${concurrentLimit.limit > 1 ? 'es' : ''} at a time, so not all Pull Requests will be opened straight away`
         : `Renovate will only keep ${concurrentLimit.limit} Pull Request${concurrentLimit.limit > 1 ? 's' : ''} open at a time, so not all of the above will be opened straight away`;
     prDesc += emojify(
-      `\n\n:children_crossing: ${notice}. See [docs for \`${concurrentLimit.key}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#${concurrentLimit.key.toLowerCase()}) for details.\n\n`,
+      `\n\n:children_crossing: ${notice}. See [docs for \`${concurrentLimit.key}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#${concurrentLimit.key.toLowerCase()}) for details.${securityBypassNote}\n\n`,
     );
   }
 
   if (
     commitHourlyLimit > 0 &&
     commitHourlyLimit < 5 &&
-    commitHourlyLimit < stats.prCount
+    commitHourlyLimit < throttledPrCount
   ) {
     prDesc += emojify(
-      `\n\n:children_crossing: Branch creation and rebasing will be limited to maximum ${commitHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`commitHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#commithourlylimit) for details.\n\n`,
+      `\n\n:children_crossing: Branch creation and rebasing will be limited to maximum ${commitHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`commitHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#commithourlylimit) for details.${securityBypassNote}\n\n`,
     );
   } else if (
     prHourlyLimit > 0 &&
     prHourlyLimit < 5 &&
-    prHourlyLimit < stats.prCount
+    prHourlyLimit < throttledPrCount
   ) {
     prDesc += emojify(
-      `\n\n:children_crossing: PR creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#prhourlylimit) for details.\n\n`,
+      `\n\n:children_crossing: PR creation will be limited to maximum ${prHourlyLimit} per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for \`prHourlyLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#prhourlylimit) for details.${securityBypassNote}\n\n`,
     );
   }
   return prDesc;
@@ -472,6 +496,7 @@ function determineLimitsNotice(
   prHourlyLimit: number,
   commitHourlyLimit: number,
   prCount: number,
+  securityCount: number,
 ): string {
   const clauses: string[] = [];
 
@@ -501,13 +526,17 @@ function determineLimitsNotice(
     );
   }
 
-  if (clauses.length) {
-    return emojify(` (at ${clauses.join(' and ')})`);
+  if (!clauses.length) {
+    if (commitHourlyLimit === 0 && prHourlyLimit === 0) {
+      return ' (with no configured maximum of PRs per hour)';
+    }
+    return '';
   }
 
-  if (commitHourlyLimit === 0 && prHourlyLimit === 0) {
-    return ' (with no configured maximum of PRs per hour)';
-  }
+  const securityNote =
+    securityCount > 0
+      ? `, plus ${securityCount} security update${securityCount > 1 ? 's' : ''} which ${securityCount > 1 ? "aren't" : "isn't"} subject to these limits`
+      : '';
 
-  return '';
+  return emojify(` (at ${clauses.join(' and ')}${securityNote})`);
 }


### PR DESCRIPTION


<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As it wasn't clear before that they would bypass limits.



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
