### PR TITLE
ci: auto-label PRs that have been dequeued from the Merge Queue

### DIFF
--- a/.github/workflows/find-dequeued-merge-queue-prs.yml
+++ b/.github/workflows/find-dequeued-merge-queue-prs.yml
@@ -1,0 +1,29 @@
+name: 'Label PRs dequeued from the merge queue'
+
+on:
+  schedule:
+    # Run every 15 minutes
+    - cron: '*/15 * * * *'
+  # Or when manually requested
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  label-dequeued-prs:
+    runs-on: ubuntu-slim
+    if: github.repository == 'renovatebot/renovate'
+
+    permissions:
+      pull-requests: write
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Find and label PRs dequeued from the merge queue
+        run: bash ./tools/find-dequeued-merge-queue-prs.sh

--- a/tools/find-dequeued-merge-queue-prs.sh
+++ b/tools/find-dequeued-merge-queue-prs.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# Find open, approved PRs which have been dequeued (removed) from the merge queue
+# but aren't currently back in the queue, and label them so they're easier to spot
+# and requeue.
+#
+# See: https://www.jvt.me/posts/2026/08/11/github-merge-queue-prs/
+
+REPO='renovatebot/renovate'
+LABEL='status:merge-queue-dequeued'
+
+QUERY='
+query {
+  search(query: "repo:'"$REPO"' is:pr is:open review:approved", type: ISSUE, first: 50) {
+    nodes {
+      ... on PullRequest {
+        number
+        mergeQueueEntry {
+          id
+        }
+        labels(first: 50) {
+          nodes {
+            name
+          }
+        }
+        timelineItems(last: 1, itemTypes: [REMOVED_FROM_MERGE_QUEUE_EVENT]) {
+          nodes {
+            ... on RemovedFromMergeQueueEvent {
+              reason
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+RESULT=$(gh api graphql -f query="$QUERY") || { echo "Failed to query GraphQL API"; exit 1; }
+
+# PRs which: have been removed from the queue, aren't currently re-queued, and don't already have the label
+DEQUEUED_PRS=$(echo "$RESULT" | jq --arg label "$LABEL" '
+  [.data.search.nodes[]
+    | select(.mergeQueueEntry == null)
+    | select(.timelineItems.nodes | length > 0)
+    | select([.labels.nodes[].name] | index($label) | not)
+    | {number, reason: .timelineItems.nodes[0].reason}]') || { echo "Failed to parse GraphQL response"; exit 1; }
+
+COUNT=$(echo "$DEQUEUED_PRS" | jq 'length')
+
+if [ "$COUNT" -eq 0 ]; then
+    echo "No newly dequeued PRs found."
+    exit 0
+fi
+
+echo "Found $COUNT PR(s) dequeued from the merge queue:"
+
+for NUMBER in $(echo "$DEQUEUED_PRS" | jq -r '.[].number'); do
+    REASON=$(echo "$DEQUEUED_PRS" | jq -r --argjson n "$NUMBER" '.[] | select(.number == $n) | .reason')
+    echo "- #$NUMBER (reason: $REASON)"
+    gh pr edit "$NUMBER" --repo "$REPO" --add-label "$LABEL" || { echo "Failed to label PR #$NUMBER"; exit 1; }
+done


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes



As a way to get better visibility for - predominantly - transient issues
GitHub are having, via [0] we can auto-label PRs, so they can then be
picked up by a maintainer.


We can use the `-slim` runners, as this doesn't need much compute, and
it reduces ours and GitHub's costs.


[0]: https://www.jvt.me/posts/2026/08/11/github-merge-queue-prs/





## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
