### PR TITLE
fix(manager/bun,gradle,npm): validate artifact-resolved versions

### DIFF
--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -1,5 +1,5 @@
 import { fs } from '~test/util.ts';
-import { extractAllPackageFiles, extractPackageFile } from './extract.ts';
+import { extractAllPackageFiles, extractPackageFile } from './index.ts';
 
 vi.mock('../../../util/fs/index.ts');
 

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -1,4 +1,6 @@
+import { codeBlock } from 'common-tags';
 import { fs } from '~test/util.ts';
+import type { ExtractConfig } from '../types.ts';
 import { extractAllPackageFiles, extractPackageFile } from './index.ts';
 
 vi.mock('../../../util/fs/index.ts');
@@ -22,6 +24,98 @@ describe('modules/manager/bun/extract', () => {
           },
         ],
       });
+    });
+
+    it('extracts the resolved version from bun.lock', async () => {
+      const result = await extractPackageFile(
+        JSON.stringify({
+          name: 'app',
+          dependencies: { lodash: '^4.17.0' },
+        }),
+        'package.json',
+        {
+          fileContents: {
+            'bun.lock': codeBlock`{
+              "lockfileVersion": 1,
+              "packages": {
+                "lodash": ["lodash@4.17.21", ""],
+              },
+            }`,
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '^4.17.0',
+            depName: 'lodash',
+            lockedVersion: '4.17.21',
+          },
+        ],
+      });
+    });
+
+    it('ignores invalid package entries in bun.lock', async () => {
+      const result = await extractPackageFile(
+        JSON.stringify({ dependencies: { lodash: '^4.17.0' } }),
+        'package.json',
+        {
+          fileContents: {
+            'bun.lock': JSON.stringify({ packages: { lodash: null } }),
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        deps: [{ depName: 'lodash', lockedVersion: undefined }],
+      });
+    });
+
+    it.each(['{', '{}'])(
+      'returns null for invalid bun.lock content',
+      async (lock) => {
+        const result = await extractPackageFile(
+          JSON.stringify({ dependencies: { lodash: '^4.17.0' } }),
+          'package.json',
+          { fileContents: { 'bun.lock': lock } },
+        );
+
+        expect(result).toBeNull();
+      },
+    );
+
+    it('returns null when a configured text lockfile cannot be read', async () => {
+      const config: ExtractConfig = {};
+      Object.assign(config, {
+        packageFiles: {
+          bun: [
+            {
+              deps: [],
+              lockFiles: ['bun.lock'],
+              packageFile: 'package.json',
+            },
+          ],
+        },
+      });
+
+      const result = await extractPackageFile(
+        JSON.stringify({ dependencies: { lodash: '^4.17.0' } }),
+        'package.json',
+        config,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when only a binary lockfile was updated', async () => {
+      const result = await extractPackageFile(
+        JSON.stringify({ dependencies: { lodash: '^4.17.0' } }),
+        'package.json',
+        { fileContents: { 'bun.lockb': 'binary lockfile' } },
+      );
+
+      expect(result).toBeNull();
     });
 
     it('returns null for invalid package.json content', async () => {

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -1,9 +1,46 @@
 import { fs } from '~test/util.ts';
-import { extractAllPackageFiles } from './extract.ts';
+import { extractAllPackageFiles, extractPackageFile } from './extract.ts';
 
 vi.mock('../../../util/fs/index.ts');
 
 describe('modules/manager/bun/extract', () => {
+  describe('extractPackageFile()', () => {
+    it('extracts dependencies from package.json content', async () => {
+      const result = await extractPackageFile(
+        JSON.stringify({ dependencies: { lodash: '^4.17.0' } }),
+        'package.json',
+        {},
+      );
+
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '^4.17.0',
+            datasource: 'npm',
+            depName: 'lodash',
+            depType: 'dependencies',
+          },
+        ],
+      });
+    });
+
+    it('returns null for invalid package.json content', async () => {
+      expect(
+        await extractPackageFile('invalid', 'package.json', {}),
+      ).toBeNull();
+    });
+
+    it('returns null when package.json is not a package manifest', async () => {
+      expect(
+        await extractPackageFile(
+          JSON.stringify({ _id: 1, _args: 1, _from: 1 }),
+          'package.json',
+          {},
+        ),
+      ).toBeNull();
+    });
+  });
+
   describe('extractAllPackageFiles()', () => {
     it('ignores non-bun files', async () => {
       expect(await extractAllPackageFiles({}, ['package.json'])).toEqual([]);

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -50,7 +50,7 @@ export async function extractPackageFile(
   };
 }
 
-export async function processPackageFile(
+async function processPackageFile(
   packageFile: string,
   config: ExtractConfig,
 ): Promise<PackageFile | null> {

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -1,5 +1,7 @@
 import { isArray, isObject, isString } from '@sindresorhus/is';
+import semver from 'semver';
 import { logger } from '../../../logger/index.ts';
+import { parseJsonc } from '../../../util/common.ts';
 import {
   getParentDir,
   getSiblingFileName,
@@ -17,10 +19,109 @@ import type {
 } from '../types.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
+interface BunExtractConfig extends ExtractConfig {
+  packageFiles?: Record<string, PackageFile[]>;
+}
+
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {
   return (
     fileNameWithPath === fileName || fileNameWithPath.endsWith(`/${fileName}`)
   );
+}
+
+function parseLockedVersions(content: string): Record<string, string> | null {
+  let lockFile: unknown;
+  try {
+    lockFile = parseJsonc(content);
+  } catch (err) {
+    logger.debug({ err }, 'Error parsing bun.lock');
+    return null;
+  }
+
+  if (
+    !isObject(lockFile) ||
+    !('packages' in lockFile) ||
+    !isObject(lockFile.packages)
+  ) {
+    return null;
+  }
+
+  const lockedVersions: Record<string, string> = {};
+  for (const [packageKey, packageData] of Object.entries(lockFile.packages)) {
+    if (!isArray(packageData) || !isString(packageData[0])) {
+      continue;
+    }
+
+    const versionSeparatorIndex = packageData[0].lastIndexOf('@');
+    const lockedVersion = semver.valid(
+      packageData[0].slice(versionSeparatorIndex + 1),
+    );
+    if (lockedVersion) {
+      lockedVersions[packageKey] = lockedVersion;
+    }
+  }
+
+  return lockedVersions;
+}
+
+async function applyLockedVersions(
+  result: PackageFileContent<NpmManagerData>,
+  packageFile: string,
+  config: ExtractConfig,
+): Promise<PackageFileContent<NpmManagerData> | null> {
+  const configuredLockFiles = (
+    config as BunExtractConfig
+  ).packageFiles?.bun?.find(
+    ({ packageFile: configuredPackageFile }) =>
+      configuredPackageFile === packageFile,
+  )?.lockFiles;
+  const lockFiles = [
+    ...new Set([
+      ...Object.keys(config.fileContents ?? {}).filter((fileName) =>
+        matchesFileName(fileName, 'bun.lock'),
+      ),
+      ...(configuredLockFiles ?? []),
+    ]),
+  ];
+  const textLockFile = lockFiles.find((fileName) =>
+    matchesFileName(fileName, 'bun.lock'),
+  );
+  if (!textLockFile) {
+    const hasBinaryLockFile = [
+      ...Object.keys(config.fileContents ?? {}),
+      ...(configuredLockFiles ?? []),
+    ].some((fileName) => matchesFileName(fileName, 'bun.lockb'));
+    return hasBinaryLockFile ? null : result;
+  }
+
+  const lockFileContent =
+    config.fileContents?.[textLockFile] ??
+    (await readLocalFile(textLockFile, 'utf8'));
+  if (!lockFileContent) {
+    return null;
+  }
+
+  const lockedVersions = parseLockedVersions(lockFileContent);
+  if (!lockedVersions) {
+    return null;
+  }
+
+  const packageName = result.managerData?.packageJsonName;
+  for (const dep of result.deps) {
+    /* v8 ignore next -- npm extraction always assigns a dependency name */
+    if (!dep.depName) {
+      continue;
+    }
+
+    const workspaceKey = packageName
+      ? `${packageName}/${dep.depName}`
+      : undefined;
+    dep.lockedVersion =
+      (workspaceKey ? lockedVersions[workspaceKey] : undefined) ??
+      lockedVersions[dep.depName];
+  }
+
+  return result;
 }
 
 export async function extractPackageFile(
@@ -44,10 +145,14 @@ export async function extractPackageFile(
 
   const { npmrc } = await resolveNpmrc(packageFile, config);
 
-  return {
-    ...result,
-    npmrc,
-  };
+  return applyLockedVersions(
+    {
+      ...result,
+      npmrc,
+    },
+    packageFile,
+    config,
+  );
 }
 
 async function processPackageFile(

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -10,13 +10,44 @@ import { extractPackageJson } from '../npm/extract/common/package-file.ts';
 import type { NpmPackage } from '../npm/extract/types.ts';
 import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
-import type { ExtractConfig, PackageFile } from '../types.ts';
+import type {
+  ExtractConfig,
+  PackageFile,
+  PackageFileContent,
+} from '../types.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {
   return (
     fileNameWithPath === fileName || fileNameWithPath.endsWith(`/${fileName}`)
   );
+}
+
+export async function extractPackageFile(
+  content: string,
+  packageFile: string,
+  config: ExtractConfig,
+): Promise<PackageFileContent<NpmManagerData> | null> {
+  let packageJson: NpmPackage;
+  try {
+    packageJson = JSON.parse(content);
+  } catch (err) {
+    logger.debug({ err }, 'Error parsing package.json');
+    return null;
+  }
+
+  const result = extractPackageJson(packageJson, packageFile);
+  if (!result) {
+    logger.debug({ packageFile }, 'No dependencies found');
+    return null;
+  }
+
+  const { npmrc } = await resolveNpmrc(packageFile, config);
+
+  return {
+    ...result,
+    npmrc,
+  };
 }
 
 export async function processPackageFile(
@@ -28,25 +59,14 @@ export async function processPackageFile(
     logger.warn({ fileName: packageFile }, 'Could not read file content');
     return null;
   }
-  let packageJson: NpmPackage;
-  try {
-    packageJson = JSON.parse(fileContent);
-  } catch (err) {
-    logger.debug({ err }, 'Error parsing package.json');
-    return null;
-  }
-  const result = extractPackageJson(packageJson, packageFile);
+  const result = await extractPackageFile(fileContent, packageFile, config);
   if (!result) {
-    logger.debug({ packageFile }, 'No dependencies found');
     return null;
   }
-
-  const { npmrc } = await resolveNpmrc(packageFile, config);
 
   return {
     ...result,
     packageFile,
-    npmrc,
   };
 }
 export async function extractAllPackageFiles(

--- a/lib/modules/manager/bun/index.ts
+++ b/lib/modules/manager/bun/index.ts
@@ -4,7 +4,7 @@ import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 export { getRangeStrategy, updateDependency } from '../npm/index.ts';
 export { updateArtifacts } from './artifacts.ts';
-export { extractAllPackageFiles } from './extract.ts';
+export { extractAllPackageFiles, extractPackageFile } from './extract.ts';
 
 export const url = 'https://bun.sh/docs/cli/install';
 export const categories: Category[] = ['js'];

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -3,7 +3,7 @@ import { Fixtures } from '~test/fixtures.ts';
 import { fs, logger, partial } from '~test/util.ts';
 import type { ExtractConfig, PackageDependency } from '../types.ts';
 import { matchesContentDescriptor } from './extract.ts';
-import { extractAllPackageFiles } from './index.ts';
+import { extractAllPackageFiles, extractPackageFile } from './index.ts';
 import * as parser from './parser.ts';
 
 vi.mock('../../../util/fs/index.ts');
@@ -32,6 +32,63 @@ function mockFs(files: Record<string, string>): void {
 describe('modules/manager/gradle/extract', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+  });
+
+  describe('extractPackageFile()', () => {
+    it('extracts a dependency from updated content', async () => {
+      mockFs({
+        'build.gradle':
+          'dependencies { implementation "com.google.guava:guava:33.4.0-jre" }',
+      });
+
+      const res = await extractPackageFile(
+        'dependencies { implementation "com.google.guava:guava:33.4.8-jre" }',
+        'build.gradle',
+        partial<ExtractConfig>(),
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '33.4.8-jre',
+            depName: 'com.google.guava:guava',
+          },
+        ],
+      });
+    });
+
+    it('uses other configured package files to resolve variables', async () => {
+      const fsMock = {
+        'gradle.properties': 'guavaVersion=33.4.0-jre',
+        'build.gradle':
+          'dependencies { implementation "com.google.guava:guava:$guavaVersion" }',
+      };
+      mockFs(fsMock);
+      const config = partial<ExtractConfig>();
+      Object.assign(config, {
+        packageFiles: {
+          gradle: Object.keys(fsMock).map((packageFile) => ({
+            deps: [],
+            packageFile,
+          })),
+        },
+      });
+
+      const res = await extractPackageFile(
+        'guavaVersion=33.4.8-jre',
+        'gradle.properties',
+        config,
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '33.4.8-jre',
+            depName: 'com.google.guava:guava',
+          },
+        ],
+      });
+    });
   });
 
   it('returns null', async () => {

--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -89,6 +89,82 @@ describe('modules/manager/gradle/extract', () => {
         ],
       });
     });
+
+    it('uses in-memory content for every configured package file', async () => {
+      const fsMock = {
+        'gradle.properties': 'guavaVersion=33.4.0-jre',
+        'build.gradle': '',
+      };
+      const updatedBuildGradle =
+        'dependencies { implementation "com.google.guava:guava:$guavaVersion" }';
+      mockFs(fsMock);
+      const config = partial<ExtractConfig>({
+        fileContents: {
+          'gradle.properties': 'guavaVersion=33.4.8-jre',
+          'build.gradle': updatedBuildGradle,
+        },
+      });
+      Object.assign(config, {
+        packageFiles: {
+          gradle: Object.keys(fsMock).map((packageFile) => ({
+            deps: [],
+            packageFile,
+          })),
+        },
+      });
+
+      const res = await extractPackageFile(
+        'guavaVersion=33.4.8-jre',
+        'gradle.properties',
+        config,
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '33.4.8-jre',
+            depName: 'com.google.guava:guava',
+          },
+        ],
+      });
+    });
+
+    it('extracts resolved versions from Gradle lockfiles', async () => {
+      const buildGradle =
+        'dependencies { implementation "com.google.guava:guava:33.+" }';
+      mockFs({ 'build.gradle': buildGradle });
+      const config = partial<ExtractConfig>({
+        fileContents: {
+          'build.gradle': buildGradle,
+          'gradle.lockfile': codeBlock`
+            # This is a Gradle generated file for dependency locking.
+            :33.0.0-jre=compileClasspath
+            com.example:empty:=compileClasspath
+            com.google.guava:guava:33.5.0-jre=compileClasspath,runtimeClasspath
+          `,
+        },
+      });
+
+      const res = await extractPackageFile(buildGradle, 'build.gradle', config);
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '33.+',
+            depName: 'com.google.guava:guava',
+            lockedVersion: '33.5.0-jre',
+          },
+        ],
+      });
+    });
+
+    it('returns null when the target file has no dependencies', async () => {
+      mockFs({ 'build.gradle': '' });
+
+      expect(
+        await extractPackageFile('', 'build.gradle', partial<ExtractConfig>()),
+      ).toBeNull();
+    });
   });
 
   it('returns null', async () => {

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -9,6 +9,7 @@ import type {
   ExtractConfig,
   PackageDependency,
   PackageFile,
+  PackageFileContent,
 } from '../types.ts';
 import {
   parseCatalog,
@@ -40,6 +41,15 @@ import {
 } from './utils.ts';
 
 const mavenDatasource = MavenDatasource.id;
+
+interface GradleExtractConfig extends ExtractConfig {
+  packageFiles?: Record<string, PackageFile[]>;
+}
+
+interface FileContentOverride {
+  content: string;
+  packageFile: string;
+}
 
 function updatePackageRegistries(
   packageRegistries: PackageRegistry[],
@@ -176,9 +186,13 @@ async function parsePackageFiles(
   extractedDeps: PackageDependency<GradleManagerData>[],
   packageFilesByName: Record<string, PackageFile>,
   packageRegistries: PackageRegistry[],
+  fileContentOverride?: FileContentOverride,
 ): Promise<PackageDependency<GradleManagerData>[]> {
   const varRegistry: VariableRegistry = {};
   const fileContents = await getLocalFiles(packageFiles);
+  if (fileContentOverride) {
+    fileContents[fileContentOverride.packageFile] = fileContentOverride.content;
+  }
 
   for (const packageFile of packageFiles) {
     packageFilesByName[packageFile] = {
@@ -242,9 +256,10 @@ async function parsePackageFiles(
   return extractedDeps;
 }
 
-export async function extractAllPackageFiles(
+async function extractPackageFiles(
   config: ExtractConfig,
   packageFiles: string[],
+  fileContentOverride?: FileContentOverride,
 ): Promise<PackageFile[] | null> {
   const packageFilesByName: Record<string, PackageFile> = {};
   const packageRegistries: PackageRegistry[] = [];
@@ -260,6 +275,7 @@ export async function extractAllPackageFiles(
     extractedDeps,
     packageFilesByName,
     packageRegistries,
+    fileContentOverride,
   );
 
   if (!extractedDeps.length) {
@@ -312,4 +328,37 @@ export async function extractAllPackageFiles(
   }
 
   return Object.values(packageFilesByName);
+}
+
+export async function extractPackageFile(
+  content: string,
+  packageFile: string,
+  config: ExtractConfig,
+): Promise<PackageFileContent<GradleManagerData> | null> {
+  const configuredPackageFiles = (
+    config as GradleExtractConfig
+  ).packageFiles?.gradle?.map(({ packageFile }) => packageFile);
+  const packageFiles = [
+    ...new Set([...(configuredPackageFiles ?? []), packageFile]),
+  ];
+  const results = await extractPackageFiles(config, packageFiles, {
+    content,
+    packageFile,
+  });
+  const result = results?.find(
+    ({ packageFile: resultPackageFile }) => resultPackageFile === packageFile,
+  );
+  if (!result) {
+    return null;
+  }
+
+  const { packageFile: _packageFile, ...packageFileContent } = result;
+  return packageFileContent;
+}
+
+export async function extractAllPackageFiles(
+  config: ExtractConfig,
+  packageFiles: string[],
+): Promise<PackageFile[] | null> {
+  return extractPackageFiles(config, packageFiles);
 }

--- a/lib/modules/manager/gradle/extract.ts
+++ b/lib/modules/manager/gradle/extract.ts
@@ -46,11 +46,6 @@ interface GradleExtractConfig extends ExtractConfig {
   packageFiles?: Record<string, PackageFile[]>;
 }
 
-interface FileContentOverride {
-  content: string;
-  packageFile: string;
-}
-
 function updatePackageRegistries(
   packageRegistries: PackageRegistry[],
   urls: PackageRegistry[],
@@ -186,13 +181,10 @@ async function parsePackageFiles(
   extractedDeps: PackageDependency<GradleManagerData>[],
   packageFilesByName: Record<string, PackageFile>,
   packageRegistries: PackageRegistry[],
-  fileContentOverride?: FileContentOverride,
 ): Promise<PackageDependency<GradleManagerData>[]> {
   const varRegistry: VariableRegistry = {};
   const fileContents = await getLocalFiles(packageFiles);
-  if (fileContentOverride) {
-    fileContents[fileContentOverride.packageFile] = fileContentOverride.content;
-  }
+  Object.assign(fileContents, config.fileContents);
 
   for (const packageFile of packageFiles) {
     packageFilesByName[packageFile] = {
@@ -259,7 +251,6 @@ async function parsePackageFiles(
 async function extractPackageFiles(
   config: ExtractConfig,
   packageFiles: string[],
-  fileContentOverride?: FileContentOverride,
 ): Promise<PackageFile[] | null> {
   const packageFilesByName: Record<string, PackageFile> = {};
   const packageRegistries: PackageRegistry[] = [];
@@ -275,7 +266,6 @@ async function extractPackageFiles(
     extractedDeps,
     packageFilesByName,
     packageRegistries,
-    fileContentOverride,
   );
 
   if (!extractedDeps.length) {
@@ -330,6 +320,38 @@ async function extractPackageFiles(
   return Object.values(packageFilesByName);
 }
 
+function getGradleLockedVersions(
+  fileContents: Record<string, string> | undefined,
+): Map<string, Set<string>> {
+  const lockedVersions = new Map<string, Set<string>>();
+
+  for (const [fileName, content] of Object.entries(fileContents ?? {})) {
+    if (!fileName.endsWith('.lockfile')) {
+      continue;
+    }
+
+    for (const line of content.split('\n')) {
+      const equalsIndex = line.indexOf('=');
+      const versionSeparatorIndex = line.lastIndexOf(':', equalsIndex);
+      if (equalsIndex < 0 || versionSeparatorIndex < 0) {
+        continue;
+      }
+
+      const depName = line.slice(0, versionSeparatorIndex);
+      const lockedVersion = line.slice(versionSeparatorIndex + 1, equalsIndex);
+      if (!depName || !lockedVersion) {
+        continue;
+      }
+
+      const versions = lockedVersions.get(depName) ?? new Set<string>();
+      versions.add(lockedVersion);
+      lockedVersions.set(depName, versions);
+    }
+  }
+
+  return lockedVersions;
+}
+
 export async function extractPackageFile(
   content: string,
   packageFile: string,
@@ -341,10 +363,13 @@ export async function extractPackageFile(
   const packageFiles = [
     ...new Set([...(configuredPackageFiles ?? []), packageFile]),
   ];
-  const results = await extractPackageFiles(config, packageFiles, {
-    content,
-    packageFile,
-  });
+  const results = await extractPackageFiles(
+    {
+      ...config,
+      fileContents: { ...config.fileContents, [packageFile]: content },
+    },
+    packageFiles,
+  );
   const result = results?.find(
     ({ packageFile: resultPackageFile }) => resultPackageFile === packageFile,
   );
@@ -353,7 +378,22 @@ export async function extractPackageFile(
   }
 
   const { packageFile: _packageFile, ...packageFileContent } = result;
-  return packageFileContent;
+  const lockedVersions = getGradleLockedVersions(config.fileContents);
+  const deps: PackageDependency<GradleManagerData>[] = [];
+  for (const dep of packageFileContent.deps) {
+    const depName = dep.packageName ?? dep.depName;
+    const versions = depName ? lockedVersions.get(depName) : undefined;
+    if (!versions?.size) {
+      deps.push(dep);
+      continue;
+    }
+
+    for (const lockedVersion of versions) {
+      deps.push({ ...dep, lockedVersion });
+    }
+  }
+
+  return { ...packageFileContent, deps };
 }
 
 export async function extractAllPackageFiles(

--- a/lib/modules/manager/gradle/index.ts
+++ b/lib/modules/manager/gradle/index.ts
@@ -4,7 +4,7 @@ import * as gradleVersioning from '../../versioning/gradle/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
 export { knownDepTypes } from './dep-types.ts';
-export { extractAllPackageFiles } from './extract.ts';
+export { extractAllPackageFiles, extractPackageFile } from './extract.ts';
 export { updateDependency } from './update.ts';
 
 export const supportsLockFileMaintenance = true;

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -56,6 +56,91 @@ describe('modules/manager/npm/extract/index', () => {
       });
     });
 
+    it('adds the resolved version from a package lock', async () => {
+      const packageLock = JSON.stringify({
+        name: 'test',
+        lockfileVersion: 3,
+        packages: {
+          '': { dependencies: { lodash: '^4.17.0' } },
+          'node_modules/lodash': { version: '4.17.21' },
+        },
+      });
+
+      const res = await extractPackageFileFromManager(
+        JSON.stringify({ dependencies: { lodash: '^4.17.0' } }),
+        'package.json',
+        {
+          ...defaultExtractConfig,
+          fileContents: { 'package-lock.json': packageLock },
+        },
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '^4.17.0',
+            depName: 'lodash',
+            lockedVersion: '4.17.21',
+          },
+        ],
+      });
+    });
+
+    it('extracts pnpm-workspace.yaml through the manager API', async () => {
+      const res = await extractPackageFileFromManager(
+        codeBlock`
+          catalog:
+            is-positive: 1.0.0
+        `,
+        'pnpm-workspace.yaml',
+        defaultExtractConfig,
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '1.0.0',
+            depName: 'is-positive',
+            depType: 'pnpm.catalog.default',
+          },
+        ],
+      });
+    });
+
+    it('extracts .yarnrc.yml through the manager API', async () => {
+      const res = await extractPackageFileFromManager(
+        codeBlock`
+          catalog:
+            is-positive: 1.0.0
+        `,
+        '.yarnrc.yml',
+        defaultExtractConfig,
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '1.0.0',
+            depName: 'is-positive',
+            depType: 'yarn.catalog.default',
+          },
+        ],
+      });
+    });
+
+    it.each([
+      { content: '', packageFile: 'package.json' },
+      { content: 'nodeLinker: node-modules', packageFile: '.yarnrc.yml' },
+    ])('returns null for unsupported manager content', async (input) => {
+      expect(
+        await extractPackageFileFromManager(
+          input.content,
+          input.packageFile,
+          defaultExtractConfig,
+        ),
+      ).toBeNull();
+    });
+
     it('returns null if cannot parse', async () => {
       const res = await npmExtract.extractPackageFile(
         'not json',

--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -3,7 +3,10 @@ import { Fixtures } from '~test/fixtures.ts';
 import { fs } from '~test/util.ts';
 import { logger } from '../../../../logger/index.ts';
 import type { ExtractConfig } from '../../types.ts';
-import { extractAllPackageFiles } from '../index.ts';
+import {
+  extractAllPackageFiles,
+  extractPackageFile as extractPackageFileFromManager,
+} from '../index.ts';
 import * as npmExtract from './index.ts';
 import { postExtract } from './post/index.ts';
 
@@ -33,6 +36,24 @@ describe('modules/manager/npm/extract/index', () => {
       fs.readLocalFile.mockResolvedValue(null);
       fs.localPathExists.mockResolvedValue(false);
       fs.getSiblingFileName.mockImplementation(realFs.getSiblingFileName);
+    });
+
+    it('is exported by the manager', async () => {
+      const res = await extractPackageFileFromManager(
+        JSON.stringify({ packageManager: 'pnpm@10.14.0' }),
+        'package.json',
+        defaultExtractConfig,
+      );
+
+      expect(res).toMatchObject({
+        deps: [
+          {
+            currentValue: '10.14.0',
+            depName: 'pnpm',
+            depType: 'packageManager',
+          },
+        ],
+      });
     });
 
     it('returns null if cannot parse', async () => {

--- a/lib/modules/manager/npm/extract/index.ts
+++ b/lib/modules/manager/npm/extract/index.ts
@@ -31,6 +31,7 @@ import {
   extractPnpmWorkspaceFile,
 } from './pnpm.ts';
 import { postExtract } from './post/index.ts';
+import { getLockedVersions } from './post/locked-versions.ts';
 import type { NpmPackage } from './types.ts';
 import { extractYarnCatalogs, isZeroInstall } from './yarn.ts';
 import {
@@ -82,7 +83,10 @@ export async function extractPackageFile(
     string,
   ][]) {
     const filePath = getSiblingFileName(packageFile, val);
-    if (await readLocalFile(filePath, 'utf8')) {
+    if (
+      config.fileContents?.[filePath] ??
+      (await readLocalFile(filePath, 'utf8'))
+    ) {
       lockFiles[key] = filePath;
     } else {
       lockFiles[key] = undefined;
@@ -230,6 +234,75 @@ export async function extractPackageFile(
   };
 }
 
+async function extractPackageFileContent(
+  content: string,
+  packageFile: string,
+  config: ExtractConfig,
+): Promise<PackageFileContent<NpmManagerData> | null> {
+  if (!content) {
+    return null;
+  }
+
+  if (packageFile.endsWith('pnpm-workspace.yaml')) {
+    logger.trace({ packageFile }, 'Extracting as a pnpm-workspace.yaml file');
+    const parsedPnpmWorkspaceYaml =
+      await PnpmWorkspaceFile.safeParseAsync(content);
+    if (!parsedPnpmWorkspaceYaml.success) {
+      logger.warn(
+        { packageFile, err: parsedPnpmWorkspaceYaml.error },
+        'Failed to parse pnpm-workspace.yaml file',
+      );
+      return null;
+    }
+
+    logger.trace(
+      { packageFile },
+      'Extracting file as a pnpm workspace YAML file',
+    );
+    return extractPnpmWorkspaceFile(parsedPnpmWorkspaceYaml.data, packageFile);
+  }
+
+  if (packageFile.endsWith('json')) {
+    logger.trace({ packageFile }, 'Extracting as a package.json file');
+    return extractPackageFile(content, packageFile, config);
+  }
+
+  logger.trace({ packageFile }, 'Extracting as a .yarnrc.yml file');
+  const yarnConfig = loadConfigFromYarnrcYml(content);
+  if (!yarnConfig?.catalogs && !yarnConfig?.catalog) {
+    return null;
+  }
+
+  const hasPackageManagerResult = await hasPackageManager(
+    upath.dirname(packageFile),
+  );
+  return extractYarnCatalogs(
+    { catalog: yarnConfig.catalog, catalogs: yarnConfig.catalogs },
+    packageFile,
+    hasPackageManagerResult,
+  );
+}
+
+export async function extractPackageFileWithLockfile(
+  content: string,
+  packageFile: string,
+  config: ExtractConfig,
+): Promise<PackageFileContent<NpmManagerData> | null> {
+  const result = await extractPackageFileContent(content, packageFile, config);
+  if (!result) {
+    return null;
+  }
+
+  const extractedPackageFile: PackageFile<NpmManagerData> = {
+    ...result,
+    packageFile,
+  };
+  await getLockedVersions([extractedPackageFile], config.fileContents);
+  const { packageFile: _packageFile, ...packageFileContent } =
+    extractedPackageFile;
+  return packageFileContent;
+}
+
 export async function extractAllPackageFiles(
   config: ExtractConfig,
   packageFiles: string[],
@@ -238,72 +311,14 @@ export async function extractAllPackageFiles(
   for (const packageFile of packageFiles) {
     const content = await readLocalFile(packageFile, 'utf8');
     if (content) {
-      // pnpm workspace files are their own package file, defined via managerFilePatterns.
-      if (packageFile.endsWith('pnpm-workspace.yaml')) {
-        logger.trace(
-          { packageFile },
-          `Extracting as a pnpm-workspace.yaml file`,
-        );
-        const parsedPnpmWorkspaceYaml =
-          await PnpmWorkspaceFile.safeParseAsync(content);
-        if (parsedPnpmWorkspaceYaml.success) {
-          logger.trace(
-            { packageFile },
-            `Extracting file as a pnpm workspace YAML file`,
-          );
-          const deps = await extractPnpmWorkspaceFile(
-            parsedPnpmWorkspaceYaml.data,
-            packageFile,
-          );
-          // v8 ignore else -- TODO: add test #40625
-          if (deps) {
-            npmFiles.push({
-              ...deps,
-              packageFile,
-            });
-          }
-        } else {
-          logger.warn(
-            { packageFile, err: parsedPnpmWorkspaceYaml.error },
-            `Failed to parse pnpm-workspace.yaml file`,
-          );
-        }
-      } else {
-        if (packageFile.endsWith('json')) {
-          logger.trace({ packageFile }, `Extracting as a package.json file`);
-
-          const deps = await extractPackageFile(content, packageFile, config);
-          // v8 ignore else -- TODO: add tests #40625
-          if (deps) {
-            npmFiles.push({
-              ...deps,
-              packageFile,
-            });
-          }
-        } else {
-          logger.trace({ packageFile }, `Extracting as a .yarnrc.yml file`);
-
-          const yarnConfig = loadConfigFromYarnrcYml(content);
-
-          // v8 ignore else -- TODO: add tests #40625
-          if (yarnConfig?.catalogs || yarnConfig?.catalog) {
-            const hasPackageManagerResult = await hasPackageManager(
-              upath.dirname(packageFile),
-            );
-            const catalogsDeps = await extractYarnCatalogs(
-              { catalog: yarnConfig.catalog, catalogs: yarnConfig.catalogs },
-              packageFile,
-              hasPackageManagerResult,
-            );
-            // v8 ignore else -- TODO: add tests #40625
-            if (catalogsDeps) {
-              npmFiles.push({
-                ...catalogsDeps,
-                packageFile,
-              });
-            }
-          }
-        }
+      const result = await extractPackageFileContent(
+        content,
+        packageFile,
+        config,
+      );
+      // v8 ignore else -- TODO: add tests #40625
+      if (result) {
+        npmFiles.push({ ...result, packageFile });
       }
     } else {
       logger.debug({ packageFile }, `No content found`);

--- a/lib/modules/manager/npm/extract/npm.ts
+++ b/lib/modules/manager/npm/extract/npm.ts
@@ -3,8 +3,11 @@ import { readLocalFile } from '../../../../util/fs/index.ts';
 import { PackageLock } from '../schema.ts';
 import type { LockFile } from './types.ts';
 
-export async function getNpmLock(filePath: string): Promise<LockFile> {
-  const lockfileContent = await readLocalFile(filePath, 'utf8');
+export async function getNpmLock(
+  filePath: string,
+  content?: string,
+): Promise<LockFile> {
+  const lockfileContent = content ?? (await readLocalFile(filePath, 'utf8'));
   if (!lockfileContent) {
     logger.debug({ filePath }, 'Npm: unable to read lockfile');
     return { lockedVersions: {} };

--- a/lib/modules/manager/npm/extract/pnpm.ts
+++ b/lib/modules/manager/npm/extract/pnpm.ts
@@ -158,9 +158,12 @@ export async function detectPnpmWorkspaces(
   }
 }
 
-export async function getPnpmLock(filePath: string): Promise<LockFile> {
+export async function getPnpmLock(
+  filePath: string,
+  content?: string,
+): Promise<LockFile> {
   try {
-    const pnpmLockRaw = await readLocalFile(filePath, 'utf8');
+    const pnpmLockRaw = content ?? (await readLocalFile(filePath, 'utf8'));
     if (!pnpmLockRaw) {
       throw new Error('Unable to read pnpm-lock.yaml');
     }

--- a/lib/modules/manager/npm/extract/post/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.ts
@@ -13,6 +13,7 @@ const pnpmCatalogDepTypeRe = /pnpm\.catalog\.(?<version>.*)/;
 
 export async function getLockedVersions(
   packageFiles: PackageFile<NpmManagerData>[],
+  fileContents?: Record<string, string>,
 ): Promise<void> {
   const lockFileCache: Record<string, LockFile> = {};
   logger.debug('Finding locked versions');
@@ -26,7 +27,10 @@ export async function getLockedVersions(
       // v8 ignore else -- TODO: add test #40625
       if (!lockFileCache[yarnLock]) {
         logger.trace(`Retrieving/parsing ${yarnLock}`);
-        lockFileCache[yarnLock] = await getYarnLock(yarnLock);
+        lockFileCache[yarnLock] = await getYarnLock(
+          yarnLock,
+          fileContents?.[yarnLock],
+        );
       }
       const { isYarn1 } = lockFileCache[yarnLock];
       let yarn: string | undefined;
@@ -56,7 +60,7 @@ export async function getLockedVersions(
       lockFiles.push(npmLock);
       if (!lockFileCache[npmLock]) {
         logger.trace(`Retrieving/parsing ${npmLock}`);
-        const cache = await getNpmLock(npmLock);
+        const cache = await getNpmLock(npmLock, fileContents?.[npmLock]);
         /* v8 ignore next 4 -- needs test */
         if (!cache) {
           logger.warn({ npmLock }, 'Npm: unable to get lockfile');
@@ -134,7 +138,10 @@ export async function getLockedVersions(
       lockFiles.push(pnpmShrinkwrap);
       if (!lockFileCache[pnpmShrinkwrap]) {
         logger.trace(`Retrieving/parsing ${pnpmShrinkwrap}`);
-        lockFileCache[pnpmShrinkwrap] = await getPnpmLock(pnpmShrinkwrap);
+        lockFileCache[pnpmShrinkwrap] = await getPnpmLock(
+          pnpmShrinkwrap,
+          fileContents?.[pnpmShrinkwrap],
+        );
       }
 
       const packageDir = upath.dirname(packageFile.packageFile);

--- a/lib/modules/manager/npm/extract/yarn.ts
+++ b/lib/modules/manager/npm/extract/yarn.ts
@@ -13,9 +13,12 @@ import type { NpmManagerData } from '../types.ts';
 import { extractCatalogDeps } from './common/catalogs.ts';
 import type { Catalog, LockFile } from './types.ts';
 
-export async function getYarnLock(filePath: string): Promise<LockFile> {
+export async function getYarnLock(
+  filePath: string,
+  content?: string,
+): Promise<LockFile> {
   // TODO #22198
-  const yarnLockRaw = (await readLocalFile(filePath, 'utf8'))!;
+  const yarnLockRaw = content ?? (await readLocalFile(filePath, 'utf8'))!;
   try {
     const parsed = parseSyml(yarnLockRaw);
     const lockedVersions: Record<string, string> = {};

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -5,7 +5,10 @@ import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
 export { detectGlobalConfig } from './detect.ts';
-export { extractAllPackageFiles, extractPackageFile } from './extract/index.ts';
+export {
+  extractAllPackageFiles,
+  extractPackageFileWithLockfile as extractPackageFile,
+} from './extract/index.ts';
 export { getRangeStrategy } from './range.ts';
 export {
   bumpPackageVersion,

--- a/lib/modules/manager/npm/index.ts
+++ b/lib/modules/manager/npm/index.ts
@@ -5,7 +5,7 @@ import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 export { updateArtifacts } from './artifacts.ts';
 export { detectGlobalConfig } from './detect.ts';
-export { extractAllPackageFiles } from './extract/index.ts';
+export { extractAllPackageFiles, extractPackageFile } from './extract/index.ts';
 export { getRangeStrategy } from './range.ts';
 export {
   bumpPackageVersion,

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -29,6 +29,8 @@ export interface ManagerData<T> {
 }
 
 export interface ExtractConfig extends CustomExtractConfig {
+  /** Current in-memory file contents available during post-artifact extraction. */
+  fileContents?: Record<string, string>;
   registryAliases?: Record<string, string>;
   npmrc?: string;
   npmrcMerge?: boolean;

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1263,6 +1263,12 @@ describe('workers/repository/update/branch/get-updated', () => {
               contents: 'some lock contents',
             },
           },
+          {
+            file: {
+              type: 'deletion',
+              path: 'composer.old.lock',
+            },
+          },
         ]);
         composer.extractPackageFile.mockResolvedValueOnce({
           deps: [
@@ -1280,6 +1286,16 @@ describe('workers/repository/update/branch/get-updated', () => {
         });
         expect(res.artifactErrors[0].stderr).toContain(
           'Artifact update for some-dep resolved to version 1.3.0, which is a pending version that has not yet passed the Minimum Release Age threshold.\nRenovate was attempting to update to 1.2.3\nThis is (likely) not a bug in Renovate, but due to the way your project pins dependencies, _and_ how Renovate calls your package manager to update them.\nUntil Renovate supports specifying an exact update to your package manager (https://github.com/renovatebot/renovate/issues/41624), it is recommended to directly pin your dependencies (with `rangeStrategy=pin` for apps, or `rangeStrategy=widen` for libraries)\nSee also: https://docs.renovatebot.com/dependency-pinning/',
+        );
+        expect(composer.extractPackageFile).toHaveBeenCalledWith(
+          'some new content',
+          'composer.json',
+          expect.objectContaining({
+            fileContents: {
+              'composer.json': 'some new content',
+              'composer.lock': 'some lock contents',
+            },
+          }),
         );
       });
 

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -358,6 +358,11 @@ export async function getUpdatedPackageFiles(
             updatedDeps,
             artifactErrors,
             config,
+            getFileContentsForExtraction(
+              updatedFileContents,
+              updatedArtifacts,
+              packageFile,
+            ),
           );
         }
       }
@@ -410,6 +415,11 @@ export async function getUpdatedPackageFiles(
             updatedDeps,
             artifactErrors,
             config,
+            getFileContentsForExtraction(
+              updatedFileContents,
+              updatedArtifacts,
+              packageFile,
+            ),
           );
         }
       }
@@ -532,6 +542,27 @@ function processUpdateArtifactResults(
   }
 }
 
+function getFileContentsForExtraction(
+  updatedFileContents: Record<string, string>,
+  updatedArtifacts: FileChange[],
+  packageFile: FileAddition,
+): Record<string, string> {
+  const fileContents = {
+    ...updatedFileContents,
+    [packageFile.path]: packageFile.contents!.toString(),
+  };
+
+  for (const artifact of updatedArtifacts) {
+    if (artifact.type === 'deletion') {
+      delete fileContents[artifact.path];
+    } else if (artifact.contents !== null) {
+      fileContents[artifact.path] = artifact.contents.toString();
+    }
+  }
+
+  return fileContents;
+}
+
 /**
  * When using Minimum Release Age, and a package manager that doesn't support being told an explicit version to update to (#41624) it is possible that an artifact update leads to a different version of a dependency being used compared to what Renovate is expecting.
  *
@@ -544,6 +575,7 @@ async function checkForPendingVersions(
   updatedDeps: BranchUpgradeConfig[],
   artifactErrors: ArtifactError[],
   config: BranchConfig,
+  fileContents: Record<string, string>,
 ): Promise<void> {
   const depNameToUpgradeInfo = new Map<
     string,
@@ -568,7 +600,7 @@ async function checkForPendingVersions(
     manager,
     packageFileContent,
     packageFileName,
-    config,
+    { ...config, fileContents },
   );
   if (!extracted) {
     logger.warn(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

### Why this happens

When `minimumReleaseAge` excludes newly published releases, Renovate records them in `pendingVersions` and selects an older eligible release for the update. Artifact generation can then invoke a package manager that cannot yet be told the exact version Renovate selected (#41624). If the updated range admits a pending release, the package manager can resolve that release into its lockfile instead.

`checkForPendingVersions()` exists to catch this after artifact generation. It re-extracts the updated dependency and compares its resolved version with `pendingVersions`; if they match, Renovate creates an Artifact Error so reviewers do not unknowingly accept a release that has not passed Minimum Release Age.

Repository discovery and this post-artifact check use different manager APIs. Discovery calls `extractAllPackageFiles(config, files)`, while the safety check calls the public `extractPackageFile(content, fileName, config)`. The bulk extractor is still required for initial repository discovery. The single-file API is required later because the updated package file and generated artifacts exist in memory.

Bun, npm, and Gradle did not satisfy that post-artifact contract:

- Bun had only bulk extraction. Re-parsing only `package.json` would remove the warning but still miss the exact version selected into `bun.lock`.
- npm's manifest parser was not exported by the manager. Exporting it directly would bypass npm's lockfile post-processing and would not support the other npm manager package files, `pnpm-workspace.yaml` and `.yarnrc.yml`.
- Gradle had only multi-file extraction. Gradle dependencies can use values from other files, and the exact artifact-selected version is stored in `gradle.lockfile`, so isolated parsing of `build.gradle` is insufficient.

The dispatcher therefore returned `null`, `checkForPendingVersions()` logged `Could not re-extract the packageFile after updating it`, and the safeguard stopped without checking the artifact-resolved version. The warning does not mean artifact generation failed; it means the Minimum Release Age safeguard was skipped.

`config:best-practices` is affected because it extends `security:minimumReleaseAgeNpm`, which applies a strict three-day `minimumReleaseAge` to the npm datasource. npm-backed dependencies managed by npm or Bun can therefore reach this path without users configuring `minimumReleaseAge` themselves. Gradle reaches the same path when Minimum Release Age is configured for Maven dependencies.

### What this changes

- The generic post-artifact path passes a snapshot containing all updated package files and cumulative artifact contents to manager re-extraction.
- Bun reuses its existing manifest parsing, reads resolved versions from the updated text `bun.lock`, and deliberately returns `null` for the legacy binary `bun.lockb` because it cannot safely validate that artifact.
- npm dispatches the public extractor across `package.json`, `pnpm-workspace.yaml`, and `.yarnrc.yml`, then runs the normal lockfile version post-processing against the in-memory npm, pnpm, or Yarn lockfile.
- Gradle re-extracts all configured Gradle files with every updated in-memory package file overlaid, then attaches versions parsed from standard Gradle lockfiles. Multiple locked versions are retained so any pending resolution is detected.

### Minimal reproduction

Public repository and harness: https://github.com/risu729/renovate-package-reextract-repro/tree/77c7b45fe7c8a0beeea04b3efe84a2161be7b4e0

The harness exercises the real `getUpdatedPackageFiles()` and artifact commands using copied minimal fixtures for all three managers:

- Bun updates `wrangler` from `4.118.0` to the bounded range `>=4.120.1 <=4.123.0`; Bun resolves pending `4.123.0` into `bun.lock`.
- npm updates the exact `packageManager` declaration from pnpm `10.13.1` to `10.14.0`; this should re-extract successfully without an Artifact Error.
- Gradle updates Guava from `33.4.0-jre` to the bounded Maven range `[33.4.8-jre,33.5.0-jre]`; Gradle resolves pending `33.5.0-jre` into `gradle.lockfile`.

The version and pending-version lists are fixed in the harness so later releases cannot change the result. The upstream run expects no Artifact Errors. The fixed run requires one Artifact Error for Bun, one for Gradle, and none for npm, and verifies that each error contains an expected pending version. The resulting package and lock files are byte-identical between the two runs.

These are the complete, unedited command outputs.

#### Latest `origin/main` (`c953fafcdc`)

```text

 RUN  v4.1.10 /tmp/renovate-upstream-main.U95Xl0
      Coverage enabled with v8

 WARN: Could not re-extract the packageFile after updating it (packageFile=fixtures/bun/package.json)
       "manager": "bun"
 WARN: Could not re-extract the packageFile after updating it (packageFile=fixtures/npm/package.json)
       "manager": "npm"
 ✓ lib/workers/repository/update/branch/reextract-repro.spec.ts > missing package-file re-extractors > 'bun' reaches the pending-version re-extraction check 411ms
 WARN: Could not re-extract the packageFile after updating it (packageFile=fixtures/gradle/build.gradle)
       "manager": "gradle"
 ✓ lib/workers/repository/update/branch/reextract-repro.spec.ts > missing package-file re-extractors > 'npm' reaches the pending-version re-extraction check 917ms
 ✓ lib/workers/repository/update/branch/reextract-repro.spec.ts > missing package-file re-extractors > 'gradle' reaches the pending-version re-extraction check 13993ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  17:55:33
   Duration  30.92s (transform 7.98s, setup 493ms, import 12.11s, tests 15.38s, environment 0ms)

 % Coverage report from v8

=============================== Coverage summary ===============================
Statements   : 13.88% ( 4437/31965 )
Branches     : 2.83% ( 478/16857 )
Functions    : 9.52% ( 453/4754 )
Lines        : 13.97% ( 4427/31684 )
================================================================================
```

#### This branch (`5cb6522233`)

```text

 RUN  v4.1.10 /home/risu/.ghr/github.com/renovatebot/renovate
      Coverage enabled with v8

 ✓ lib/workers/repository/update/branch/reextract-repro.spec.ts > missing package-file re-extractors > 'bun' reaches the pending-version re-extraction check 280ms
 ✓ lib/workers/repository/update/branch/reextract-repro.spec.ts > missing package-file re-extractors > 'npm' reaches the pending-version re-extraction check 940ms
 ✓ lib/workers/repository/update/branch/reextract-repro.spec.ts > missing package-file re-extractors > 'gradle' reaches the pending-version re-extraction check 13978ms

 Test Files  1 passed (1)
      Tests  3 passed (3)
   Start at  17:56:19
   Duration  31.25s (transform 8.30s, setup 516ms, import 12.39s, tests 15.26s, environment 0ms)

 % Coverage report from v8

=============================== Coverage summary ===============================
Statements   : 15.29% ( 4904/32058 )
Branches     : 4.3% ( 729/16933 )
Functions    : 11.23% ( 536/4769 )
Lines        : 15.4% ( 4894/31777 )
================================================================================
```

The behavior was first observed in https://github.com/risu729/github-notification-cleanup with Bun and `config:best-practices`.

No earlier Renovate issue or pull request containing this exact warning was found. Related work includes #41622, which introduced the pending-version artifact check; #41624 and #41652, which track passing version and Minimum Release Age constraints to package managers; and #43348, which adjusted handling of extracted dependencies without a resolvable version.

Validation includes the affected manager and branch-update unit suites, 100% changed-line coverage, repository formatting/static/type/schema checks, and the real-artifact reproduction above.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex with GPT-5.6 Sol and high reasoning effort investigated the failure, implemented non-trivial code and tests, created the multi-manager reproduction, and drafted the pull request documentation. The contributor reviewed the changes and validation evidence.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @risu729 will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public reproduction: https://github.com/risu729/renovate-package-reextract-repro/tree/77c7b45fe7c8a0beeea04b3efe84a2161be7b4e0

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
