### PR TITLE
fix(terraform): deduplicate provider lockfile hashes

### DIFF
--- a/lib/modules/manager/terraform/lockfile/hash.spec.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.spec.ts
@@ -96,6 +96,51 @@ describe('modules/manager/terraform/lockfile/hash', () => {
     expect(result).toBeNull();
   });
 
+  it('deduplicates hashes from different shasum URLs and builds', async () => {
+    const builds = [
+      {
+        name: 'example/provider',
+        version: '1.0.0',
+        os: 'linux',
+        arch: 'amd64',
+        filename: 'terraform-provider-example_1.0.0_linux_amd64.zip',
+        url: 'https://example.com/linux.zip',
+        shasums_url: 'https://example.com/SHA256SUMS?signature=one',
+      },
+      {
+        name: 'example/provider',
+        version: '1.0.0',
+        os: 'darwin',
+        arch: 'arm64',
+        filename: 'terraform-provider-example_1.0.0_darwin_arm64.zip',
+        url: 'https://example.com/darwin.zip',
+        shasums_url: 'https://example.com/SHA256SUMS?signature=two',
+      },
+    ];
+    const getBuilds = vi
+      .spyOn(TerraformProviderHash.terraformDatasource, 'getBuilds')
+      .mockResolvedValueOnce(builds);
+    const getZipHashes = vi
+      .spyOn(TerraformProviderHash.terraformDatasource, 'getZipHashes')
+      .mockResolvedValue(['1234567890abcdef']);
+    const calculateHashScheme1Hashes = vi
+      .spyOn(TerraformProviderHash, 'calculateHashScheme1Hashes')
+      .mockResolvedValueOnce(['same-hash', 'same-hash']);
+
+    const result = await TerraformProviderHash.createHashes(
+      'https://registry.example.com',
+      'example/provider',
+      '1.0.0',
+    );
+
+    expect(getZipHashes).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(['h1:same-hash', 'zh:1234567890abcdef']);
+
+    getBuilds.mockRestore();
+    getZipHashes.mockRestore();
+    calculateHashScheme1Hashes.mockRestore();
+  });
+
   it('fail to create hashes', async () => {
     const readStreamLinux = createReadStream(
       getFixturePath('releaseBackendAzurerm_2_56_0.json'),
@@ -154,9 +199,8 @@ describe('modules/manager/terraform/lockfile/hash', () => {
     );
     expect(log.error.mock.calls).toMatchSnapshot();
     expect(result).not.toBeNull();
-    expect(result).toBeArrayOfSize(2);
+    expect(result).toBeArrayOfSize(1);
     expect(result).toMatchObject([
-      'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
       'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
     ]);
   });
@@ -217,7 +261,6 @@ describe('modules/manager/terraform/lockfile/hash', () => {
     );
     expect(log.error.mock.calls).toBeEmptyArray();
     expect(result).toMatchObject([
-      'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
       'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
       'zh:1d47d00730fab764bddb6d548fed7e124739b0bcebb9f3b3c6aa247de55fb804',
       'zh:29bff92b4375a35a7729248b3bc5db8991ca1b9ba640fc25b13700e12f99c195',
@@ -325,7 +368,6 @@ describe('modules/manager/terraform/lockfile/hash', () => {
     expect(log.error.mock.calls).toBeEmptyArray();
     expect(result).toMatchObject([
       'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
-      'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
       'zh:1d47d00730fab764bddb6d548fed7e124739b0bcebb9f3b3c6aa247de55fb804',
       'zh:29bff92b4375a35a7729248b3bc5db8991ca1b9ba640fc25b13700e12f99c195',
     ]);
@@ -379,7 +421,6 @@ describe('modules/manager/terraform/lockfile/hash', () => {
     );
     expect(log.error.mock.calls).toBeEmptyArray();
     expect(result).toMatchObject([
-      'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
       'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
     ]);
   });
@@ -442,7 +483,6 @@ describe('modules/manager/terraform/lockfile/hash', () => {
 
     expect(log.error.mock.calls).toBeEmptyArray();
     expect(result).toMatchObject([
-      'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
       'h1:I2F2atKZqKEOYk1tTLe15Llf9rVqxz48ZL1eZB9g8zM=',
     ]);
   });

--- a/lib/modules/manager/terraform/lockfile/hash.ts
+++ b/lib/modules/manager/terraform/lockfile/hash.ts
@@ -204,7 +204,7 @@ export class TerraformProviderHash {
     hashes.push(...h1Hashes.map((hash) => `h1:${hash}`));
     hashes.push(...zhHashes.map((hash) => `zh:${hash}`));
 
-    // sorting the hash alphabetically as terraform does this as well
-    return hashes.sort();
+    // hashes are a logical set which Terraform deduplicates and sorts
+    return deduplicateArray(hashes).sort();
   }
 }


### PR DESCRIPTION
## Changes

De-duplicate Terraform provider hashes before writing `.terraform.lock.hcl`.

Terraform treats provider hashes as a logical set and normalizes duplicate entries. Renovate previously only sorted the generated hashes, which allowed duplicates when:

- different pre-signed `shasums_url` values returned the same checksum file; or
- multiple provider builds produced identical `h1:` content hashes.

The final combined hash list is now de-duplicated and sorted. Unit tests cover duplicate `zh:` hashes from different checksum URLs and duplicate `h1:` hashes from builds.

## Context

Reported in https://github.com/renovatebot/renovate/discussions/44630.

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GitHub Copilot using GPT-5.6 Sol assisted with codebase analysis, implementation, tests, and the pull request description.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The targeted `pnpm check --all` checks passed, including formatting, Oxlint, Biome, and unit tests.