### PR TITLE
chore(tools): allow unsafe askpass in agent hooks git config

### DIFF
--- a/tools/agents/hooks/utils/git.ts
+++ b/tools/agents/hooks/utils/git.ts
@@ -6,6 +6,7 @@ const config: Partial<SimpleGitOptions> = {
   unsafe: {
     allowUnsafePager: true,
     allowUnsafeEditor: true,
+    allowUnsafeAskPass: true, // set by vscode
   },
 };
 


### PR DESCRIPTION
## Changes

VS Code sets `GIT_ASKPASS` in its integrated terminal. `simple-git` treats that env var as unsafe and refuses to run unless `allowUnsafeAskPass` is enabled, so the agent hooks fail when invoked from a VS Code terminal. Enable `allowUnsafeAskPass` alongside the pager/editor options already set in `tools/agents/hooks/utils/git.ts`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The one-line change was written by hand; Claude Code (Opus 5) wrote the commit message and this PR description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @viceice will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
