### PR TITLE
fix(platform/github): abort branch update when PR is in merge queue

### DIFF
--- a/lib/constants/error-messages.ts
+++ b/lib/constants/error-messages.ts
@@ -110,6 +110,9 @@ export const HOST_DISABLED = 'host-disabled';
 // Worker Error
 export const WORKER_FILE_UPDATE_FAILED = 'update-failure';
 
+// PR Error
+export const PR_ALREADY_IN_MERGE_QUEUE = 'pr-already-in-merge-queue';
+
 // Bundler Error
 export const BUNDLER_INVALID_CREDENTIALS = 'bundler-credentials';
 

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -73,18 +73,7 @@ export const prIsInMergeQueueQuery = `
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
-      id
       isInMergeQueue
-    }
-  }
-}
-`;
-
-export const dequeuePullRequestMutation = `
-mutation DequeuePullRequest($pullRequestId: ID!) {
-  dequeuePullRequest(input: { id: $pullRequestId }) {
-    mergeQueueEntry {
-      id
     }
   }
 }

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -69,6 +69,16 @@ query(
 }
 `;
 
+export const prIsInMergeQueueQuery = `
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      isInMergeQueue
+    }
+  }
+}
+`;
+
 export const enableAutoMergeMutation = `
 mutation EnablePullRequestAutoMerge(
   $pullRequestId: ID!,

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -69,6 +69,16 @@ query(
 }
 `;
 
+export const repoMergeQueueQuery = `
+query($owner: String!, $name: String!, $branch: String!) {
+  repository(owner: $owner, name: $name) {
+    mergeQueue(branch: $branch) {
+      id
+    }
+  }
+}
+`;
+
 export const prIsInMergeQueueQuery = `
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -73,7 +73,18 @@ export const prIsInMergeQueueQuery = `
 query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
+      id
       isInMergeQueue
+    }
+  }
+}
+`;
+
+export const dequeuePullRequestMutation = `
+mutation DequeuePullRequest($pullRequestId: ID!) {
+  dequeuePullRequest(input: { id: $pullRequestId }) {
+    mergeQueueEntry {
+      id
     }
   }
 }

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -15,6 +15,7 @@ query($owner: String!, $name: String!, $user: String) {
     mergeCommitAllowed
     rebaseMergeAllowed
     squashMergeAllowed
+    mergeQueue { id }
     defaultBranchRef {
       name
       target {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -4646,6 +4646,15 @@ describe('modules/platform/github/index', () => {
   });
 
   describe('updatePr(prNo, title, body)', () => {
+    function mergeQueueCheckMock(
+      scope: httpMock.Scope,
+      isInMergeQueue = false,
+    ): void {
+      scope.post('/graphql').reply(200, {
+        data: { repository: { pullRequest: { isInMergeQueue } } },
+      });
+    }
+
     it('should update the PR', async () => {
       const pr: UpdatePrConfig = {
         number: 1234,
@@ -4655,6 +4664,7 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueCheckMock(scope);
       scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
 
       await expect(github.updatePr(pr)).toResolve();
@@ -4670,6 +4680,7 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueCheckMock(scope);
       scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
 
       await expect(github.updatePr(pr)).toResolve();
@@ -4685,6 +4696,86 @@ describe('modules/platform/github/index', () => {
       };
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      mergeQueueCheckMock(scope);
+      scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
+
+      await expect(github.updatePr(pr)).toResolve();
+    });
+
+    it('should skip update if PR is in the merge queue', async () => {
+      const pr: UpdatePrConfig = {
+        number: 1234,
+        prTitle: 'The New Title',
+        prBody: 'Hello world again',
+      };
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      mergeQueueCheckMock(scope, true);
+
+      await expect(github.updatePr(pr)).toResolve();
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'PR #1234 is in the merge queue - skipping update',
+      );
+    });
+
+    it('should update if merge queue check returns errors', async () => {
+      const pr: UpdatePrConfig = {
+        number: 1234,
+        prTitle: 'The New Title',
+        prBody: 'Hello world again',
+      };
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      scope
+        .post('/graphql')
+        .reply(200, { errors: [{ message: 'some error' }] })
+        .patch('/repos/some/repo/pulls/1234')
+        .reply(200, pr);
+
+      await expect(github.updatePr(pr)).toResolve();
+    });
+
+    it('should update if merge queue check fails', async () => {
+      const pr: UpdatePrConfig = {
+        number: 1234,
+        prTitle: 'The New Title',
+        prBody: 'Hello world again',
+      };
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      scope
+        .post('/graphql')
+        .reply(500)
+        .patch('/repos/some/repo/pulls/1234')
+        .reply(200, pr);
+
+      await expect(github.updatePr(pr)).toResolve();
+    });
+
+    it('should skip merge queue check on GHE <3.12.0', async () => {
+      const pr: UpdatePrConfig = {
+        number: 1234,
+        prTitle: 'The New Title',
+        prBody: 'Hello world again',
+      };
+      const scope = httpMock
+        .scope('https://github.company.com')
+        .head('/')
+        .reply(200, '', { 'x-github-enterprise-version': '3.11.0' })
+        .get('/user')
+        .reply(200, { login: 'renovate-bot' })
+        .get('/user/emails')
+        .reply(200, {});
+      initRepoMock(scope, 'some/repo');
+      await github.initPlatform({
+        endpoint: 'https://github.company.com',
+        token: '123test',
+      });
       await github.initRepo({ repository: 'some/repo' });
       scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
 
@@ -4704,6 +4795,7 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueCheckMock(scope);
       scope
         .patch('/repos/some/repo/pulls/1234')
         .reply(200, {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -4651,7 +4651,11 @@ describe('modules/platform/github/index', () => {
       isInMergeQueue = false,
     ): void {
       scope.post('/graphql').reply(200, {
-        data: { repository: { pullRequest: { isInMergeQueue } } },
+        data: {
+          repository: {
+            pullRequest: { id: 'abcd', isInMergeQueue },
+          },
+        },
       });
     }
 
@@ -4703,7 +4707,7 @@ describe('modules/platform/github/index', () => {
       await expect(github.updatePr(pr)).toResolve();
     });
 
-    it('should skip update if PR is in the merge queue', async () => {
+    it('should dequeue PR from the merge queue before update', async () => {
       const pr: UpdatePrConfig = {
         number: 1234,
         prTitle: 'The New Title',
@@ -4713,11 +4717,42 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
       mergeQueueCheckMock(scope, true);
+      scope
+        .post('/graphql')
+        .reply(200, {
+          data: { dequeuePullRequest: { mergeQueueEntry: { id: 'efgh' } } },
+        })
+        .patch('/repos/some/repo/pulls/1234')
+        .reply(200, pr);
 
       await expect(github.updatePr(pr)).toResolve();
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
-        'PR #1234 is in the merge queue - skipping update',
+        'PR #1234 is in the merge queue - dequeueing before update',
+      );
+    });
+
+    it('should update if dequeue returns errors', async () => {
+      const pr: UpdatePrConfig = {
+        number: 1234,
+        prTitle: 'The New Title',
+        prBody: 'Hello world again',
+      };
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      mergeQueueCheckMock(scope, true);
+      scope
+        .post('/graphql')
+        .reply(200, { errors: [{ message: 'some error' }] })
+        .patch('/repos/some/repo/pulls/1234')
+        .reply(200, pr);
+
+      await expect(github.updatePr(pr)).toResolve();
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { prNo: 1234, errors: [{ message: 'some error' }] },
+        'Failed to dequeue PR from merge queue',
       );
     });
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -4645,7 +4645,26 @@ describe('modules/platform/github/index', () => {
     });
   });
 
-  describe('updatePr(prNo, title, body)', () => {
+  describe('tryDequeuePr()', () => {
+    const prList = [
+      {
+        number: 1234,
+        head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+        state: 'open',
+        title: 'PR title',
+        updated_at: '01-09-2022',
+        node_id: 'abcd',
+      },
+    ];
+
+    function prListMock(scope: httpMock.Scope, prs: unknown[] = prList): void {
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, prs);
+    }
+
     function mergeQueueCheckMock(
       scope: httpMock.Scope,
       isInMergeQueue = false,
@@ -4659,6 +4678,108 @@ describe('modules/platform/github/index', () => {
       });
     }
 
+    it('does nothing if there is no open PR for the branch', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope, []);
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+    });
+
+    it('does nothing if the PR is not in the merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope);
+      mergeQueueCheckMock(scope);
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+    });
+
+    it('dequeues a queued PR', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope);
+      mergeQueueCheckMock(scope, true);
+      scope.post('/graphql').reply(200, {
+        data: { dequeuePullRequest: { mergeQueueEntry: { id: 'efgh' } } },
+      });
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'PR #1234 is in the merge queue - dequeueing before push',
+      );
+    });
+
+    it('logs if dequeue returns errors', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope);
+      mergeQueueCheckMock(scope, true);
+      scope
+        .post('/graphql')
+        .reply(200, { errors: [{ message: 'some error' }] });
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { prNo: 1234, errors: [{ message: 'some error' }] },
+        'Failed to dequeue PR from merge queue',
+      );
+    });
+
+    it('logs if the merge queue check returns errors', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope);
+      scope
+        .post('/graphql')
+        .reply(200, { errors: [{ message: 'some error' }] });
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { prNo: 1234, errors: [{ message: 'some error' }] },
+        'Failed to fetch PR merge queue status',
+      );
+    });
+
+    it('ignores merge queue check failures', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope);
+      scope.post('/graphql').reply(500);
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+    });
+
+    it('skips merge queue check on GHE <3.12.0', async () => {
+      const scope = httpMock
+        .scope('https://github.company.com')
+        .head('/')
+        .reply(200, '', { 'x-github-enterprise-version': '3.11.0' })
+        .get('/user')
+        .reply(200, { login: 'renovate-bot' })
+        .get('/user/emails')
+        .reply(200, {});
+      initRepoMock(scope, 'some/repo');
+      await github.initPlatform({
+        endpoint: 'https://github.company.com',
+        token: '123test',
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      await expect(github.tryDequeuePr('somebranch')).toResolve();
+    });
+  });
+
+  describe('updatePr(prNo, title, body)', () => {
     it('should update the PR', async () => {
       const pr: UpdatePrConfig = {
         number: 1234,
@@ -4668,7 +4789,6 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
-      mergeQueueCheckMock(scope);
       scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
 
       await expect(github.updatePr(pr)).toResolve();
@@ -4684,7 +4804,6 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
-      mergeQueueCheckMock(scope);
       scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
 
       await expect(github.updatePr(pr)).toResolve();
@@ -4700,117 +4819,6 @@ describe('modules/platform/github/index', () => {
       };
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
-      await github.initRepo({ repository: 'some/repo' });
-      mergeQueueCheckMock(scope);
-      scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
-
-      await expect(github.updatePr(pr)).toResolve();
-    });
-
-    it('should dequeue PR from the merge queue before update', async () => {
-      const pr: UpdatePrConfig = {
-        number: 1234,
-        prTitle: 'The New Title',
-        prBody: 'Hello world again',
-      };
-      const scope = httpMock.scope(githubApiHost);
-      initRepoMock(scope, 'some/repo');
-      await github.initRepo({ repository: 'some/repo' });
-      mergeQueueCheckMock(scope, true);
-      scope
-        .post('/graphql')
-        .reply(200, {
-          data: { dequeuePullRequest: { mergeQueueEntry: { id: 'efgh' } } },
-        })
-        .patch('/repos/some/repo/pulls/1234')
-        .reply(200, pr);
-
-      await expect(github.updatePr(pr)).toResolve();
-
-      expect(logger.logger.debug).toHaveBeenCalledWith(
-        'PR #1234 is in the merge queue - dequeueing before update',
-      );
-    });
-
-    it('should update if dequeue returns errors', async () => {
-      const pr: UpdatePrConfig = {
-        number: 1234,
-        prTitle: 'The New Title',
-        prBody: 'Hello world again',
-      };
-      const scope = httpMock.scope(githubApiHost);
-      initRepoMock(scope, 'some/repo');
-      await github.initRepo({ repository: 'some/repo' });
-      mergeQueueCheckMock(scope, true);
-      scope
-        .post('/graphql')
-        .reply(200, { errors: [{ message: 'some error' }] })
-        .patch('/repos/some/repo/pulls/1234')
-        .reply(200, pr);
-
-      await expect(github.updatePr(pr)).toResolve();
-
-      expect(logger.logger.debug).toHaveBeenCalledWith(
-        { prNo: 1234, errors: [{ message: 'some error' }] },
-        'Failed to dequeue PR from merge queue',
-      );
-    });
-
-    it('should update if merge queue check returns errors', async () => {
-      const pr: UpdatePrConfig = {
-        number: 1234,
-        prTitle: 'The New Title',
-        prBody: 'Hello world again',
-      };
-      const scope = httpMock.scope(githubApiHost);
-      initRepoMock(scope, 'some/repo');
-      await github.initRepo({ repository: 'some/repo' });
-      scope
-        .post('/graphql')
-        .reply(200, { errors: [{ message: 'some error' }] })
-        .patch('/repos/some/repo/pulls/1234')
-        .reply(200, pr);
-
-      await expect(github.updatePr(pr)).toResolve();
-    });
-
-    it('should update if merge queue check fails', async () => {
-      const pr: UpdatePrConfig = {
-        number: 1234,
-        prTitle: 'The New Title',
-        prBody: 'Hello world again',
-      };
-      const scope = httpMock.scope(githubApiHost);
-      initRepoMock(scope, 'some/repo');
-      await github.initRepo({ repository: 'some/repo' });
-      scope
-        .post('/graphql')
-        .reply(500)
-        .patch('/repos/some/repo/pulls/1234')
-        .reply(200, pr);
-
-      await expect(github.updatePr(pr)).toResolve();
-    });
-
-    it('should skip merge queue check on GHE <3.12.0', async () => {
-      const pr: UpdatePrConfig = {
-        number: 1234,
-        prTitle: 'The New Title',
-        prBody: 'Hello world again',
-      };
-      const scope = httpMock
-        .scope('https://github.company.com')
-        .head('/')
-        .reply(200, '', { 'x-github-enterprise-version': '3.11.0' })
-        .get('/user')
-        .reply(200, { login: 'renovate-bot' })
-        .get('/user/emails')
-        .reply(200, {});
-      initRepoMock(scope, 'some/repo');
-      await github.initPlatform({
-        endpoint: 'https://github.company.com',
-        token: '123test',
-      });
       await github.initRepo({ repository: 'some/repo' });
       scope.patch('/repos/some/repo/pulls/1234').reply(200, pr);
 
@@ -4830,7 +4838,6 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
-      mergeQueueCheckMock(scope);
       scope
         .patch('/repos/some/repo/pulls/1234')
         .reply(200, {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -9,6 +9,7 @@ import {
   CONFIG_GIT_URL_UNAVAILABLE,
   PLATFORM_RATE_LIMIT_EXCEEDED,
   PLATFORM_UNKNOWN_ERROR,
+  PR_ALREADY_IN_MERGE_QUEUE,
   REPOSITORY_CANNOT_FORK,
   REPOSITORY_FORKED,
   REPOSITORY_FORK_MISSING,
@@ -4645,7 +4646,7 @@ describe('modules/platform/github/index', () => {
     });
   });
 
-  describe('tryDequeuePr()', () => {
+  describe('assertPrNotInMergeQueue()', () => {
     const prList = [
       {
         number: 1234,
@@ -4672,7 +4673,7 @@ describe('modules/platform/github/index', () => {
       scope.post('/graphql').reply(200, {
         data: {
           repository: {
-            pullRequest: { id: 'abcd', isInMergeQueue },
+            pullRequest: { isInMergeQueue },
           },
         },
       });
@@ -4684,7 +4685,7 @@ describe('modules/platform/github/index', () => {
       await github.initRepo({ repository: 'some/repo' });
       prListMock(scope, []);
 
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
+      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
     });
 
     it('does nothing if the PR is not in the merge queue', async () => {
@@ -4694,41 +4695,22 @@ describe('modules/platform/github/index', () => {
       prListMock(scope);
       mergeQueueCheckMock(scope);
 
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
+      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
     });
 
-    it('dequeues a queued PR', async () => {
+    it('throws if the PR is in the merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
       prListMock(scope);
       mergeQueueCheckMock(scope, true);
-      scope.post('/graphql').reply(200, {
-        data: { dequeuePullRequest: { mergeQueueEntry: { id: 'efgh' } } },
-      });
 
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
-
-      expect(logger.logger.debug).toHaveBeenCalledWith(
-        'PR #1234 is in the merge queue - dequeueing before push',
-      );
-    });
-
-    it('logs if dequeue returns errors', async () => {
-      const scope = httpMock.scope(githubApiHost);
-      initRepoMock(scope, 'some/repo');
-      await github.initRepo({ repository: 'some/repo' });
-      prListMock(scope);
-      mergeQueueCheckMock(scope, true);
-      scope
-        .post('/graphql')
-        .reply(200, { errors: [{ message: 'some error' }] });
-
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch'),
+      ).rejects.toThrow(PR_ALREADY_IN_MERGE_QUEUE);
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
-        { prNo: 1234, errors: [{ message: 'some error' }] },
-        'Failed to dequeue PR from merge queue',
+        'PR #1234 is in the merge queue - aborting push',
       );
     });
 
@@ -4741,7 +4723,7 @@ describe('modules/platform/github/index', () => {
         .post('/graphql')
         .reply(200, { errors: [{ message: 'some error' }] });
 
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
+      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
         { prNo: 1234, errors: [{ message: 'some error' }] },
@@ -4756,7 +4738,7 @@ describe('modules/platform/github/index', () => {
       prListMock(scope);
       scope.post('/graphql').reply(500);
 
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
+      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
     });
 
     it('skips merge queue check on GHE <3.12.0', async () => {
@@ -4775,7 +4757,7 @@ describe('modules/platform/github/index', () => {
       });
       await github.initRepo({ repository: 'some/repo' });
 
-      await expect(github.tryDequeuePr('somebranch')).toResolve();
+      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
     });
   });
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -4710,9 +4710,21 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
-      mergeQueueEnabledMock(scope, null);
 
+      // default branch merge queue status is cached during initRepo
       await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+    });
+
+    it('uses merge queue status fetched during initRepo for the default branch', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo', { mergeQueue: { id: 'queue' } });
+      await github.initRepo({ repository: 'some/repo' });
+      prListMock(scope);
+      mergeQueueCheckMock(scope, true);
+
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'master'),
+      ).rejects.toThrow(PR_ALREADY_IN_MERGE_QUEUE);
     });
 
     it('does nothing if there is no open PR for the branch', async () => {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -4666,6 +4666,17 @@ describe('modules/platform/github/index', () => {
         .reply(200, prs);
     }
 
+    function mergeQueueEnabledMock(
+      scope: httpMock.Scope,
+      mergeQueue: { id: string } | null = { id: 'queue' },
+    ): void {
+      scope.post('/graphql').reply(200, {
+        data: {
+          repository: { mergeQueue },
+        },
+      });
+    }
+
     function mergeQueueCheckMock(
       scope: httpMock.Scope,
       isInMergeQueue = false,
@@ -4679,34 +4690,66 @@ describe('modules/platform/github/index', () => {
       });
     }
 
+    it('does nothing if merge queue is not enabled for the base branch', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope, null);
+
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
+
+      // cached, no new request
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
+    });
+
+    it('defaults to the default branch when no base branch is given', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope, null);
+
+      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+    });
+
     it('does nothing if there is no open PR for the branch', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope);
       prListMock(scope, []);
 
-      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
     });
 
     it('does nothing if the PR is not in the merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope);
       prListMock(scope);
       mergeQueueCheckMock(scope);
 
-      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
     });
 
     it('throws if the PR is in the merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope);
       prListMock(scope);
       mergeQueueCheckMock(scope, true);
 
       await expect(
-        github.assertPrNotInMergeQueue('somebranch'),
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
       ).rejects.toThrow(PR_ALREADY_IN_MERGE_QUEUE);
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
@@ -4714,16 +4757,52 @@ describe('modules/platform/github/index', () => {
       );
     });
 
+    it('assumes merge queue is enabled if the base branch check returns errors', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      scope
+        .post('/graphql')
+        .reply(200, { errors: [{ message: 'some error' }] });
+      prListMock(scope);
+      mergeQueueCheckMock(scope, true);
+
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).rejects.toThrow(PR_ALREADY_IN_MERGE_QUEUE);
+
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { baseBranch: 'main', errors: [{ message: 'some error' }] },
+        'Failed to fetch merge queue status - assuming merge queue is enabled',
+      );
+    });
+
+    it('assumes merge queue is enabled if the base branch check fails', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      await github.initRepo({ repository: 'some/repo' });
+      scope.post('/graphql').reply(500);
+      prListMock(scope);
+      mergeQueueCheckMock(scope, true);
+
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).rejects.toThrow(PR_ALREADY_IN_MERGE_QUEUE);
+    });
+
     it('logs if the merge queue check returns errors', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope);
       prListMock(scope);
       scope
         .post('/graphql')
         .reply(200, { errors: [{ message: 'some error' }] });
 
-      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
 
       expect(logger.logger.debug).toHaveBeenCalledWith(
         { prNo: 1234, errors: [{ message: 'some error' }] },
@@ -4735,10 +4814,13 @@ describe('modules/platform/github/index', () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope);
       prListMock(scope);
       scope.post('/graphql').reply(500);
 
-      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
     });
 
     it('skips merge queue check on GHE <3.12.0', async () => {
@@ -4757,7 +4839,9 @@ describe('modules/platform/github/index', () => {
       });
       await github.initRepo({ repository: 'some/repo' });
 
-      await expect(github.assertPrNotInMergeQueue('somebranch')).toResolve();
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
     });
   });
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -77,15 +77,13 @@ import { smartTruncate } from '../utils/pr-body.ts';
 import { remoteBranchExists } from './branch.ts';
 import { coerceRestPr, githubApi, mapMergeStartegy } from './common.ts';
 import {
-  dequeuePullRequestMutation,
   enableAutoMergeMutation,
   getIssuesQuery,
-  prIsInMergeQueueQuery,
   repoInfoQuery,
 } from './graphql.ts';
 import { GithubIssueCache } from './issue.ts';
 import { massageMarkdownLinks } from './massage-markdown-links.ts';
-import { getPrCache, updatePrCache } from './pr.ts';
+import { dequeuePr, getPrCache, updatePrCache } from './pr.ts';
 import {
   GithubBranchProtection,
   GithubBranchRulesets,
@@ -1991,50 +1989,13 @@ export async function tryDequeuePr(branchName: string): Promise<void> {
   if (!pr) {
     return;
   }
-  const prNo = pr.number;
 
-  try {
-    const res = await githubApi.requestGraphql<{
-      repository: {
-        pullRequest: { id: string; isInMergeQueue: boolean } | null;
-      };
-    }>(prIsInMergeQueueQuery, {
-      variables: {
-        owner: config.repositoryOwner,
-        name: config.repositoryName,
-        number: prNo,
-      },
-      readOnly: true,
-      count: 1, // bypass graphql check
-    });
-    if (res?.errors) {
-      logger.debug(
-        { prNo, errors: res.errors },
-        'Failed to fetch PR merge queue status',
-      );
-      return;
-    }
-    const pullRequest = res?.data?.repository?.pullRequest;
-    if (!pullRequest?.isInMergeQueue) {
-      return;
-    }
-    logger.debug(`PR #${prNo} is in the merge queue - dequeueing before push`);
-    const dequeueRes = await githubApi.requestGraphql(
-      dequeuePullRequestMutation,
-      {
-        variables: { pullRequestId: pullRequest.id },
-        count: 1, // bypass graphql check
-      },
-    );
-    if (dequeueRes?.errors) {
-      logger.debug(
-        { prNo, errors: dequeueRes.errors },
-        'Failed to dequeue PR from merge queue',
-      );
-    }
-  } catch (err) {
-    logger.debug({ prNo, err }, 'Error dequeueing PR from merge queue');
-  }
+  await dequeuePr(
+    githubApi,
+    config.repositoryOwner,
+    config.repositoryName,
+    pr.number,
+  );
 }
 
 export async function updatePr({

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -79,6 +79,7 @@ import { coerceRestPr, githubApi, mapMergeStartegy } from './common.ts';
 import {
   enableAutoMergeMutation,
   getIssuesQuery,
+  prIsInMergeQueueQuery,
   repoInfoQuery,
 } from './graphql.ts';
 import { GithubIssueCache } from './issue.ts';
@@ -1974,6 +1975,43 @@ export async function createPr({
   return result;
 }
 
+async function isPrInMergeQueue(prNo: number): Promise<boolean> {
+  // TODO #22198
+  // semver not null safe, accepts null and undefined
+  if (
+    platformConfig.isGhe &&
+    semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
+  ) {
+    // Merge queues are only supported on GHES >=3.12.0
+    return false;
+  }
+
+  try {
+    const res = await githubApi.requestGraphql<{
+      repository: { pullRequest: { isInMergeQueue: boolean } | null };
+    }>(prIsInMergeQueueQuery, {
+      variables: {
+        owner: config.repositoryOwner,
+        name: config.repositoryName,
+        number: prNo,
+      },
+      readOnly: true,
+      count: 1, // bypass graphql check
+    });
+    if (res?.errors) {
+      logger.debug(
+        { prNo, errors: res.errors },
+        'Failed to fetch PR merge queue status',
+      );
+      return false;
+    }
+    return res?.data?.repository?.pullRequest?.isInMergeQueue === true;
+  } catch (err) {
+    logger.debug({ prNo, err }, 'Error fetching PR merge queue status');
+    return false;
+  }
+}
+
 export async function updatePr({
   number: prNo,
   prTitle: title,
@@ -1984,6 +2022,10 @@ export async function updatePr({
   targetBranch,
 }: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
+  if (await isPrInMergeQueue(prNo)) {
+    logger.debug(`PR #${prNo} is in the merge queue - skipping update`);
+    return;
+  }
   const body = sanitize(rawBody);
   const patchBody: any = { title };
   // v8 ignore else -- TODO: add test #40625

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -77,6 +77,7 @@ import { smartTruncate } from '../utils/pr-body.ts';
 import { remoteBranchExists } from './branch.ts';
 import { coerceRestPr, githubApi, mapMergeStartegy } from './common.ts';
 import {
+  dequeuePullRequestMutation,
   enableAutoMergeMutation,
   getIssuesQuery,
   prIsInMergeQueueQuery,
@@ -1975,7 +1976,7 @@ export async function createPr({
   return result;
 }
 
-async function isPrInMergeQueue(prNo: number): Promise<boolean> {
+async function tryDequeuePr(prNo: number): Promise<void> {
   // TODO #22198
   // semver not null safe, accepts null and undefined
   if (
@@ -1983,12 +1984,14 @@ async function isPrInMergeQueue(prNo: number): Promise<boolean> {
     semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
   ) {
     // Merge queues are only supported on GHES >=3.12.0
-    return false;
+    return;
   }
 
   try {
     const res = await githubApi.requestGraphql<{
-      repository: { pullRequest: { isInMergeQueue: boolean } | null };
+      repository: {
+        pullRequest: { id: string; isInMergeQueue: boolean } | null;
+      };
     }>(prIsInMergeQueueQuery, {
       variables: {
         owner: config.repositoryOwner,
@@ -2003,12 +2006,30 @@ async function isPrInMergeQueue(prNo: number): Promise<boolean> {
         { prNo, errors: res.errors },
         'Failed to fetch PR merge queue status',
       );
-      return false;
+      return;
     }
-    return res?.data?.repository?.pullRequest?.isInMergeQueue === true;
+    const pullRequest = res?.data?.repository?.pullRequest;
+    if (!pullRequest?.isInMergeQueue) {
+      return;
+    }
+    logger.debug(
+      `PR #${prNo} is in the merge queue - dequeueing before update`,
+    );
+    const dequeueRes = await githubApi.requestGraphql(
+      dequeuePullRequestMutation,
+      {
+        variables: { pullRequestId: pullRequest.id },
+        count: 1, // bypass graphql check
+      },
+    );
+    if (dequeueRes?.errors) {
+      logger.debug(
+        { prNo, errors: dequeueRes.errors },
+        'Failed to dequeue PR from merge queue',
+      );
+    }
   } catch (err) {
-    logger.debug({ prNo, err }, 'Error fetching PR merge queue status');
-    return false;
+    logger.debug({ prNo, err }, 'Error dequeueing PR from merge queue');
   }
 }
 
@@ -2022,10 +2043,8 @@ export async function updatePr({
   targetBranch,
 }: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
-  if (await isPrInMergeQueue(prNo)) {
-    logger.debug(`PR #${prNo} is in the merge queue - skipping update`);
-    return;
-  }
+  // a queued PR could otherwise merge before the update takes effect
+  await tryDequeuePr(prNo);
   const body = sanitize(rawBody);
   const patchBody: any = { title };
   // v8 ignore else -- TODO: add test #40625

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -563,6 +563,18 @@ export async function initRepo({
       );
     }
 
+    // GitHub Enterprise Server <3.12.0 doesn't support merge queues
+    if (
+      platformConfig.isGhe &&
+      // semver not null safe, accepts null and undefined
+      semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
+    ) {
+      infoQuery = infoQuery.replace(
+        /\n\s*mergeQueue\s*\{\s*id\s*\}\s*\n/,
+        '\n',
+      );
+    }
+
     const res = await githubApi.requestGraphql<{
       repository: GhRepo;
     }>(infoQuery, {
@@ -632,6 +644,9 @@ export async function initRepo({
     config.autoMergeAllowed = repo.autoMergeAllowed;
     config.hasIssuesEnabled = repo.hasIssuesEnabled;
     config.hasVulnerabilityAlertsEnabled = repo.hasVulnerabilityAlertsEnabled;
+    config.mergeQueueEnabled[config.defaultBranch] = isNonEmptyObject(
+      repo.mergeQueue,
+    );
 
     const recentIssues = Issue.array()
       .catch([])

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -81,6 +81,7 @@ import {
   enableAutoMergeMutation,
   getIssuesQuery,
   repoInfoQuery,
+  repoMergeQueueQuery,
 } from './graphql.ts';
 import { GithubIssueCache } from './issue.ts';
 import { massageMarkdownLinks } from './massage-markdown-links.ts';
@@ -525,6 +526,7 @@ export async function initRepo({
     cloneSubmodules,
     cloneSubmodulesFilter,
     ignorePrAuthor: GlobalConfig.get('ignorePrAuthor'),
+    mergeQueueEnabled: {},
   } as any;
   const opts = hostRules.find({
     hostType: 'github',
@@ -1975,9 +1977,12 @@ export async function createPr({
   return result;
 }
 
-export async function assertPrNotInMergeQueue(
-  branchName: string,
-): Promise<void> {
+async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
+  const cachedResult = config.mergeQueueEnabled[baseBranch];
+  if (cachedResult !== undefined) {
+    return cachedResult;
+  }
+
   // TODO #22198
   // semver not null safe, accepts null and undefined
   if (
@@ -1985,6 +1990,49 @@ export async function assertPrNotInMergeQueue(
     semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
   ) {
     // Merge queues are only supported on GHES >=3.12.0
+    config.mergeQueueEnabled[baseBranch] = false;
+    return false;
+  }
+
+  // Assume enabled unless proven otherwise, so the merge queue check is not
+  // skipped by mistake
+  let result = true;
+  try {
+    const res = await githubApi.requestGraphql<{
+      repository: { mergeQueue: { id: string } | null };
+    }>(repoMergeQueueQuery, {
+      variables: {
+        owner: config.repositoryOwner,
+        name: config.repositoryName,
+        branch: baseBranch,
+      },
+      readOnly: true,
+      count: 1, // bypass graphql check
+    });
+    if (res?.errors) {
+      logger.debug(
+        { baseBranch, errors: res.errors },
+        'Failed to fetch merge queue status - assuming merge queue is enabled',
+      );
+    } else {
+      result = isNonEmptyObject(res?.data?.repository?.mergeQueue);
+    }
+  } catch (err) {
+    logger.debug(
+      { baseBranch, err },
+      'Error fetching merge queue status - assuming merge queue is enabled',
+    );
+  }
+
+  config.mergeQueueEnabled[baseBranch] = result;
+  return result;
+}
+
+export async function assertPrNotInMergeQueue(
+  branchName: string,
+  baseBranch?: string,
+): Promise<void> {
+  if (!(await isMergeQueueEnabled(baseBranch ?? config.defaultBranch))) {
     return;
   }
 

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -6,6 +6,7 @@ import {
   PLATFORM_INTEGRATION_UNAUTHORIZED,
   PLATFORM_RATE_LIMIT_EXCEEDED,
   PLATFORM_UNKNOWN_ERROR,
+  PR_ALREADY_IN_MERGE_QUEUE,
   REPOSITORY_ACCESS_FORBIDDEN,
   REPOSITORY_ARCHIVED,
   REPOSITORY_BLOCKED,
@@ -83,7 +84,7 @@ import {
 } from './graphql.ts';
 import { GithubIssueCache } from './issue.ts';
 import { massageMarkdownLinks } from './massage-markdown-links.ts';
-import { dequeuePr, getPrCache, updatePrCache } from './pr.ts';
+import { getPrCache, isPrInMergeQueue, updatePrCache } from './pr.ts';
 import {
   GithubBranchProtection,
   GithubBranchRulesets,
@@ -1974,7 +1975,9 @@ export async function createPr({
   return result;
 }
 
-export async function tryDequeuePr(branchName: string): Promise<void> {
+export async function assertPrNotInMergeQueue(
+  branchName: string,
+): Promise<void> {
   // TODO #22198
   // semver not null safe, accepts null and undefined
   if (
@@ -1990,12 +1993,17 @@ export async function tryDequeuePr(branchName: string): Promise<void> {
     return;
   }
 
-  await dequeuePr(
-    githubApi,
-    config.repositoryOwner,
-    config.repositoryName,
-    pr.number,
-  );
+  if (
+    await isPrInMergeQueue(
+      githubApi,
+      config.repositoryOwner,
+      config.repositoryName,
+      pr.number,
+    )
+  ) {
+    logger.debug(`PR #${pr.number} is in the merge queue - aborting push`);
+    throw new Error(PR_ALREADY_IN_MERGE_QUEUE);
+  }
 }
 
 export async function updatePr({

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1976,7 +1976,7 @@ export async function createPr({
   return result;
 }
 
-async function tryDequeuePr(prNo: number): Promise<void> {
+export async function tryDequeuePr(branchName: string): Promise<void> {
   // TODO #22198
   // semver not null safe, accepts null and undefined
   if (
@@ -1986,6 +1986,12 @@ async function tryDequeuePr(prNo: number): Promise<void> {
     // Merge queues are only supported on GHES >=3.12.0
     return;
   }
+
+  const pr = await findPr({ branchName, state: 'open' });
+  if (!pr) {
+    return;
+  }
+  const prNo = pr.number;
 
   try {
     const res = await githubApi.requestGraphql<{
@@ -2012,9 +2018,7 @@ async function tryDequeuePr(prNo: number): Promise<void> {
     if (!pullRequest?.isInMergeQueue) {
       return;
     }
-    logger.debug(
-      `PR #${prNo} is in the merge queue - dequeueing before update`,
-    );
+    logger.debug(`PR #${prNo} is in the merge queue - dequeueing before push`);
     const dequeueRes = await githubApi.requestGraphql(
       dequeuePullRequestMutation,
       {
@@ -2043,9 +2047,6 @@ export async function updatePr({
   targetBranch,
 }: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
-  // a queued PR could otherwise merge before the update takes effect
-  // will be re-queued if automerge is enabled and the PR is still mergeable after the update
-  await tryDequeuePr(prNo);
   const body = sanitize(rawBody);
   const patchBody: any = { title };
   // v8 ignore else -- TODO: add test #40625

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -2044,6 +2044,7 @@ export async function updatePr({
 }: UpdatePrConfig): Promise<void> {
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
   // a queued PR could otherwise merge before the update takes effect
+  // will be re-queued if automerge is enabled and the PR is still mergeable after the update
   await tryDequeuePr(prNo);
   const body = sanitize(rawBody);
   const patchBody: any = { title };

--- a/lib/modules/platform/github/pr.ts
+++ b/lib/modules/platform/github/pr.ts
@@ -13,10 +13,7 @@ import type {
 import { parseLinkHeader } from '../../../util/url.ts';
 import { ApiCache } from './api-cache.ts';
 import { coerceRestPr } from './common.ts';
-import {
-  dequeuePullRequestMutation,
-  prIsInMergeQueueQuery,
-} from './graphql.ts';
+import { prIsInMergeQueueQuery } from './graphql.ts';
 import type { ApiPageCache, GhPr, GhRestPr } from './types.ts';
 
 function getPrApiCache(): ApiCache<GhPr> {
@@ -202,19 +199,19 @@ export function updatePrCache(pr: GhPr): void {
 }
 
 /**
- * Cancel the PR's merge queue entry, if it has one.
- * Fails open: errors are logged at debug level and swallowed.
+ * Check whether the PR is currently in the merge queue.
+ * Fails open: errors are logged at debug level and treated as "not queued".
  */
-export async function dequeuePr(
+export async function isPrInMergeQueue(
   http: GithubHttp,
   owner: string,
   name: string,
   prNo: number,
-): Promise<void> {
+): Promise<boolean> {
   try {
     const res = await http.requestGraphql<{
       repository: {
-        pullRequest: { id: string; isInMergeQueue: boolean } | null;
+        pullRequest: { isInMergeQueue: boolean } | null;
       };
     }>(prIsInMergeQueueQuery, {
       variables: { owner, name, number: prNo },
@@ -226,24 +223,11 @@ export async function dequeuePr(
         { prNo, errors: res.errors },
         'Failed to fetch PR merge queue status',
       );
-      return;
+      return false;
     }
-    const pullRequest = res?.data?.repository?.pullRequest;
-    if (!pullRequest?.isInMergeQueue) {
-      return;
-    }
-    logger.debug(`PR #${prNo} is in the merge queue - dequeueing before push`);
-    const dequeueRes = await http.requestGraphql(dequeuePullRequestMutation, {
-      variables: { pullRequestId: pullRequest.id },
-      count: 1, // bypass graphql check
-    });
-    if (dequeueRes?.errors) {
-      logger.debug(
-        { prNo, errors: dequeueRes.errors },
-        'Failed to dequeue PR from merge queue',
-      );
-    }
+    return res?.data?.repository?.pullRequest?.isInMergeQueue === true;
   } catch (err) {
-    logger.debug({ prNo, err }, 'Error dequeueing PR from merge queue');
+    logger.debug({ prNo, err }, 'Error fetching PR merge queue status');
+    return false;
   }
 }

--- a/lib/modules/platform/github/pr.ts
+++ b/lib/modules/platform/github/pr.ts
@@ -13,6 +13,10 @@ import type {
 import { parseLinkHeader } from '../../../util/url.ts';
 import { ApiCache } from './api-cache.ts';
 import { coerceRestPr } from './common.ts';
+import {
+  dequeuePullRequestMutation,
+  prIsInMergeQueueQuery,
+} from './graphql.ts';
 import type { ApiPageCache, GhPr, GhRestPr } from './types.ts';
 
 function getPrApiCache(): ApiCache<GhPr> {
@@ -195,4 +199,51 @@ export async function getPrCache(
 export function updatePrCache(pr: GhPr): void {
   const cache = getPrApiCache();
   cache.updateItem(pr);
+}
+
+/**
+ * Cancel the PR's merge queue entry, if it has one.
+ * Fails open: errors are logged at debug level and swallowed.
+ */
+export async function dequeuePr(
+  http: GithubHttp,
+  owner: string,
+  name: string,
+  prNo: number,
+): Promise<void> {
+  try {
+    const res = await http.requestGraphql<{
+      repository: {
+        pullRequest: { id: string; isInMergeQueue: boolean } | null;
+      };
+    }>(prIsInMergeQueueQuery, {
+      variables: { owner, name, number: prNo },
+      readOnly: true,
+      count: 1, // bypass graphql check
+    });
+    if (res?.errors) {
+      logger.debug(
+        { prNo, errors: res.errors },
+        'Failed to fetch PR merge queue status',
+      );
+      return;
+    }
+    const pullRequest = res?.data?.repository?.pullRequest;
+    if (!pullRequest?.isInMergeQueue) {
+      return;
+    }
+    logger.debug(`PR #${prNo} is in the merge queue - dequeueing before push`);
+    const dequeueRes = await http.requestGraphql(dequeuePullRequestMutation, {
+      variables: { pullRequestId: pullRequest.id },
+      count: 1, // bypass graphql check
+    });
+    if (dequeueRes?.errors) {
+      logger.debug(
+        { prNo, errors: dequeueRes.errors },
+        'Failed to dequeue PR from merge queue',
+      );
+    }
+  } catch (err) {
+    logger.debug({ prNo, err }, 'Error dequeueing PR from merge queue');
+  }
 }

--- a/lib/modules/platform/github/scm.spec.ts
+++ b/lib/modules/platform/github/scm.spec.ts
@@ -1,4 +1,5 @@
 import { fakeSha, git } from '~test/util.ts';
+import { PR_ALREADY_IN_MERGE_QUEUE } from '../../../constants/error-messages.ts';
 import type { CommitFilesConfig } from '../../../util/git/types.ts';
 import * as _github from './index.ts';
 import { GithubScm } from './scm.ts';
@@ -74,9 +75,24 @@ describe('modules/platform/github/scm', () => {
     });
   });
 
-  it('dequeues the branch PR from the merge queue before committing', async () => {
+  it('checks the merge queue before committing', async () => {
     await githubScm.commitAndPush(commitObj);
 
-    expect(github.tryDequeuePr).toHaveBeenCalledExactlyOnceWith('branch');
+    expect(github.assertPrNotInMergeQueue).toHaveBeenCalledExactlyOnceWith(
+      'branch',
+    );
+  });
+
+  it('does not commit if the branch PR is in the merge queue', async () => {
+    github.assertPrNotInMergeQueue.mockRejectedValueOnce(
+      new Error(PR_ALREADY_IN_MERGE_QUEUE),
+    );
+
+    await expect(githubScm.commitAndPush(commitObj)).rejects.toThrow(
+      PR_ALREADY_IN_MERGE_QUEUE,
+    );
+
+    expect(git.commitFiles).not.toHaveBeenCalled();
+    expect(github.commitFiles).not.toHaveBeenCalled();
   });
 });

--- a/lib/modules/platform/github/scm.spec.ts
+++ b/lib/modules/platform/github/scm.spec.ts
@@ -80,6 +80,7 @@ describe('modules/platform/github/scm', () => {
 
     expect(github.assertPrNotInMergeQueue).toHaveBeenCalledExactlyOnceWith(
       'branch',
+      'main',
     );
   });
 

--- a/lib/modules/platform/github/scm.spec.ts
+++ b/lib/modules/platform/github/scm.spec.ts
@@ -73,4 +73,10 @@ describe('modules/platform/github/scm', () => {
       platformCommit: 'auto',
     });
   });
+
+  it('dequeues the branch PR from the merge queue before committing', async () => {
+    await githubScm.commitAndPush(commitObj);
+
+    expect(github.tryDequeuePr).toHaveBeenCalledExactlyOnceWith('branch');
+  });
 });

--- a/lib/modules/platform/github/scm.ts
+++ b/lib/modules/platform/github/scm.ts
@@ -14,7 +14,10 @@ export class GithubScm extends DefaultGitScm {
     }
 
     // a queued PR could otherwise merge before the pushed changes take effect
-    await assertPrNotInMergeQueue(commitConfig.branchName);
+    await assertPrNotInMergeQueue(
+      commitConfig.branchName,
+      commitConfig.baseBranch,
+    );
 
     return platformCommit === 'enabled'
       ? commitFiles(commitConfig)

--- a/lib/modules/platform/github/scm.ts
+++ b/lib/modules/platform/github/scm.ts
@@ -2,7 +2,7 @@ import * as git from '../../../util/git/index.ts';
 import type { CommitFilesConfig } from '../../../util/git/types.ts';
 import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { DefaultGitScm } from '../default-scm.ts';
-import { commitFiles, isGHApp, tryDequeuePr } from './index.ts';
+import { assertPrNotInMergeQueue, commitFiles, isGHApp } from './index.ts';
 
 export class GithubScm extends DefaultGitScm {
   override async commitAndPush(
@@ -13,9 +13,8 @@ export class GithubScm extends DefaultGitScm {
       platformCommit = 'enabled';
     }
 
-    // a queued PR could otherwise merge before the pushed changes take effect;
-    // it will be re-queued if automerge is enabled and the PR is still mergeable
-    await tryDequeuePr(commitConfig.branchName);
+    // a queued PR could otherwise merge before the pushed changes take effect
+    await assertPrNotInMergeQueue(commitConfig.branchName);
 
     return platformCommit === 'enabled'
       ? commitFiles(commitConfig)

--- a/lib/modules/platform/github/scm.ts
+++ b/lib/modules/platform/github/scm.ts
@@ -2,16 +2,20 @@ import * as git from '../../../util/git/index.ts';
 import type { CommitFilesConfig } from '../../../util/git/types.ts';
 import type { LongCommitSha } from '../../../util/schema-utils/git.ts';
 import { DefaultGitScm } from '../default-scm.ts';
-import { commitFiles, isGHApp } from './index.ts';
+import { commitFiles, isGHApp, tryDequeuePr } from './index.ts';
 
 export class GithubScm extends DefaultGitScm {
-  override commitAndPush(
+  override async commitAndPush(
     commitConfig: CommitFilesConfig,
   ): Promise<LongCommitSha | null> {
     let platformCommit = commitConfig.platformCommit;
     if (platformCommit === 'auto' && isGHApp()) {
       platformCommit = 'enabled';
     }
+
+    // a queued PR could otherwise merge before the pushed changes take effect;
+    // it will be re-queued if automerge is enabled and the PR is still mergeable
+    await tryDequeuePr(commitConfig.branchName);
 
     return platformCommit === 'enabled'
       ? commitFiles(commitConfig)

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -120,6 +120,7 @@ export interface LocalRepoConfig {
   autoMergeAllowed: boolean;
   hasIssuesEnabled: boolean;
   hasVulnerabilityAlertsEnabled: boolean;
+  mergeQueueEnabled: Record<string, boolean>;
 }
 
 export interface GhRepo {

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -135,6 +135,7 @@ export interface GhRepo {
   autoMergeAllowed: boolean;
   hasIssuesEnabled: boolean;
   hasVulnerabilityAlertsEnabled: boolean;
+  mergeQueue?: { id: string } | null;
   mergeCommitAllowed: boolean;
   rebaseMergeAllowed: boolean;
   squashMergeAllowed: boolean;

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../config/types.ts';
 import {
   MANAGER_LOCKFILE_ERROR,
+  PR_ALREADY_IN_MERGE_QUEUE,
   REPOSITORY_CHANGED,
 } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
@@ -1756,6 +1757,32 @@ describe('workers/repository/update/branch/index', () => {
         prNo: undefined,
         result: 'error',
       });
+    });
+
+    it('returns when the branch PR is in the merge queue', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>()],
+        }),
+      );
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>()],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      commit.commitFilesToBranch.mockRejectedValueOnce(
+        new Error(PR_ALREADY_IN_MERGE_QUEUE),
+      );
+      const processBranchResult = await branchWorker.processBranch(config);
+      expect(processBranchResult).toEqual({
+        branchExists: true,
+        commitSha: null,
+        prNo: undefined,
+        result: 'done',
+      });
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Branch PR is in the merge queue - skipping branch update',
+      );
     });
 
     it('throws and swallows branch errors', async () => {

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -13,6 +13,7 @@ import {
   PLATFORM_BAD_CREDENTIALS,
   PLATFORM_INTEGRATION_UNAUTHORIZED,
   PLATFORM_RATE_LIMIT_EXCEEDED,
+  PR_ALREADY_IN_MERGE_QUEUE,
   REPOSITORY_CHANGED,
   SYSTEM_INSUFFICIENT_DISK_SPACE,
   TEMPORARY_ERROR,
@@ -924,6 +925,15 @@ export async function processBranch(
     if (err.message === MANAGER_LOCKFILE_ERROR) {
       logger.debug('Passing lockfile-error up');
       throw err;
+    }
+    if (err.message === PR_ALREADY_IN_MERGE_QUEUE) {
+      logger.debug('Branch PR is in the merge queue - skipping branch update');
+      return {
+        branchExists,
+        prNo: branchPr?.number,
+        result: 'done',
+        commitSha,
+      };
     }
     /* v8 ignore if -- needs test */
     if (err.message?.includes('space left on device')) {


### PR DESCRIPTION
## Changes

`GithubScm.commitAndPush()` now checks whether the branch's open PR is currently in a merge queue (via the GraphQL `isInMergeQueue` field), and if so throws a new `PR_ALREADY_IN_MERGE_QUEUE` error instead of pushing. `processBranch()` handles this error and returns gracefully (`result: 'done'`), so Renovate does not update a branch whose PR is queued for merging.

Pushing does not kick the PR out of the merge queue, but the final merge uses the PR title / commit message at merge time - so updating a queued PR could produce a merged commit message that no longer matches the changes that actually got merged. See #41903.

Details:

- New `prIsInMergeQueueQuery` GraphQL query (`graphql.ts`), since merge queue status is not exposed via the REST API; `isPrInMergeQueue()` in `pr.ts` wraps it.
- New `assertPrNotInMergeQueue(branchName, baseBranch)` in `index.ts`, called by `GithubScm.commitAndPush()`. It looks up the branch's open PR from the PR cache and throws `PR_ALREADY_IN_MERGE_QUEUE` if the PR is queued.
  - Merge queue enablement is checked per base branch and cached in `config.mergeQueueEnabled`, following the `getBranchForceRebase` pattern - repos/branches without a merge queue skip the per-PR check entirely.
  - For the default branch, enablement comes for free: `repoInfoQuery` now includes `mergeQueue { id }`, so `initRepo` seeds the cache without any extra API call. Only non-default base branches use the lazy `repoMergeQueueQuery` (`Repository.mergeQueue(branch:)`), once per branch per run.
  - The check is skipped on GHES <3.12.0 (no merge queue support): the `mergeQueue` field is stripped from `repoInfoQuery` like other unsupported fields, and the per-branch check short-circuits, following the existing GHE version guard patterns.
  - It fails open: on GraphQL errors or request failures (in both the enablement and PR status checks) it logs at debug level and continues as if a merge queue may exist, so the safety check is not skipped by mistake.
- New `PR_ALREADY_IN_MERGE_QUEUE` constant in `lib/constants/error-messages.ts`.
- `processBranch()` (`lib/workers/repository/update/branch/index.ts`) catches the error and returns `{ result: 'done' }` instead of treating it as a branch error.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41903 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, tests, and this PR description were written by Claude Code (model: Claude Fable 5) under the direction of @viceice.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @viceice will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)
