### PR TITLE
refactor(linter): oxlint prefer partial typed casts for consts

### DIFF
--- a/lib/config-validator.spec.ts
+++ b/lib/config-validator.spec.ts
@@ -82,6 +82,7 @@ describe.concurrent('config-validator', () => {
 
     it('exits 1 for a config with an unknown option', async () => {
       await withTmpDir(async (dirPath) => {
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid unknown option to test validator error handling
         const file = await writeRepoConfig(dirPath, 'renovate.json', {
           notARealOption: true,
         } as RenovateConfig);

--- a/lib/config/migration.spec.ts
+++ b/lib/config/migration.spec.ts
@@ -256,6 +256,7 @@ describe('config/migration', () => {
     });
 
     it('migrates packages', () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid legacy packages config for migration test
       const config = {
         packages: [
           {
@@ -421,11 +422,13 @@ describe('config/migration', () => {
       let config: TestRenovateConfig;
       let res: MigratedConfig;
 
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid string `extends` for migration test
       config = { extends: ':js-app' } as never;
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
       expect(res.migratedConfig).toMatchObject({ extends: ['config:js-app'] });
 
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid string `extends` for migration test
       config = { extends: 'foo' } as never;
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();
@@ -451,6 +454,7 @@ describe('config/migration', () => {
         extends: ['security:minimumReleaseAgeNpm'],
       });
 
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid legacy unpublishSafe/string extends for migration test
       config = { unpublishSafe: true, extends: 'foo' } as never;
       res = configMigration.migrateConfig(config);
       expect(res.isMigrated).toBeTrue();

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -44,6 +44,7 @@ describe('config/validation', () => {
     it('returns the deprecationMsg for `dnsCache` as a warning', async () => {
       const config: RenovateConfig = {
         hostRules: [
+          // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid/removed HostRule property
           {
             dnsCache: true,
           } as HostRule,
@@ -1602,9 +1603,10 @@ describe('config/validation', () => {
     it('errors if registryAliases depth is more than 1', async () => {
       const config = {
         registryAliases: {
+          // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentional incorrect config to check error message
           sample: {
             example1: 'http://www.example.com',
-          } as unknown as string, // intentional incorrect config to check error message
+          } as unknown as string,
         },
       };
       const { warnings, errors } = await configValidation.validateConfig(
@@ -1685,6 +1687,7 @@ describe('config/validation', () => {
     });
 
     it('errors if manager objects are nested', async () => {
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid nested manager config
       const config = {
         pyenv: {
           enabled: false,
@@ -2127,6 +2130,7 @@ describe('config/validation', () => {
         hostRules: [
           {
             matchHost: 'https://domain.com/all-versions',
+            // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid header value type
             headers: {
               'X-Auth-Token': 10,
             } as unknown as Record<string, string>,

--- a/lib/modules/datasource/common.spec.ts
+++ b/lib/modules/datasource/common.spec.ts
@@ -232,12 +232,17 @@ describe('modules/datasource/common', () => {
         datasource: 'foo',
         packageName: 'bar',
         constraintsFiltering: 'strict' as const,
+        // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally using invalid constraint names
         constraints: { baz: '^1.0.0', qux: 'invalid' } as never,
       };
       const releaseResult = {
         releases: [
           { version: '1.0.0' },
-          { version: '2.0.0', constraints: { baz: [undefined] } as never },
+          {
+            version: '2.0.0',
+            // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally using invalid constraint value
+            constraints: { baz: [undefined] } as never,
+          },
           { version: '3.0.0', constraints: { baz: ['^0.9.0', 'invalid'] } },
         ],
       };

--- a/lib/modules/datasource/jsr/index.spec.ts
+++ b/lib/modules/datasource/jsr/index.spec.ts
@@ -1,9 +1,15 @@
+import { partial } from '~test/util.ts';
 import * as httpMock from '../../../../test/http-mock.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { JsrDatasource } from './index.ts';
 import { MINIMUM_RELEASE_TIMESTAMP } from './schema.ts';
 
-const jsrPackageMetadataResponse = {
+interface JsrPackageMetadataResponse {
+  latest: string;
+  versions: Record<string, { createdAt?: string; yanked?: boolean }>;
+}
+
+const jsrPackageMetadataResponse = partial<JsrPackageMetadataResponse>({
   latest: '0.0.2',
   versions: {
     // Mixed createdAt fields for testing:
@@ -13,10 +19,7 @@ const jsrPackageMetadataResponse = {
     // has explicit createdAt (should use actual timestamp)
     '0.0.2': { createdAt: '2025-11-15T00:00:00.000Z' },
   },
-} as {
-  latest: string;
-  versions: Record<string, { createdAt?: string; yanked?: boolean }>;
-};
+});
 
 describe('modules/datasource/jsr/index', () => {
   const jsr = new JsrDatasource();

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -27,7 +27,7 @@ function httpError({
   message?: string;
   code?: HttpError['code'];
   request?: Record<string, unknown>;
-  response?: Partial<Response>;
+  response?: Partial<NonNullable<HttpError['response']>>;
 }): HttpError {
   type Writeable<T> = { -readonly [P in keyof T]: T[P] };
 
@@ -42,7 +42,7 @@ function httpError({
   }
 
   if (response) {
-    err.response = response as never;
+    err.response = response as HttpError['response'];
   }
 
   return err;
@@ -219,8 +219,7 @@ describe('modules/datasource/maven/util', () => {
               Promise.reject(
                 httpError({
                   code: 'ECONNRESET',
-                  // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
-                  response: { statusCode: 429 } as never,
+                  response: { statusCode: 429 },
                 }),
               ),
           });
@@ -242,8 +241,7 @@ describe('modules/datasource/maven/util', () => {
             Promise.reject(
               httpError({
                 code: 'ECONNRESET',
-                // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
-                response: { statusCode: 429 } as never,
+                response: { statusCode: 429 },
               }),
             ),
         });
@@ -308,10 +306,7 @@ describe('modules/datasource/maven/util', () => {
         vi.spyOn(packageCache, 'get').mockResolvedValue(null);
         const http = partial<Http>({
           getText: () =>
-            Promise.reject(
-              // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
-              httpError({ response: { statusCode: 404 } as never }),
-            ),
+            Promise.reject(httpError({ response: { statusCode: 404 } })),
         });
 
         const res = await downloadHttpProtocol(http, metadataUrl);
@@ -334,10 +329,7 @@ describe('modules/datasource/maven/util', () => {
           .mockResolvedValue(undefined);
         const http = partial<Http>({
           getText: () =>
-            Promise.reject(
-              // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
-              httpError({ response: { statusCode: 404 } as never }),
-            ),
+            Promise.reject(httpError({ response: { statusCode: 404 } })),
         });
 
         await downloadHttpProtocol(http, nonMetadataUrl);

--- a/lib/modules/datasource/maven/util.spec.ts
+++ b/lib/modules/datasource/maven/util.spec.ts
@@ -219,6 +219,7 @@ describe('modules/datasource/maven/util', () => {
               Promise.reject(
                 httpError({
                   code: 'ECONNRESET',
+                  // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
                   response: { statusCode: 429 } as never,
                 }),
               ),
@@ -241,6 +242,7 @@ describe('modules/datasource/maven/util', () => {
             Promise.reject(
               httpError({
                 code: 'ECONNRESET',
+                // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
                 response: { statusCode: 429 } as never,
               }),
             ),
@@ -307,6 +309,7 @@ describe('modules/datasource/maven/util', () => {
         const http = partial<Http>({
           getText: () =>
             Promise.reject(
+              // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
               httpError({ response: { statusCode: 404 } as never }),
             ),
         });
@@ -332,6 +335,7 @@ describe('modules/datasource/maven/util', () => {
         const http = partial<Http>({
           getText: () =>
             Promise.reject(
+              // oxlint-disable-next-line renovate/prefer-partial-in-specs -- statusCode belongs to got's response shape, not the global Response type used by this helper
               httpError({ response: { statusCode: 404 } as never }),
             ),
         });

--- a/lib/modules/manager/custom/jsonata/index.spec.ts
+++ b/lib/modules/manager/custom/jsonata/index.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { logger } from '~test/util.ts';
+import { logger, partial } from '~test/util.ts';
 import { defaultConfig, extractPackageFile } from './index.ts';
 import type { JsonataExtractConfig } from './types.ts';
 
@@ -11,9 +11,13 @@ describe('modules/manager/custom/jsonata/index', () => {
   });
 
   it('returns null when content does not match specified file format', async () => {
-    const res = await extractPackageFile('not-json', 'foo-file', {
-      fileFormat: 'json',
-    } as JsonataExtractConfig);
+    const res = await extractPackageFile(
+      'not-json',
+      'foo-file',
+      partial<JsonataExtractConfig>({
+        fileFormat: 'json',
+      }),
+    );
     expect(res).toBeNull();
 
     expect(logger.logger.debug).toHaveBeenCalledWith(

--- a/lib/modules/manager/deno/post.spec.ts
+++ b/lib/modules/manager/deno/post.spec.ts
@@ -1,6 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { findPackages } from 'find-packages';
-import { fs } from '../../../../test/util.ts';
+import { fs, partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type { PackageDependency } from '../types.ts';
 import * as compat from './compat.ts';
@@ -481,11 +481,11 @@ describe('modules/manager/deno/post', () => {
       const packageFiles = [
         {
           deps: [
-            {
+            partial<PackageDependency<DenoManagerData>>({
               datasource: 'jsr',
               currentRawValue: 'jsr:@scope/name@1.2.3',
               depName: '@scope/name',
-            } as PackageDependency<DenoManagerData>,
+            }),
           ],
           lockFiles: ['deno.lock'],
           packageFile: 'deno.json',
@@ -507,11 +507,11 @@ describe('modules/manager/deno/post', () => {
       const packageFiles = [
         {
           deps: [
-            {
+            partial<PackageDependency<DenoManagerData>>({
               datasource: 'jsr',
               currentRawValue: 'jsr:@scope/name@1.2.3',
               depName: '@scope/name',
-            } as PackageDependency<DenoManagerData>,
+            }),
           ],
           lockFiles: [],
           packageFile: 'deno.json',
@@ -541,22 +541,22 @@ describe('modules/manager/deno/post', () => {
       const packageFiles = [
         {
           deps: [
-            {
+            partial<PackageDependency<DenoManagerData>>({
               datasource: 'jsr',
               currentRawValue: 'jsr:@scope/name@1.2.3',
               depName: '@scope/name',
-            } as PackageDependency<DenoManagerData>,
+            }),
           ],
           lockFiles: ['deno.lock'],
           packageFile: 'deno.json',
         },
         {
           deps: [
-            {
+            partial<PackageDependency<DenoManagerData>>({
               datasource: 'jsr',
               currentRawValue: 'jsr:@scope/name@1.2.3',
               depName: '@scope/name',
-            } as PackageDependency<DenoManagerData>,
+            }),
           ],
           lockFiles: ['deno.lock'],
           packageFile: 'sub/deno.json',
@@ -625,11 +625,11 @@ describe('modules/manager/deno/post', () => {
       const packageFiles = [
         {
           deps: [
-            {
+            partial<PackageDependency<DenoManagerData>>({
               datasource: 'jsr',
               currentRawValue: 'jsr:@scope/name@1.2.3',
               depName: '@scope/name',
-            } as PackageDependency<DenoManagerData>,
+            }),
           ],
           lockFiles: ['deno.lock'],
           packageFile: 'deno.json',

--- a/lib/modules/manager/nuget/integration.spec.ts
+++ b/lib/modules/manager/nuget/integration.spec.ts
@@ -47,11 +47,12 @@ describe('modules/manager/nuget/integration', () => {
     const managerConfig = getManagerConfig(baseConfig, 'nuget');
     let depConfig = mergeChildConfig(managerConfig, dep);
     depConfig = await applyPackageRules(depConfig, 'pre-lookup');
-    return {
+    return partial<LookupUpdateConfig>({
       ...depConfig,
       currentValue: dep.currentValue ?? undefined,
       packageName: dep.packageName ?? dep.depName!,
-    } as LookupUpdateConfig;
+      abandonmentThreshold: depConfig.abandonmentThreshold ?? undefined,
+    });
   }
 
   it('proposes updates for Sdk elements in sqlproj files', async () => {

--- a/lib/modules/manager/pipenv/artifacts.spec.ts
+++ b/lib/modules/manager/pipenv/artifacts.spec.ts
@@ -1,5 +1,7 @@
+import type { Stats } from 'node:fs';
 import * as _fsExtra from 'fs-extra';
 import upath from 'upath';
+import type { MockInstance } from 'vitest';
 import { mockDeep } from 'vitest-mock-extended';
 import { envMock, mockExecAll } from '~test/exec-util.ts';
 import { Fixtures } from '~test/fixtures.ts';
@@ -27,9 +29,10 @@ import type { PipfileLock } from './types.ts';
 // mock for cjs require for `@renovatebot/detect-tools`
 // https://github.com/vitest-dev/vitest/discussions/3134
 vi.hoisted(() => {
-  require.cache[require.resolve('fs-extra')] = {
+  const fsExtraModule: Partial<NodeJS.Module> = {
     exports: fixtures.fsExtra(),
-  } as never;
+  };
+  require.cache[require.resolve('fs-extra')] = fsExtraModule as NodeJS.Module;
 });
 vi.mock('fs-extra', () => fixtures.fsExtra());
 vi.mock('../../../util/exec/env.ts', () => mockDeep());
@@ -39,6 +42,11 @@ vi.mock('../../datasource/index.ts', () => mockDeep());
 
 const datasource = vi.mocked(_datasource);
 const fsExtra = vi.mocked(_fsExtra);
+// vi.mocked() resolves stat() to its callback overload, so
+// mockResolvedValueOnce() would expect void; retype via the promise overload
+const statMock = fsExtra.stat as unknown as MockInstance<
+  (path: string) => Promise<Stats>
+>;
 
 process.env.CONTAINERBASE = 'true';
 
@@ -131,7 +139,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('returns null if unchanged', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': JSON.stringify({
@@ -184,7 +192,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('gets python full version from Pipfile', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile': Fixtures.get('Pipfile1'),
@@ -237,7 +245,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('gets python version from Pipfile', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile': Fixtures.get('Pipfile2'),
@@ -290,7 +298,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('gets full python version from .python-version', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': '{}',
@@ -349,7 +357,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('gets python stream, from .python-version', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     fsExtra.ensureDir.mockResolvedValue(undefined);
 
@@ -407,7 +415,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('handles no constraint', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': 'unparseable pipfile lock',
@@ -463,7 +471,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('returns updated Pipfile.lock', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': ['current pipfile.lock', 'new pipfile.lock'],
@@ -526,7 +534,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('supports docker mode', async () => {
     GlobalConfig.set(dockerAdminConfig);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     const pipFileLock = JSON.stringify({
       _meta: { requires: { python_version: '3.7' } },
@@ -614,7 +622,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('supports install mode', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     const pipFileLock = JSON.stringify({
       _meta: { requires: { python_version: '3.6' } },
@@ -686,7 +694,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('defaults to latest if no lock constraints', async () => {
     GlobalConfig.set({ ...adminConfig, binarySource: 'install' });
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
     fsExtra.ensureDir.mockResolvedValue(undefined);
 
     mockFiles({
@@ -758,7 +766,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('catches errors', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': 'Current Pipfile.lock',
@@ -785,7 +793,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('returns updated Pipenv.lock when doing lockfile maintenance', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
     fsExtra.remove.mockResolvedValue();
 
     mockFiles({
@@ -833,7 +841,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('uses pipenv version from Pipfile', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     GlobalConfig.set(dockerAdminConfig);
 
@@ -920,7 +928,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('uses pipenv version from Pipfile dev packages', async () => {
     GlobalConfig.set(dockerAdminConfig);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     fsExtra.ensureDir.mockResolvedValue(undefined);
 
@@ -1007,7 +1015,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('uses pipenv version from config', async () => {
     GlobalConfig.set(dockerAdminConfig);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
     fsExtra.ensureDir.mockResolvedValue(undefined);
 
     const oldLock = JSON.stringify({
@@ -1088,7 +1096,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('passes private credential environment vars', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': ['current Pipfile.lock', 'New Pipfile.lock'],
@@ -1172,7 +1180,7 @@ describe('modules/manager/pipenv/artifacts', () => {
 
   it('updates extraEnv if variable names differ from default', async () => {
     fsExtra.ensureDir.mockResolvedValue(undefined);
-    fsExtra.stat.mockResolvedValueOnce({} as never);
+    statMock.mockResolvedValueOnce(partial<Stats>());
 
     mockFiles({
       '/Pipfile.lock': ['current Pipfile.lock', 'New Pipfile.lock'],

--- a/lib/modules/manager/pipenv/extract.spec.ts
+++ b/lib/modules/manager/pipenv/extract.spec.ts
@@ -1,21 +1,30 @@
+import type { Stats } from 'node:fs';
 import { codeBlock } from 'common-tags';
 import * as _fsExtra from 'fs-extra';
 import upath from 'upath';
+import type { MockInstance } from 'vitest';
 import { Fixtures } from '~test/fixtures.ts';
+import { partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { extractPackageFile } from './index.ts';
 
 // mock for cjs require for `@renovatebot/detect-tools`
 // https://github.com/vitest-dev/vitest/discussions/3134
 vi.hoisted(() => {
-  require.cache[require.resolve('fs-extra')] = {
+  const fsExtraModule: Partial<NodeJS.Module> = {
     exports: fixtures.fsExtra(),
-  } as never;
+  };
+  require.cache[require.resolve('fs-extra')] = fsExtraModule as NodeJS.Module;
 });
 
 vi.mock('fs-extra', () => fixtures.fsExtra());
 
 const fsExtra = vi.mocked(_fsExtra);
+// vi.mocked() resolves stat() to its callback overload, so
+// mockResolvedValueOnce() would expect void; retype via the promise overload
+const statMock = fsExtra.stat as unknown as MockInstance<
+  (path: string) => Promise<Stats>
+>;
 
 const pipfile1 = Fixtures.get('Pipfile1');
 const pipfile2 = Fixtures.get('Pipfile2');
@@ -43,7 +52,7 @@ describe('modules/manager/pipenv/extract', () => {
     });
 
     it('extracts dependencies', async () => {
-      fsExtra.stat.mockResolvedValueOnce({} as never);
+      statMock.mockResolvedValueOnce(partial<Stats>());
       Fixtures.mock({ Pipfile: pipfile1 }, localDir);
       const res = await extractPackageFile(pipfile1, 'Pipfile');
       expect(res).toMatchObject({
@@ -140,7 +149,7 @@ describe('modules/manager/pipenv/extract', () => {
     });
 
     it('extracts multiple dependencies', async () => {
-      fsExtra.stat.mockResolvedValueOnce({} as never);
+      statMock.mockResolvedValueOnce(partial<Stats>());
       Fixtures.mock({ Pipfile: pipfile2 }, localDir);
       const res = await extractPackageFile(pipfile2, 'Pipfile');
       expect(res).toMatchObject({
@@ -245,7 +254,7 @@ describe('modules/manager/pipenv/extract', () => {
     });
 
     it('extracts example pipfile', async () => {
-      fsExtra.stat.mockResolvedValueOnce({} as never);
+      statMock.mockResolvedValueOnce(partial<Stats>());
       fsExtra.readFile.mockResolvedValueOnce(pipfile4 as never);
       const res = await extractPackageFile(pipfile4, 'Pipfile');
       expect(res).toMatchObject({
@@ -311,7 +320,7 @@ describe('modules/manager/pipenv/extract', () => {
     });
 
     it('supports custom index', async () => {
-      fsExtra.stat.mockResolvedValueOnce({} as never);
+      statMock.mockResolvedValueOnce(partial<Stats>());
       const res = await extractPackageFile(pipfile5, 'Pipfile');
       expect(res).toMatchObject({
         deps: [

--- a/lib/modules/platform/azure/issue.spec.ts
+++ b/lib/modules/platform/azure/issue.spec.ts
@@ -24,12 +24,12 @@ describe('modules/platform/azure/issue', () => {
   let issueService: IssueService;
 
   beforeEach(() => {
-    config = {
+    config = partial<Config>({
       repository: 'test/repo',
       project: 'testProject',
       repoId: '123',
       workItemType: 'Issue',
-    } as Config;
+    });
 
     issueService = new IssueService(config);
   });

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -2171,7 +2171,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     it('should pass pushOptions to git.push', async () => {
       const pushSpy = vi
         .spyOn(SimpleGit.prototype, 'push')
-        .mockResolvedValue({} as PushResult);
+        .mockResolvedValue(partial<PushResult>());
       await expect(
         git.pushCommit({
           sourceRef: defaultBranch,

--- a/lib/util/github/graphql/query-adapters/branches-query-adapter.spec.ts
+++ b/lib/util/github/graphql/query-adapters/branches-query-adapter.spec.ts
@@ -22,6 +22,7 @@ describe('util/github/graphql/query-adapters/branches-query-adapter', () => {
 
   it('returns null for invalid input', () => {
     expect(
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid target.type
       adapter.transform({
         target: { type: 'Blob' },
       } as never),

--- a/lib/util/github/graphql/query-adapters/releases-query-adapter.spec.ts
+++ b/lib/util/github/graphql/query-adapters/releases-query-adapter.spec.ts
@@ -1,3 +1,4 @@
+import { partial } from '~test/util.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
 import type { GithubGraphqlRelease } from './releases-query-adapter.ts';
 import { adapter } from './releases-query-adapter.ts';
@@ -30,7 +31,7 @@ describe('util/github/graphql/query-adapters/releases-query-adapter', () => {
   });
 
   it('handles invalid items', () => {
-    expect(adapter.transform({} as never)).toBeNull();
+    expect(adapter.transform(partial<GithubGraphqlRelease>())).toBeNull();
   });
 
   it('marks prereleases as unstable', () => {

--- a/lib/util/github/graphql/query-adapters/tags-query-adapter.spec.ts
+++ b/lib/util/github/graphql/query-adapters/tags-query-adapter.spec.ts
@@ -58,6 +58,7 @@ describe('util/github/graphql/query-adapters/tags-query-adapter', () => {
 
   it('returns null for other types', () => {
     expect(
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid target.type
       adapter.transform({
         target: { type: 'Blob' },
       } as never),

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -1,6 +1,8 @@
+import { partial } from '~test/util.ts';
 import { NugetDatasource } from '../modules/datasource/nuget/index.ts';
 import type { HostRule } from '../types/index.ts';
 import {
+  type LegacyHostRule,
   add,
   clear,
   confidentialFields,
@@ -58,11 +60,13 @@ describe('util/host-rules', () => {
   describe('add()', () => {
     it('throws if both domainName and hostName', () => {
       expect(() =>
-        add({
-          hostType: 'azure',
-          domainName: 'github.com',
-          hostName: 'api.github.com',
-        } as never),
+        add(
+          partial<LegacyHostRule & HostRule>({
+            hostType: 'azure',
+            domainName: 'github.com',
+            hostName: 'api.github.com',
+          }),
+        ),
       ).toThrow(
         'hostRules cannot contain more than one host-matching field - use',
       );
@@ -70,11 +74,13 @@ describe('util/host-rules', () => {
 
     it('throws if both domainName and baseUrl', () => {
       expect(() =>
-        add({
-          hostType: 'azure',
-          domainName: 'github.com',
-          matchHost: 'https://api.github.com',
-        } as never),
+        add(
+          partial<LegacyHostRule & HostRule>({
+            hostType: 'azure',
+            domainName: 'github.com',
+            matchHost: 'https://api.github.com',
+          }),
+        ),
       ).toThrow(
         'hostRules cannot contain more than one host-matching field - use',
       );
@@ -82,11 +88,13 @@ describe('util/host-rules', () => {
 
     it('throws if both hostName and baseUrl', () => {
       expect(() =>
-        add({
-          hostType: 'azure',
-          hostName: 'api.github.com',
-          matchHost: 'https://api.github.com',
-        } as never),
+        add(
+          partial<LegacyHostRule & HostRule>({
+            hostType: 'azure',
+            hostName: 'api.github.com',
+            matchHost: 'https://api.github.com',
+          }),
+        ),
       ).toThrow(
         'hostRules cannot contain more than one host-matching field - use',
       );
@@ -175,13 +183,15 @@ describe('util/host-rules', () => {
     });
 
     it('needs exact host matches', () => {
-      add({
-        hostType: NugetDatasource.id,
-        hostName: 'nuget.org',
-        username: 'root',
-        password: 'p4$$w0rd',
-        token: undefined,
-      } as never);
+      add(
+        partial<LegacyHostRule & HostRule>({
+          hostType: NugetDatasource.id,
+          hostName: 'nuget.org',
+          username: 'root',
+          password: 'p4$$w0rd',
+          token: undefined,
+        }),
+      );
       expect(find({ hostType: NugetDatasource.id })).toEqual({});
       expect(
         find({ hostType: NugetDatasource.id, url: 'https://nuget.org' }),
@@ -214,10 +224,12 @@ describe('util/host-rules', () => {
     });
 
     it('matches on domainName', () => {
-      add({
-        domainName: 'github.com',
-        token: 'def',
-      } as never);
+      add(
+        partial<LegacyHostRule & HostRule>({
+          domainName: 'github.com',
+          token: 'def',
+        }),
+      );
       expect(
         find({ hostType: NugetDatasource.id, url: 'https://api.github.com' })
           .token,
@@ -297,10 +309,12 @@ describe('util/host-rules', () => {
     });
 
     it('matches on hostName', () => {
-      add({
-        hostName: 'nuget.local',
-        token: 'abc',
-      } as never);
+      add(
+        partial<LegacyHostRule & HostRule>({
+          hostName: 'nuget.local',
+          token: 'abc',
+        }),
+      );
       expect(
         find({ hostType: NugetDatasource.id, url: 'https://nuget.local/api' }),
       ).toEqual({ token: 'abc' });
@@ -424,11 +438,13 @@ describe('util/host-rules', () => {
         matchHost: 'https://nuget.local/api',
         token: 'abc',
       });
-      add({
-        hostType: NugetDatasource.id,
-        hostName: 'my.local.registry',
-        token: 'def',
-      } as never);
+      add(
+        partial<LegacyHostRule & HostRule>({
+          hostType: NugetDatasource.id,
+          hostName: 'my.local.registry',
+          token: 'def',
+        }),
+      );
       add({
         hostType: NugetDatasource.id,
         matchHost: 'another.local.registry',

--- a/lib/util/http/cache/package-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/package-http-cache-provider.spec.ts
@@ -2,6 +2,7 @@ import { DateTime, Settings } from 'luxon';
 import { mockDeep } from 'vitest-mock-extended';
 import { z } from 'zod/v4';
 import * as httpMock from '~test/http-mock.ts';
+import { partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import * as _packageCache from '../../cache/package/index.ts';
 import { Http, type HttpResponse } from '../index.ts';
@@ -517,7 +518,7 @@ describe('util/http/cache/package-http-cache-provider', () => {
           checkAuthorizationHeader,
         });
 
-        const response = { headers: {} } as HttpResponse;
+        const response = partial<HttpResponse>({ headers: {} });
 
         if (cacheControl !== undefined) {
           response.headers['cache-control'] = cacheControl;
@@ -538,9 +539,9 @@ describe('util/http/cache/package-http-cache-provider', () => {
         checkCacheControlHeader: true,
       });
 
-      const response = {
+      const response = partial<HttpResponse>({
         headers: { 'cache-control': 'PUBLIC, max-age=300' },
-      } as HttpResponse;
+      });
 
       expect(cacheProvider.cacheAllowed(response)).toBe(true);
     });

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -1,10 +1,13 @@
 import type { RenovateConfig } from '~test/util.ts';
+import { partial } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
 import { MavenDatasource } from '../../../modules/datasource/maven/index.ts';
 import type { PackageFile } from '../../../modules/manager/types.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
+import { Result } from '../../../util/result.ts';
 import { fetchUpdates } from './fetch.ts';
 import * as lookup from './lookup/index.ts';
+import type { UpdateResult } from './lookup/types.ts';
 
 const lookupUpdates = vi.mocked(lookup).lookupUpdates;
 
@@ -95,7 +98,9 @@ describe('workers/repository/process/fetch', () => {
           },
         ],
       };
-      lookupUpdates.mockResolvedValue({ updates: ['a', 'b'] } as never);
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: ['a', 'b'] as never })),
+      );
       await fetchUpdates(config, packageFiles);
       expect(packageFiles).toEqual({
         maven: [
@@ -130,7 +135,9 @@ describe('workers/repository/process/fetch', () => {
             },
           ],
         };
-        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+        lookupUpdates.mockResolvedValue(
+          Result.ok(partial<UpdateResult>({ updates: [] })),
+        );
 
         await fetchUpdates(config, packageFiles);
 
@@ -154,7 +161,9 @@ describe('workers/repository/process/fetch', () => {
             },
           ],
         };
-        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+        lookupUpdates.mockResolvedValue(
+          Result.ok(partial<UpdateResult>({ updates: [] })),
+        );
 
         await fetchUpdates(config, packageFiles);
 
@@ -175,7 +184,9 @@ describe('workers/repository/process/fetch', () => {
             },
           ],
         };
-        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+        lookupUpdates.mockResolvedValue(
+          Result.ok(partial<UpdateResult>({ updates: [] })),
+        );
 
         await fetchUpdates(config, packageFiles);
 
@@ -198,7 +209,9 @@ describe('workers/repository/process/fetch', () => {
             },
           ],
         };
-        lookupUpdates.mockResolvedValue({ updates: [] } as never);
+        lookupUpdates.mockResolvedValue(
+          Result.ok(partial<UpdateResult>({ updates: [] })),
+        );
         await fetchUpdates(config, packageFiles);
         expect(lookupUpdates).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -226,7 +239,9 @@ describe('workers/repository/process/fetch', () => {
           },
         ],
       };
-      lookupUpdates.mockResolvedValue({ updates: ['a', 'b'] } as never);
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: ['a', 'b'] as never })),
+      );
 
       await fetchUpdates(config, packageFiles);
 
@@ -257,6 +272,7 @@ describe('workers/repository/process/fetch', () => {
               { depName: ' ' },
               {},
               { depName: undefined },
+              // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid depName type to test invalid-name skip handling
               { depName: { oh: 'no' } as unknown as string },
             ],
           },
@@ -312,7 +328,9 @@ describe('workers/repository/process/fetch', () => {
           },
         ],
       };
-      lookupUpdates.mockResolvedValue({ updates: ['a', 'b'] } as never);
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: ['a', 'b'] as never })),
+      );
       await fetchUpdates(config, packageFiles);
       expect(packageFiles.maven[0].deps[0].updates).toHaveLength(2);
     });

--- a/lib/workers/repository/process/index.spec.ts
+++ b/lib/workers/repository/process/index.spec.ts
@@ -1,9 +1,10 @@
 import type { RenovateConfig } from '~test/util.ts';
-import { git, logger, platform, scm } from '~test/util.ts';
+import { git, logger, partial, platform, scm } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import { addMeta } from '../../../logger/index.ts';
+import type { PackageFile } from '../../../modules/manager/types.ts';
 import { getCache } from '../../../util/cache/repository/index.ts';
 import * as _extractUpdate from './extract-update.ts';
 import { lookup } from './extract-update.ts';
@@ -31,7 +32,7 @@ describe('workers/repository/process/index', () => {
     });
 
     it('processes baseBranchPatterns', async () => {
-      extract.mockResolvedValue({} as never);
+      extract.mockResolvedValue(partial<Record<string, PackageFile[]>>());
       config.baseBranchPatterns = ['branch1', 'branch2'];
       scm.branchExists.mockResolvedValueOnce(false);
       scm.branchExists.mockResolvedValueOnce(true);
@@ -125,7 +126,7 @@ describe('workers/repository/process/index', () => {
     });
 
     it('processes baseBranchPatterns dryRun extract', async () => {
-      extract.mockResolvedValue({} as never);
+      extract.mockResolvedValue(partial<Record<string, PackageFile[]>>());
       GlobalConfig.set({ dryRun: 'extract' });
       const res = await extractDependencies(config);
       await updateRepo(config, res.branches);
@@ -138,7 +139,7 @@ describe('workers/repository/process/index', () => {
     });
 
     it('finds baseBranches via regular expressions', async () => {
-      extract.mockResolvedValue({} as never);
+      extract.mockResolvedValue(partial<Record<string, PackageFile[]>>());
       config.baseBranchPatterns = [
         '/^release\\/.*/i',
         'dev',
@@ -189,7 +190,7 @@ describe('workers/repository/process/index', () => {
     });
 
     it('maps $default to defaultBranch', async () => {
-      extract.mockResolvedValue({} as never);
+      extract.mockResolvedValue(partial<Record<string, PackageFile[]>>());
       config.baseBranchPatterns = ['$default'];
       config.defaultBranch = 'master';
       git.getBranchList.mockReturnValue(['dev', 'master']);

--- a/lib/workers/repository/update/branch/bump-versions.spec.ts
+++ b/lib/workers/repository/update/branch/bump-versions.spec.ts
@@ -9,7 +9,7 @@ vi.mock('../../../../util/fs/index.ts');
 describe('workers/repository/update/branch/bump-versions', () => {
   describe('bumpVersions', () => {
     it('should be noop if bumpVersions is undefined', async () => {
-      const config = {} as BranchConfig;
+      const config = partial<BranchConfig>();
       await bumpVersions(config);
 
       expect(config).toEqual({});

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -1210,6 +1210,7 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
             // jenkins is a valid value for a constraint, but isn't a valid tool for Containerbase
             jenkins: '2.541.3',
           },
+          // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally uses `jenkins`, which is not a valid ToolName, to test that invalid tools are ignored
           installTools: {
             jenkins: {},
           } as never, // TODO can't tighten the type constraints, as the arguments to the test function don't match

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -2340,6 +2340,7 @@ describe('workers/repository/update/branch/index', () => {
         updatedArtifacts: [],
         artifactNotices: [],
       } satisfies PackageFilesResult);
+      // oxlint-disable-next-line renovate/prefer-partial-in-specs -- updatedArtifacts entry intentionally uses a `name` field instead of `type`/`path`, which FileChange does not allow
       npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
         artifactErrors: [],
         updatedArtifacts: [
@@ -2392,6 +2393,7 @@ describe('workers/repository/update/branch/index', () => {
       await branchWorker.processBranch({
         ...config,
         upgrades: [
+          // oxlint-disable-next-line renovate/prefer-partial-in-specs -- spreading getConfig() (AllConfig) is not assignable to BranchUpgradeConfig due to a pre-existing type incompatibility (see TODO #22198 above)
           {
             ...getConfig(),
             depName: 'some-dep-name',

--- a/lib/workers/repository/update/pr/participants.spec.ts
+++ b/lib/workers/repository/update/pr/participants.spec.ts
@@ -13,6 +13,7 @@ vi.mock('./code-owners.ts');
 const codeOwners = vi.mocked(_codeOwners);
 
 describe('workers/repository/update/pr/participants', () => {
+  // oxlint-disable-next-line renovate/prefer-partial-in-specs -- assigneesSampleSize/reviewersSampleSize intentionally set to null, which the type does not allow, to simulate an unset value
   const config: RenovateConfig = {
     assignees: ['a', 'b', '@c'],
     reviewers: ['x', 'y', '@z'],

--- a/tools/lint/rules/prefer-partial-in-specs.js
+++ b/tools/lint/rules/prefer-partial-in-specs.js
@@ -4,9 +4,23 @@
  * estree typings and oxlint does not export its own node types, so the fields
  * this rule reads are described here.
  *
- * @typedef {{ type: string }} TSType
+ * @typedef {{ type: string, typeName?: { type: string, name?: string } }} TSType
  * @typedef {{ type: string, expression: { type: string }, typeAnnotation: TSType }} TSAsExpression
  */
+
+/**
+ * `as const` assertions are represented as a type reference named `const`.
+ * They narrow instead of bypassing type checking, so they stay allowed.
+ *
+ * @param {TSType} typeAnnotation
+ */
+function isConstAssertion(typeAnnotation) {
+  return (
+    typeAnnotation.type === 'TSTypeReference' &&
+    typeAnnotation.typeName?.type === 'Identifier' &&
+    typeAnnotation.typeName.name === 'const'
+  );
+}
 
 /** @type {import('eslint').Rule.RuleModule} */
 export default {
@@ -14,7 +28,7 @@ export default {
     type: 'problem',
     messages: {
       preferPartial:
-        'Casting an object literal to `any` bypasses the type system; use `partial<T>()` from `test/util` (or a properly typed value) instead.',
+        'Casting an object literal with `as` bypasses type checking; use `partial<T>()` from `test/util` (or a properly typed value) instead.',
     },
   },
   create(context) {
@@ -24,7 +38,7 @@ export default {
         const asExpr = /** @type {TSAsExpression} */ (node);
         if (
           asExpr.expression.type === 'ObjectExpression' &&
-          asExpr.typeAnnotation.type === 'TSAnyKeyword'
+          !isConstAssertion(asExpr.typeAnnotation)
         ) {
           context.report({
             node: /** @type {import('estree').Node} */ (node),


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

- Extends our partial helper linter rule to cover constants 
- Update all new findings 
- Small type change in `maven` tests to prevent to have to exclude everything containing a response

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44763
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
