### PR TITLE
refactor(linters): add rules for @sindresorhus/is helpers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -83,7 +83,7 @@
     "renovate/prefer-json-pipe": "error",
     "renovate/prefer-luxon": "error",
     "renovate/prefer-is-helpers": "error",
-    "renovate/prefer-is-object": "warn",
+    "renovate/prefer-is-object": "error",
     "renovate/prefer-nullish-util": "error",
     "renovate/zod-schema-location": "error",
     "renovate/v8-ignore-reason": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -82,7 +82,7 @@
     "renovate/prefer-fs-util": "error",
     "renovate/prefer-json-pipe": "error",
     "renovate/prefer-luxon": "error",
-    "renovate/prefer-is-helpers": "warn",
+    "renovate/prefer-is-helpers": "error",
     "renovate/prefer-is-object": "warn",
     "renovate/prefer-nullish-util": "error",
     "renovate/zod-schema-location": "error",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -82,6 +82,8 @@
     "renovate/prefer-fs-util": "error",
     "renovate/prefer-json-pipe": "error",
     "renovate/prefer-luxon": "error",
+    "renovate/prefer-is-helpers": "warn",
+    "renovate/prefer-is-object": "warn",
     "renovate/prefer-nullish-util": "error",
     "renovate/zod-schema-location": "error",
     "renovate/v8-ignore-reason": "error",

--- a/lib/logger/bunyan.ts
+++ b/lib/logger/bunyan.ts
@@ -1,4 +1,4 @@
-import { isString, isUndefined } from '@sindresorhus/is';
+import { isString, isTruthy, isUndefined } from '@sindresorhus/is';
 import fs from 'fs-extra';
 import upath from 'upath';
 import { bunyan } from '../expose.ts';
@@ -45,9 +45,7 @@ export function createDefaultStreams(
     ? createLogFileStream(logFile)
     : undefined;
 
-  return [stdout, problemsStream, logFileStream].filter(
-    Boolean,
-  ) as BunyanStream[];
+  return [stdout, problemsStream, logFileStream].filter(isTruthy);
 }
 
 function createLogFileStream(logFile: string): BunyanStream {

--- a/lib/logger/cmd-serializer.ts
+++ b/lib/logger/cmd-serializer.ts
@@ -1,9 +1,10 @@
+import { isString } from '@sindresorhus/is';
 import { regEx } from '../util/regex.ts';
 
 export default function cmdSerializer(
   cmd: string | string[],
 ): string | string[] {
-  if (typeof cmd === 'string') {
+  if (isString(cmd)) {
     return cmd.replace(regEx(/https:\/\/[^@]*@/g), 'https://**redacted**@');
   }
   return cmd;

--- a/lib/modules/datasource/go/goproxy-parser.ts
+++ b/lib/modules/datasource/go/goproxy-parser.ts
@@ -1,4 +1,4 @@
-import { isString } from '@sindresorhus/is';
+import { isString, isTruthy } from '@sindresorhus/is';
 import moo from 'moo';
 import * as memCache from '../../../util/cache/memory/index.ts';
 import { getEnv } from '../../../util/env.ts';
@@ -33,7 +33,7 @@ export function parseGoproxy(
 
   const result: GoproxyItem[] = input
     .split(regEx(/([^,|]*(?:,|\|))/))
-    .filter(Boolean)
+    .filter(isTruthy)
     .map((s) => s.split(/(?=,|\|)/)) // TODO: #12872 lookahead
     .map(([url, separator]) => ({
       url,

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -1,5 +1,10 @@
 import { ATTR_CODE_FUNCTION_NAME } from '@opentelemetry/semantic-conventions';
-import { isFunction, isNonEmptyArray, isString } from '@sindresorhus/is';
+import {
+  isFunction,
+  isNonEmptyArray,
+  isString,
+  isTruthy,
+} from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { GlobalConfig } from '../../config/global.ts';
 import { HOST_DISABLED } from '../../constants/error-messages.ts';
@@ -292,7 +297,7 @@ async function mergeRegistries(
 }
 
 function massageRegistryUrls(registryUrls: string[]): string[] {
-  return registryUrls.filter(Boolean).map(trimTrailingSlash);
+  return registryUrls.filter(isTruthy).map(trimTrailingSlash);
 }
 
 function resolveRegistryUrls(
@@ -321,7 +326,7 @@ function resolveRegistryUrls(
       ? datasource.defaultRegistryUrls()
       : (datasource.defaultRegistryUrls ?? []);
   }
-  const customUrls = registryUrls?.filter(Boolean);
+  const customUrls = registryUrls?.filter(isTruthy);
   let resolvedUrls: string[] = [];
   if (isNonEmptyArray(customUrls)) {
     resolvedUrls = [...customUrls];

--- a/lib/modules/datasource/nuget/common.ts
+++ b/lib/modules/datasource/nuget/common.ts
@@ -1,3 +1,4 @@
+import { isNullOrUndefined } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { parseUrl } from '../../../util/url.ts';
@@ -13,7 +14,7 @@ export function removeBuildMeta(version: string): string {
 const urlWhitespaceRe = regEx(/\s/g);
 
 export function massageUrl(url: string | null | undefined): string | null {
-  if (url === null || url === undefined) {
+  if (isNullOrUndefined(url)) {
     return null;
   }
 

--- a/lib/modules/datasource/packagist/schema.ts
+++ b/lib/modules/datasource/packagist/schema.ts
@@ -1,4 +1,4 @@
-import { isUndefined } from '@sindresorhus/is';
+import { isString, isUndefined } from '@sindresorhus/is';
 import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
 import {
@@ -163,7 +163,7 @@ export function extractReleaseResult(
 
 function getAbandonedMessage(abandoned: string | boolean): string {
   const message = 'This package is abandoned and no longer maintained.';
-  if (typeof abandoned === 'string') {
+  if (isString(abandoned)) {
     return `${message} The author suggests using the \`${abandoned}\` package instead.`;
   }
   return message;

--- a/lib/modules/datasource/rpm/providers/common.ts
+++ b/lib/modules/datasource/rpm/providers/common.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { createGunzip } from 'node:zlib';
+import { isNullOrUndefined } from '@sindresorhus/is';
 import upath from 'upath';
 import { logger } from '../../../../logger/index.ts';
 import * as fs from '../../../../util/fs/index.ts';
@@ -17,13 +18,13 @@ export function formatRpmVersion(
   ver: RpmVersionValue,
   rel?: RpmVersionValue,
 ): string | null {
-  if (ver === undefined || ver === null) {
+  if (isNullOrUndefined(ver)) {
     return null;
   }
 
   const version = String(ver);
 
-  if (rel === undefined || rel === null) {
+  if (isNullOrUndefined(rel)) {
     return version;
   }
 

--- a/lib/modules/datasource/sbt-package/index.spec.ts
+++ b/lib/modules/datasource/sbt-package/index.spec.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
@@ -300,7 +301,7 @@ describe('modules/datasource/sbt-package/index', () => {
         .spyOn(urlUtil, 'parseUrl')
         .mockImplementation((url) => {
           if (
-            typeof url === 'string' &&
+            isString(url) &&
             url === 'https://repo.maven.apache.org/maven2/org/example/'
           ) {
             return null;
@@ -339,7 +340,7 @@ describe('modules/datasource/sbt-package/index', () => {
         .spyOn(urlUtil, 'parseUrl')
         .mockImplementation((url) => {
           if (
-            typeof url === 'string' &&
+            isString(url) &&
             url === 'https://repo.maven.apache.org/maven2/org/example/example/'
           ) {
             return null;

--- a/lib/modules/manager/ant/update.ts
+++ b/lib/modules/manager/ant/update.ts
@@ -1,3 +1,4 @@
+import { isNullOrUndefined } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import type { UpdateDependencyConfig } from '../types.ts';
 
@@ -8,7 +9,7 @@ export function updateDependency({
 }: UpdateDependencyConfig): string | null {
   const { depName, currentValue, newValue, fileReplacePosition } = upgrade;
 
-  if (fileReplacePosition === undefined || fileReplacePosition === null) {
+  if (isNullOrUndefined(fileReplacePosition)) {
     logger.debug({ depName }, 'No fileReplacePosition for ant dependency');
     return null;
   }

--- a/lib/modules/manager/bazel-module/parser/fragments.ts
+++ b/lib/modules/manager/bazel-module/parser/fragments.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { z } from 'zod/v4';
 import {
   LooseArray,
@@ -126,7 +127,7 @@ export function boolean(value: string | boolean): BooleanFragment {
   return {
     type: 'boolean',
     isComplete: true,
-    value: typeof value === 'string' ? starlark.asBoolean(value) : value,
+    value: isString(value) ? starlark.asBoolean(value) : value,
   };
 }
 

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -1,4 +1,4 @@
-import { isArray, isString } from '@sindresorhus/is';
+import { isArray, isObject, isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import {
   getParentDir,
@@ -75,7 +75,7 @@ export async function extractAllPackageFiles(
     let workspaces = res?.managerData?.workspaces;
 
     // Check for nested packages property https://bun.com/docs/pm/catalogs#1-define-catalogs-in-root-package-json
-    if (typeof workspaces === 'object' && 'packages' in workspaces) {
+    if (isObject(workspaces) && 'packages' in workspaces) {
       workspaces = workspaces.packages;
     }
 

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { Result } from '../../../util/result.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
@@ -17,7 +18,7 @@ function extractDefinition(
   registryAliases: Record<string, string>,
 ): void {
   for (const [key, orb] of Object.entries(definition.orbs)) {
-    if (typeof orb === 'string') {
+    if (isString(orb)) {
       const [packageName, currentValue] = orb.split('@');
 
       deps.push({

--- a/lib/modules/manager/deno/post.ts
+++ b/lib/modules/manager/deno/post.ts
@@ -2,6 +2,7 @@ import {
   isEmptyObject,
   isNonEmptyArray,
   isNonEmptyObject,
+  isString,
 } from '@sindresorhus/is';
 import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
@@ -110,7 +111,7 @@ export function getLockedVersion(
       const match = depValueRegex.exec(key);
       // find "jsr:@scope/name@1" intersects "jsr:@scope/name@^1.0.0"
       if (
-        typeof depName === 'string' &&
+        isString(depName) &&
         match?.groups?.depName === depName &&
         match?.groups?.datasource === datasource &&
         currentValue &&

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { parseYaml } from '../../../util/yaml.ts';
 import { id as dockerVersioning } from '../../versioning/docker/index.ts';
@@ -43,7 +44,7 @@ export function findDependenciesInternal(
   packageDependencies: PackageDependency[],
   registryAliases: Record<string, string> | undefined,
 ): PackageDependency[] {
-  if (!parsedContent || typeof parsedContent !== 'object') {
+  if (!isObject(parsedContent)) {
     return packageDependencies;
   }
 

--- a/lib/modules/manager/helm-values/util.ts
+++ b/lib/modules/manager/helm-values/util.ts
@@ -1,4 +1,4 @@
-import { isString } from '@sindresorhus/is';
+import { isObject, isString } from '@sindresorhus/is';
 import { hasKey } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { HelmDockerImageDependency } from './types.ts';
@@ -29,8 +29,7 @@ export function matchesHelmValuesDockerHeuristic(
 ): data is HelmDockerImageDependency {
   return !!(
     parentKeyRe.test(parentKey) &&
-    data &&
-    typeof data === 'object' &&
+    isObject(data) &&
     hasKey('repository', data) &&
     (hasKey('tag', data) || hasKey('version', data))
   );

--- a/lib/modules/manager/helm-values/util.ts
+++ b/lib/modules/manager/helm-values/util.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { hasKey } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { HelmDockerImageDependency } from './types.ts';
@@ -39,5 +40,5 @@ export function matchesHelmValuesInlineImage(
   parentKey: string,
   data: unknown,
 ): data is string {
-  return !!(parentKeyRe.test(parentKey) && data && typeof data === 'string');
+  return !!(parentKeyRe.test(parentKey) && data && isString(data));
 }

--- a/lib/modules/manager/index.spec.ts
+++ b/lib/modules/manager/index.spec.ts
@@ -1,3 +1,4 @@
+import { isBoolean, isString } from '@sindresorhus/is';
 import upath from 'upath';
 import { loadModules } from '../../util/modules.ts';
 import { getDatasourceList } from '../datasource/index.ts';
@@ -40,7 +41,7 @@ describe('modules/manager/index', () => {
     )) {
       it(`has lockFileMaintenanceIsDelegatedToPackageManager for ${name}`, () => {
         expect(mgr.lockFileMaintenanceIsDelegatedToPackageManager).toSatisfy(
-          (value) => typeof value === 'boolean' || typeof value === 'string',
+          (value) => isBoolean(value) || isString(value),
         );
       });
     }

--- a/lib/modules/manager/npm/extract/common/dependency.ts
+++ b/lib/modules/manager/npm/extract/common/dependency.ts
@@ -57,7 +57,7 @@ export function extractDependency(
     dep.skipReason = 'invalid-name';
     return dep;
   }
-  if (typeof input !== 'string') {
+  if (!isString(input)) {
     dep.skipReason = 'invalid-value';
     return dep;
   }

--- a/lib/modules/manager/npm/extract/post/monorepo.ts
+++ b/lib/modules/manager/npm/extract/post/monorepo.ts
@@ -1,4 +1,4 @@
-import { isArray, isString } from '@sindresorhus/is';
+import { isArray, isString, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../../../logger/index.ts';
 import {
   getParentDir,
@@ -37,7 +37,7 @@ export async function detectMonorepos(
       );
       const internalPackageNames = internalPackageFiles
         .map((sp) => sp.managerData?.packageJsonName)
-        .filter(Boolean);
+        .filter(isTruthy);
 
       p.deps?.forEach((dep) => {
         if (
@@ -66,7 +66,10 @@ export async function detectMonorepos(
         }
 
         subPackage.deps?.forEach((dep) => {
-          if (internalPackageNames.includes(dep.depName)) {
+          if (
+            isString(dep.depName) &&
+            internalPackageNames.includes(dep.depName)
+          ) {
             dep.isInternal = true;
           }
         });

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -1,4 +1,4 @@
-import { isString } from '@sindresorhus/is';
+import { isNullOrUndefined, isString } from '@sindresorhus/is';
 import { logger } from '../../../../logger/index.ts';
 import * as hostRules from '../../../../util/host-rules.ts';
 import { regEx } from '../../../../util/regex.ts';
@@ -23,7 +23,7 @@ export function processHostRules(): HostRulesResult {
   // Include host rules without specific type to mimic the behavior used when determining dependencies with updates.
   const noTypeHostRules = hostRules
     .getAll()
-    .filter((rule) => rule.hostType === null || rule.hostType === undefined);
+    .filter((rule) => isNullOrUndefined(rule.hostType));
   logger.debug(
     `Found ${noTypeHostRules.length} host rule(s) without host type`,
   );

--- a/lib/modules/manager/osgi/extract.ts
+++ b/lib/modules/manager/osgi/extract.ts
@@ -1,4 +1,4 @@
-import { isArray, isNullOrUndefined } from '@sindresorhus/is';
+import { isArray, isNullOrUndefined, isString } from '@sindresorhus/is';
 import json5 from 'json5';
 import { coerce, satisfies } from 'semver';
 import { logger } from '../../../logger/index.ts';
@@ -62,7 +62,7 @@ export function extractPackageFile(
 
   // convert bundles to dependencies
   for (const entry of allBundles) {
-    const rawGav = typeof entry === 'string' ? entry : entry.id;
+    const rawGav = isString(entry) ? entry : entry.id;
     // skip invalid definitions, such as objects without an id set
     if (!rawGav) {
       continue;

--- a/lib/modules/manager/pipenv/extract.ts
+++ b/lib/modules/manager/pipenv/extract.ts
@@ -1,6 +1,6 @@
 import { pipenv as pipenvDetect } from '@renovatebot/detect-tools';
 import { RANGE_PATTERN } from '@renovatebot/pep440';
-import { isArray, isObject, isString } from '@sindresorhus/is';
+import { isArray, isObject, isString, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import type { SkipReason } from '../../../types/index.ts';
 import type { ConstraintName } from '../../../util/exec/types.ts';
@@ -106,7 +106,7 @@ function extractFromSection(
       }
       return dep;
     })
-    .filter(Boolean);
+    .filter(isTruthy);
   return deps;
 }
 

--- a/lib/modules/manager/pre-commit/parsing.ts
+++ b/lib/modules/manager/pre-commit/parsing.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@sindresorhus/is';
 import { hasKey } from '../../../util/object.ts';
 import type { PreCommitConfig, PreCommitDependency } from './types.ts';
 
@@ -12,7 +13,7 @@ import type { PreCommitConfig, PreCommitDependency } from './types.ts';
 export function matchesPrecommitConfigHeuristic(
   data: unknown,
 ): data is PreCommitConfig {
-  return !!(data && typeof data === 'object' && hasKey('repos', data));
+  return !!(isObject(data) && hasKey('repos', data));
 }
 
 /**
@@ -25,10 +26,5 @@ export function matchesPrecommitConfigHeuristic(
 export function matchesPrecommitDependencyHeuristic(
   data: unknown,
 ): data is PreCommitDependency {
-  return !!(
-    data &&
-    typeof data === 'object' &&
-    hasKey('repo', data) &&
-    hasKey('rev', data)
-  );
+  return !!(isObject(data) && hasKey('repo', data) && hasKey('rev', data));
 }

--- a/lib/modules/manager/proto/schema.ts
+++ b/lib/modules/manager/proto/schema.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { z } from 'zod/v4';
 import { Toml } from '../../../util/schema-utils/index.ts';
 
@@ -19,7 +20,7 @@ export const ProtoToolsFile = Toml.pipe(
   z.record(z.string(), z.unknown()).transform((data) => {
     const versions: Record<string, string> = {};
     for (const [key, value] of Object.entries(data)) {
-      if (typeof value === 'string' && !nonVersionKeys.has(key)) {
+      if (isString(value) && !nonVersionKeys.has(key)) {
         versions[key] = value;
       }
     }

--- a/lib/modules/manager/woodpecker/extract.ts
+++ b/lib/modules/manager/woodpecker/extract.ts
@@ -1,4 +1,4 @@
-import { isString } from '@sindresorhus/is';
+import { isObject, isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
 import { getDep } from '../dockerfile/extract.ts';
@@ -31,7 +31,7 @@ export function extractPackageFile(
       );
       return null;
     }
-    if (typeof config !== 'object') {
+    if (!isObject(config)) {
       logger.debug(
         { packageFile, type: typeof config },
         'Unexpected type for Woodpecker Configuration content',

--- a/lib/modules/versioning/apk/index.ts
+++ b/lib/modules/versioning/apk/index.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
 import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
@@ -82,7 +83,7 @@ class ApkVersioningApi extends GenericVersioningApi {
       const extraParts = extra
         .substring(1)
         .split('.')
-        .filter(Boolean)
+        .filter(isTruthy)
         .map(Number);
       release.push(...extraParts);
     }

--- a/lib/modules/versioning/bazel-module/bzlmod-version.ts
+++ b/lib/modules/versioning/bazel-module/bzlmod-version.ts
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Contains classes that represent a Bazel module version.
  */
+import { isString } from '@sindresorhus/is';
 
 /**
  * Represents a single value in a VersionPart. For example, the version string
@@ -80,7 +81,7 @@ export class VersionPart extends Array<Identifier> {
    */
   static create(...items: (Identifier | string)[]): VersionPart {
     const idents = items.map((item) => {
-      if (typeof item === 'string') {
+      if (isString(item)) {
         return new Identifier(item);
       }
       return item;

--- a/lib/modules/versioning/bazel-module/index.ts
+++ b/lib/modules/versioning/bazel-module/index.ts
@@ -1,3 +1,4 @@
+import { isNullOrUndefined } from '@sindresorhus/is';
 import type { NewValueConfig, VersioningApi } from '../types.ts';
 import { BzlmodVersion } from './bzlmod-version.ts';
 
@@ -154,7 +155,7 @@ function isValid(input: string): boolean {
  * Check whether the `input` is a valid version string.
  */
 function isVersion(input: string | undefined | null): boolean {
-  if (input === undefined || input === null) {
+  if (isNullOrUndefined(input)) {
     return false;
   }
   return isValid(input);

--- a/lib/modules/versioning/conan/common.ts
+++ b/lib/modules/versioning/conan/common.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import * as semver from 'semver';
 import { regEx } from '../../../util/regex.ts';
 import { coerceString } from '../../../util/string.ts';
@@ -90,7 +91,7 @@ export function findSatisfyingVersion(
 
   for (const v of versions) {
     const versionFromList = makeVersion(v, options);
-    if (typeof versionFromList === 'string') {
+    if (isString(versionFromList)) {
       const cleanedVersion = cleanVersion(versionFromList);
       const options = getOptions(range);
       const cleanRange = cleanVersion(range);

--- a/lib/modules/versioning/conan/range.ts
+++ b/lib/modules/versioning/conan/range.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import * as semver from 'semver';
 import type { SemVer } from 'semver-utils';
 import { parseRange } from 'semver-utils';
@@ -18,7 +19,7 @@ export function getMajor(version: string): null | number {
   const options = getOptions(version);
   options.includePrerelease = true;
   const cleanerVersion = makeVersion(cleanedVersion, options);
-  if (typeof cleanerVersion === 'string') {
+  if (isString(cleanerVersion)) {
     return Number(cleanerVersion.split('.')[0]);
   }
   return null;
@@ -30,7 +31,7 @@ export function getMinor(version: string): null | number {
   const options = getOptions(version);
   options.includePrerelease = true;
   const cleanerVersion = makeVersion(cleanedVersion, options);
-  if (typeof cleanerVersion === 'string') {
+  if (isString(cleanerVersion)) {
     return Number(cleanerVersion.split('.')[1]);
   }
   return null;
@@ -43,7 +44,7 @@ export function getPatch(version: string): null | number {
   options.includePrerelease = true;
   const cleanerVersion = makeVersion(cleanedVersion, options);
 
-  if (typeof cleanerVersion === 'string') {
+  if (isString(cleanerVersion)) {
     const newVersion = semver.valid(
       semver.coerce(cleanedVersion, {
         loose: false,

--- a/lib/modules/versioning/gradle/compare.ts
+++ b/lib/modules/versioning/gradle/compare.ts
@@ -167,7 +167,7 @@ function tokenCmp(left: Token | null, right: Token | null): number {
     if (left.val > right.val) {
       return 1;
     }
-  } else if (typeof left.val === 'string' && typeof right.val === 'string') {
+  } else if (isString(left.val) && isString(right.val)) {
     return stringTokenCmp(left.val, right.val);
   } else if (right.type === TokenType.Number) {
     return -1;

--- a/lib/modules/versioning/lambda-node/index.ts
+++ b/lib/modules/versioning/lambda-node/index.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { api as nodeApi } from '../node/index.ts';
 import type { VersioningApi } from '../types.ts';
@@ -15,7 +16,7 @@ export function isStable(version: string): boolean {
     return false;
   }
 
-  if (typeof schedule.support === 'string') {
+  if (isString(schedule.support)) {
     return DateTime.local() < DateTime.fromISO(schedule.support);
   }
 

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
 
 const PREFIX_DOT = 'PREFIX_DOT';
@@ -280,7 +281,7 @@ function compare(left: string, right: string): number {
 }
 
 function isVersion(version: unknown): version is string {
-  if (!version || typeof version !== 'string') {
+  if (!version || !isString(version)) {
     return false;
   }
   if (!regEx(/^[-.a-z_+0-9]+$/i).test(version)) {

--- a/lib/modules/versioning/pep440/range.ts
+++ b/lib/modules/versioning/pep440/range.ts
@@ -1,6 +1,7 @@
 import { gte, lt, lte, satisfies } from '@renovatebot/pep440';
 import { parse as parseRange } from '@renovatebot/pep440/lib/specifier.js';
 import { parse as parseVersion } from '@renovatebot/pep440/lib/version.js';
+import { isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -203,7 +204,7 @@ export function getNewValue({
       });
   }
 
-  let result = updatedRange.filter(Boolean).join(', ');
+  let result = updatedRange.filter(isTruthy).join(', ');
 
   if (result.includes(', ') && !currentValue.includes(', ')) {
     result = result.replace(regEx(/, /g), ',');

--- a/lib/modules/versioning/pvp/index.ts
+++ b/lib/modules/versioning/pvp/index.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import type { RangeStrategy } from '../../../types/versioning.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -200,7 +201,7 @@ function subset(subRange: string, superRange: string): boolean | undefined {
 }
 
 function isVersion(maybeRange: string | undefined | null): boolean {
-  return typeof maybeRange === 'string' && parseRange(maybeRange) === null;
+  return isString(maybeRange) && parseRange(maybeRange) === null;
 }
 
 function isValid(ver: string): boolean {

--- a/lib/modules/versioning/ruby/index.ts
+++ b/lib/modules/versioning/ruby/index.ts
@@ -6,6 +6,7 @@ import {
   satisfies,
   valid,
 } from '@renovatebot/ruby-semver';
+import { isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import type { RangeStrategy } from '../../../types/versioning.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -30,7 +31,7 @@ export const supportedRangeStrategies: RangeStrategy[] = [
 ];
 
 function vtrim<T = unknown>(version: T): string | T {
-  if (typeof version === 'string') {
+  if (isString(version)) {
     return version.replace(regEx(/^v/), '').replace(regEx(/('|")/g), '');
   }
   return version;

--- a/lib/util/cache/package/impl/file.ts
+++ b/lib/util/cache/package/impl/file.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@sindresorhus/is';
 import cacache from 'cacache';
 import { DateTime } from 'luxon';
 import upath from 'upath';
@@ -139,7 +140,7 @@ export class PackageCacheFile extends PackageCacheBase {
 }
 
 function getMetadataExpiry(metadata: unknown): number | undefined {
-  if (!metadata || typeof metadata !== 'object') {
+  if (!isObject(metadata)) {
     return undefined;
   }
 

--- a/lib/util/cache/package/legacy.ts
+++ b/lib/util/cache/package/legacy.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { decompressFromBase64, decompressFromBuffer } from '../../compress.ts';
 
@@ -25,7 +26,7 @@ export async function decodeLegacyEntry(data: Buffer): Promise<LegacyEntry> {
 async function decodeLegacyJsonEntry(data: Buffer): Promise<LegacyEntry> {
   const cached = JSON.parse(data.toString('utf8')) as LegacyJsonEntry;
 
-  if (typeof cached.value !== 'string' || typeof cached.expiry !== 'string') {
+  if (!isString(cached.value) || !isString(cached.expiry)) {
     throw new Error('Invalid legacy JSON package cache entry');
   }
 

--- a/lib/util/date.ts
+++ b/lib/util/date.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 
 const ONE_MINUTE_MS = 60 * 1000;
@@ -18,10 +19,9 @@ export function getElapsedMinutes(date: Date): number {
 }
 
 export function getElapsedHours(date: Date | string): number {
-  const pastDate =
-    typeof date === 'string'
-      ? DateTime.fromISO(date)
-      : DateTime.fromJSDate(date);
+  const pastDate = isString(date)
+    ? DateTime.fromISO(date)
+    : DateTime.fromJSDate(date);
 
   if (!pastDate.isValid) {
     return 0;

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { isNonEmptyString, isString, isTruthy } from '@sindresorhus/is';
 import { join, quote } from 'shlex';
 import { GlobalConfig } from '../../../config/global.ts';
 import { SYSTEM_INSUFFICIENT_MEMORY } from '../../../constants/error-messages.ts';
@@ -124,7 +124,7 @@ export async function removeDanglingContainers(): Promise<void> {
         .trim()
         .split(newlineRegex)
         .map((container) => container.trim())
-        .filter(Boolean);
+        .filter(isTruthy);
       logger.debug({ containerIds }, 'Removing dangling child containers');
       await rawExec(`docker rm -f ${containerIds.join(' ')}`, {});
     } else {

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '@sindresorhus/is';
+import { isNonEmptyString, isString } from '@sindresorhus/is';
 import upath from 'upath';
 import { GlobalConfig } from '../../config/global.ts';
 import type { RepoToolSettingsOptions } from '../../config/types.ts';
@@ -93,7 +93,7 @@ async function prepareRawExec(
 
   let rawOptions = getRawExecOptions(opts);
 
-  let rawCommands = typeof cmd === 'string' ? [cmd] : cmd;
+  let rawCommands = isString(cmd) ? [cmd] : cmd;
 
   if (isDocker(docker)) {
     logger.debug({ image: sideCarImage }, 'Using docker to execute');

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -1,6 +1,7 @@
 import {
   isBoolean,
   isNonEmptyStringAndNotWhitespace,
+  isObject,
   isString,
 } from '@sindresorhus/is';
 import { join } from 'shlex';
@@ -44,7 +45,7 @@ export function getChildEnv({
 }
 
 export function isCommandWithOptions(cmd: unknown): cmd is CommandWithOptions {
-  if (!(typeof cmd === 'object' && cmd !== null && 'command' in cmd)) {
+  if (!(isObject(cmd) && 'command' in cmd)) {
     return false;
   }
 

--- a/lib/util/fingerprint.ts
+++ b/lib/util/fingerprint.ts
@@ -15,6 +15,7 @@ function isEmittable(value: unknown, cache: WeakMap<object, boolean>): boolean {
   ) {
     return false;
   }
+  // oxlint-disable-next-line renovate/prefer-is-object -- byte-exact JSON canonicalization: functions are handled explicitly above and must not take the object path
   if (value === null || typeof value !== 'object') {
     return true;
   }
@@ -40,6 +41,7 @@ function fingerprintInto(
   seen: WeakSet<object>,
   emittableCache: WeakMap<object, boolean>,
 ): void {
+  // oxlint-disable-next-line renovate/prefer-is-object -- byte-exact JSON canonicalization: functions must take the JSON.stringify primitive path, but isObject() matches them
   if (value === null || typeof value !== 'object') {
     h.update(JSON.stringify(value));
     return;

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -1,3 +1,4 @@
+import { isTruthy } from '@sindresorhus/is';
 import { codeBlock } from 'common-tags';
 import fs from 'fs-extra';
 import { DateTime } from 'luxon';
@@ -1716,7 +1717,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       )
         .split(newlineRegex)
         .map((line) => line.replace(regEx(/[0-9a-f]+\s+/i), ''))
-        .filter(Boolean);
+        .filter(isTruthy);
     }
 
     it('creates renovate ref in default section', async () => {

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -5,6 +5,7 @@ import {
   isNonEmptyObject,
   isNonEmptyStringAndNotWhitespace,
   isString,
+  isTruthy,
 } from '@sindresorhus/is';
 import fs from 'fs-extra';
 import { DateTime } from 'luxon';
@@ -281,7 +282,7 @@ async function fetchBranchCommits(preferUpstream = true): Promise<void> {
     logger.trace({ lsRemoteRes }, 'git ls-remote result');
     lsRemoteRes
       .split(newlineRegex)
-      .filter(Boolean)
+      .filter(isTruthy)
       .map((line) => line.trim().split(regEx(/\s+/)))
       .forEach(([sha, ref]) => {
         config.branchCommits[ref.replace('refs/heads/', '')] =
@@ -1419,7 +1420,7 @@ export async function prepareCommit({
         } else {
           let contents: Buffer;
           /* v8 ignore else -- TODO: add test #40625 */
-          if (typeof file.contents === 'string') {
+          if (isString(file.contents)) {
             contents = Buffer.from(file.contents);
           } else {
             contents = file.contents;

--- a/lib/util/git/instrument.ts
+++ b/lib/util/git/instrument.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import type {
   BranchSummary,
   CommitResult,
@@ -113,7 +114,7 @@ export class InstrumentedSimpleGit {
     return await instrument(
       spanName,
       async () => {
-        if (typeof whatOrOptions === 'string') {
+        if (isString(whatOrOptions)) {
           return await this.git.checkout(whatOrOptions);
         }
         return await this.git.checkout(whatOrOptions);
@@ -221,7 +222,7 @@ export class InstrumentedSimpleGit {
     return await instrument(
       spanName,
       async () => {
-        if (typeof optionOrOptions === 'string') {
+        if (isString(optionOrOptions)) {
           return await this.git.revparse(optionOrOptions);
         }
         return await this.git.revparse(optionOrOptions);

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -40,7 +40,9 @@ export function migrateRule(rule: LegacyHostRule & HostRule): HostRule {
 
   const { matchHost } = result;
   const { hostName, domainName, baseUrl } = rule;
-  const hostValues = [matchHost, hostName, domainName, baseUrl].filter(Boolean);
+  const hostValues = [matchHost, hostName, domainName, baseUrl].filter(
+    isTruthy,
+  );
   if (hostValues.length === 1) {
     const [matchHost] = hostValues;
     result.matchHost = matchHost;

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -1,3 +1,4 @@
+import { isObject } from '@sindresorhus/is';
 import { codeBlock } from 'common-tags';
 import { DateTime } from 'luxon';
 import * as httpMock from '~test/http-mock.ts';
@@ -350,7 +351,7 @@ describe('util/http/github', () => {
             // eslint-disable-next-line prefer-arrow-callback
             function reply() {
               // https://github.com/nock/nock/issues/1979
-              if (typeof body === 'object' && 'message' in body) {
+              if (isObject(body) && 'message' in body) {
                 (this.req as any).response.statusMessage = body?.message;
               }
               return body;
@@ -467,7 +468,7 @@ describe('util/http/github', () => {
               // eslint-disable-next-line prefer-arrow-callback
               function reply() {
                 // https://github.com/nock/nock/issues/1979
-                if (typeof body === 'object' && 'message' in body) {
+                if (isObject(body) && 'message' in body) {
                   (this.req as any).response.statusMessage = body?.message;
                 }
                 return body;

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -3,6 +3,7 @@ import {
   isNonEmptyObject,
   isNullOrUndefined,
   isPlainObject,
+  isString,
 } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { z } from 'zod/v4';
@@ -232,8 +233,7 @@ interface GraphqlPaginatedContent<T = unknown> {
 
 function constructAcceptString(input?: unknown): string {
   const defaultAccept = 'application/vnd.github.v3+json';
-  const acceptStrings =
-    typeof input === 'string' ? input.split(regEx(/\s*,\s*/)) : [];
+  const acceptStrings = isString(input) ? input.split(regEx(/\s*,\s*/)) : [];
 
   // TODO: regression of #6736
   // v8 ignore else -- TODO: add test #40625

--- a/lib/util/object.ts
+++ b/lib/util/object.ts
@@ -9,6 +9,7 @@ export function hasKey<K extends string, T>(
   k: K,
   o: T,
 ): o is T & Record<K, unknown> {
+  // oxlint-disable-next-line renovate/prefer-is-object -- generic guard used on arbitrary values across the codebase; isObject() additionally matches functions, which would change semantics for every caller
   return o && typeof o === 'object' && k in o;
 }
 

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -32,6 +32,7 @@ function isZodResult<Output extends Val>(
   input: unknown,
 ): input is ZodSafeParseResult<Output> {
   if (
+    // oxlint-disable-next-line renovate/prefer-is-object -- guards arbitrary callback results; isObject() matches functions, which must never be classified as zod results
     typeof input !== 'object' ||
     input === null ||
     Object.keys(input).length !== 2 ||

--- a/lib/util/s3.ts
+++ b/lib/util/s3.ts
@@ -1,6 +1,6 @@
 // Singleton S3 instance initialized on-demand.
 import { S3Client } from '@aws-sdk/client-s3';
-import { isUndefined } from '@sindresorhus/is';
+import { isString, isUndefined } from '@sindresorhus/is';
 import { GlobalConfig } from '../config/global.ts';
 import { parseUrl } from './url.ts';
 
@@ -29,7 +29,7 @@ export interface S3UrlParts {
 }
 
 export function parseS3Url(rawUrl: URL | string): S3UrlParts | null {
-  const parsedUrl = typeof rawUrl === 'string' ? parseUrl(rawUrl) : rawUrl;
+  const parsedUrl = isString(rawUrl) ? parseUrl(rawUrl) : rawUrl;
   if (parsedUrl === null) {
     return null;
   }

--- a/lib/util/schema-utils/index.ts
+++ b/lib/util/schema-utils/index.ts
@@ -395,6 +395,7 @@ export function withTraceMessage<Output>(
 }
 
 function isCircular(value: unknown, visited = new Set<unknown>()): boolean {
+  // oxlint-disable-next-line renovate/prefer-is-object -- functions must stay non-circular leaves; isObject() matches functions and would send them into the property walk
   if (value === null || typeof value !== 'object') {
     return false;
   }

--- a/lib/util/timestamp.ts
+++ b/lib/util/timestamp.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import { z } from 'zod/v4';
 
@@ -41,7 +42,7 @@ export function asTimestamp(input: unknown): Timestamp | null {
     return null;
   }
 
-  if (typeof input === 'string') {
+  if (isString(input)) {
     const isoDate = DateTime.fromISO(input, { zone: 'UTC' });
     if (isValid(isoDate)) {
       return isoDate.toISO() as Timestamp;

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyArray, isNonEmptyObject } from '@sindresorhus/is';
+import { isNonEmptyArray, isNonEmptyObject, isString } from '@sindresorhus/is';
 import { setUserConfigFileNames } from '../../../../config/app-strings.ts';
 import { setPrivateKeys } from '../../../../config/decrypt.ts';
 import * as defaultsParser from '../../../../config/defaults.ts';
@@ -129,9 +129,7 @@ export async function parseConfigs(
     ];
 
     if (isNonEmptyArray(existingRepos)) {
-      const allStrings = existingRepos.every(
-        (repo) => typeof repo === 'string',
-      );
+      const allStrings = existingRepos.every((repo) => isString(repo));
       let shouldWarn = true;
 
       if (allStrings) {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -223,7 +223,7 @@ export async function start(): Promise<number> {
       }
 
       const { owner, repo } = repositoryToOwnerAndRepo(
-        typeof repository === 'string' ? repository : repository.repository,
+        isString(repository) ? repository : repository.repository,
       );
 
       await instrument(
@@ -250,10 +250,9 @@ export async function start(): Promise<number> {
             [ATTR_VCS_OWNER_NAME]: owner,
             [ATTR_VCS_REPOSITORY_NAME]: repo,
             /** @deprecated TODO remove */
-            repository:
-              typeof repository === 'string'
-                ? repository
-                : repository.repository,
+            repository: isString(repository)
+              ? repository
+              : repository.repository,
           },
         },
       );

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -1,7 +1,7 @@
 // TODO #22198
 
 import crypto from 'node:crypto';
-import { isArray, isNonEmptyArray } from '@sindresorhus/is';
+import { isArray, isNonEmptyArray, isString } from '@sindresorhus/is';
 import upath from 'upath';
 import { GlobalConfig } from '../../../../config/global.ts';
 import { mergeChildConfig } from '../../../../config/index.ts';
@@ -91,7 +91,7 @@ export async function postUpgradeCommandsExecutor(
         const canWriteFile = await localPathIsFile(file.path);
         if (file.type === 'addition' && !file.isSymlink && canWriteFile) {
           let contents: Buffer | null;
-          if (typeof file.contents === 'string') {
+          if (isString(file.contents)) {
             contents = Buffer.from(file.contents);
           } else {
             contents = file.contents;

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -1,4 +1,4 @@
-import { isDate, isUndefined } from '@sindresorhus/is';
+import { isDate, isTruthy, isUndefined } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
 import { logger } from '../../../../../logger/index.ts';
@@ -384,7 +384,7 @@ export async function getReleaseNotesMd(
           const title = heading
             .replace(regEx(/^\s*#*\s*/), '')
             .split(' ')
-            .filter(Boolean);
+            .filter(isTruthy);
           const body = section.replace(regEx(/.*?\n(-{3,}\n)?/), '').trim();
           const notesSourceUrl = getNotesSourceUrl(
             baseUrl,

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -12,6 +12,8 @@ import noUnquotedExecInterpolation from './rules/no-unquoted-exec-interpolation.
 import noUnvalidatedPaginationUrl from './rules/no-unvalidated-pagination-url.js';
 import preferFakeShaInSpecs from './rules/prefer-fake-sha-in-specs.js';
 import preferFsUtil from './rules/prefer-fs-util.js';
+import preferIsHelpers from './rules/prefer-is-helpers.js';
+import preferIsObject from './rules/prefer-is-object.js';
 import preferJsonPipe from './rules/prefer-json-pipe.js';
 import preferLuxon from './rules/prefer-luxon.js';
 import preferNullishUtil from './rules/prefer-nullish-util.js';
@@ -43,6 +45,8 @@ export default {
     'prefer-fs-util': preferFsUtil,
     'prefer-json-pipe': preferJsonPipe,
     'prefer-luxon': preferLuxon,
+    'prefer-is-helpers': preferIsHelpers,
+    'prefer-is-object': preferIsObject,
     'prefer-nullish-util': preferNullishUtil,
     'prefer-partial-in-specs': preferPartialInSpecs,
     'test-root-describe': testRootDescribe,

--- a/tools/lint/rules/prefer-is-helpers.js
+++ b/tools/lint/rules/prefer-is-helpers.js
@@ -1,0 +1,202 @@
+/**
+ * Operators used when both comparisons assert equality with `null` /
+ * `undefined` (`x === null || x === undefined`).
+ */
+const EQUALITY_OPERATORS = new Set(['===', '==']);
+
+/**
+ * Operators used when both comparisons assert inequality with `null` /
+ * `undefined` (`x !== null && x !== undefined`).
+ */
+const INEQUALITY_OPERATORS = new Set(['!==', '!=']);
+
+/**
+ * Unwrap `ChainExpression` nodes so optional chains (`a?.b`) compare
+ * structurally equal to their inner member expression.
+ * @param {import('estree').Node} node
+ * @returns {import('estree').Node}
+ */
+function unwrapChain(node) {
+  return node.type === 'ChainExpression' ? node.expression : node;
+}
+
+/**
+ * Whether two nodes are the same simple reference: an identifier, `this`, or
+ * a member chain of those with identifier or literal keys. Anything with
+ * possible side effects (calls, complex computed keys) is not considered.
+ * @param {import('estree').Node} rawA
+ * @param {import('estree').Node} rawB
+ * @returns {boolean}
+ */
+function isSameRef(rawA, rawB) {
+  const a = unwrapChain(rawA);
+  const b = unwrapChain(rawB);
+  if (a.type !== b.type) {
+    return false;
+  }
+  switch (a.type) {
+    case 'Identifier':
+      return a.name === /** @type {import('estree').Identifier} */ (b).name;
+    case 'ThisExpression':
+      return true;
+    case 'MemberExpression': {
+      const other = /** @type {import('estree').MemberExpression} */ (b);
+      if (a.computed !== other.computed) {
+        return false;
+      }
+      if (
+        a.computed &&
+        !(
+          a.property.type === 'Literal' &&
+          other.property.type === 'Literal' &&
+          a.property.value === other.property.value
+        )
+      ) {
+        return false;
+      }
+      if (
+        !a.computed &&
+        !(
+          a.property.type === 'Identifier' &&
+          other.property.type === 'Identifier' &&
+          a.property.name === other.property.name
+        )
+      ) {
+        return false;
+      }
+      return isSameRef(a.object, other.object);
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * If `node` compares a simple reference with `null` or `undefined` using one
+ * of the given operators, return the reference and which nullish value it is
+ * compared against; otherwise return null.
+ * @param {import('estree').Node} node
+ * @param {Set<string>} operators
+ * @returns {{ ref: import('estree').Node, nullish: 'null' | 'undefined' } | null}
+ */
+function getNullishComparison(node, operators) {
+  if (node.type !== 'BinaryExpression' || !operators.has(node.operator)) {
+    return null;
+  }
+  for (const [side, ref] of [
+    [node.right, node.left],
+    [node.left, node.right],
+  ]) {
+    if (side.type === 'Literal' && side.value === null) {
+      return { ref, nullish: 'null' };
+    }
+    if (side.type === 'Identifier' && side.name === 'undefined') {
+      return { ref, nullish: 'undefined' };
+    }
+  }
+  return null;
+}
+
+/**
+ * Whether `node` is `typeof <expr> ==/===/!=/!== '<literalValue>'` (either
+ * operand order).
+ * @param {import('estree').BinaryExpression} node
+ * @param {string} literalValue
+ * @returns {boolean}
+ */
+function isTypeofComparison(node, literalValue) {
+  if (
+    !EQUALITY_OPERATORS.has(node.operator) &&
+    !INEQUALITY_OPERATORS.has(node.operator)
+  ) {
+    return false;
+  }
+  for (const [a, b] of [
+    [node.left, node.right],
+    [node.right, node.left],
+  ]) {
+    if (
+      a.type === 'UnaryExpression' &&
+      a.operator === 'typeof' &&
+      b.type === 'Literal' &&
+      b.value === literalValue
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      preferIsTruthy:
+        'Use `.filter(isTruthy)` with `isTruthy` from `@sindresorhus/is` instead of `.filter(Boolean)` for a properly typed result.',
+      preferIsString:
+        "Use `isString()` from `@sindresorhus/is` instead of comparing `typeof` against 'string'.",
+      preferIsNullOrUndefined:
+        'Use `isNullOrUndefined()` from `@sindresorhus/is` instead of comparing against both `null` and `undefined`.',
+      preferNotIsNullOrUndefined:
+        'Use `!isNullOrUndefined()` from `@sindresorhus/is` instead of comparing against both `null` and `undefined`.',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.physicalFilename ?? '';
+    // Only enforce in lib/ (sources and specs)
+    if (!filename.includes('/lib/')) {
+      return {};
+    }
+    return {
+      CallExpression(node) {
+        // `.filter(Boolean)`
+        if (
+          node.callee.type === 'MemberExpression' &&
+          !node.callee.computed &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'filter' &&
+          node.arguments.length === 1 &&
+          node.arguments[0].type === 'Identifier' &&
+          node.arguments[0].name === 'Boolean'
+        ) {
+          context.report({ node, messageId: 'preferIsTruthy' });
+        }
+      },
+      BinaryExpression(node) {
+        // `typeof x === 'string'` / `typeof x !== 'string'`
+        if (isTypeofComparison(node, 'string')) {
+          context.report({ node, messageId: 'preferIsString' });
+        }
+      },
+      LogicalExpression(node) {
+        // `x === null || x === undefined` / `x !== null && x !== undefined`
+        /** @type {Set<string>} */
+        let operators;
+        if (node.operator === '||') {
+          operators = EQUALITY_OPERATORS;
+        } else if (node.operator === '&&') {
+          operators = INEQUALITY_OPERATORS;
+        } else {
+          return;
+        }
+        const left = getNullishComparison(node.left, operators);
+        const right = getNullishComparison(node.right, operators);
+        if (
+          left &&
+          right &&
+          left.nullish !== right.nullish &&
+          isSameRef(left.ref, right.ref)
+        ) {
+          context.report({
+            node,
+            messageId:
+              node.operator === '||'
+                ? 'preferIsNullOrUndefined'
+                : 'preferNotIsNullOrUndefined',
+          });
+        }
+      },
+    };
+  },
+};

--- a/tools/lint/rules/prefer-is-object.js
+++ b/tools/lint/rules/prefer-is-object.js
@@ -1,0 +1,38 @@
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'suggestion',
+    messages: {
+      preferIsObject:
+        "Consider `isObject()` or `isPlainObject()` from `@sindresorhus/is` instead of comparing `typeof` against 'object'. Semantics differ (`typeof null === 'object'`, arrays are objects, `isObject()` includes functions) — verify equivalence before changing.",
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.physicalFilename ?? '';
+    // Only enforce in lib/ (sources and specs)
+    if (!filename.includes('/lib/')) {
+      return {};
+    }
+    return {
+      BinaryExpression(node) {
+        if (!['===', '!==', '==', '!='].includes(node.operator)) {
+          return;
+        }
+        for (const [a, b] of [
+          [node.left, node.right],
+          [node.right, node.left],
+        ]) {
+          if (
+            a.type === 'UnaryExpression' &&
+            a.operator === 'typeof' &&
+            b.type === 'Literal' &&
+            b.value === 'object'
+          ) {
+            context.report({ node, messageId: 'preferIsObject' });
+            return;
+          }
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds two linting rules to enforce usages of `@sindresorhus/is` 
- `renovate/prefer-is-helpers` for literal comparisons 
- `renovate/prefer-is-object` for object tests 

They are split as the first are drop in replacements and the second has a little bit of different behavior 

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->

---

Supersedes #44686 (branch moved into this repo so the stack can use the parent branch as base).
