### PR TITLE
refactor(manager): add utility for creating Artifact Error messages

### DIFF
--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -26,6 +26,7 @@ import type {
   PostUpdateConfig,
   Upgrade,
 } from '../../types.ts';
+import { artifactErrorMessageFromExecError } from '../../util.ts';
 import {
   NPM_CACHE_DIR,
   PNPM_CACHE_BASE_DIR,
@@ -580,8 +581,7 @@ export async function getAdditionalFiles(
 
       artifactErrors.push({
         fileName: yarnLock,
-        // oxlint-disable-next-line typescript/prefer-nullish-coalescing
-        stderr: res.stderr || res.stdout,
+        stderr: artifactErrorMessageFromExecError(res, ''),
       });
     } else {
       const existingContent = await getFile(
@@ -652,8 +652,7 @@ export async function getAdditionalFiles(
 
       artifactErrors.push({
         fileName: pnpmShrinkwrap,
-        // oxlint-disable-next-line typescript/prefer-nullish-coalescing
-        stderr: res.stderr || res.stdout,
+        stderr: artifactErrorMessageFromExecError(res, ''),
       });
     } else {
       const existingContent = await getFile(

--- a/lib/modules/manager/util.spec.ts
+++ b/lib/modules/manager/util.spec.ts
@@ -4,7 +4,7 @@ import { GitTagsDatasource } from '../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../datasource/gitlab-tags/index.ts';
 import { type PackageDependency } from './types.ts';
-import { applyGitSource } from './util.ts';
+import { applyGitSource, artifactErrorMessageFromExecError } from './util.ts';
 
 describe('modules/manager/util', () => {
   beforeEach(() => {
@@ -169,5 +169,58 @@ describe('modules/manager/util', () => {
       currentValue: undefined,
       skipReason: 'unspecified-version',
     });
+  });
+});
+
+describe('modules/manager/util', () => {
+  it('returns stderr when present', () => {
+    const message = artifactErrorMessageFromExecError(
+      { stderr: 'some error', stdout: 'some output' },
+      'fallback message',
+    );
+
+    expect(message).toBe('some error');
+  });
+
+  it('returns stdout when stderr is empty', () => {
+    const message = artifactErrorMessageFromExecError(
+      { stderr: '', stdout: 'some output' },
+      'fallback message',
+    );
+
+    expect(message).toBe('some output');
+  });
+
+  it('returns stdout when stderr is only whitespace', () => {
+    const message = artifactErrorMessageFromExecError(
+      { stderr: '   ', stdout: 'some output' },
+      'fallback message',
+    );
+
+    expect(message).toBe('some output');
+  });
+
+  it('returns stdout when stderr is undefined', () => {
+    const message = artifactErrorMessageFromExecError(
+      { stdout: 'some output' },
+      'fallback message',
+    );
+
+    expect(message).toBe('some output');
+  });
+
+  it('returns fallback message when neither stderr nor stdout are present', () => {
+    const message = artifactErrorMessageFromExecError({}, 'fallback message');
+
+    expect(message).toBe('fallback message');
+  });
+
+  it('returns fallback message when stderr and stdout are only whitespace', () => {
+    const message = artifactErrorMessageFromExecError(
+      { stderr: '  ', stdout: '  ' },
+      'fallback message',
+    );
+
+    expect(message).toBe('fallback message');
   });
 });

--- a/lib/modules/manager/util.ts
+++ b/lib/modules/manager/util.ts
@@ -1,4 +1,5 @@
 import { detectPlatform } from '../../util/common.ts';
+import type { ExecError } from '../../util/exec/exec-error.ts';
 import { parseGitUrl } from '../../util/git/url.ts';
 import { GitRefsDatasource } from '../datasource/git-refs/index.ts';
 import { GitTagsDatasource } from '../datasource/git-tags/index.ts';
@@ -52,10 +53,7 @@ export function applyGitSource(
  *
  */
 export function artifactErrorMessageFromExecError(
-  err: {
-    stderr?: string;
-    stdout?: string;
-  },
+  err: Partial<ExecError>,
   message: string,
 ): string {
   if (err.stderr?.trim()) {

--- a/lib/modules/manager/util.ts
+++ b/lib/modules/manager/util.ts
@@ -44,3 +44,27 @@ export function applyGitSource(
     dep.skipReason = branch ? 'git-dependency' : 'unspecified-version';
   }
 }
+
+/**
+ * Given an {@link ExecError}, retrieve the message which will be used for an {@link ArtifactError}.
+ *
+ * An `ExecError` always carries a `stderr` property, so nullish coalescing would keep an empty string and render an artifact error with no message at all.
+ *
+ */
+export function artifactErrorMessageFromExecError(
+  err: {
+    stderr?: string;
+    stdout?: string;
+  },
+  message: string,
+): string {
+  if (err.stderr?.trim()) {
+    return err.stderr;
+  }
+
+  if (err.stdout?.trim()) {
+    return err.stdout;
+  }
+
+  return message;
+}


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

To prevent ignoring linting rules for nullish coalescing, as well as for
future changes that will use this helper, we can extract out a helper
function for this.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
