### PR TITLE
fix(manager/terraform): stream-based H1 hashing

### DIFF
--- a/lib/modules/manager/terraform/lockfile/hash.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.spec.ts
@@ -1,14 +1,54 @@
-import { createReadStream } from 'node:fs';
+import { createReadStream, createWriteStream } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 import type { DirectoryResult } from 'tmp-promise';
 import { dir } from 'tmp-promise';
 import upath from 'upath';
+import * as yauzl from 'yauzl';
+import { ZipFile } from 'yazl';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
-import { getFixturePath, logger } from '~test/util.ts';
+import { getFixturePath, logger, partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
+import * as fs from '../../../../util/fs/index.ts';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider/index.ts';
+import type { TerraformBuild } from '../../../datasource/terraform-provider/schema.ts';
 import { TerraformProviderHash } from './hash.ts';
+
+async function writeZip(
+  zipFilePath: string,
+  addEntries: (archive: ZipFile) => void,
+): Promise<void> {
+  const archive = new ZipFile();
+  addEntries(archive);
+  const writePromise = pipeline(
+    archive.outputStream,
+    createWriteStream(zipFilePath),
+  );
+  archive.end();
+  await writePromise;
+}
+
+function replaceZipEntryName(
+  zip: Buffer,
+  originalName: string,
+  replacementName: string,
+): number {
+  const original = Buffer.from(originalName);
+  const replacement = Buffer.from(replacementName);
+  expect(replacement).toHaveLength(original.length);
+
+  let offset = 0;
+  let replacements = 0;
+  while ((offset = zip.indexOf(original, offset)) !== -1) {
+    replacement.copy(zip, offset);
+    offset += replacement.length;
+    replacements += 1;
+  }
+  return replacements;
+}
 
 const releaseBackendUrl = TerraformProviderDatasource.defaultRegistryUrls[1];
 const terraformCloudReleaseBackendUrl =
@@ -122,9 +162,7 @@ describe('modules/manager/terraform/lockfile/hash', () => {
         'hashicorp/azurerm',
         '2.56.0',
       ),
-    ).rejects.toThrow(
-      'ADM-ZIP: Invalid or unsupported zip format. No END header found',
-    );
+    ).rejects.toThrow('End of central directory record signature not found');
   });
 
   it('full walkthrough', async () => {
@@ -450,13 +488,216 @@ describe('modules/manager/terraform/lockfile/hash', () => {
   describe('hashOfZipContent', () => {
     const zipWithFolderPath = Fixtures.getPath('test_with_folder.zip');
 
-    it('return hash for content with subfolders', async () => {
+    it('streams the recursive directory fixture without extracting it', async () => {
+      const readCacheFile = vi.spyOn(fs, 'readCacheFile');
+
       await expect(
-        TerraformProviderHash.hashOfZipContent(
-          zipWithFolderPath,
-          upath.join(cacheDir.path, 'test'),
-        ),
+        TerraformProviderHash.hashOfZipContent(zipWithFolderPath),
       ).resolves.toBe('g92f/mR2hlVmeWBlplxxJyP2H3fdyPwYccr7uJhcRz8=');
+
+      expect(readCacheFile).not.toHaveBeenCalled();
+    });
+
+    it('hashes nested paths, empty files, and stored entries', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'streaming-fixture.zip');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addBuffer(
+          Buffer.from('nested content'),
+          'nested/deeper/file.txt',
+        );
+        archive.addBuffer(Buffer.alloc(0), 'empty.txt');
+        archive.addBuffer(Buffer.from('stored content'), 'stored.txt', {
+          compress: false,
+        });
+      });
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).resolves.toBe('FmiOVJrRLyrSAUWoZdPZz6alBSnQ0S+2ZCBGdWls+Lg=');
+    });
+
+    it('ignores directory entries ending in a backslash', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'backslash-directory.zip');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addEmptyDirectory('folder');
+      });
+
+      const zip = await readFile(zipFilePath);
+      expect(replaceZipEntryName(zip, 'folder/', 'folder\\')).toBe(2);
+      await writeFile(zipFilePath, zip);
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).resolves.toBe('47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=');
+    });
+
+    it('rejects entry names containing newlines', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'newline-path.zip');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addBuffer(Buffer.from('provider content'), 'line-break.txt');
+      });
+
+      const zip = await readFile(zipFilePath);
+      expect(
+        replaceZipEntryName(zip, 'line-break.txt', 'line\nbreak.txt'),
+      ).toBe(2);
+      await writeFile(zipFilePath, zip);
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).rejects.toThrow('ZIP entry name contains a newline');
+    });
+
+    it('rejects duplicate normalized entry paths', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'duplicate-path.zip');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addBuffer(Buffer.from('first'), 'a/file.txt');
+        archive.addBuffer(Buffer.from('second'), 'b/file.txt');
+      });
+
+      const zip = await readFile(zipFilePath);
+      expect(replaceZipEntryName(zip, 'b/file.txt', 'a/file.txt')).toBe(2);
+      await writeFile(zipFilePath, zip);
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).rejects.toThrow('Duplicate ZIP entry path: a/file.txt');
+    });
+
+    it('rejects an entry whose contents do not match its CRC-32', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'invalid-crc.zip');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addBuffer(Buffer.from('original content'), 'corrupted.txt', {
+          compress: false,
+        });
+      });
+
+      const zip = await readFile(zipFilePath);
+      const fileNameLength = zip.readUInt16LE(26);
+      const extraFieldLength = zip.readUInt16LE(28);
+      zip[30 + fileNameLength + extraFieldLength] ^= 0xff;
+      await writeFile(zipFilePath, zip);
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).rejects.toThrow('CRC-32 mismatch for ZIP entry corrupted.txt');
+    });
+
+    it('preserves unflagged UTF-8 filename bytes', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'unflagged-utf8.zip');
+      const fileName = 'café.txt';
+      const content = Buffer.from('provider content');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addBuffer(content, fileName);
+      });
+
+      const zip = await readFile(zipFilePath);
+      zip.writeUInt16LE(zip.readUInt16LE(6) & ~0x800, 6);
+      const centralDirectoryOffset = zip.indexOf(Buffer.from('PK\x01\x02'));
+      expect(centralDirectoryOffset).toBeGreaterThan(-1);
+      zip.writeUInt16LE(
+        zip.readUInt16LE(centralDirectoryOffset + 8) & ~0x800,
+        centralDirectoryOffset + 8,
+      );
+      await writeFile(zipFilePath, zip);
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).resolves.toBe('mhCPfNU/KjrNmtYY+P1iAT4o+PXmNLq8jJINomI60Jc=');
+    });
+
+    it('rejects unsafe entry paths', async () => {
+      const zipFilePath = upath.join(cacheDir.path, 'unsafe-path.zip');
+      await writeZip(zipFilePath, (archive) => {
+        archive.addBuffer(Buffer.from('provider content'), 'aa/outside.txt');
+      });
+
+      const zip = await readFile(zipFilePath);
+      expect(replaceZipEntryName(zip, 'aa/outside.txt', '../outside.txt')).toBe(
+        2,
+      );
+      await writeFile(zipFilePath, zip);
+
+      await expect(
+        TerraformProviderHash.hashOfZipContent(zipFilePath),
+      ).rejects.toThrow('invalid relative path');
+    });
+
+    it('isolates concurrent downloads that have the same filename', async () => {
+      const fileName = 'provider.zip';
+      const firstBuild = partial<TerraformBuild>({
+        name: 'first',
+        version: '1.0.0',
+        filename: fileName,
+        url: 'https://example.com/first/provider.zip',
+      });
+      const secondBuild = partial<TerraformBuild>({
+        name: 'second',
+        version: '1.0.0',
+        filename: fileName,
+        url: 'https://example.com/second/provider.zip',
+      });
+      vi.spyOn(TerraformProviderHash.http, 'stream')
+        .mockReturnValueOnce(createReadStream(zipWithFolderPath))
+        .mockReturnValueOnce(createReadStream(zipWithFolderPath));
+      const createCacheWriteStream = vi.spyOn(fs, 'createCacheWriteStream');
+
+      await expect(
+        Promise.all([
+          TerraformProviderHash.calculateSingleHash(firstBuild, cacheDir.path),
+          TerraformProviderHash.calculateSingleHash(secondBuild, cacheDir.path),
+        ]),
+      ).resolves.toEqual([
+        'g92f/mR2hlVmeWBlplxxJyP2H3fdyPwYccr7uJhcRz8=',
+        'g92f/mR2hlVmeWBlplxxJyP2H3fdyPwYccr7uJhcRz8=',
+      ]);
+
+      const downloadFileNames = createCacheWriteStream.mock.calls.map(
+        ([downloadFileName]) => downloadFileName,
+      );
+      expect(downloadFileNames).toHaveLength(2);
+      expect(new Set(downloadFileNames).size).toBe(2);
+      for (const downloadFileName of downloadFileNames) {
+        expect(upath.dirname(downloadFileName)).toBe(cacheDir.path);
+        expect(upath.basename(downloadFileName)).not.toBe(fileName);
+        await expect(fs.cachePathExists(downloadFileName)).resolves.toBeFalse();
+      }
+    });
+
+    it('closes the ZIP and removes the download after an entry stream error', async () => {
+      const fileName = 'entry-stream-error.zip';
+      const build = partial<TerraformBuild>({
+        name: 'test',
+        version: '1.0.0',
+        filename: fileName,
+        url: 'https://example.com/entry-stream-error.zip',
+      });
+      vi.spyOn(TerraformProviderHash.http, 'stream').mockReturnValue(
+        createReadStream(zipWithFolderPath),
+      );
+      const createCacheWriteStream = vi.spyOn(fs, 'createCacheWriteStream');
+      const close = vi.spyOn(yauzl.ZipFile.prototype, 'close');
+      vi.spyOn(
+        yauzl.ZipFile.prototype,
+        'openReadStreamPromise',
+      ).mockResolvedValue(
+        new Readable({
+          read() {
+            this.destroy(new Error('entry stream failed'));
+          },
+        }),
+      );
+
+      await expect(
+        TerraformProviderHash.calculateSingleHash(build, cacheDir.path),
+      ).rejects.toThrow('entry stream failed');
+
+      expect(close).toHaveBeenCalledOnce();
+      expect(createCacheWriteStream).toHaveBeenCalledOnce();
+      const downloadFileName = createCacheWriteStream.mock.calls[0][0];
+      expect(upath.dirname(downloadFileName)).toBe(cacheDir.path);
+      expect(upath.basename(downloadFileName)).not.toBe(fileName);
+      await expect(fs.cachePathExists(downloadFileName)).resolves.toBeFalse();
     });
   });
 });

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -39,16 +39,13 @@ export class TerraformProviderHash {
   static hashCacheTTL = 10080; // in minutes == 1 week
 
   /**
-   * Computes a provider H1 hash in Go's `dirhash.Hash1` format without
-   * extracting the archive.
+   * Computes the `h1:` checksum used in Terraform dependency lock files.
    *
-   * Go's `HashZip` includes explicit directory entries, while `HashDir` ignores
-   * them. This can produce different H1 values for the same files. See
-   * https://github.com/golang/go/issues/53448.
+   * Terraform verifies extracted providers with Go's `HashDir`, which ignores
+   * ZIP directory entries. Ignore them here so the archive produces the same
+   * checksum as the extracted provider.
    *
-   * Renovate historically extracted provider ZIPs and therefore returned the
-   * `HashDir` result. This method preserves that behavior while streaming each
-   * file directly from the ZIP.
+   * See https://github.com/golang/go/issues/53448.
    */
   static async hashOfZipContent(zipFilePath: string): Promise<string> {
     const zipFile = await openPromise(zipFilePath, {

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -1,6 +1,9 @@
 import crypto from 'node:crypto';
-import AdmZip from 'adm-zip';
+import { once } from 'node:events';
+import { Transform, type TransformCallback } from 'node:stream';
+import { crc32 } from 'node:zlib';
 import upath from 'upath';
+import { openPromise, validateFileName } from 'yauzl';
 import { logger } from '../../../../logger/index.ts';
 import {
   coerceArray,
@@ -9,11 +12,24 @@ import {
 } from '../../../../util/array.ts';
 import { withCache } from '../../../../util/cache/package/with-cache.ts';
 import * as fs from '../../../../util/fs/index.ts';
-import { ensureCacheDir } from '../../../../util/fs/index.ts';
+import { hashStream } from '../../../../util/hash.ts';
 import { Http } from '../../../../util/http/index.ts';
 import * as p from '../../../../util/promises.ts';
 import { TerraformProviderDatasource } from '../../../datasource/terraform-provider/index.ts';
 import type { TerraformBuild } from '../../../datasource/terraform-provider/schema.ts';
+
+class Crc32Stream extends Transform {
+  checksum = 0;
+
+  override _transform(
+    chunk: Buffer,
+    _encoding: BufferEncoding,
+    callback: TransformCallback,
+  ): void {
+    this.checksum = crc32(chunk, this.checksum);
+    callback(null, chunk);
+  }
+}
 
 export class TerraformProviderHash {
   static http = new Http(TerraformProviderDatasource.id);
@@ -22,95 +38,75 @@ export class TerraformProviderHash {
 
   static hashCacheTTL = 10080; // in minutes == 1 week
 
-  private static async hashElementList(
-    basePath: string,
-    fileSystemEntries: string[],
-  ): Promise<string> {
-    const rootHash = crypto.createHash('sha256');
+  static async hashOfZipContent(zipFilePath: string): Promise<string> {
+    const zipFile = await openPromise(zipFilePath, {
+      autoClose: false,
+      decodeStrings: false,
+    });
+    const entryHashes: { path: Buffer; hash: string }[] = [];
+    const entryPaths = new Set<string>();
 
-    for (const entryPath of fileSystemEntries) {
-      const absolutePath = upath.resolve(basePath, entryPath);
-      if (!(await fs.cachePathIsFile(absolutePath))) {
-        continue;
+    try {
+      for await (const entry of zipFile.eachEntry()) {
+        // Go's ZIP reader preserves the central-directory name bytes instead of decoding CP437 or Unicode path fields.
+        const fileName = entry.fileNameRaw
+          .toString('latin1')
+          .replaceAll('\\', '/');
+
+        // Terraform verifies extracted packages with Go HashDir semantics, which omit directory records.
+        if (fileName.endsWith('/')) {
+          continue;
+        }
+        if (fileName.includes('\n')) {
+          throw new Error('ZIP entry name contains a newline');
+        }
+        const fileNameError = validateFileName(fileName);
+        if (fileNameError) {
+          throw new Error(fileNameError);
+        }
+        const normalizedPath = upath.normalize(fileName);
+        if (entryPaths.has(normalizedPath)) {
+          throw new Error(`Duplicate ZIP entry path: ${normalizedPath}`);
+        }
+        entryPaths.add(normalizedPath);
+        const path = Buffer.from(normalizedPath, 'latin1');
+
+        const entryStream = await zipFile.openReadStreamPromise(entry);
+        const crc32Stream = new Crc32Stream();
+        const hash = await hashStream(
+          entryStream.compose(crc32Stream),
+          'sha256',
+        );
+        if (crc32Stream.checksum !== entry.crc32) {
+          throw new Error(
+            `CRC-32 mismatch for ZIP entry ${entry.fileNameRaw.toString('utf8')}`,
+          );
+        }
+        entryHashes.push({ path, hash });
       }
+    } finally {
+      const closePromise = once(zipFile, 'close');
+      zipFile.close();
+      await closePromise;
+    }
 
-      // build for every file a line looking like "aaaaaaaaaaaaaaa  file.txt\n"
+    entryHashes.sort((left, right) => Buffer.compare(left.path, right.path));
 
-      // get hash of specific file
-      const hash = crypto.createHash('sha256');
-      const fileBuffer = await fs.readCacheFile(absolutePath);
-      hash.update(fileBuffer);
-
-      const line = `${hash.digest('hex')}  ${upath.normalize(entryPath)}\n`;
-      rootHash.update(line);
+    const rootHash = crypto.createHash('sha256');
+    for (const entry of entryHashes) {
+      rootHash.update(`${entry.hash}  `);
+      rootHash.update(entry.path);
+      rootHash.update('\n');
     }
 
     return rootHash.digest('base64');
-  }
-
-  /**
-   * This is a reimplementation of the Go H1 hash algorithm found at https://github.com/golang/mod/blob/master/sumdb/dirhash/hash.go
-   * The package provides two function HashDir and HashZip where the first is for hashing the contents of a directory
-   * and the second for doing the same but implicitly extracting the contents first.
-   *
-   * The problem starts with that there is a bug which leads to the fact that HashDir and HashZip do not return the same
-   * hash if there are folders inside the content which should be hashed.
-   *
-   * In a folder structure such as
-   * .
-   * ├── Readme.md
-   * └── readme-assets/
-   *     └── image.jpg
-   *
-   * HashDir will create a list of following entries which in turn will hash again
-   * aaaaaaaaaaa  Readme.md\n
-   * ccccccccccc  readme-assets/image.jpg\n
-   *
-   * HashZip in contrast will not filter out the directory itself but rather includes it in the hash list
-   * aaaaaaaaaaa  Readme.md\n
-   * bbbbbbbbbbb  readme-assets/\n
-   * ccccccccccc  readme-assets/image.jpg\n
-   *
-   * As the resulting string is used to generate the final hash it will differ based on which function has been used.
-   * The issue is tracked here: https://github.com/golang/go/issues/53448
-   *
-   * This implementation follows the intended implementation and filters out folder entries.
-   * Terraform seems NOT to use HashZip for provider validation, but rather extracts it and then do the hash calculation
-   * even as both are set up in their code base.
-   * https://github.com/hashicorp/terraform/blob/3fdfbd69448b14a4982b3c62a5d36835956fcbaa/internal/getproviders/hash.go#L283-L305
-   *
-   * @param zipFilePath path to the zip file
-   * @param extractPath path to where to temporarily extract the data
-   */
-  static async hashOfZipContent(
-    zipFilePath: string,
-    extractPath: string,
-  ): Promise<string> {
-    const zip = new AdmZip(zipFilePath);
-    zip.extractAllTo(extractPath);
-    const hash = await this.hashOfDir(extractPath);
-    // delete extracted files
-    await fs.rmCache(extractPath);
-
-    return hash;
-  }
-
-  static async hashOfDir(dirPath: string): Promise<string> {
-    const elements = await fs.listCacheDir(dirPath, { recursive: true });
-
-    const sortedFileSystemObjects = elements.sort();
-    return await TerraformProviderHash.hashElementList(
-      dirPath,
-      sortedFileSystemObjects,
-    );
   }
 
   private static async _calculateSingleHash(
     build: TerraformBuild,
     cacheDir: string,
   ): Promise<string> {
-    const downloadFileName = upath.join(cacheDir, build.filename);
-    const extractPath = upath.join(cacheDir, 'extract', build.filename);
+    const downloadFileName = upath.join(cacheDir, crypto.randomUUID());
     logger.trace(
       `Downloading archive and generating hash for ${build.name}-${build.version}...`,
     );
@@ -121,13 +117,12 @@ export class TerraformProviderHash {
     try {
       await fs.pipeline(readStream, writeStream);
 
-      const hash = await this.hashOfZipContent(downloadFileName, extractPath);
+      const hash = await this.hashOfZipContent(downloadFileName);
       logger.debug(
         `Hash generation for ${build.url} took ${Date.now() - startTime}ms for ${build.name}-${build.version}`,
       );
       return hash;
     } finally {
-      // delete zip file
       await fs.rmCache(downloadFileName);
     }
   }
@@ -150,9 +145,8 @@ export class TerraformProviderHash {
     builds: TerraformBuild[],
   ): Promise<string[]> {
     logger.debug(`Calculating hashes for ${builds.length} builds`);
-    const cacheDir = await ensureCacheDir('terraform');
+    const cacheDir = await fs.ensureCacheDir('terraform');
 
-    // for each build download ZIP, extract content and generate hash for all containing files
     return p.map(builds, (build) => this.calculateSingleHash(build, cacheDir), {
       concurrency: 4,
     });

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -38,6 +38,18 @@ export class TerraformProviderHash {
 
   static hashCacheTTL = 10080; // in minutes == 1 week
 
+  /**
+   * Computes a provider H1 hash in Go's `dirhash.Hash1` format without
+   * extracting the archive.
+   *
+   * Go's `HashZip` includes explicit directory entries, while `HashDir` ignores
+   * them. This can produce different H1 values for the same files. See
+   * https://github.com/golang/go/issues/53448.
+   *
+   * Renovate historically extracted provider ZIPs and therefore returned the
+   * `HashDir` result. This method preserves that behavior while streaming each
+   * file directly from the ZIP.
+   */
   static async hashOfZipContent(zipFilePath: string): Promise<string> {
     const zipFile = await openPromise(zipFilePath, {
       autoClose: false,

--- a/package.json
+++ b/package.json
@@ -266,6 +266,7 @@
     "validate-npm-package-name": "7.0.2",
     "xmldoc": "2.0.3",
     "yaml": "2.9.0",
+    "yauzl": "3.4.0",
     "zod": "4.4.3"
   },
   "optionalDependencies": {
@@ -316,6 +317,8 @@
     "@types/semver-utils": "1.1.3",
     "@types/tmp": "0.2.6",
     "@types/validate-npm-package-name": "4.0.2",
+    "@types/yauzl": "3.4.0",
+    "@types/yazl": "3.3.1",
     "@vitest/coverage-v8": "4.1.10",
     "ajv": "8.20.0",
     "ajv-formats": "3.0.1",
@@ -348,7 +351,8 @@
     "unified": "11.0.5",
     "vite": "catalog:",
     "vitest": "4.1.10",
-    "vitest-mock-extended": "5.1.1"
+    "vitest-mock-extended": "5.1.1",
+    "yazl": "3.3.1"
   },
   "packageManager": "pnpm@11.20.0",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -373,6 +373,9 @@ importers:
       yaml:
         specifier: 2.9.0
         version: 2.9.0
+      yauzl:
+        specifier: 3.4.0
+        version: 3.4.0
       zod:
         specifier: 4.4.3
         version: 4.4.3
@@ -506,6 +509,12 @@ importers:
       '@types/validate-npm-package-name':
         specifier: 4.0.2
         version: 4.0.2
+      '@types/yauzl':
+        specifier: 3.4.0
+        version: 3.4.0
+      '@types/yazl':
+        specifier: 3.3.1
+        version: 3.3.1
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -605,6 +614,9 @@ importers:
       vitest-mock-extended:
         specifier: 5.1.1
         version: 5.1.1(typescript@7.0.2)(vitest@4.1.10)
+      yazl:
+        specifier: 3.3.1
+        version: 3.3.1
     optionalDependencies:
       openpgp:
         specifier: 6.3.1
@@ -2180,6 +2192,12 @@ packages:
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
+  '@types/yauzl@3.4.0':
+    resolution: {integrity: sha512-NRPn5w6h8dhcnmx3YIRQcqMywY/+nND/uOkJessedcrowO3C0AssHp3tMJpxKAwOhFOo0OV1y9VtsC5hbKKBAw==}
+
+  '@types/yazl@3.3.1':
+    resolution: {integrity: sha512-DIWfCKpsTp6hE5BDBHV3+fIL/bLUF9Bv13iDrWnMlmhQpH67buNvI291ZauQ1xcccxK3FqQ9honnXpq4R8NMuQ==}
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
     engines: {node: '>=16.20.0'}
@@ -2671,6 +2689,10 @@ packages:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@1.0.0:
+    resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
+    engines: {node: '>=8.0.0'}
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
@@ -4726,6 +4748,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5738,6 +5763,13 @@ packages:
   yargs@18.1.0:
     resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yauzl@3.4.0:
+    resolution: {integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==}
+    engines: {node: '>=12'}
+
+  yazl@3.3.1:
+    resolution: {integrity: sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -7411,6 +7443,14 @@ snapshots:
 
   '@types/validate-npm-package-name@4.0.2': {}
 
+  '@types/yauzl@3.4.0':
+    dependencies:
+      '@types/node': 24.13.3
+
+  '@types/yazl@3.3.1':
+    dependencies:
+      '@types/node': 24.13.3
+
   '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
@@ -7805,6 +7845,8 @@ snapshots:
       electron-to-chromium: 1.5.399
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
+
+  buffer-crc32@1.0.0: {}
 
   buffer-equal-constant-time@1.0.1: {}
 
@@ -10001,6 +10043,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pend@1.2.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
@@ -11022,6 +11066,14 @@ snapshots:
       string-width: 8.2.2
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yauzl@3.4.0:
+    dependencies:
+      pend: 1.2.0
+
+  yazl@3.3.1:
+    dependencies:
+      buffer-crc32: 1.0.0
 
   yocto-queue@1.2.2: {}
 


### PR DESCRIPTION
## Changes

Terraform provider `h1:` generation now reads cached ZIP entries one at a time with `yauzl` and streams them through SHA-256 and CRC-32 hashing. This replaces `AdmZip` extraction and whole-file reads, so Renovate no longer buffers the complete archive or provider binaries.

The change preserves existing H1 output, caching, `zh:` retrieval, and four-build concurrency. It also cleans up ZIP handles and temporary downloads on failure.

- Related: #44908

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). GPT-5.6 Sol helped implement and review the code and tests.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>