### PR TITLE
fix(manager/pixi): support optional channel options

### DIFF
--- a/lib/modules/manager/pixi/extract.spec.ts
+++ b/lib/modules/manager/pixi/extract.spec.ts
@@ -1,6 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { describe, expect, it, vi } from 'vitest';
 import { fs } from '~test/util.ts';
+import { getUserPixiConfig } from './extract.ts';
 import { extractPackageFile } from './index.ts';
 
 vi.mock('../../../util/fs/index.ts');
@@ -627,7 +628,7 @@ describe('modules/manager/pixi/extract', () => {
     });
   });
 
-  it(`extract package with channel priority`, async () => {
+  it(`extract package with channel options`, async () => {
     const result = await extractPackageFile(
       codeBlock`
         [project]
@@ -638,7 +639,12 @@ describe('modules/manager/pixi/extract', () => {
         version = "0.1.0"
 
         [feature.scipy]
-        channels = ["anaconda", {channel = 'cuda', priority = 1},  {channel = 'cuda2', priority = 1}]
+        channels = [
+          "anaconda",
+          { channel = "community", exclude-newer = "7d" },
+          { channel = "cuda", priority = 1 },
+          { channel = "cuda2", priority = 1 },
+        ]
         dependencies = { scipy = "==1.15.1" }
 
         [feature.numpy]
@@ -657,6 +663,7 @@ describe('modules/manager/pixi/extract', () => {
             'https://api.anaconda.org/package/cuda/',
             'https://api.anaconda.org/package/cuda2/',
             'https://api.anaconda.org/package/anaconda/',
+            'https://api.anaconda.org/package/community/',
             'https://api.anaconda.org/package/conda-forge/',
             'https://api.anaconda.org/package/conda-not-forge/',
           ],
@@ -676,6 +683,24 @@ describe('modules/manager/pixi/extract', () => {
       ],
       lockFiles: [],
     });
+  });
+
+  it('parses optional channel configuration', () => {
+    expect(
+      getUserPixiConfig(
+        codeBlock`
+          [project]
+          channels = [
+            { channel = "conda-forge", exclude-newer = "7d" },
+            { channel = "cuda", priority = 1 },
+          ]
+        `,
+        'pixi.toml',
+      )?.project.channels,
+    ).toEqual([
+      { channel: 'conda-forge', 'exclude-newer': '7d' },
+      { channel: 'cuda', priority: 1 },
+    ]);
   });
 
   it('returns null for non-known config file', async () => {

--- a/lib/modules/manager/pixi/extract.ts
+++ b/lib/modules/manager/pixi/extract.ts
@@ -163,7 +163,7 @@ function orderChannels(channels: Channels = []): string[] {
         return { channel, priority: 0, index };
       }
 
-      return { ...channel, index: 0 };
+      return { ...channel, priority: channel.priority ?? 0, index };
     })
     .toSorted((a, b) => {
       // first based on priority then based on index

--- a/lib/modules/manager/pixi/extract.ts
+++ b/lib/modules/manager/pixi/extract.ts
@@ -163,7 +163,7 @@ function orderChannels(channels: Channels = []): string[] {
         return { channel, priority: 0, index };
       }
 
-      return { ...channel, priority: channel.priority ?? 0, index };
+      return { ...channel, priority: coerceNumber(channel.priority), index };
     })
     .toSorted((a, b) => {
       // first based on priority then based on index

--- a/lib/modules/manager/pixi/extract.ts
+++ b/lib/modules/manager/pixi/extract.ts
@@ -4,6 +4,7 @@ import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getSiblingFileName, localPathExists } from '../../../util/fs/index.ts';
+import { coerceNumber } from '../../../util/number.ts';
 import { Result } from '../../../util/result.ts';
 import {
   ensureTrailingSlash,

--- a/lib/modules/manager/pixi/schema.ts
+++ b/lib/modules/manager/pixi/schema.ts
@@ -13,7 +13,11 @@ export type Channels = z.infer<typeof Channel>[];
 
 const Channel = z.union([
   z.string(),
-  z.object({ channel: z.string(), priority: z.number() }),
+  z.object({
+    channel: z.string(),
+    priority: z.number().optional(),
+    'exclude-newer': z.string().optional(),
+  }),
 ]);
 
 export interface PixiPackageDependency extends PackageDependency {


### PR DESCRIPTION
## Changes

- Accept Pixi channel tables without a `priority` and retain the optional `exclude-newer` setting.
- Treat omitted channel priorities as zero while preserving declaration order.
- Add regression tests for channel parsing and registry URL ordering.

Context: https://github.com/renovatebot/renovate/discussions/44671

Validation performed:

- `pnpm check --all lib/modules/manager/pixi`
- `pnpm test-schema`
- Full Vitest suite (25,139 tests; two sandbox-related git/submodule failures passed when rerun outside the sandbox)

## Context

Please select one of the following:

- [x] This closes an existing Issue: #44671
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). OpenAI Codex (GPT-5) implemented the code and tests, ran validation, and drafted this PR description.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jonashaag
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable.
