### PR TITLE
fix: Revert "fix(manager/npm): pass correct arguments to pnpm dedupe"

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4158,7 +4158,7 @@ Run `npm install` commands _twice_ to work around bugs where `npm` generates inv
 
 ### `pnpmDedupe`
 
-Run `pnpm dedupe` after `pnpm-lock.yaml` updates.
+Run `pnpm dedupe --ignore-scripts` after `pnpm-lock.yaml` updates.
 
 ### `yarnDedupeFewer`
 

--- a/lib/modules/manager/npm/post-update/pnpm.spec.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.spec.ts
@@ -316,7 +316,7 @@ describe('modules/manager/npm/post-update/pnpm', () => {
         cmd: 'pnpm install --lockfile-only --ignore-scripts --ignore-pnpmfile',
       },
       {
-        cmd: 'pnpm dedupe --lockfile-only --ignore-scripts --ignore-pnpmfile',
+        cmd: 'pnpm dedupe --ignore-scripts',
       },
     ]);
   });

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -149,7 +149,7 @@ export async function generateLockFile(
 
     // postUpdateOptions
     if (config.postUpdateOptions?.includes('pnpmDedupe')) {
-      commands.push(`pnpm dedupe ${args}`);
+      commands.push('pnpm dedupe --ignore-scripts');
     }
 
     if (upgrades.find((upgrade) => upgrade.isLockFileMaintenance)) {


### PR DESCRIPTION
Reverts renovatebot/renovate#42024

it breaks on monorepos because of `--recursive` flag

```
[ERROR] Unknown option: 'recursive'
Did you mean 'runtime'? Use "--config.unknown=value" to force an unknown option.
For help, run: pnpm help dedupe
```