### PR TITLE
feat(config): support base branch patterns via CLI

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1238,7 +1238,6 @@ const options: Readonly<RenovateOptions>[] = [
     type: 'array',
     subType: 'string',
     stage: 'package',
-    cli: false,
     patternMatch: true,
   },
   {

--- a/lib/workers/global/config/parse/cli.spec.ts
+++ b/lib/workers/global/config/parse/cli.spec.ts
@@ -81,6 +81,13 @@ describe('workers/global/config/parse/cli', () => {
       expect(cli.getConfig(argv)).toEqual({ labels: ['a', 'b', 'c'] });
     });
 
+    it('supports base branch patterns', () => {
+      argv.push('--base-branch-patterns=main,develop');
+      expect(cli.getConfig(argv)).toEqual({
+        baseBranchPatterns: ['main', 'develop'],
+      });
+    });
+
     it('supports string', () => {
       argv.push('--token=a');
       expect(cli.getConfig(argv)).toEqual({ token: 'a' });


### PR DESCRIPTION
## Changes

Expose the existing `baseBranchPatterns` option through the CLI as `--base-branch-patterns`. Comma-separated values use Renovate's existing array parsing, so `main,develop` becomes two patterns.

Add a CLI parsing regression test and verify the generated help entry.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #11242
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5) was used to inspect the CLI/config metadata, write the focused change and regression test, and run the verification commands. I reviewed the diff and validation results before submission.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @Boulea7 will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

The existing configuration documentation already covers `baseBranchPatterns`; CLI help is generated from the option metadata.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A — this is CLI parsing behavior covered by unit tests and generated help verification.
