### PR TITLE
feat(manager/mise): add support for OCI CLI

### DIFF
--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -75,6 +75,7 @@ describe('modules/manager/mise/extract', () => {
       localstack = "4.3.0"
       lychee = "0.19.1"
       npm = "11.2.0"
+      oci = "3.90.1"
       opentofu = "1.6.1"
       openfga = "1.14.0"
       packer = "1.15.0"
@@ -243,6 +244,12 @@ describe('modules/manager/mise/extract', () => {
             datasource: 'npm',
             depName: 'npm',
             packageName: 'npm',
+          },
+          {
+            currentValue: '3.90.1',
+            datasource: 'pypi',
+            depName: 'oci',
+            packageName: 'oci-cli',
           },
           {
             currentValue: '1.6.1',

--- a/lib/modules/manager/mise/index.ts
+++ b/lib/modules/manager/mise/index.ts
@@ -44,6 +44,7 @@ const backendDatasources = {
     GithubTagsDatasource.id,
     JavaVersionDatasource.id,
     NodeVersionDatasource.id,
+    PypiDatasource.id,
     RubyVersionDatasource.id,
     RustVersionDatasource.id,
   ],

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -6,6 +6,7 @@ import { HexpmBobDatasource } from '../../datasource/hexpm-bob/index.ts';
 import { JavaVersionDatasource } from '../../datasource/java-version/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
+import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as regexVersioning from '../../versioning/regex/index.ts';
@@ -371,6 +372,13 @@ const miseRegistryTooling: Record<string, ToolingDefinition> = {
     config: {
       packageName: 'npm',
       datasource: NpmDatasource.id,
+    },
+  },
+  oci: {
+    misePluginUrl: 'https://mise.jdx.dev/registry.html#tools',
+    config: {
+      packageName: 'oci-cli',
+      datasource: PypiDatasource.id,
     },
   },
   opentofu: {


### PR DESCRIPTION
## Changes

- teach the mise manager that the registry's `oci` tool is the `oci-cli` PyPI package
- allow the PyPI datasource for mise core/registry tools
- cover OCI CLI extraction in the mise registry fixture

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

The mise registry installs `oci` from PyPI, but Renovate currently extracts the pin without a datasource. This mapping lets Renovate update bare `oci = "..."` entries.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI Codex (GPT-5) prepared the implementation and tests under human direction.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] Nobody has explicitly committed to replying.

## Documentation

- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [x] Newly added/modified unit tests

Commands run:

```text
pnpm vitest run lib/modules/manager/mise/extract.spec.ts
pnpm vitest run lib/modules/manager/index.spec.ts
pnpm check --all lib/modules/manager/mise/upgradeable-tooling.ts lib/modules/manager/mise/index.ts lib/modules/manager/mise/extract.spec.ts
```
