### PR TITLE
feat(manager/mix): support private hex repos via registryAliases

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4638,6 +4638,7 @@ This feature works with the following managers:
 - [`helmfile`](modules/manager/helmfile/index.md)
 - [`helmv3`](modules/manager/helmv3/index.md)
 - [`kubernetes`](modules/manager/kubernetes/index.md)
+- [`mix`](modules/manager/mix/index.md)
 - [`terraform`](modules/manager/terraform/index.md)
 - [`woodpecker`](modules/manager/woodpecker/index.md)
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4618,6 +4618,7 @@ This feature works with the following managers:
 - [`helmfile`](modules/manager/helmfile/index.md)
 - [`helmv3`](modules/manager/helmv3/index.md)
 - [`kubernetes`](modules/manager/kubernetes/index.md)
+- [`mix`](modules/manager/mix/index.md)
 - [`terraform`](modules/manager/terraform/index.md)
 - [`woodpecker`](modules/manager/woodpecker/index.md)
 

--- a/lib/modules/manager/mix/__fixtures__/mix.exs
+++ b/lib/modules/manager/mix/__fixtures__/mix.exs
@@ -26,6 +26,7 @@ defmodule MyProject.MixProject do
       {:ecto, github: "elixir-ecto/ecto", ref: "795036d997c7503b21fb64d6bf1a89b83c44f2b5"},
       {:secret, "~> 1.0", organization: "acme"},
       {:also_secret, "~> 1.0", only: [:dev, :test], organization: "acme", runtime: false},
+      {:oban_pro, "~> 1.7", repo: "oban"},
       {:metrics, ">0.2.0 and <=1.0.0"},
       {:jason, ">= 1.0.0", only: :prod},
       {:hackney, "~> 1.0",

--- a/lib/modules/manager/mix/__fixtures__/mix.lock
+++ b/lib/modules/manager/mix/__fixtures__/mix.lock
@@ -10,6 +10,7 @@
   "ecto": {:git, "https://github.com/elixir-ecto/ecto.git", "795036d997c7503b21fb64d6bf1a89b83c44f2b5", [ref: "795036d997c7503b21fb64d6bf1a89b83c44f2b5"]},
   "secret": {:hex, :secret, "1.5.0", "344dbbf6610d205760ec37e2848bff2aab5a2de182bb5cdaa72cc2fd19d74535", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "19c205c8de0e2e5817f2250100281c58e717cb11ff1bb410bf661ee78c24e79b"},
   "also_secret": {:hex, :also_secret, "1.3.4", "344dbbf6610d205760ec37e2848bff2aab5a2de182bb5cdaa72cc2fd19d74535", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: false]}], "hexpm", "19c205c8de0e2e5817f2250100281c58e717cb11ff1bb410bf661ee78c24e79b"},
+  "oban_pro": {:hex, :oban_pro, "1.7.2", "c6703c06bf7f66cecefc4de79f358116ec3db0cfff5950ca57fe36b3fb04bdcf", [:mix], [], "oban", "039eed187190555efe687a6f88547f4a68bbcd5faf423395d322a4ef7ec177cd"},
   "file_system": {:hex, :file_system, "1.0.1", "79e8ceaddb0416f8b8cd02a0127bdbababe7bf4a23d2a395b983c1f8b3f73edd", [:mix], [], "hexpm", "4414d1f38863ddf9120720cd976fce5bdde8e91d8283353f0e31850fa89feb9e"},
   "floki": {:hex, :floki, "0.37.0", "b83e0280bbc6372f2a403b2848013650b16640cd2470aea6701f0632223d719e", [:mix], [], "hexpm", "516a0c15a69f78c47dc8e0b9b3724b29608aa6619379f91b1ffa47109b5d0dd3"},
   "gun": {:hex, :grpc_gun, "2.0.1", "221b792df3a93e8fead96f697cbaf920120deacced85c6cd3329d2e67f0871f8", [:rebar3], [{:cowlib, "~> 2.11", [hex: :cowlib, repo: "hexpm", optional: false]}], "hexpm", "795a65eb9d0ba16697e6b0e1886009ce024799e43bb42753f0c59b029f592831"},

--- a/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -7,11 +7,12 @@ exports[`modules/manager/mix/artifacts > authenticates to private repositories i
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth renovate_test --key valid_test_token && mix deps.update private_package other_package'",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e HEX_HOME -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth renovate_test --key valid_test_token && mix deps.update private_package other_package'",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
         "CONTAINERBASE_CACHE_DIR": "/tmp/cache/containerbase",
+        "HEX_HOME": "/tmp/cache/__renovate-private-cache/hex",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -49,6 +50,7 @@ exports[`modules/manager/mix/artifacts > returns null if unchanged 1`] = `
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
+        "HEX_HOME": "/tmp/cache/__renovate-private-cache/hex",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -78,11 +80,12 @@ exports[`modules/manager/mix/artifacts > returns updated mix.lock 1`] = `
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix deps.update plug'",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e HEX_HOME -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix deps.update plug'",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
         "CONTAINERBASE_CACHE_DIR": "/tmp/cache/containerbase",
+        "HEX_HOME": "/tmp/cache/__renovate-private-cache/hex",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
+++ b/lib/modules/manager/mix/__snapshots__/artifacts.spec.ts.snap
@@ -7,12 +7,13 @@ exports[`modules/manager/mix/artifacts > authenticates to private repositories i
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CI -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth renovate_test --key valid_test_token && mix deps.update private_package other_package'",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CI -e HEX_HOME -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix hex.organization auth renovate_test --key valid_test_token && mix deps.update private_package other_package'",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
         "CI": "true",
         "CONTAINERBASE_CACHE_DIR": "/tmp/cache/containerbase",
+        "HEX_HOME": "/tmp/cache/__renovate-private-cache/hex",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -51,6 +52,7 @@ exports[`modules/manager/mix/artifacts > returns null if unchanged 1`] = `
       "cwd": "/tmp/github/some/repo",
       "env": {
         "CI": "true",
+        "HEX_HOME": "/tmp/cache/__renovate-private-cache/hex",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",
@@ -80,12 +82,13 @@ exports[`modules/manager/mix/artifacts > returns updated mix.lock 1`] = `
     "options": {},
   },
   {
-    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CI -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix deps.update plug'",
+    "cmd": "docker run --rm --name=renovate_sidecar --label=renovate_child -v "/tmp/github/some/repo":"/tmp/github/some/repo" -v "/tmp/cache":"/tmp/cache" -e CI -e HEX_HOME -e CONTAINERBASE_CACHE_DIR -w "/tmp/github/some/repo" ghcr.io/renovatebot/base-image bash -l -c 'install-tool erlang 25.0.0.0 && install-tool elixir v1.13.4 && mix deps.update plug'",
     "options": {
       "cwd": "/tmp/github/some/repo",
       "env": {
         "CI": "true",
         "CONTAINERBASE_CACHE_DIR": "/tmp/cache/containerbase",
+        "HEX_HOME": "/tmp/cache/__renovate-private-cache/hex",
         "HOME": "/home/user",
         "HTTPS_PROXY": "https://example.com",
         "HTTP_PROXY": "http://example.com",

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -1,7 +1,9 @@
 import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
+import type { ExecSnapshots } from '~test/exec-util.ts';
 import { envMock, mockExecAll } from '~test/exec-util.ts';
 import { hostRules } from '~test/host-rules.ts';
+import * as httpMock from '~test/http-mock.ts';
 import { env, fs, logger } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type {
@@ -10,7 +12,7 @@ import type {
 } from '../../../config/types.ts';
 import type { ConstraintName } from '../../../util/exec/types.ts';
 import { getPkgReleases as _getPkgReleases } from '../../datasource/index.ts';
-import type { UpdateArtifactsConfig } from '../types.ts';
+import type { UpdateArtifactsConfig, UpdateArtifactsResult } from '../types.ts';
 import { updateArtifacts } from './index.ts';
 
 vi.mock('../../../util/exec/env.ts');
@@ -30,6 +32,8 @@ const adminConfig: RepoGlobalConfig & InternalGlobalConfigOptions = {
 // support install mode
 process.env.CONTAINERBASE = 'true';
 
+const privateCacheDir = upath.join('/tmp/cache/__renovate-private-cache');
+
 const config: UpdateArtifactsConfig = {};
 const constraints: Partial<Record<ConstraintName, string>> = {
   erlang: '25.0.0.0',
@@ -40,6 +44,7 @@ describe('modules/manager/mix/artifacts', () => {
   beforeEach(() => {
     env.getChildProcessEnv.mockReturnValue(envMock.basic);
     GlobalConfig.set(adminConfig);
+    fs.privateCacheDir.mockReturnValue(privateCacheDir);
   });
 
   afterEach(() => {
@@ -306,6 +311,174 @@ describe('modules/manager/mix/artifacts', () => {
       'mix hex.organization auth renovate_test --key valid_test_token && ' +
         'mix deps.update private_package other_package',
     );
+  });
+
+  describe('private registries via registryAliases', () => {
+    const publicKey =
+      '-----BEGIN RSA PUBLIC KEY-----\nabc\n-----END RSA PUBLIC KEY-----';
+    const hexHome = upath.join(privateCacheDir, 'hex');
+    const keyFile = upath.join(hexHome, 'oban.pem');
+    const mixExs = `
+      defp deps do
+        [{:oban_pro, "~> 1.7", repo: "oban"}]
+      end
+    `;
+    const installTools = [
+      'install-tool erlang 25.0.0.0',
+      'install-tool elixir v1.13.4',
+    ];
+
+    let execSnapshots: ExecSnapshots;
+
+    beforeEach(() => {
+      GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
+      // erlang
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '25.0.0.0' }],
+      });
+      // elixir
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v1.13.4' }],
+      });
+      fs.getSiblingFileName.mockReturnValueOnce('mix.lock');
+      fs.readLocalFile.mockResolvedValueOnce('Old mix.lock');
+      fs.readLocalFile.mockResolvedValueOnce('New mix.lock');
+      execSnapshots = mockExecAll();
+    });
+
+    function updateObanPro(
+      registryAliases: Record<string, string>,
+    ): Promise<UpdateArtifactsResult[] | null> {
+      return updateArtifacts({
+        packageFileName: 'mix.exs',
+        updatedDeps: [{ depName: 'oban_pro' }],
+        newPackageFileContent: mixExs,
+        config: { ...config, registryAliases },
+      });
+    }
+
+    it('adds the repo with its public key and auth key', async () => {
+      hostRules.add({
+        matchHost: 'https://repo.oban.pro',
+        token: 'oban_license_key',
+        authType: 'Token-Only',
+      });
+      httpMock
+        .scope('https://repo.oban.pro')
+        .get('/public_key')
+        .reply(200, publicKey);
+
+      const result = await updateObanPro({ oban: 'https://repo.oban.pro' });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'mix.lock',
+            contents: 'New mix.lock',
+          },
+        },
+      ]);
+      expect(fs.outputCacheFile).toHaveBeenCalledWith(keyFile, publicKey);
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        `mix hex.repo add oban https://repo.oban.pro --public-key ${keyFile} --auth-key oban_license_key`,
+        'mix deps.update oban_pro',
+      ]);
+    });
+
+    it('adds an unauthenticated repo without an auth key', async () => {
+      httpMock
+        .scope('https://repo.oban.pro')
+        .get('/public_key')
+        .reply(200, publicKey);
+
+      await updateObanPro({ oban: 'https://repo.oban.pro' });
+
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        `mix hex.repo add oban https://repo.oban.pro --public-key ${keyFile}`,
+        'mix deps.update oban_pro',
+      ]);
+      expect(execSnapshots.at(-1)?.options?.env).toMatchObject({
+        HEX_HOME: hexHome,
+      });
+    });
+
+    it('ignores registryAliases that mix.exs does not declare', async () => {
+      // inherited from top-level config, meant for another manager
+      await updateObanPro({ 'jfrog.com': 'some.jfrog.mirror' });
+
+      expect(fs.outputCacheFile).not.toHaveBeenCalled();
+      expect(logger.logger.warn).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'Skipping hex repo, unable to fetch its registry public key',
+      );
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        'mix deps.update oban_pro',
+      ]);
+    });
+
+    it('ignores an alias for hex.pm itself', async () => {
+      await updateArtifacts({
+        packageFileName: 'mix.exs',
+        updatedDeps: [{ depName: 'secret' }],
+        newPackageFileContent: `
+          defp deps do
+            [{:secret, "~> 1.0", repo: "hexpm:acme"}, {:plug, "~> 1.0", repo: "hexpm"}]
+          end
+        `,
+        config: {
+          ...config,
+          registryAliases: {
+            hexpm: 'https://repo.hex.pm',
+            'hexpm:acme': 'https://repo.hex.pm',
+          },
+        },
+      });
+
+      expect(fs.outputCacheFile).not.toHaveBeenCalled();
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        'mix deps.update secret',
+      ]);
+    });
+
+    it('skips a repo whose public key cannot be fetched', async () => {
+      hostRules.add({
+        matchHost: 'https://repo.oban.pro',
+        token: 'oban_license_key',
+      });
+      httpMock.scope('https://repo.oban.pro').get('/public_key').reply(404);
+
+      await updateObanPro({ oban: 'https://repo.oban.pro' });
+
+      expect(fs.outputCacheFile).not.toHaveBeenCalled();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { repo: 'oban', url: 'https://repo.oban.pro' },
+        'Skipping hex repo, unable to fetch its registry public key',
+      );
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        'mix deps.update oban_pro',
+      ]);
+    });
+
+    it('skips a repo serving an empty public key', async () => {
+      httpMock
+        .scope('https://repo.oban.pro')
+        .get('/public_key')
+        .reply(200, '   ');
+
+      await updateObanPro({ oban: 'https://repo.oban.pro' });
+
+      expect(fs.outputCacheFile).not.toHaveBeenCalled();
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        'mix deps.update oban_pro',
+      ]);
+    });
   });
 
   it('authenticates to private repositories configured in hostRules', async () => {

--- a/lib/modules/manager/mix/artifacts.spec.ts
+++ b/lib/modules/manager/mix/artifacts.spec.ts
@@ -420,6 +420,30 @@ describe('modules/manager/mix/artifacts', () => {
       ]);
     });
 
+    it('ignores a commented-out repo option', async () => {
+      await updateArtifacts({
+        packageFileName: 'mix.exs',
+        updatedDeps: [{ depName: 'plug' }],
+        newPackageFileContent: `
+          defp deps do
+            # [{:oban_pro, "~> 1.7", repo: "oban"}]
+            [{:plug, "~> 1.0"}]
+          end
+        `,
+        config: {
+          ...config,
+          registryAliases: { oban: 'https://repo.oban.pro' },
+        },
+      });
+
+      expect(httpMock.getTrace()).toEqual([]);
+      expect(fs.outputCacheFile).not.toHaveBeenCalled();
+      expect(execSnapshots.map((s) => s.cmd)).toEqual([
+        ...installTools,
+        'mix deps.update plug',
+      ]);
+    });
+
     it('ignores an alias for hex.pm itself', async () => {
       await updateArtifacts({
         packageFileName: 'mix.exs',

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -1,5 +1,6 @@
 import { isEmptyArray, isString } from '@sindresorhus/is';
 import { quote } from 'shlex';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
@@ -8,21 +9,32 @@ import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   deleteLocalFile,
   ensureCacheDir,
+  ensureDir,
   findLocalSiblingOrParent,
   getSiblingFileName,
   localPathExists,
+  outputCacheFile,
+  privateCacheDir,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
+import { Http } from '../../../util/http/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
+import { joinUrlParts } from '../../../util/url.ts';
+import { HexDatasource } from '../../datasource/hex/index.ts';
 
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+
+const http = new Http(HexDatasource.id);
 
 const hexRepoUrl = 'https://hex.pm/';
 const hexRepoOrgUrlRegex = regEx(
   `^https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`,
 );
+const repoOptionRegex = regEx(/repo:\s*"(?<name>[^"]+)"/g);
 
 export async function updateArtifacts({
   packageFileName,
@@ -145,6 +157,13 @@ export async function updateArtifacts({
     return acc;
   }, [] as string[]);
 
+  preCommands.push(
+    ...(await getRepoAddCommands(
+      newPackageFileContent,
+      config.registryAliases,
+    )),
+  );
+
   // renovate: will update this
   const erlangVersion = '26';
 
@@ -153,6 +172,11 @@ export async function updateArtifacts({
       // https://hexdocs.pm/mix/1.15.0/Mix.Tasks.Archive.html
       // TODO: should include a version constraint
       MIX_ARCHIVES: await ensureCacheDir('mix_archives'),
+      // `mix hex.organization auth` and `mix hex.repo add` persist registry
+      // URLs and their credentials in `$HEX_HOME/hex.config`. Keep that under
+      // privateCacheDir, which is wiped between repositories, so credentials
+      // cannot leak into the next repository of the same run.
+      HEX_HOME: await hexHomeDir(),
     },
     cwdFile: packageFileName,
     docker: {},
@@ -222,6 +246,97 @@ export async function updateArtifacts({
       },
     },
   ];
+}
+
+async function hexHomeDir(): Promise<string> {
+  const dir = upath.join(privateCacheDir(), 'hex');
+  await ensureDir(dir);
+  return dir;
+}
+
+/**
+ * `mix` will not fetch from a third-party repo unless a registry public key is
+ * stored for it — with none, `:mix_hex_registry.key(nil)` raises and the fetch
+ * hangs until the registry timeout. `registryAliases` is a name-to-URL map with
+ * nowhere to put a key or its fingerprint, so we fetch the key from the registry
+ * ourselves. This is the same trust-on-first-use model the hex datasource
+ * already applies when it verifies V2 payloads.
+ *
+ * `registryAliases` is inherited from top-level config, so it may hold entries
+ * belonging to other managers. Only the repos `mix.exs` declares are added.
+ */
+async function getRepoAddCommands(
+  packageFileContent: string,
+  registryAliases: Record<string, string> | undefined,
+): Promise<string[]> {
+  const commands: string[] = [];
+  const declaredRepos = new Set(
+    Array.from(
+      packageFileContent.matchAll(repoOptionRegex),
+      ({ groups }) => groups!.name,
+    ),
+  );
+
+  for (const [name, url] of Object.entries(coerceObject(registryAliases))) {
+    // `hexpm` and `hexpm:<org>` are hex.pm itself, authenticated above through
+    // `mix hex.organization auth`.
+    if (
+      !declaredRepos.has(name) ||
+      name === 'hexpm' ||
+      name.startsWith('hexpm:')
+    ) {
+      continue;
+    }
+
+    const publicKey = await getRegistryPublicKey(url);
+    if (!publicKey) {
+      logger.warn(
+        { repo: name, url },
+        'Skipping hex repo, unable to fetch its registry public key',
+      );
+      continue;
+    }
+
+    const keyFile = upath.join(await hexHomeDir(), `${name}.pem`);
+    await outputCacheFile(keyFile, publicKey);
+
+    logger.debug(`Adding hex repo ${name}`);
+    const command = [
+      'mix',
+      'hex.repo',
+      'add',
+      quote(name),
+      quote(url),
+      '--public-key',
+      quote(keyFile),
+    ];
+
+    // An unauthenticated third-party registry still needs adding, so a missing
+    // token is not a reason to skip the repo.
+    const { token } = hostRules.find({ hostType: HexDatasource.id, url });
+    if (token) {
+      command.push('--auth-key', quote(token));
+    } else {
+      logger.debug(`No hostRules token found for hex repo ${name}`);
+    }
+
+    commands.push(command.join(' '));
+  }
+
+  return commands;
+}
+
+async function getRegistryPublicKey(url: string): Promise<string | null> {
+  const keyUrl = joinUrlParts(url, 'public_key');
+  try {
+    const { body } = await http.getText(keyUrl, {
+      cacheProvider: memCacheProvider,
+    });
+    return body.trim() || null;
+  } catch (err) {
+    logger.debug({ err, keyUrl }, 'Failed to fetch hex registry public key');
+    return null;
+  }
 }
 
 async function checkLockFileReadError(

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -156,10 +156,13 @@ export async function updateArtifacts({
     return acc;
   }, [] as string[]);
 
+  const hexHome = await hexHomeDir();
+
   preCommands.push(
     ...(await getRepoAddCommands(
       newPackageFileContent,
       config.registryAliases,
+      hexHome,
     )),
   );
 
@@ -175,7 +178,7 @@ export async function updateArtifacts({
       // URLs and their credentials in `$HEX_HOME/hex.config`. Keep that under
       // privateCacheDir, which is wiped between repositories, so credentials
       // cannot leak into the next repository of the same run.
-      HEX_HOME: await hexHomeDir(),
+      HEX_HOME: hexHome,
     },
     cwdFile: packageFileName,
     docker: {},
@@ -267,6 +270,7 @@ async function hexHomeDir(): Promise<string> {
 async function getRepoAddCommands(
   packageFileContent: string,
   registryAliases: Record<string, string> | undefined,
+  hexHome: string,
 ): Promise<string[]> {
   const commands: string[] = [];
   const declaredRepos = new Set(getRepoOptions(packageFileContent));
@@ -291,7 +295,7 @@ async function getRepoAddCommands(
       continue;
     }
 
-    const keyFile = upath.join(await hexHomeDir(), `${name}.pem`);
+    const keyFile = upath.join(hexHome, `${name}.pem`);
     await outputCacheFile(keyFile, publicKey);
 
     logger.debug(`Adding hex repo ${name}`);

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -26,6 +26,7 @@ import { joinUrlParts } from '../../../util/url.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
 
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { getRepoOptions } from './utils.ts';
 
 const http = new Http(HexDatasource.id);
 
@@ -33,7 +34,6 @@ const hexRepoUrl = 'https://hex.pm/';
 const hexRepoOrgUrlRegex = regEx(
   `^https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`,
 );
-const repoOptionRegex = regEx(/repo:\s*"(?<name>[^"]+)"/g);
 
 export async function updateArtifacts({
   packageFileName,
@@ -269,12 +269,7 @@ async function getRepoAddCommands(
   registryAliases: Record<string, string> | undefined,
 ): Promise<string[]> {
   const commands: string[] = [];
-  const declaredRepos = new Set(
-    Array.from(
-      packageFileContent.matchAll(repoOptionRegex),
-      ({ groups }) => groups!.name,
-    ),
-  );
+  const declaredRepos = new Set(getRepoOptions(packageFileContent));
 
   for (const [name, url] of Object.entries(registryAliases ?? {})) {
     // `hexpm` and `hexpm:<org>` are hex.pm itself, authenticated above through

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -157,10 +157,13 @@ export async function updateArtifacts({
     return acc;
   }, [] as string[]);
 
+  const hexHome = await hexHomeDir();
+
   preCommands.push(
     ...(await getRepoAddCommands(
       newPackageFileContent,
       config.registryAliases,
+      hexHome,
     )),
   );
 
@@ -176,7 +179,7 @@ export async function updateArtifacts({
       // URLs and their credentials in `$HEX_HOME/hex.config`. Keep that under
       // privateCacheDir, which is wiped between repositories, so credentials
       // cannot leak into the next repository of the same run.
-      HEX_HOME: await hexHomeDir(),
+      HEX_HOME: hexHome,
     },
     cwdFile: packageFileName,
     docker: {},
@@ -268,6 +271,7 @@ async function hexHomeDir(): Promise<string> {
 async function getRepoAddCommands(
   packageFileContent: string,
   registryAliases: Record<string, string> | undefined,
+  hexHome: string,
 ): Promise<string[]> {
   const commands: string[] = [];
   const declaredRepos = new Set(getRepoOptions(packageFileContent));
@@ -292,7 +296,7 @@ async function getRepoAddCommands(
       continue;
     }
 
-    const keyFile = upath.join(await hexHomeDir(), `${name}.pem`);
+    const keyFile = upath.join(hexHome, `${name}.pem`);
     await outputCacheFile(keyFile, publicKey);
 
     logger.debug(`Adding hex repo ${name}`);

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -1,5 +1,6 @@
 import { isEmptyArray, isString } from '@sindresorhus/is';
 import { quote } from 'shlex';
+import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
@@ -8,21 +9,31 @@ import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   deleteLocalFile,
   ensureCacheDir,
+  ensureDir,
   findLocalSiblingOrParent,
   getSiblingFileName,
   localPathExists,
+  outputCacheFile,
+  privateCacheDir,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
+import { Http } from '../../../util/http/index.ts';
 import { regEx } from '../../../util/regex.ts';
+import { joinUrlParts } from '../../../util/url.ts';
+import { HexDatasource } from '../../datasource/hex/index.ts';
 
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+
+const http = new Http(HexDatasource.id);
 
 const hexRepoUrl = 'https://hex.pm/';
 const hexRepoOrgUrlRegex = regEx(
   `^https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`,
 );
+const repoOptionRegex = regEx(/repo:\s*"(?<name>[^"]+)"/g);
 
 export async function updateArtifacts({
   packageFileName,
@@ -145,6 +156,13 @@ export async function updateArtifacts({
     return acc;
   }, [] as string[]);
 
+  preCommands.push(
+    ...(await getRepoAddCommands(
+      newPackageFileContent,
+      config.registryAliases,
+    )),
+  );
+
   // renovate: will update this
   const erlangVersion = '26';
 
@@ -153,6 +171,11 @@ export async function updateArtifacts({
       // https://hexdocs.pm/mix/1.15.0/Mix.Tasks.Archive.html
       // TODO: should include a version constraint
       MIX_ARCHIVES: await ensureCacheDir('mix_archives'),
+      // `mix hex.organization auth` and `mix hex.repo add` persist registry
+      // URLs and their credentials in `$HEX_HOME/hex.config`. Keep that under
+      // privateCacheDir, which is wiped between repositories, so credentials
+      // cannot leak into the next repository of the same run.
+      HEX_HOME: await hexHomeDir(),
     },
     cwdFile: packageFileName,
     docker: {},
@@ -222,6 +245,97 @@ export async function updateArtifacts({
       },
     },
   ];
+}
+
+async function hexHomeDir(): Promise<string> {
+  const dir = upath.join(privateCacheDir(), 'hex');
+  await ensureDir(dir);
+  return dir;
+}
+
+/**
+ * `mix` will not fetch from a third-party repo unless a registry public key is
+ * stored for it — with none, `:mix_hex_registry.key(nil)` raises and the fetch
+ * hangs until the registry timeout. `registryAliases` is a name-to-URL map with
+ * nowhere to put a key or its fingerprint, so we fetch the key from the registry
+ * ourselves. This is the same trust-on-first-use model the hex datasource
+ * already applies when it verifies V2 payloads.
+ *
+ * `registryAliases` is inherited from top-level config, so it may hold entries
+ * belonging to other managers. Only the repos `mix.exs` declares are added.
+ */
+async function getRepoAddCommands(
+  packageFileContent: string,
+  registryAliases: Record<string, string> | undefined,
+): Promise<string[]> {
+  const commands: string[] = [];
+  const declaredRepos = new Set(
+    Array.from(
+      packageFileContent.matchAll(repoOptionRegex),
+      ({ groups }) => groups!.name,
+    ),
+  );
+
+  for (const [name, url] of Object.entries(registryAliases ?? {})) {
+    // `hexpm` and `hexpm:<org>` are hex.pm itself, authenticated above through
+    // `mix hex.organization auth`.
+    if (
+      !declaredRepos.has(name) ||
+      name === 'hexpm' ||
+      name.startsWith('hexpm:')
+    ) {
+      continue;
+    }
+
+    const publicKey = await getRegistryPublicKey(url);
+    if (!publicKey) {
+      logger.warn(
+        { repo: name, url },
+        'Skipping hex repo, unable to fetch its registry public key',
+      );
+      continue;
+    }
+
+    const keyFile = upath.join(await hexHomeDir(), `${name}.pem`);
+    await outputCacheFile(keyFile, publicKey);
+
+    logger.debug(`Adding hex repo ${name}`);
+    const command = [
+      'mix',
+      'hex.repo',
+      'add',
+      quote(name),
+      quote(url),
+      '--public-key',
+      quote(keyFile),
+    ];
+
+    // An unauthenticated third-party registry still needs adding, so a missing
+    // token is not a reason to skip the repo.
+    const { token } = hostRules.find({ hostType: HexDatasource.id, url });
+    if (token) {
+      command.push('--auth-key', quote(token));
+    } else {
+      logger.debug(`No hostRules token found for hex repo ${name}`);
+    }
+
+    commands.push(command.join(' '));
+  }
+
+  return commands;
+}
+
+async function getRegistryPublicKey(url: string): Promise<string | null> {
+  const keyUrl = joinUrlParts(url, 'public_key');
+  try {
+    const { body } = await http.getText(keyUrl, {
+      cacheProvider: memCacheProvider,
+    });
+    return body.trim() || null;
+  } catch (err) {
+    logger.debug({ err, keyUrl }, 'Failed to fetch hex registry public key');
+    return null;
+  }
 }
 
 async function checkLockFileReadError(

--- a/lib/modules/manager/mix/artifacts.ts
+++ b/lib/modules/manager/mix/artifacts.ts
@@ -27,6 +27,7 @@ import { joinUrlParts } from '../../../util/url.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
 
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { getRepoOptions } from './utils.ts';
 
 const http = new Http(HexDatasource.id);
 
@@ -34,7 +35,6 @@ const hexRepoUrl = 'https://hex.pm/';
 const hexRepoOrgUrlRegex = regEx(
   `^https://hex\\.pm/api/repos/(?<organization>[a-z0-9_]+)/$`,
 );
-const repoOptionRegex = regEx(/repo:\s*"(?<name>[^"]+)"/g);
 
 export async function updateArtifacts({
   packageFileName,
@@ -270,12 +270,7 @@ async function getRepoAddCommands(
   registryAliases: Record<string, string> | undefined,
 ): Promise<string[]> {
   const commands: string[] = [];
-  const declaredRepos = new Set(
-    Array.from(
-      packageFileContent.matchAll(repoOptionRegex),
-      ({ groups }) => groups!.name,
-    ),
-  );
+  const declaredRepos = new Set(getRepoOptions(packageFileContent));
 
   for (const [name, url] of Object.entries(coerceObject(registryAliases))) {
     // `hexpm` and `hexpm:<org>` are hex.pm itself, authenticated above through

--- a/lib/modules/manager/mix/extract.spec.ts
+++ b/lib/modules/manager/mix/extract.spec.ts
@@ -69,6 +69,14 @@ describe('modules/manager/mix/extract', () => {
           packageName: 'also_secret:acme',
         },
         {
+          currentValue: '~> 1.7',
+          datasource: 'hex',
+          depName: 'oban_pro',
+          depType: 'prod',
+          packageName: 'oban_pro',
+          skipReason: 'unknown-registry',
+        },
+        {
           currentValue: '>0.2.0 and <=1.0.0',
           datasource: 'hex',
           depName: 'metrics',
@@ -201,6 +209,15 @@ describe('modules/manager/mix/extract', () => {
           lockedVersion: '1.3.4',
         },
         {
+          currentValue: '~> 1.7',
+          datasource: 'hex',
+          depName: 'oban_pro',
+          depType: 'prod',
+          packageName: 'oban_pro',
+          lockedVersion: '1.7.2',
+          skipReason: 'unknown-registry',
+        },
+        {
           currentValue: '>0.2.0 and <=1.0.0',
           datasource: 'hex',
           depName: 'metrics',
@@ -273,6 +290,72 @@ describe('modules/manager/mix/extract', () => {
           depType: 'dev',
           lockedVersion: '0.37.0',
           packageName: 'floki',
+        },
+      ]);
+    });
+
+    it('resolves a repo dependency through registryAliases', async () => {
+      const res = await extractPackageFile(Fixtures.get('mix.exs'), 'mix.exs', {
+        registryAliases: { oban: 'https://repo.oban.pro' },
+      });
+
+      expect(res?.deps).toContainEqual({
+        currentValue: '~> 1.7',
+        datasource: 'hex',
+        depName: 'oban_pro',
+        depType: 'prod',
+        packageName: 'oban_pro',
+        registryUrls: ['https://repo.oban.pro'],
+      });
+      expect(res?.deps).not.toContainEqual(
+        expect.objectContaining({ skipReason: 'unknown-registry' }),
+      );
+    });
+
+    it('skips a repo dependency missing from registryAliases', async () => {
+      const res = await extractPackageFile(Fixtures.get('mix.exs'), 'mix.exs', {
+        registryAliases: { other: 'https://example.com' },
+      });
+
+      expect(res?.deps).toContainEqual({
+        currentValue: '~> 1.7',
+        datasource: 'hex',
+        depName: 'oban_pro',
+        depType: 'prod',
+        packageName: 'oban_pro',
+        skipReason: 'unknown-registry',
+      });
+      expect(res?.deps).not.toContainEqual(
+        expect.objectContaining({ registryUrls: expect.anything() }),
+      );
+    });
+
+    it('treats hexpm repos as hex.pm itself', async () => {
+      const content = [
+        'defp deps do',
+        '  [',
+        '    {:plug, "~> 1.0", repo: "hexpm"},',
+        '    {:secret, "~> 1.0", repo: "hexpm:acme"}',
+        '  ]',
+        'end',
+      ].join('\n');
+
+      const res = await extractPackageFile(content, 'mix.exs', {});
+
+      expect(res?.deps).toEqual([
+        {
+          currentValue: '~> 1.0',
+          datasource: 'hex',
+          depName: 'plug',
+          depType: 'prod',
+          packageName: 'plug',
+        },
+        {
+          currentValue: '~> 1.0',
+          datasource: 'hex',
+          depName: 'secret',
+          depType: 'prod',
+          packageName: 'secret:acme',
         },
       ]);
     });

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -13,6 +13,7 @@ import type {
   PackageDependency,
   PackageFileContent,
 } from '../types.ts';
+import { getRepoOptions, stripComments } from './utils.ts';
 
 const depSectionRegExp = regEx(/defp\s+deps.*do/g);
 const depMatchRegExp = regEx(
@@ -23,8 +24,6 @@ const githubRegexp = regEx(/github:\s*"(?<value>[^"]+)"/);
 const refRegexp = regEx(/ref:\s*"(?<value>[^"]+)"/);
 const branchOrTagRegexp = regEx(/(?:branch|tag):\s*"(?<value>[^"]+)"/);
 const organizationRegexp = regEx(/organization:\s*"(?<value>[^"]+)"/);
-const repoRegexp = regEx(/repo:\s*"(?<value>[^"]+)"/);
-const commentMatchRegExp = regEx(/#.*$/);
 const lockedVersionRegExp = regEx(
   /^\s+"(?<app>\w+)".*?"(?<lockedVersion>\d+\.\d+\.\d+)"/,
 );
@@ -39,9 +38,7 @@ export async function extractPackageFile(
 ): Promise<PackageFileContent | null> {
   logger.trace(`mix.extractPackageFile(${packageFile})`);
   const deps = new Map<string, PackageDependency>();
-  const contentArr = content
-    .split(newlineRegex)
-    .map((line) => line.replace(commentMatchRegExp, ''));
+  const contentArr = stripComments(content).split(newlineRegex);
   for (let lineNumber = 0; lineNumber < contentArr.length; lineNumber += 1) {
     if (contentArr[lineNumber].match(depSectionRegExp)) {
       let depBuffer = '';
@@ -58,7 +55,9 @@ export async function extractPackageFile(
         // `repo: "hexpm"` is the explicit default registry and
         // `repo: "hexpm:<org>"` is the canonical form of `organization:`.
         // Any other name refers to a third-party registry.
-        const repoOption = repoRegexp.exec(opts)?.groups?.value;
+        // `opts` is an optional match group, so it is absent for deps
+        // declared without any options.
+        const [repoOption] = getRepoOptions(opts ?? '');
         const [repoName, repoOrganization] = coerceArray(
           repoOption?.split(':'),
         );

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -12,6 +12,7 @@ import type {
   PackageDependency,
   PackageFileContent,
 } from '../types.ts';
+import { getRepoOptions, stripComments } from './utils.ts';
 
 const depSectionRegExp = regEx(/defp\s+deps.*do/g);
 const depMatchRegExp = regEx(
@@ -22,8 +23,6 @@ const githubRegexp = regEx(/github:\s*"(?<value>[^"]+)"/);
 const refRegexp = regEx(/ref:\s*"(?<value>[^"]+)"/);
 const branchOrTagRegexp = regEx(/(?:branch|tag):\s*"(?<value>[^"]+)"/);
 const organizationRegexp = regEx(/organization:\s*"(?<value>[^"]+)"/);
-const repoRegexp = regEx(/repo:\s*"(?<value>[^"]+)"/);
-const commentMatchRegExp = regEx(/#.*$/);
 const lockedVersionRegExp = regEx(
   /^\s+"(?<app>\w+)".*?"(?<lockedVersion>\d+\.\d+\.\d+)"/,
 );
@@ -38,9 +37,7 @@ export async function extractPackageFile(
 ): Promise<PackageFileContent | null> {
   logger.trace(`mix.extractPackageFile(${packageFile})`);
   const deps = new Map<string, PackageDependency>();
-  const contentArr = content
-    .split(newlineRegex)
-    .map((line) => line.replace(commentMatchRegExp, ''));
+  const contentArr = stripComments(content).split(newlineRegex);
   for (let lineNumber = 0; lineNumber < contentArr.length; lineNumber += 1) {
     if (contentArr[lineNumber].match(depSectionRegExp)) {
       let depBuffer = '';
@@ -57,7 +54,9 @@ export async function extractPackageFile(
         // `repo: "hexpm"` is the explicit default registry and
         // `repo: "hexpm:<org>"` is the canonical form of `organization:`.
         // Any other name refers to a third-party registry.
-        const repoOption = repoRegexp.exec(opts)?.groups?.value;
+        // `opts` is an optional match group, so it is absent for deps
+        // declared without any options.
+        const [repoOption] = getRepoOptions(opts ?? '');
         const [repoName, repoOrganization] = repoOption?.split(':') ?? [];
         const isHexpmRepo = repoName === 'hexpm';
         const repo = isHexpmRepo ? undefined : repoOption;

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import {
   findLocalSiblingOrParent,
   readLocalFile,
@@ -7,7 +8,11 @@ import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
-import type { PackageDependency, PackageFileContent } from '../types.ts';
+import type {
+  ExtractConfig,
+  PackageDependency,
+  PackageFileContent,
+} from '../types.ts';
 
 const depSectionRegExp = regEx(/defp\s+deps.*do/g);
 const depMatchRegExp = regEx(
@@ -18,6 +23,7 @@ const githubRegexp = regEx(/github:\s*"(?<value>[^"]+)"/);
 const refRegexp = regEx(/ref:\s*"(?<value>[^"]+)"/);
 const branchOrTagRegexp = regEx(/(?:branch|tag):\s*"(?<value>[^"]+)"/);
 const organizationRegexp = regEx(/organization:\s*"(?<value>[^"]+)"/);
+const repoRegexp = regEx(/repo:\s*"(?<value>[^"]+)"/);
 const commentMatchRegExp = regEx(/#.*$/);
 const lockedVersionRegExp = regEx(
   /^\s+"(?<app>\w+)".*?"(?<lockedVersion>\d+\.\d+\.\d+)"/,
@@ -29,6 +35,7 @@ const onlyEnvironmentsRegexp = regEx(/:(\w+)/gm);
 export async function extractPackageFile(
   content: string,
   packageFile: string,
+  config?: ExtractConfig,
 ): Promise<PackageFileContent | null> {
   logger.trace(`mix.extractPackageFile(${packageFile})`);
   const deps = new Map<string, PackageDependency>();
@@ -48,7 +55,18 @@ export async function extractPackageFile(
         const git = gitRegexp.exec(opts)?.groups?.value;
         const ref = refRegexp.exec(opts)?.groups?.value;
         const branchOrTag = branchOrTagRegexp.exec(opts)?.groups?.value;
-        const organization = organizationRegexp.exec(opts)?.groups?.value;
+        // `repo: "hexpm"` is the explicit default registry and
+        // `repo: "hexpm:<org>"` is the canonical form of `organization:`.
+        // Any other name refers to a third-party registry.
+        const repoOption = repoRegexp.exec(opts)?.groups?.value;
+        const [repoName, repoOrganization] = coerceArray(
+          repoOption?.split(':'),
+        );
+        const isHexpmRepo = repoName === 'hexpm';
+        const repo = isHexpmRepo ? undefined : repoOption;
+        const organization =
+          organizationRegexp.exec(opts)?.groups?.value ??
+          (isHexpmRepo ? repoOrganization : undefined);
         const hexGroups = hexRegexp.exec(opts)?.groups;
         const hex = hexGroups?.strValue ?? hexGroups?.atomValue;
 
@@ -83,6 +101,20 @@ export async function extractPackageFile(
 
           if (requirement?.startsWith('==')) {
             dep.currentVersion = requirement.replace(regEx(/^==\s*/), '');
+          }
+
+          // A third-party `repo:` has no URL in `mix.exs`, so it must be mapped
+          // through `registryAliases`, keyed by the repo name.
+          if (repo) {
+            const registryUrl = config?.registryAliases?.[repo];
+            if (registryUrl) {
+              dep.registryUrls = [registryUrl];
+            } else {
+              logger.debug(
+                `No registryAliases entry for mix repo ${repo}, skipping ${app}`,
+              );
+              dep.skipReason = 'unknown-registry';
+            }
           }
         }
 

--- a/lib/modules/manager/mix/extract.ts
+++ b/lib/modules/manager/mix/extract.ts
@@ -7,7 +7,11 @@ import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
-import type { PackageDependency, PackageFileContent } from '../types.ts';
+import type {
+  ExtractConfig,
+  PackageDependency,
+  PackageFileContent,
+} from '../types.ts';
 
 const depSectionRegExp = regEx(/defp\s+deps.*do/g);
 const depMatchRegExp = regEx(
@@ -18,6 +22,7 @@ const githubRegexp = regEx(/github:\s*"(?<value>[^"]+)"/);
 const refRegexp = regEx(/ref:\s*"(?<value>[^"]+)"/);
 const branchOrTagRegexp = regEx(/(?:branch|tag):\s*"(?<value>[^"]+)"/);
 const organizationRegexp = regEx(/organization:\s*"(?<value>[^"]+)"/);
+const repoRegexp = regEx(/repo:\s*"(?<value>[^"]+)"/);
 const commentMatchRegExp = regEx(/#.*$/);
 const lockedVersionRegExp = regEx(
   /^\s+"(?<app>\w+)".*?"(?<lockedVersion>\d+\.\d+\.\d+)"/,
@@ -29,6 +34,7 @@ const onlyEnvironmentsRegexp = regEx(/:(\w+)/gm);
 export async function extractPackageFile(
   content: string,
   packageFile: string,
+  config?: ExtractConfig,
 ): Promise<PackageFileContent | null> {
   logger.trace(`mix.extractPackageFile(${packageFile})`);
   const deps = new Map<string, PackageDependency>();
@@ -48,7 +54,16 @@ export async function extractPackageFile(
         const git = gitRegexp.exec(opts)?.groups?.value;
         const ref = refRegexp.exec(opts)?.groups?.value;
         const branchOrTag = branchOrTagRegexp.exec(opts)?.groups?.value;
-        const organization = organizationRegexp.exec(opts)?.groups?.value;
+        // `repo: "hexpm"` is the explicit default registry and
+        // `repo: "hexpm:<org>"` is the canonical form of `organization:`.
+        // Any other name refers to a third-party registry.
+        const repoOption = repoRegexp.exec(opts)?.groups?.value;
+        const [repoName, repoOrganization] = repoOption?.split(':') ?? [];
+        const isHexpmRepo = repoName === 'hexpm';
+        const repo = isHexpmRepo ? undefined : repoOption;
+        const organization =
+          organizationRegexp.exec(opts)?.groups?.value ??
+          (isHexpmRepo ? repoOrganization : undefined);
         const hexGroups = hexRegexp.exec(opts)?.groups;
         const hex = hexGroups?.strValue ?? hexGroups?.atomValue;
 
@@ -83,6 +98,20 @@ export async function extractPackageFile(
 
           if (requirement?.startsWith('==')) {
             dep.currentVersion = requirement.replace(regEx(/^==\s*/), '');
+          }
+
+          // A third-party `repo:` has no URL in `mix.exs`, so it must be mapped
+          // through `registryAliases`, keyed by the repo name.
+          if (repo) {
+            const registryUrl = config?.registryAliases?.[repo];
+            if (registryUrl) {
+              dep.registryUrls = [registryUrl];
+            } else {
+              logger.debug(
+                `No registryAliases entry for mix repo ${repo}, skipping ${app}`,
+              );
+              dep.skipReason = 'unknown-registry';
+            }
           }
         }
 

--- a/lib/modules/manager/mix/readme.md
+++ b/lib/modules/manager/mix/readme.md
@@ -7,6 +7,65 @@ The following `depTypes` are currently supported by the `mix` manager :
 - `prod`: all dependencies by default
 - `dev`: dependencies with [`:only` option](https://hexdocs.pm/mix/Mix.Tasks.Deps.html#module-dependency-definition-options) not containing `:prod`
 
+### Private organizations on hex.pm
+
+For dependencies in a private [hex.pm organization](https://hex.pm/docs/private), add a `hostRule` matching the organization's API URL.
+The token needs API read and organization access.
+
+```elixir
+{:private_package, "~> 1.0", organization: "your_org"}
+```
+
+```json
+{
+  "hostRules": [
+    {
+      "matchHost": "https://hex.pm/api/repos/your_org/",
+      "token": "{{ secrets.HEX_TOKEN }}",
+      "authType": "Token-Only"
+    }
+  ]
+}
+```
+
+### Private registries
+
+Dependencies with a `repo:` option come from a third-party registry instead of hex.pm.
+Their URL cannot be discovered from `mix.exs`, so map the repo name to its URL with [`registryAliases`](../../../configuration-options.md#registryaliases), scoped to the `mix` manager.
+
+```elixir
+{:oban_pro, "~> 1.7", repo: "oban"}
+```
+
+```json
+{
+  "mix": {
+    "registryAliases": {
+      "oban": "https://repo.oban.pro"
+    }
+  },
+  "hostRules": [
+    {
+      "matchHost": "https://repo.oban.pro",
+      "token": "{{ secrets.OBAN_LICENSE_KEY }}",
+      "authType": "Token-Only"
+    }
+  ]
+}
+```
+
+The `registryAliases` key must match the `repo:` name in `mix.exs`, because `mix` verifies that the registry's signed metadata reports the same repository name it was configured under.
+Only the repos that `mix.exs` declares are added, so aliases set for other managers are ignored.
+
+`repo: "hexpm"` and `repo: "hexpm:<org>"` point at hex.pm itself, and need no alias: they are the explicit forms of the default registry and of `organization:` respectively.
+
+Renovate fetches the registry's public key from `<url>/public_key` to satisfy `mix`, which refuses to fetch from a repo that has no stored key.
+A registry that does not serve that endpoint is skipped.
+
+!!! note
+  `matchHost` matches on hostname and ignores any port.
+  To target a registry on a non-default port, give the full URL form, such as `http://localhost:8123`.
+
 ### `lockFileMaintenance`
 
 We recommend you use [`lockFileMaintenance`](../../../configuration-options.md#lockfilemaintenance) for the `mix` manager.

--- a/lib/modules/manager/mix/utils.ts
+++ b/lib/modules/manager/mix/utils.ts
@@ -1,0 +1,25 @@
+import { newlineRegex, regEx } from '../../../util/regex.ts';
+
+const commentMatchRegExp = regEx(/#.*$/);
+const repoOptionRegExp = regEx(/repo:\s*"(?<value>[^"]+)"/g);
+
+/**
+ * `#` starts a line comment in Elixir. Both extraction and artifact updates
+ * must ignore commented-out code, or they disagree on what `mix.exs` declares.
+ */
+export function stripComments(content: string): string {
+  return content
+    .split(newlineRegex)
+    .map((line) => line.replace(commentMatchRegExp, ''))
+    .join('\n');
+}
+
+/**
+ * Repo names declared through the `repo:` dep option, in order of appearance.
+ */
+export function getRepoOptions(content: string): string[] {
+  return Array.from(
+    stripComments(content).matchAll(repoOptionRegExp),
+    ({ groups }) => groups!.value,
+  );
+}

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -55,6 +55,8 @@ async function disableGitAutoMaintenance(
   await repo.addConfig('gc.auto', '0');
   await repo.addConfig('maintenance.auto', 'false');
   await repo.addConfig('receive.autogc', 'false');
+  await repo.addConfig('gc.autodetach', 'false');
+  await repo.addConfig('pack.writeReverseIndex', 'false');
 }
 
 describe('util/git/index', { timeout: 30000 }, () => {
@@ -204,6 +206,8 @@ describe('util/git/index', { timeout: 30000 }, () => {
   });
 
   afterEach(async () => {
+    // Give Git operations time to fully complete and release file handles
+    await new Promise((resolve) => setTimeout(resolve, 100));
     await tmpDir?.cleanup();
     await origin?.cleanup();
     vi.restoreAllMocks();

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -55,6 +55,8 @@ async function disableGitAutoMaintenance(
   await repo.addConfig('gc.auto', '0');
   await repo.addConfig('maintenance.auto', 'false');
   await repo.addConfig('receive.autogc', 'false');
+  await repo.addConfig('gc.autodetach', 'false');
+  await repo.addConfig('pack.writeReverseIndex', 'false');
 }
 
 describe('util/git/index', { timeout: 30000 }, () => {
@@ -201,6 +203,8 @@ describe('util/git/index', { timeout: 30000 }, () => {
   });
 
   afterEach(async () => {
+    // Give Git operations time to fully complete and release file handles
+    await new Promise((resolve) => setTimeout(resolve, 100));
     await tmpDir?.cleanup();
     await origin?.cleanup();
     vi.restoreAllMocks();

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -196,11 +196,15 @@ describe('util/git/index', { timeout: 30000 }, () => {
     setNoVerify([]);
     await git.syncGit();
     // override some local git settings for better testing
-    const local = simpleGit(tmpDir.path);
+    const local = simpleGit(tmpDir.path, {
+      unsafe: { allowUnsafeHooksPath: true },
+    });
     await local.addConfig('commit.gpgsign', 'false');
     await local.addConfig('user.name', 'Jest');
     await local.addConfig('user.email', 'Jest@example.com');
     await disableGitAutoMaintenance(local);
+    // a developer's global core.hooksPath must not run hooks inside test repos
+    await local.addConfig('core.hooksPath', '/dev/null');
     behindBaseCache.getCachedBehindBaseResult.mockReturnValue(null);
     updateDateCache.getCachedUpdateDateResult.mockReturnValue(null);
   });

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -193,11 +193,15 @@ describe('util/git/index', { timeout: 30000 }, () => {
     setNoVerify([]);
     await git.syncGit();
     // override some local git settings for better testing
-    const local = simpleGit(tmpDir.path);
+    const local = simpleGit(tmpDir.path, {
+      unsafe: { allowUnsafeHooksPath: true },
+    });
     await local.addConfig('commit.gpgsign', 'false');
     await local.addConfig('user.name', 'Jest');
     await local.addConfig('user.email', 'Jest@example.com');
     await disableGitAutoMaintenance(local);
+    // a developer's global core.hooksPath must not run hooks inside test repos
+    await local.addConfig('core.hooksPath', '/dev/null');
     behindBaseCache.getCachedBehindBaseResult.mockReturnValue(null);
     updateDateCache.getCachedUpdateDateResult.mockReturnValue(null);
   });


### PR DESCRIPTION
## Changes

Adds support for private/third-party hex registries in the `mix` manager.

Dependencies declared with a `repo:` option (`{:my_dep, "~> 1.0", repo: "acme"}`) come from a third-party hex registry rather than hex.pm. The registry URL is not discoverable from `mix.exs`, so the repo name is mapped to its URL through `registryAliases`, and authenticated with `hostRules`:

```json
{
  "registryAliases": {
    "acme": "https://hex.acme.com"
  },
  "hostRules": [
    {
      "matchHost": "hex.acme.com",
      "token": "...",
      "authType": "Token-Only"
    }
  ]
}
```

Details:

- **Extract** sets `registryUrls` for deps with a `repo:` option. The hex datasource already speaks the V2 registry protocol for any non-default registry, so no datasource change is needed. `packageName` is deliberately left as the bare app name, so the existing `app:organization` format used by the datasource is untouched.
- **Artifacts** runs `mix hex.repo add` for each aliased repo before updating the lockfile. `mix` refuses to fetch from a repo that has no stored registry public key — without one, `:mix_hex_registry.key(nil)` raises and the fetch hangs until the registry timeout. `registryAliases` is a name-to-URL map with nowhere to put a key or its fingerprint, so the key is fetched from the registry and passed to `mix hex.repo add` on disk. This is the same trust-on-first-use model the hex datasource already applies when verifying V2 payloads. A registry that does not serve `/public_key` is skipped rather than added in a state that would crash `mix`.

Based on the approach in #29775 by @bryannaegele, which stalled on a `packageName` format change that is no longer required.

Verified end to end against a self-signed registry built with `mix hex.registry build`, served both locally and from S3 behind a CloudFront function enforcing the hex `authorization` header. In both cases the dep resolves to its private `registryUrl`, the update is found, and the generated `mix hex.repo add` command authenticates and updates `mix.lock` inside a container with the cache dir mounted. The datasource returns both published versions with a valid token and fails closed with a wrong or absent one, and an origin that rejects `Bearer`-prefixed tokens confirms `authType: 'Token-Only'` sends the bare token hex expects.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #29622
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Opus 5) was used for non-trivial portions of the code, tests, and documentation, as well as for the end-to-end verification setup described above.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @indrekj will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

`docs/usage/configuration-options.md` (registryAliases manager list) and `lib/modules/manager/mix/readme.md` (private registry setup).

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: not public — verified against a local repository plus a self-hosted hex registry (local and S3/CloudFront), since a private registry cannot be exercised from a public repo.
