### PR TITLE
fix(http/github): support cursor pagination

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -5392,11 +5392,11 @@ describe('modules/platform/github/index', () => {
             },
           ],
           {
-            link: `<${githubApiHost}/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&page=2>; rel="next", <${githubApiHost}/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&page=2>; rel="last"`,
+            link: `<${githubApiHost}/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&after=cursor-1>; rel="next"`,
           },
         )
         .get(
-          '/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&page=2',
+          '/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&after=cursor-1',
         )
         .reply(200, [
           {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -5392,6 +5392,103 @@ describe('modules/platform/github/index', () => {
             },
           ],
           {
+            link: `<${githubApiHost}/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&page=2>; rel="next", <${githubApiHost}/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&page=2>; rel="last"`,
+          },
+        )
+        .get(
+          '/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&page=2',
+        )
+        .reply(200, [
+          {
+            security_advisory: {
+              ghsa_id: 'GHSA-1234-5678-9012',
+              summary: 'summary',
+              description: 'description',
+              identifiers: [{ type: 'type', value: 'value' }],
+              references: [],
+              severity: 'low',
+            },
+            security_vulnerability: {
+              package: {
+                ecosystem: 'npm',
+                name: 'center-pad',
+              },
+              severity: 'low',
+              vulnerable_version_range: '0.0.3',
+              first_patched_version: { identifier: '0.0.4' },
+            },
+            dependency: {
+              manifest_path: 'bar/foo',
+            },
+          },
+        ]);
+
+      await github.initRepo({ repository: 'some/repo' });
+      const res = await github.getVulnerabilityAlerts();
+
+      expect(res).toHaveLength(3);
+      expect(res[0].security_vulnerability!.package.name).toBe('left-pad');
+      expect(res[1].security_vulnerability!.package.name).toBe('right-pad');
+      expect(res[2].security_vulnerability!.package.name).toBe('center-pad');
+    });
+
+    it('handles cursor pagination correctly', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+
+      scope
+        .get(
+          '/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100',
+        )
+        .reply(
+          200,
+          [
+            {
+              security_advisory: {
+                ghsa_id: 'GHSA-1234-5678-9012',
+                summary: 'summary',
+                description: 'description',
+                identifiers: [{ type: 'type', value: 'value' }],
+                references: [],
+                severity: 'high',
+              },
+              security_vulnerability: {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'left-pad',
+                },
+                severity: 'high',
+                vulnerable_version_range: '0.0.2',
+                first_patched_version: { identifier: '0.0.3' },
+              },
+              dependency: {
+                manifest_path: 'bar/foo',
+              },
+            },
+            {
+              security_advisory: {
+                ghsa_id: 'GHSA-1234-5678-9012',
+                summary: 'summary',
+                description: 'description',
+                identifiers: [{ type: 'type', value: 'value' }],
+                references: [],
+                severity: 'critical',
+              },
+              security_vulnerability: {
+                package: {
+                  ecosystem: 'npm',
+                  name: 'right-pad',
+                },
+                severity: 'critical',
+                vulnerable_version_range: '0.0.1',
+                first_patched_version: { identifier: '0.0.2' },
+              },
+              dependency: {
+                manifest_path: 'bar/foo',
+              },
+            },
+          ],
+          {
             link: `<${githubApiHost}/repos/some/repo/dependabot/alerts?state=open&direction=asc&per_page=100&after=cursor-1>; rel="next"`,
           },
         )

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -170,6 +170,23 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
     });
 
+    it('limits full cursor pagination', async () => {
+      const url = '/some-url?per_page=1';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .times(100)
+        .reply(200, ['a'], {
+          link: `<${url}>; rel="next"`,
+        });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: 'all' });
+      expect(res.body).toHaveLength(100);
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { maxPages: 100 },
+        'GitHub cursor pagination limit reached',
+      );
+    });
+
     it('does not follow cursor pagination links to a different origin', async () => {
       const url = '/some-url?per_page=2';
       httpMock

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -112,6 +112,87 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
     });
 
+    it('paginates cursor links', async () => {
+      const url = '/some-url?per_page=2';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a', 'b'], {
+          link: `<${url}&after=cursor-1>; rel="next"`,
+        })
+        .get(`${url}&after=cursor-1`)
+        .reply(200, ['c', 'd'], {
+          link: `<${url}&after=cursor-2>; rel="next", <${url}&before=cursor-1>; rel="prev"`,
+        })
+        .get(`${url}&after=cursor-2`)
+        .reply(200, ['e']);
+      const res = await githubApi.getJsonUnchecked(url, { paginate: true });
+      expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+
+    it('limits cursor pagination', async () => {
+      const url = '/some-url?per_page=2';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a', 'b'], {
+          link: `<${url}&after=cursor-1>; rel="next"`,
+        })
+        .get(`${url}&after=cursor-1`)
+        .reply(200, ['c', 'd'], {
+          link: `<${url}&after=cursor-2>; rel="next"`,
+        });
+      const res = await githubApi.getJsonUnchecked(url, {
+        paginate: true,
+        pageLimit: 2,
+      });
+      expect(res.body).toEqual(['a', 'b', 'c', 'd']);
+    });
+
+    it('paginates all cursor links', async () => {
+      const url = '/some-url?per_page=2';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a', 'b'], {
+          link: `<${url}&after=cursor-1>; rel="next"`,
+        })
+        .get(`${url}&after=cursor-1`)
+        .reply(200, ['c', 'd'], {
+          link: `<${url}&after=cursor-2>; rel="next"`,
+        })
+        .get(`${url}&after=cursor-2`)
+        .reply(200, ['e']);
+      const res = await githubApi.getJsonUnchecked(url, {
+        paginate: 'all',
+        pageLimit: 2,
+      });
+      expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+
+    it('does not follow cursor pagination links to a different origin', async () => {
+      const url = '/some-url?per_page=2';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a', 'b'], {
+          link: `<${url}&after=cursor-1>; rel="next"`,
+        })
+        .get(`${url}&after=cursor-1`)
+        .reply(200, ['c', 'd'], {
+          link: '<https://attacker.example.com/some-url?after=cursor-2>; rel="next"',
+        });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: true });
+      expect(res.body).toEqual(['a', 'b', 'c', 'd']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          requestHost: 'api.github.com',
+          paginationHost: 'attacker.example.com',
+        },
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+      );
+    });
+
     it('uses paginationField', async () => {
       const url = '/some-url';
       httpMock

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -39,6 +39,7 @@ import type {
 } from './types.ts';
 
 const githubBaseUrl = 'https://api.github.com/';
+const MAX_PAGINATION_PAGES = 100;
 let baseUrl = githubBaseUrl;
 export function setBaseUrl(url: string): void {
   baseUrl = url;
@@ -333,6 +334,20 @@ function replaceUrlBase(url: URL, baseUrl: string): URL {
   return new URL(relativeUrl, baseUrl);
 }
 
+function resolvePaginationUrl(
+  url: string,
+  baseUrl: string | undefined,
+  rebasePaginationLinks: boolean,
+): URL {
+  const parsedUrl = new URL(url, baseUrl);
+  const rebasePagination =
+    !!baseUrl &&
+    rebasePaginationLinks &&
+    // Preserve github.com URLs for use cases like release notes
+    parsedUrl.origin !== 'https://api.github.com';
+  return rebasePagination ? replaceUrlBase(parsedUrl, baseUrl) : parsedUrl;
+}
+
 export class GithubHttp extends HttpBase<GithubHttpOptions> {
   protected override get baseUrl(): string | undefined {
     return baseUrl;
@@ -425,18 +440,12 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
       const env = getEnv();
       if (next?.url) {
         const baseUrl = httpOptions.baseUrl ?? this.baseUrl;
-        function resolvePaginationUrl(url: string): URL {
-          const parsedUrl = new URL(url, baseUrl);
-          const rebasePagination =
-            !!baseUrl &&
-            !!env.RENOVATE_X_REBASE_PAGINATION_LINKS &&
-            // Preserve github.com URLs for use cases like release notes
-            parsedUrl.origin !== 'https://api.github.com';
-          return rebasePagination
-            ? replaceUrlBase(parsedUrl, baseUrl)
-            : parsedUrl;
-        }
-        const firstPageUrl = resolvePaginationUrl(next.url);
+        const rebasePaginationLinks = !!env.RENOVATE_X_REBASE_PAGINATION_LINKS;
+        const firstPageUrl = resolvePaginationUrl(
+          next.url,
+          baseUrl,
+          rebasePaginationLinks,
+        );
         // Don't follow a cross-origin request, unless we've been explicitly requested to do so with `RENOVATE_X_REBASE_PAGINATION_LINKS`
         if (firstPageUrl.origin === resolvedUrl.origin) {
           let pages: HttpResponse<T>[];
@@ -462,12 +471,12 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
             pages = [];
             const paginateAll =
               !!env.RENOVATE_PAGINATE_ALL || httpOptions.paginate === 'all';
+            const cursorPageLimit = paginateAll
+              ? MAX_PAGINATION_PAGES
+              : pageLimit;
             let nextUrl: URL | null = firstPageUrl;
-            for (
-              let pageNumber = 2;
-              nextUrl && (paginateAll || pageNumber <= pageLimit);
-              pageNumber += 1
-            ) {
+            let pageNumber = 2;
+            for (; nextUrl && pageNumber <= cursorPageLimit; pageNumber += 1) {
               if (nextUrl.origin !== resolvedUrl.origin) {
                 logger.once.warn(
                   {
@@ -486,8 +495,18 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
               pages.push(nextPage);
               const nextLink = parseLinkHeader(nextPage.headers.link)?.next;
               nextUrl = nextLink?.url
-                ? resolvePaginationUrl(nextLink.url)
+                ? resolvePaginationUrl(
+                    nextLink.url,
+                    baseUrl,
+                    rebasePaginationLinks,
+                  )
                 : null;
+            }
+            if (paginateAll && nextUrl && pageNumber > cursorPageLimit) {
+              logger.warn(
+                { maxPages: MAX_PAGINATION_PAGES },
+                'GitHub cursor pagination limit reached',
+              );
             }
           }
           // v8 ignore else -- TODO: add test #40625

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -450,6 +450,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
         if (firstPageUrl.origin === resolvedUrl.origin) {
           let pages: HttpResponse<T>[];
           if (linkHeader?.last?.page) {
+            logger.debug('Using GitHub offset-based pagination');
             let lastPage = parseInt(linkHeader.last.page, 10);
             // v8 ignore else -- TODO: add test #40625
             if (!env.RENOVATE_PAGINATE_ALL && httpOptions.paginate !== 'all') {
@@ -468,6 +469,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
             );
             pages = await p.all(queue);
           } else {
+            logger.debug('Using GitHub cursor-based pagination');
             pages = [];
             const paginateAll =
               !!env.RENOVATE_PAGINATE_ALL || httpOptions.paginate === 'all';

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -423,36 +423,73 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
       const linkHeader = parseLinkHeader(result?.headers?.link);
       const next = linkHeader?.next;
       const env = getEnv();
-      if (next?.url && linkHeader?.last?.page) {
-        let lastPage = parseInt(linkHeader.last.page, 10);
-        // v8 ignore else -- TODO: add test #40625
-        if (!env.RENOVATE_PAGINATE_ALL && httpOptions.paginate !== 'all') {
-          lastPage = Math.min(pageLimit, lastPage);
-        }
+      if (next?.url) {
         const baseUrl = httpOptions.baseUrl ?? this.baseUrl;
-        const parsedUrl = new URL(next.url, baseUrl);
-        const rebasePagination =
-          !!baseUrl &&
-          !!env.RENOVATE_X_REBASE_PAGINATION_LINKS &&
-          // Preserve github.com URLs for use cases like release notes
-          parsedUrl.origin !== 'https://api.github.com';
-        const firstPageUrl = rebasePagination
-          ? replaceUrlBase(parsedUrl, baseUrl)
-          : parsedUrl;
+        function resolvePaginationUrl(url: string): URL {
+          const parsedUrl = new URL(url, baseUrl);
+          const rebasePagination =
+            !!baseUrl &&
+            !!env.RENOVATE_X_REBASE_PAGINATION_LINKS &&
+            // Preserve github.com URLs for use cases like release notes
+            parsedUrl.origin !== 'https://api.github.com';
+          return rebasePagination
+            ? replaceUrlBase(parsedUrl, baseUrl)
+            : parsedUrl;
+        }
+        const firstPageUrl = resolvePaginationUrl(next.url);
         // Don't follow a cross-origin request, unless we've been explicitly requested to do so with `RENOVATE_X_REBASE_PAGINATION_LINKS`
         if (firstPageUrl.origin === resolvedUrl.origin) {
-          const queue = [...range(2, lastPage)].map(
-            (pageNumber) => (): Promise<HttpResponse<T>> => {
-              // copy before modifying searchParams
-              const nextUrl = parseUrl(firstPageUrl.toString())!;
-              nextUrl.searchParams.set('page', String(pageNumber));
-              return super.requestJsonUnsafe<T>(method, {
-                ...opts,
-                url: nextUrl,
-              });
-            },
-          );
-          const pages = await p.all(queue);
+          let pages: HttpResponse<T>[];
+          if (linkHeader?.last?.page) {
+            let lastPage = parseInt(linkHeader.last.page, 10);
+            // v8 ignore else -- TODO: add test #40625
+            if (!env.RENOVATE_PAGINATE_ALL && httpOptions.paginate !== 'all') {
+              lastPage = Math.min(pageLimit, lastPage);
+            }
+            const queue = [...range(2, lastPage)].map(
+              (pageNumber) => (): Promise<HttpResponse<T>> => {
+                // copy before modifying searchParams
+                const nextUrl = parseUrl(firstPageUrl.toString())!;
+                nextUrl.searchParams.set('page', String(pageNumber));
+                return super.requestJsonUnsafe<T>(method, {
+                  ...opts,
+                  url: nextUrl,
+                });
+              },
+            );
+            pages = await p.all(queue);
+          } else {
+            pages = [];
+            const paginateAll =
+              !!env.RENOVATE_PAGINATE_ALL || httpOptions.paginate === 'all';
+            let nextUrl: URL | null = firstPageUrl;
+            for (
+              let pageNumber = 2;
+              nextUrl && (paginateAll || pageNumber <= pageLimit);
+              pageNumber += 1
+            ) {
+              if (nextUrl.origin !== resolvedUrl.origin) {
+                logger.once.warn(
+                  {
+                    requestHost: resolvedUrl.host,
+                    paginationHost: nextUrl.host,
+                  },
+                  'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+                );
+                break;
+              }
+              const nextPage: HttpResponse<T> =
+                await super.requestJsonUnsafe<T>(method, {
+                  ...opts,
+                  url: nextUrl,
+                });
+              pages.push(nextPage);
+              const nextLink = parseLinkHeader(nextPage.headers.link)?.next;
+              nextUrl = nextLink?.url
+                ? resolvePaginationUrl(nextLink.url)
+                : null;
+            }
+          }
           // v8 ignore else -- TODO: add test #40625
           if (httpOptions.paginationField && isPlainObject(result.body)) {
             const paginatedResult = result.body[httpOptions.paginationField];


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

GitHub removed offset-based pagination (`page`, `first`, and `last`) from the Dependabot alerts API. Dependabot alert endpoints now support cursor-based pagination using `before`, `after`, and `per_page`.

Sources:
- [GitHub REST API: List Dependabot alerts for a repository](https://docs.github.com/en/rest/dependabot/alerts#list-dependabot-alerts-for-a-repository)

GitHub HTTP pagination previously constructed subsequent URLs using `page=N`, so Renovate could not retrieve Dependabot alerts beyond the first page.

This change:

- follows cursor-based `rel="next"` links sequentially
- preserves existing parallel pagination for page-number-based endpoints
- respects `pageLimit` and `paginate: "all"`
- retains cross-origin pagination protection
- updates the Dependabot alerts integration test to use an `after` cursor
- adds unit tests for cursor traversal, page limits, full pagination, and cross-origin links

Validated with `pnpm check`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (gpt-5.6-sol) was used to inspect the existing pagination implementation, implement cursor pagination, add tests.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @goda6565 will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
