### PR TITLE
docs(minimum-release-age): filter disabled dependencies from timestamp query

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -441,6 +441,7 @@ jq '
     | to_entries[] as $ent
     | $ent.value[] as $group
     | $group.deps[] as $dep
+    | select($dep.enabled != false)
     | select($dep.currentVersionTimestamp == null)
     | {
         manager: $ent.key,


### PR DESCRIPTION
## Changes

The documented `jq` query now excludes dependencies with `enabled: false` from `missingCurrentVersionTimestamps`. Dependencies where `enabled` is unset, `true`, or `null` remain in the result, and the `missingReleaseTimestamps` query is unchanged.

I ran the query against the redacted log from discussion #40720: a disabled dependency appears with the current query and is excluded with this change. A smaller sample also covered all four `enabled` states. The targeted check, Markdown lint, fenced-code check, docs tests, and docs build pass.

## Context

- [x] This closes an existing Issue, Closes: #40725
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5) inspected the repository guidance, drafted the `jq` change, and ran the validation listed above. @Boulea7 reviewed the change and this PR text before publication.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @Boulea7 will read and reply directly.
- [x] An agent will draft replies and @Boulea7 will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: the reporter's repository is not public; its redacted log sample is available in https://github.com/renovatebot/renovate/discussions/40720.
