### PR TITLE
fix(presets): support Red Hat Hardened Images

### DIFF
--- a/lib/config/presets/internal/workarounds.preset.ts
+++ b/lib/config/presets/internal/workarounds.preset.ts
@@ -350,12 +350,22 @@ export const presets: Record<string, Preset> = {
     ],
   },
   supportRedHatImageVersion: {
+    customDatasources: {
+      'redhat-hi': {
+        defaultRegistryUrlTemplate:
+          'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/{{packageName}}/images?page_size=100&sort_by=creation_date%5Bdesc%5D&include=data.repositories.tags.name',
+        transformTemplates: [
+          '{"releases": $map($distinct(data.repositories.tags.name), function($version) { {"version": $version} })}',
+        ],
+      },
+    },
     description:
       'Use specific versioning for Red Hat-maintained container images.',
     packageRules: [
       {
         matchDatasources: ['docker'],
         matchPackageNames: [
+          'registry.access.redhat.com/hi{,/}**',
           'registry.access.redhat.com/rhel',
           'registry.access.redhat.com/rhel-atomic',
           'registry.access.redhat.com/rhel-init',
@@ -367,9 +377,27 @@ export const presets: Record<string, Preset> = {
           'registry.access.redhat.com/rhel9/**',
           'registry.access.redhat.com/rhscl/**',
           'registry.access.redhat.com/ubi*{,/}**',
+          'registry.redhat.io/hi{,/}**',
           'redhat/**',
         ],
         versioning: 'redhat',
+      },
+      {
+        description:
+          'Discover Red Hat Hardened Image tags from the public catalog',
+        matchDatasources: ['docker'],
+        matchPackageNames: ['registry.access.redhat.com/hi{,/}**'],
+        overrideDatasource: 'custom.redhat-hi',
+        overridePackageName:
+          "{{replace 'registry.access.redhat.com/' '' packageName}}",
+      },
+      {
+        description:
+          'Discover terms-based Red Hat Hardened Image tags from the public catalog',
+        matchDatasources: ['docker'],
+        matchPackageNames: ['registry.redhat.io/hi{,/}**'],
+        overrideDatasource: 'custom.redhat-hi',
+        overridePackageName: "{{replace 'registry.redhat.io/' '' packageName}}",
       },
     ],
   },

--- a/lib/config/presets/internal/workarounds.spec.ts
+++ b/lib/config/presets/internal/workarounds.spec.ts
@@ -341,4 +341,42 @@ describe('config/presets/internal/workarounds', () => {
       });
     });
   });
+
+  describe('supportRedHatImageVersion', () => {
+    const preset = presets.supportRedHatImageVersion;
+    const packageRules = preset.packageRules!;
+
+    it.each`
+      packageName                               | expectedPackageName
+      ${'registry.access.redhat.com/hi/nodejs'} | ${'hi/nodejs'}
+      ${'registry.redhat.io/hi/nodejs'}         | ${'hi/nodejs'}
+    `(
+      'discovers $packageName from the Red Hat catalog',
+      async ({ packageName, expectedPackageName }) => {
+        const res = await applyPackageRules<PackageRuleInputConfig>({
+          datasource: 'docker',
+          depName: packageName,
+          packageName,
+          currentValue: '26.4.0-1783711702',
+          packageRules,
+        });
+
+        expect(res.datasource).toEqual('custom.redhat-hi');
+        expect(res.packageName).toEqual(expectedPackageName);
+        expect(res.versioning).toEqual('redhat');
+      },
+    );
+
+    it('configures the public catalog response transformation', () => {
+      expect(preset.customDatasources).toEqual({
+        'redhat-hi': {
+          defaultRegistryUrlTemplate:
+            'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/{{packageName}}/images?page_size=100&sort_by=creation_date%5Bdesc%5D&include=data.repositories.tags.name',
+          transformTemplates: [
+            '{"releases": $map($distinct(data.repositories.tags.name), function($version) { {"version": $version} })}',
+          ],
+        },
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Changes

Extend the internal Red Hat image workaround preset so Hardened Image repositories on both Red Hat registry hostnames use Red Hat versioning and discover tags through the public Red Hat Ecosystem Catalog. Add focused package-rule and custom-datasource tests.

This addresses Hardened Image tags such as 26.4.0-1783711702, which the Docker registry path does not currently expose as update candidates.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related prior report: #15781.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GPT-5 Codex prepared the implementation, tests, validation, and pull request text.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. Name the account.
- [ ] An agent will draft replies and @username will read them before they are posted. Name the account.
- [x] Nobody has explicitly committed to replying.

## Documentation

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://gitlab.com/xrow-public/renovate-config/-/merge_requests/31

Validation:

- pnpm vitest lib/config/presets/internal/workarounds.spec.ts --run
- pnpm check --all lib/config/presets/internal/workarounds.preset.ts lib/config/presets/internal/workarounds.spec.ts
- Equivalent custom-datasource validation updated registry.access.redhat.com/hi/nodejs from 26.4.0-1783711702 to 26.7.0-1786504792.
