### PR TITLE
fix(manager/gitlabci): support ~latest component refs

### DIFF
--- a/lib/modules/manager/gitlabci/extract.spec.ts
+++ b/lib/modules/manager/gitlabci/extract.spec.ts
@@ -358,7 +358,6 @@ describe('modules/manager/gitlabci/extract', () => {
           depType: 'repository',
           registryUrls: ['https://gitlab.example.com'],
           versioning: 'semver-partial',
-          skipReason: 'unsupported-version',
         },
         {
           currentValue: '1.0',
@@ -377,6 +376,9 @@ describe('modules/manager/gitlabci/extract', () => {
           versioning: 'semver-partial',
         },
       ]);
+      expect(
+        res?.deps.find((dep) => dep.currentValue === '~latest'),
+      ).not.toHaveProperty('skipReason');
     });
 
     it('extracts component references', () => {
@@ -429,7 +431,6 @@ describe('modules/manager/gitlabci/extract', () => {
           depType: 'repository',
           registryUrls: ['https://gitlab.example.com'],
           versioning: 'semver-partial',
-          skipReason: 'unsupported-version',
         },
         {
           currentValue: '1.0',
@@ -440,6 +441,9 @@ describe('modules/manager/gitlabci/extract', () => {
           registryUrls: ['https://other-gitlab.example.com'],
         },
       ]);
+      expect(
+        res?.deps.find((dep) => dep.currentValue === '~latest'),
+      ).not.toHaveProperty('skipReason');
     });
   });
 });

--- a/lib/modules/manager/gitlabci/extract.ts
+++ b/lib/modules/manager/gitlabci/extract.ts
@@ -23,7 +23,6 @@ import { getGitlabDep } from './utils.ts';
 const componentReferenceRegex = regEx(
   /(?<fqdn>[^/]+)\/(?<projectPath>.+)\/(?:.+)@(?<specificVersion>.+)/,
 );
-const componentReferenceLatestVersion = '~latest';
 
 function extractDepFromIncludeComponent(
   component: string,
@@ -60,13 +59,6 @@ function extractDepFromIncludeComponent(
     registryUrls: [`https://${componentReference.fqdn}`],
     versioning: semverPartialId,
   };
-  if (dep.currentValue === componentReferenceLatestVersion) {
-    logger.debug(
-      { componentVersion: dep.currentValue },
-      'Ignoring component version',
-    );
-    dep.skipReason = 'unsupported-version';
-  }
   return dep;
 }
 


### PR DESCRIPTION
## Changes

- Allow GitLab CI component references using `@~latest` to proceed to version lookup instead of being marked unsupported.
- Keep using the existing `semver-partial` behavior so `rangeStrategy: pin` can resolve `~latest` to a concrete component tag.
- Cover both direct component references and references expanded through registry aliases.

## Context

- [x] This closes an existing Issue, Closes: #44713
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex assisted with the implementation, regression tests, verification, and pull request text.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] Codex will monitor and reply directly through @Boulea7; AI-generated replies will be disclosed.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The supported `~latest` semantics are already documented by the `semver-partial` versioning module; this change removes an obsolete manager-level skip.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Tests and checks run:

- `pnpm check --all lib/modules/manager/gitlabci`
- `pnpm type-check`
- `vitest run lib/modules/versioning/semver-partial` (271 tests)