### PR TITLE
test(bun): mock util/fs instead of fs-extra in artifacts spec

### DIFF
--- a/lib/modules/manager/bun/artifacts.spec.ts
+++ b/lib/modules/manager/bun/artifacts.spec.ts
@@ -1,4 +1,4 @@
-import _fs from 'fs-extra';
+import { fs } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type {
   InternalGlobalConfigOptions,
@@ -11,10 +11,9 @@ import type { UpdateArtifact } from '../types.ts';
 import { updateArtifacts } from './artifacts.ts';
 
 vi.mock('../../../util/exec/index.ts');
-vi.mock('fs-extra');
+vi.mock('../../../util/fs/index.ts');
 
 const exec = vi.mocked(_exec);
-const fs = vi.mocked(_fs);
 
 const globalConfig: RepoGlobalConfig & InternalGlobalConfigOptions = {
   localDir: '',
@@ -57,8 +56,8 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lockb'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         expect(await updateArtifacts(updateArtifact)).toBeNull();
       });
 
@@ -67,11 +66,11 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lockb'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         // npmrc
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           {
             file: {
@@ -89,10 +88,10 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lockb'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
 
         const result = await updateArtifacts(updateArtifact);
 
@@ -123,11 +122,11 @@ describe('modules/manager/bun/artifacts', () => {
         ];
         updateArtifact.config.isLockFileMaintenance = true;
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         // npmrc
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           {
             file: {
@@ -143,11 +142,11 @@ describe('modules/manager/bun/artifacts', () => {
         updateArtifact.config.lockFiles = ['bun.lockb'];
         updateArtifact.config.isLockFileMaintenance = true;
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         // npmrc
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           {
             file: {
@@ -170,7 +169,7 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lockb'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         exec.mockRejectedValueOnce(execError);
         await expect(updateArtifacts(updateArtifact)).rejects.toThrow(
           TEMPORARY_ERROR,
@@ -188,7 +187,7 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lockb'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         exec.mockRejectedValueOnce(execError);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           { artifactError: { fileName: 'bun.lockb', stderr: 'nope' } },
@@ -209,8 +208,8 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lock'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         expect(await updateArtifacts(updateArtifact)).toBeNull();
       });
 
@@ -219,11 +218,11 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lock'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         // npmrc
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           {
             file: {
@@ -241,11 +240,11 @@ describe('modules/manager/bun/artifacts', () => {
         ];
         updateArtifact.config.isLockFileMaintenance = true;
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         // npmrc
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           {
             file: {
@@ -261,11 +260,11 @@ describe('modules/manager/bun/artifacts', () => {
         updateArtifact.config.lockFiles = ['bun.lock'];
         updateArtifact.config.isLockFileMaintenance = true;
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         // npmrc
-        fs.readFile.mockResolvedValueOnce('# dummy' as never);
+        fs.readLocalFile.mockResolvedValueOnce('# dummy');
         const newLock = Buffer.from('new');
-        fs.readFile.mockResolvedValueOnce(newLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(newLock as never);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           {
             file: {
@@ -288,7 +287,7 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lock'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         exec.mockRejectedValueOnce(execError);
         await expect(updateArtifacts(updateArtifact)).rejects.toThrow(
           TEMPORARY_ERROR,
@@ -306,7 +305,7 @@ describe('modules/manager/bun/artifacts', () => {
           { manager: 'bun', lockFiles: ['bun.lock'] },
         ];
         const oldLock = Buffer.from('old');
-        fs.readFile.mockResolvedValueOnce(oldLock as never);
+        fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
         exec.mockRejectedValueOnce(execError);
         expect(await updateArtifacts(updateArtifact)).toEqual([
           { artifactError: { fileName: 'bun.lock', stderr: 'nope' } },
@@ -380,9 +379,9 @@ describe('modules/manager/bun/artifacts', () => {
           };
 
           const oldLock = Buffer.from('old');
-          fs.readFile.mockResolvedValueOnce(oldLock as never);
+          fs.readLocalFile.mockResolvedValueOnce(oldLock as never);
           const newLock = Buffer.from('new');
-          fs.readFile.mockResolvedValueOnce(newLock as never);
+          fs.readLocalFile.mockResolvedValueOnce(newLock as never);
 
           await updateArtifacts(updateArtifact);
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Refactor the bun manager artifacts test to mock the `util/fs` wrapper (via the shared `fs` mock from `~test/util.ts`) instead of mocking `fs-extra` directly.

The bun spec was the only manager artifacts spec that mocked `fs-extra`. Every other manager artifacts spec, including the sibling `deno` manager, mocks `util/fs`. This brings bun in line with that convention and removes most of the `as never` casts on the mock return values. Buffer reads keep `as never`, matching the `deno` spec, because the `readLocalFile` overloads resolve the mock return type to `string | null`.

There are no production code changes and the runtime behavior is unchanged.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The test refactor was produced with Claude Code (Claude Opus 4.8), directed and reviewed by @RahulGautamSingh.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @RahulGautamSingh will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (test-only refactor, verified via `pnpm vitest run lib/modules/manager/bun/artifacts.spec.ts`, `pnpm check --all`, and `pnpm tsc --noEmit`)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
