### PR TITLE
fix(platform/azure): skip work item Markdown format on Azure DevOps Server

### DIFF
--- a/lib/modules/platform/azure/azure-got-wrapper.spec.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.spec.ts
@@ -142,4 +142,44 @@ describe('modules/platform/azure/azure-got-wrapper', () => {
       );
     });
   });
+
+  describe('isHosted', () => {
+    let sdk: typeof import('azure-devops-node-api');
+
+    beforeEach(async () => {
+      sdk = await vi.importActual('azure-devops-node-api');
+      hostRules.add({
+        hostType: 'azure',
+        token: '123test',
+        matchHost: 'https://dev.azure.com/renovate7',
+      });
+      azure.setEndpoint('https://dev.azure.com/renovate7');
+    });
+
+    it('returns true when deployment type is Hosted', async () => {
+      // DeploymentFlags.Hosted === 1
+      vi.spyOn(sdk.WebApi.prototype, 'connect').mockResolvedValue({
+        deploymentType: 1,
+      });
+
+      expect(await azure.isHosted()).toBe(true);
+    });
+
+    it('returns false when deployment type is OnPremises', async () => {
+      // DeploymentFlags.OnPremises === 2
+      vi.spyOn(sdk.WebApi.prototype, 'connect').mockResolvedValue({
+        deploymentType: 2,
+      });
+
+      expect(await azure.isHosted()).toBe(false);
+    });
+
+    it('returns false when connectionData cannot be read', async () => {
+      vi.spyOn(sdk.WebApi.prototype, 'connect').mockRejectedValue(
+        new Error('boom'),
+      );
+
+      expect(await azure.isHosted()).toBe(false);
+    });
+  });
 });

--- a/lib/modules/platform/azure/azure-got-wrapper.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.ts
@@ -6,6 +6,7 @@ import {
 } from 'azure-devops-node-api';
 import type { ICoreApi } from 'azure-devops-node-api/CoreApi.js';
 import type { IGitApi } from 'azure-devops-node-api/GitApi.js';
+import { DeploymentFlags } from 'azure-devops-node-api/interfaces/common/VSSInterfaces.js';
 import type { IRequestHandler } from 'azure-devops-node-api/interfaces/common/VsoBaseInterfaces.js';
 import type { IPolicyApi } from 'azure-devops-node-api/PolicyApi.js';
 import type { IWorkItemTrackingApi } from 'azure-devops-node-api/WorkItemTrackingApi.js';
@@ -56,6 +57,26 @@ export function policyApi(): Promise<IPolicyApi> {
 
 export function workItemTrackingApi(): Promise<IWorkItemTrackingApi> {
   return azureObj().getWorkItemTrackingApi();
+}
+
+/**
+ * Whether the endpoint is Azure DevOps Services (cloud) rather than Azure
+ * DevOps Server (on-premises). Read from the location service's
+ * `_apis/connectionData`, which reports the deployment type authoritatively.
+ * Defaults to `false` (on-premises) when the type cannot be determined, so
+ * callers stay on the behaviour that both products support.
+ */
+export async function isHosted(): Promise<boolean> {
+  try {
+    const { deploymentType } = await azureObj().connect();
+    return deploymentType === DeploymentFlags.Hosted;
+  } catch (err) {
+    logger.debug(
+      { err },
+      'Azure: could not determine deployment type, assuming on-premises',
+    );
+    return false;
+  }
 }
 
 export function setEndpoint(e: string): void {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -66,6 +66,8 @@ describe('modules/platform/azure/index', () => {
     hostRules.clear();
     hostRules.add({ token: 'token' });
     azureHelper.getPolicyEvaluations.mockResolvedValue([]);
+    // Default to the hosted (cloud) endpoint used across these tests.
+    azureApi.isHosted.mockResolvedValue(true);
     await azure.initPlatform({
       endpoint: 'https://dev.azure.com/renovate12345',
       token: 'token',

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -437,6 +437,82 @@ describe('modules/platform/azure/issue', () => {
       expect(result).toEqual('updated');
     });
 
+    const markdownOp = {
+      op: 'add',
+      path: '/multilineFieldsFormat/System.Description',
+      value: 'Markdown',
+    };
+
+    it('sends Markdown format op on hosted (cloud) when creating', async () => {
+      azureApi.isHosted.mockResolvedValue(true);
+      vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
+
+      const createWorkItemMock = vi.fn().mockResolvedValue({ id: 123 });
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          createWorkItem: createWorkItemMock,
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
+        }),
+      );
+
+      await issueService.ensureIssue({ title: 'Test Issue', body: 'body' });
+
+      expect(createWorkItemMock).toHaveBeenCalledWith(
+        undefined,
+        expect.arrayContaining([markdownOp]),
+        'testProject',
+        'Issue',
+      );
+    });
+
+    it('omits Markdown format op on-premises when creating', async () => {
+      azureApi.isHosted.mockResolvedValue(false);
+      vi.spyOn(issueService, 'getIssueList').mockResolvedValue([]);
+
+      const createWorkItemMock = vi.fn().mockResolvedValue({ id: 123 });
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({
+          createWorkItem: createWorkItemMock,
+          getWorkItemTypes: vi.fn().mockResolvedValue([{ name: 'Issue' }]),
+        }),
+      );
+
+      await issueService.ensureIssue({ title: 'Test Issue', body: 'body' });
+
+      expect(createWorkItemMock).toHaveBeenCalledWith(
+        undefined,
+        expect.not.arrayContaining([markdownOp]),
+        'testProject',
+        'Issue',
+      );
+    });
+
+    it('omits Markdown format op on-premises when updating', async () => {
+      azureApi.isHosted.mockResolvedValue(false);
+      vi.spyOn(issueService, 'getIssueList').mockResolvedValue([
+        {
+          number: 1,
+          title: '[Renovate] Test Issue',
+          state: 'open',
+          body: 'Old description',
+        },
+      ]);
+
+      const updateWorkItemMock = vi.fn();
+      azureApi.workItemTrackingApi.mockResolvedValue(
+        partial<IWorkItemTrackingApi>({ updateWorkItem: updateWorkItemMock }),
+      );
+
+      await issueService.ensureIssue({ title: 'Test Issue', body: 'new body' });
+
+      expect(updateWorkItemMock).toHaveBeenCalledWith(
+        undefined,
+        expect.not.arrayContaining([{ ...markdownOp, op: 'replace' }]),
+        1,
+        'testProject',
+      );
+    });
+
     it('should not reopen closed issue when once is true', async () => {
       const mockClosedIssue = {
         number: 1,

--- a/lib/modules/platform/azure/issue.ts
+++ b/lib/modules/platform/azure/issue.ts
@@ -49,15 +49,36 @@ function namesByCategory(
     .map((s) => s.name!);
 }
 
+/**
+ * Op that renders the issue body as Markdown. Only Azure DevOps Services
+ * (cloud) supports the `multilineFieldsFormat` field; Azure DevOps Server
+ * (on-premises) rejects it with a 400, so this is only included when the
+ * instance is hosted (see discussion #45068).
+ */
+function markdownFormatOp(op: 'add' | 'replace'): {
+  op: string;
+  path: string;
+  value: string;
+} {
+  return {
+    op,
+    path: '/multilineFieldsFormat/System.Description',
+    value: 'Markdown',
+  };
+}
+
 export class IssueService {
   private config: Config;
   private readonly workItemStates: Lazy<Promise<WorkItemStates>>;
+  private readonly hosted: Lazy<Promise<boolean>>;
 
   constructor(config: Config) {
     this.config = config;
     // Wrapped in `Lazy` so concurrent callers share a single resolution
     // instead of each firing a duplicate `getWorkItemTypeStates` request.
     this.workItemStates = new Lazy(() => this.resolveWorkItemStates());
+    // Same reason: resolve the deployment type once per run, not per issue.
+    this.hosted = new Lazy(() => azureApi.isHosted());
   }
 
   /**
@@ -226,6 +247,7 @@ export class IssueService {
       const finalTitle = getWorkItemTitle(title, this.config.repository);
       const issues = await this.getIssueList(finalTitle);
       const { open, closed } = await this.workItemStates.getValue();
+      const hosted = await this.hosted.getValue();
 
       // Close duplicate open issues if any
       const openIssues = issues.filter((issue) => issue.state === 'open');
@@ -278,11 +300,7 @@ export class IssueService {
                 path: '/fields/System.Description',
                 value: sanitize(body),
               },
-              {
-                op: 'replace',
-                path: '/multilineFieldsFormat/System.Description',
-                value: 'Markdown',
-              },
+              ...(hosted ? [markdownFormatOp('replace')] : []),
             ],
             existingIssue.number,
             this.config.project,
@@ -313,11 +331,7 @@ export class IssueService {
                   path: '/fields/System.Description',
                   value: sanitize(body),
                 },
-                {
-                  op: 'replace',
-                  path: '/multilineFieldsFormat/System.Description',
-                  value: 'Markdown',
-                },
+                ...(hosted ? [markdownFormatOp('replace')] : []),
               ],
               existingIssue.number,
               this.config.project,
@@ -368,11 +382,7 @@ export class IssueService {
             path: '/fields/System.Description',
             value: sanitize(body),
           },
-          {
-            op: 'add',
-            path: '/multilineFieldsFormat/System.Description',
-            value: 'Markdown',
-          },
+          ...(hosted ? [markdownFormatOp('add')] : []),
         ],
         this.config.project,
         this.config.workItemType,

--- a/lib/modules/platform/azure/readme.md
+++ b/lib/modules/platform/azure/readme.md
@@ -264,6 +264,9 @@ Renovate resolves the correct open and closed state names from the process for t
 When creating the work item, Renovate does not set a state, so Azure DevOps applies the default initial state of the work item type.
 If the states cannot be read (for example on older Azure DevOps Server versions), Renovate falls back to the `New` and `Closed` state names.
 
+The work item description is rendered as Markdown only on Azure DevOps Services (cloud), which is the only product that supports the work item Markdown format field.
+On Azure DevOps Server (on-premises) Renovate omits that field, so the description is stored as plain text.
+
 ### Adding tags to Pull Requests
 
 Tags can be added to Pull Requests using the `labels` or `addLabels` configurations.


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

This gates the Markdown format op on the deployment type:

- Added `isHosted()` to `azure-got-wrapper.ts`, which reads `WebApi.connect()`'s `deploymentType` (`DeploymentFlags.Hosted` vs `OnPremises`) from the location service's `_apis/connectionData`. It defaults to `false` (on-premises) when the type cannot be determined, so we only opt in to the Markdown field when the instance is known to support it.
- In `issue.ts`, the deployment type is resolved once per run (wrapped in `Lazy`, like the existing work item state resolution) and the Markdown op is only included when the instance is hosted. On Azure DevOps Server the op is omitted and the description is stored as plain text.
- Updated the Azure platform docs to note that Markdown rendering of the work item description is cloud-only.

Reported in https://github.com/renovatebot/renovate/discussions/45068.

Note: this gates on `deploymentType` because no Azure DevOps Server version currently supports the work item Markdown format field. If Microsoft ships it to on-premises later, the correct gate becomes the server version rather than the deployment type.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The code, unit tests, and docs were produced with Claude Code (Claude Opus 4.8), directed and reviewed by @RahulGautamSingh.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @RahulGautamSingh  will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (verified via `pnpm check --all lib/modules/platform/azure`)

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
