### PR TITLE
fix(manager/pre-commit): allow leading zeros in semver-coerced versioning for CalVer support

### DIFF
--- a/lib/modules/versioning/semver-coerced/index.spec.ts
+++ b/lib/modules/versioning/semver-coerced/index.spec.ts
@@ -9,6 +9,8 @@ describe('modules/versioning/semver-coerced/index', () => {
     it('should return true for non-strictly equal versions', () => {
       expect(semverCoerced.equals('v1.0', '1.0.0')).toBeTrue();
       expect(semverCoerced.equals('v1.0', 'v1.x')).toBeTrue();
+      expect(semverCoerced.equals('2026.08.07', '2026.8.7')).toBeTrue();
+      expect(semverCoerced.equals('1.1.1', '01.01.01')).toBeTrue();
     });
 
     it('should return false for non-equal versions', () => {
@@ -27,6 +29,7 @@ describe('modules/versioning/semver-coerced/index', () => {
 
     it('should return major version number for non-strict semver', () => {
       expect(semverCoerced.getMajor('v3.1')).toBe(3);
+      expect(semverCoerced.getMajor('2026.08.07')).toBe(2026);
     });
 
     it('invalid version', () => {
@@ -41,6 +44,7 @@ describe('modules/versioning/semver-coerced/index', () => {
 
     it('should return minor version number for non-strict semver', () => {
       expect(semverCoerced.getMinor('v3.1')).toBe(1);
+      expect(semverCoerced.getMinor('2026.08.07')).toBe(8);
     });
 
     it('invalid version', () => {
@@ -66,6 +70,7 @@ describe('modules/versioning/semver-coerced/index', () => {
       ${'two1.0'}       | ${0}
       ${'ver1.2.3'}     | ${3}
       ${'r3.0'}         | ${0}
+      ${'2026.08.07'}   | ${7}
       ${'abc'}          | ${null}
     `('getPatch("$version") === $expected', ({ version, expected }) => {
       expect(semverCoerced.getPatch(version)).toBe(expected);
@@ -75,14 +80,17 @@ describe('modules/versioning/semver-coerced/index', () => {
   describe('.isBreaking(current, version)', () => {
     it('should return false for patch updates', () => {
       expect(semverCoerced.isBreaking!('1.0', '1.0.1')).toBeFalse();
+      expect(semverCoerced.isBreaking!('2026.08.01', '2026.08.07')).toBeFalse();
     });
 
     it('should return false for minor updates', () => {
       expect(semverCoerced.isBreaking!('1.0', '1.1')).toBeFalse();
+      expect(semverCoerced.isBreaking!('2026.07.01', '2026.08.07')).toBeFalse();
     });
 
     it('should return true for major updates', () => {
       expect(semverCoerced.isBreaking!('1.0.0', '2')).toBeTrue();
+      expect(semverCoerced.isBreaking!('2025.07.01', '2026.08.07')).toBeTrue();
     });
 
     it('should return true for major updates from v0.x', () => {
@@ -101,6 +109,7 @@ describe('modules/versioning/semver-coerced/index', () => {
 
     it('should return true for non-strict semver', () => {
       expect(semverCoerced.isCompatible('v3.1.2-foo')).toBeTrue();
+      expect(semverCoerced.isCompatible('2026.08.07')).toBeTrue();
     });
 
     it('should return false for non-semver', () => {
@@ -113,8 +122,16 @@ describe('modules/versioning/semver-coerced/index', () => {
       expect(semverCoerced.isGreaterThan('1.0.2', '1.0.0')).toBeTrue();
     });
 
+    it('should return true for a greater version in non-strict semver', () => {
+      expect(semverCoerced.isGreaterThan('01.02.03', '01.01.01')).toBeTrue();
+    });
+
     it('should return false for lower version in strict semver', () => {
       expect(semverCoerced.isGreaterThan('3.1.2', '4.1.0')).toBeFalse();
+    });
+
+    it('should return false for lower version in non-strict semver', () => {
+      expect(semverCoerced.isGreaterThan('03.01.02', '04.01.01')).toBeFalse();
     });
 
     it('should return false if version cannot be coerced', () => {
@@ -127,8 +144,16 @@ describe('modules/versioning/semver-coerced/index', () => {
       expect(semverCoerced.isLessThanRange?.('1.0.2', '~2.0')).toBeTrue();
     });
 
+    it('should return true for a lower version in non-strict semver', () => {
+      expect(semverCoerced.isLessThanRange?.('01.01.02', '~2.0')).toBeTrue();
+    });
+
     it('should return false for in-range version in strict semver', () => {
       expect(semverCoerced.isLessThanRange?.('3.0.2', '~3.0')).toBeFalse();
+    });
+
+    it('should return false for in-range version in non-strict semver', () => {
+      expect(semverCoerced.isLessThanRange?.('03.01.02', '~3.0')).toBeFalse();
     });
 
     it('invalid version', () => {
@@ -140,11 +165,15 @@ describe('modules/versioning/semver-coerced/index', () => {
     it('returns true if naked version', () => {
       expect(semverCoerced.isSingleVersion('1.2.3')).toBeTrue();
       expect(semverCoerced.isSingleVersion('1.2.3-alpha.1')).toBeTrue();
+      expect(semverCoerced.isSingleVersion('01.02.03')).toBeTrue();
+      expect(semverCoerced.isSingleVersion('01.02.03-alpha.1')).toBeTrue();
     });
 
     it('returns false if equals', () => {
       expect(semverCoerced.isSingleVersion('=1.2.3')).toBeFalse();
       expect(semverCoerced.isSingleVersion('= 1.2.3')).toBeFalse();
+      expect(semverCoerced.isSingleVersion('=01.02.03')).toBeFalse();
+      expect(semverCoerced.isSingleVersion('= 01.02.03')).toBeFalse();
     });
 
     it('returns false when not version', () => {
@@ -156,6 +185,7 @@ describe('modules/versioning/semver-coerced/index', () => {
     it.each`
       version           | expected
       ${'1.0.0'}        | ${true}
+      ${'02026.08.07'}  | ${true}
       ${'v1.3.5'}       | ${true}
       ${'v2.1'}         | ${true}
       ${'3.4'}          | ${true}
@@ -180,8 +210,8 @@ describe('modules/versioning/semver-coerced/index', () => {
       expect(semverCoerced.isValid('version two')).toBeFalse();
     });
 
-    it('should return null for irregular version strings', () => {
-      expect(semverCoerced.isValid('17.04.0')).toBeFalse();
+    it('should support calendar versioning', () => {
+      expect(semverCoerced.isValid('17.04.0')).toBeTrue();
     });
 
     it('should support strict semver', () => {
@@ -222,6 +252,7 @@ describe('modules/versioning/semver-coerced/index', () => {
 
     it('should support non-strict versions', () => {
       expect(semverCoerced.isValid('v1.2')).toBeTrue();
+      expect(semverCoerced.isValid('2026.08.07')).toBeTrue();
     });
   });
 
@@ -232,10 +263,12 @@ describe('modules/versioning/semver-coerced/index', () => {
 
     it('should return true with non-strict version in range', () => {
       expect(semverCoerced.matches('v1.0', '1.0.0 || 1.0.1')).toBeTrue();
+      expect(semverCoerced.matches('01.01.01', '1.0.0 || 1.1.1')).toBeTrue();
     });
 
     it('should return false when version is not in range', () => {
       expect(semverCoerced.matches('1.2.3', '1.4.1 || 1.4.2')).toBeFalse();
+      expect(semverCoerced.matches('01.01.01', '1.0.0 || 1.0.1')).toBeFalse();
     });
 
     it('invalid version', () => {
@@ -254,6 +287,9 @@ describe('modules/versioning/semver-coerced/index', () => {
       expect(
         semverCoerced.getSatisfyingVersion(['v1.0', '1.0.4-foo'], '^1.0'),
       ).toBe('1.0.0');
+      expect(
+        semverCoerced.getSatisfyingVersion(['1.0.0', '01.01.01'], '^1.0'),
+      ).toBe('1.1.1');
     });
   });
 
@@ -267,6 +303,9 @@ describe('modules/versioning/semver-coerced/index', () => {
     it('should support coercion', () => {
       expect(
         semverCoerced.minSatisfyingVersion(['v1.0', '1.0.4-foo'], '^1.0'),
+      ).toBe('1.0.0');
+      expect(
+        semverCoerced.minSatisfyingVersion(['1.0.0', '01.01.01'], '^1.0'),
       ).toBe('1.0.0');
     });
   });
@@ -297,20 +336,31 @@ describe('modules/versioning/semver-coerced/index', () => {
           newVersion: '1.1.0',
         }),
       ).toBe('1.1.0');
+      expect(
+        semverCoerced.getNewValue({
+          currentValue: '2025.12.31',
+          rangeStrategy: 'auto',
+          currentVersion: '2025.12.31',
+          newVersion: '2026.08.07',
+        }),
+      ).toBe('2026.08.07');
     });
   });
 
   describe('.sortVersions(a, b)', () => {
     it('should return zero for equal versions', () => {
       expect(semverCoerced.sortVersions('1.0.0', '1.0.0')).toBe(0);
+      expect(semverCoerced.sortVersions('2026.8.7', '2026.08.07')).toBe(0);
     });
 
     it('should return -1 for a < b', () => {
       expect(semverCoerced.sortVersions('1.0.0', '1.0.1')).toBe(-1);
+      expect(semverCoerced.sortVersions('2025.12.31', '2026.08.07')).toBe(-1);
     });
 
     it('should return 1 for a > b', () => {
       expect(semverCoerced.sortVersions('1.0.1', '1.0.0')).toBe(1);
+      expect(semverCoerced.sortVersions('2026.08.07', '2025.12.31')).toBe(1);
     });
 
     it('should return zero for equal non-strict versions', () => {

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -23,49 +23,52 @@ function isStable(version: string): boolean {
     return false;
   }
 
-  const major = m.groups.major;
-  const newMinor = m.groups.minor ?? '.0';
-  const newPatch = m.groups.patch ?? '.0';
+  const minor = m.groups.minor ?? '.0';
+  const patch = m.groups.patch ?? '.0';
   const others = m.groups.others ?? '';
-  const fixed = major + newMinor + newPatch + others;
+  const fixed = `${m.groups.major}${minor}${patch}${others}`.replace(
+    /(^|\.)0+(?=\d)/g,
+    '$1',
+  );
+
   return stable.is(fixed);
 }
 
 function sortVersions(a: string, b: string): number {
-  const aCoerced = semver.coerce(a);
-  const bCoerced = semver.coerce(b);
+  const aCoerced = semver.coerce(a, { loose: true });
+  const bCoerced = semver.coerce(b, { loose: true });
 
   return aCoerced && bCoerced ? semver.compare(aCoerced, bCoerced) : 0;
 }
 
 function getMajor(a: string | SemVer): number | null {
-  const aCoerced = semver.coerce(a);
+  const aCoerced = semver.coerce(a, { loose: true });
   return aCoerced ? semver.major(aCoerced) : null;
 }
 
 function getMinor(a: string | SemVer): number | null {
-  const aCoerced = semver.coerce(a);
+  const aCoerced = semver.coerce(a, { loose: true });
   return aCoerced ? semver.minor(aCoerced) : null;
 }
 
 function getPatch(a: string | SemVer): number | null {
-  const aCoerced = semver.coerce(a);
+  const aCoerced = semver.coerce(a, { loose: true });
   return aCoerced ? semver.patch(aCoerced) : null;
 }
 
 function matches(version: string, range: string): boolean {
-  const coercedVersion = semver.coerce(version);
+  const coercedVersion = semver.coerce(version, { loose: true });
   return coercedVersion ? semver.satisfies(coercedVersion, range) : false;
 }
 
 function equals(a: string, b: string): boolean {
-  const aCoerced = semver.coerce(a);
-  const bCoerced = semver.coerce(b);
+  const aCoerced = semver.coerce(a, { loose: true });
+  const bCoerced = semver.coerce(b, { loose: true });
   return aCoerced && bCoerced ? semver.eq(aCoerced, bCoerced) : false;
 }
 
 function isValid(version: string): boolean {
-  return !!semver.valid(semver.coerce(version));
+  return !!semver.valid(semver.coerce(version, { loose: true }));
 }
 
 function getSatisfyingVersion(
@@ -74,7 +77,9 @@ function getSatisfyingVersion(
 ): string | null {
   const coercedVersions = versions
     .map((version) =>
-      semver.valid(version) ? version : semver.coerce(version)?.version,
+      semver.valid(version)
+        ? version
+        : semver.coerce(version, { loose: true })?.version,
     )
     .filter(isString);
 
@@ -86,20 +91,20 @@ function minSatisfyingVersion(
   range: string,
 ): string | null {
   const coercedVersions = versions
-    .map((version) => semver.coerce(version)?.version)
+    .map((version) => semver.coerce(version, { loose: true })?.version)
     .filter(isString);
 
   return semver.minSatisfying(coercedVersions, range);
 }
 
 function isLessThanRange(version: string, range: string): boolean {
-  const coercedVersion = semver.coerce(version);
+  const coercedVersion = semver.coerce(version, { loose: true });
   return coercedVersion ? semver.ltr(coercedVersion, range) : false;
 }
 
 function isGreaterThan(version: string, other: string): boolean {
-  const coercedVersion = semver.coerce(version);
-  const coercedOther = semver.coerce(other);
+  const coercedVersion = semver.coerce(version, { loose: true });
+  const coercedOther = semver.coerce(other, { loose: true });
   if (!coercedVersion || !coercedOther) {
     return false;
   }
@@ -115,7 +120,7 @@ function isSingleVersion(version: string): boolean {
     return false;
   }
 
-  return !!semver.valid(semver.coerce(version));
+  return !!semver.valid(semver.coerce(version, { loose: true }));
 }
 
 // If this is left as an alias, inputs like "17.04.0" throw errors
@@ -137,8 +142,8 @@ function getNewValue({
 }
 
 function isBreaking(version: string, current: string): boolean {
-  const coercedVersion = semver.coerce(version)?.toString();
-  const coercedCurrent = semver.coerce(current)?.toString();
+  const coercedVersion = semver.coerce(version, { loose: true })?.toString();
+  const coercedCurrent = semver.coerce(current, { loose: true })?.toString();
   return !!(
     coercedVersion &&
     coercedCurrent &&

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -3,6 +3,7 @@ import type { SemVer } from 'semver';
 import semver from 'semver';
 import stable from 'semver-stable';
 import { regEx } from '../../../util/regex.ts';
+import { coerceString } from '../../../util/string.ts';
 import { isBreaking as semverIsBreaking } from '../semver/index.ts';
 import type { NewValueConfig, VersioningApi } from '../types.ts';
 
@@ -27,8 +28,8 @@ function isStable(version: string): boolean {
   const patch = coerceString(m.groups.patch, '.0');
   const others = coerceString(m.groups.others);
   const fixed = `${m.groups.major}${minor}${patch}${others}`.replace(
-    regEx(/(^|\.)0+(?=\d)/g),
-    '$1',
+    regEx(/(^|\.)0+(\d)/g),
+    '$1$2',
   );
 
   return stable.is(fixed);

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -28,8 +28,8 @@ function isStable(version: string): boolean {
   const patch = coerceString(m.groups.patch, '.0');
   const others = coerceString(m.groups.others);
   const fixed = `${m.groups.major}${minor}${patch}${others}`.replace(
-    regEx(/(^|\.)0+(\d)/g),
-    '$1$2',
+    regEx(/(?<prefix>^|\.)0+(?<digit>\d)/g),
+    '$<prefix>$<digit>',
   );
 
   return stable.is(fixed);

--- a/lib/modules/versioning/semver-coerced/index.ts
+++ b/lib/modules/versioning/semver-coerced/index.ts
@@ -23,11 +23,11 @@ function isStable(version: string): boolean {
     return false;
   }
 
-  const minor = m.groups.minor ?? '.0';
-  const patch = m.groups.patch ?? '.0';
-  const others = m.groups.others ?? '';
+  const minor = coerceString(m.groups.minor, '.0');
+  const patch = coerceString(m.groups.patch, '.0');
+  const others = coerceString(m.groups.others);
   const fixed = `${m.groups.major}${minor}${patch}${others}`.replace(
-    /(^|\.)0+(?=\d)/g,
+    regEx(/(^|\.)0+(?=\d)/g),
     '$1',
   );
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes
Make semver-coerced versioning more permissive by allowing leading zeros, i.e. supporting calendar versioning.

`pre-commit.ci` bot can update Calendar Versioning dependencies (e.g. 2026.08.01 → 2026.08.08), but Renovate currently errors on such dependencies:

```
DEBUG: Dependency henryiii/validate-pyproject-schema-store has unsupported/unversioned value 2026.08.01 (versioning=semver-coerced)
```

This PR makes Renovate behave like the `pre-commit.ci` bot, allowing it to correctly update dependencies with leading zeros.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39894 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @vivodi will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/vivodi/loose-semver-coerced

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
