### PR TITLE
fix(linters): forbid inert counts in v8 coverage-ignore comments

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -81,6 +81,7 @@
     "renovate/prefer-json-pipe": "error",
     "renovate/prefer-nullish-util": "error",
     "renovate/require-regex-util": "error",
+    "renovate/v8-ignore-no-count": "error",
     "renovate/v8-ignore-reason": "error",
     "renovate/validate-config-warnings-and-errors": "error",
     "renovate/zod-schema-naming": "error",

--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -31,6 +31,7 @@ Read the [GitHub Docs, renaming a branch](https://docs.github.com/en/repositorie
 - Always add unit tests for full code coverage
   - Only use [`v8` comments](https://github.com/AriPerkkio/ast-v8-to-istanbul?tab=readme-ov-file#ignore-hints) for unreachable code coverage that is needed for `codecov` completion
   - Use descriptive `v8` comments
+  - Do not add a line count after `next`, for example `next 3`, because V8 does not honor the count and always exempts only the next code block
 - Avoid cast or prefer `x as T` instead of `<T>x` cast
 - Prefer `satisfies` operator over `as`, read the [TypeScript release notes for `satisfies` operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html#the-satisfies-operator) to learn more
 - Avoid `Boolean` instead use `is` functions from `@sindresorhus/is` package, for example: `is.string`

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -262,7 +262,7 @@ export async function validateConfig(
 
       for (const [key, val] of Object.entries(config)) {
         const currentPath = parentPath ? `${parentPath}.${key}` : key;
-        /* v8 ignore next 7 -- TODO: add test */
+        /* v8 ignore next -- TODO: add test */
         if (key === '__proto__') {
           errors.push({
             topic: 'Config security error',
@@ -1089,7 +1089,7 @@ async function validateGlobalConfig(
   currentPath: string | undefined,
   config: AllConfig,
 ): Promise<void> {
-  /* v8 ignore next 5 -- not testable yet */
+  /* v8 ignore next -- not testable yet */
   if (getDeprecationMessage(key)) {
     warnings.push({
       topic: 'Deprecation Warning',

--- a/lib/logger/once.ts
+++ b/lib/logger/once.ts
@@ -34,7 +34,7 @@ function getCallSite(omitFn: OmitFn): string | null {
     if (callsite) {
       result = callsite.toString();
     }
-    /* v8 ignore next 2 -- should not happen */
+    /* v8 ignore next -- should not happen */
   } catch {
     // no-op
   } finally {
@@ -55,7 +55,7 @@ export function once(
 ): void {
   const callsite = getCallSite(omitFn);
 
-  /* v8 ignore next 3 -- should not happen */
+  /* v8 ignore next -- should not happen */
   if (!callsite) {
     return;
   }

--- a/lib/logger/renovate-logger.ts
+++ b/lib/logger/renovate-logger.ts
@@ -158,7 +158,7 @@ export class RenovateLogger implements Logger {
 
       if (isString(msg)) {
         const remappedLevel = getRemappedLevel(msg);
-        /* v8 ignore next 4 -- not easily testable */
+        /* v8 ignore next -- not easily testable */
         if (remappedLevel) {
           meta.oldLevel = level;
           level = remappedLevel;

--- a/lib/modules/datasource/bitrise/index.ts
+++ b/lib/modules/datasource/bitrise/index.ts
@@ -40,7 +40,7 @@ export class BitriseDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/cpan/index.ts
+++ b/lib/modules/datasource/cpan/index.ts
@@ -27,7 +27,7 @@ export class CpanDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/crate/index.ts
+++ b/lib/modules/datasource/crate/index.ts
@@ -328,7 +328,7 @@ export class CrateDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<RegistryInfo | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/dart-version/index.ts
+++ b/lib/modules/datasource/dart-version/index.ts
@@ -34,7 +34,7 @@ export class DartVersionDatasource extends Datasource {
   async getReleases({
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/dart/index.ts
+++ b/lib/modules/datasource/dart/index.ts
@@ -30,7 +30,7 @@ export class DartDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/deb/index.ts
+++ b/lib/modules/datasource/deb/index.ts
@@ -152,7 +152,7 @@ export class DebDatasource extends Datasource {
     registryUrl,
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/deno/index.ts
+++ b/lib/modules/datasource/deno/index.ts
@@ -98,7 +98,7 @@ export class DenoDatasource extends Datasource {
       versions,
       async (version) => {
         const cacheRelease = releasesCache[version];
-        /* v8 ignore next 3: hard to test */
+        /* v8 ignore next: hard to test */
         if (cacheRelease) {
           return cacheRelease;
         }

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -214,7 +214,7 @@ export async function getAuthHeaders(
     ).body;
 
     const token = authResponse.token ?? authResponse.access_token;
-    /* v8 ignore next 4 -- TODO: add test */
+    /* v8 ignore next -- TODO: add test */
     if (!token) {
       logger.warn('Failed to obtain docker registry token');
       return null;

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -203,7 +203,7 @@ export class DockerDatasource extends Datasource {
       registryHost,
       dockerRepository,
     );
-    /* v8 ignore next 4 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!headers) {
       logger.warn('No docker auth found - returning');
       return undefined;
@@ -254,7 +254,7 @@ export class DockerDatasource extends Datasource {
       registryHost,
       dockerRepository,
     );
-    /* v8 ignore next 4 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!headers) {
       logger.warn('No docker auth found - returning');
       return undefined;
@@ -316,7 +316,7 @@ export class DockerDatasource extends Datasource {
     // If getting the manifest fails here, then abort
     // This means that the latest tag doesn't have a manifest, which shouldn't
     // be possible
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!manifestResponse) {
       return null;
     }
@@ -608,7 +608,7 @@ export class DockerDatasource extends Datasource {
             manifest.config.digest,
           );
 
-          /* v8 ignore next 3 -- should never happen */
+          /* v8 ignore next -- should never happen */
           if (!configResponse) {
             return labels;
           }
@@ -1270,7 +1270,7 @@ export class DockerDatasource extends Datasource {
       ? 'latest'
       : (findLatestStable(tags) ?? tags.at(-1));
 
-    /* v8 ignore next 3 -- TODO: add test */
+    /* v8 ignore next -- TODO: add test */
     if (!latestTag) {
       return ret;
     }

--- a/lib/modules/datasource/flutter-version/index.ts
+++ b/lib/modules/datasource/flutter-version/index.ts
@@ -32,7 +32,7 @@ export class FlutterVersionDatasource extends Datasource {
   async getReleases({
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/git-refs/index.ts
+++ b/lib/modules/datasource/git-refs/index.ts
@@ -78,7 +78,7 @@ export class GitRefsDatasource extends GitDatasource {
   ): Promise<string | null> {
     const rawRefs: RawRefs[] | null = await this.getRawRefs({ packageName });
 
-    /* v8 ignore next 3 -- TODO: add test */
+    /* v8 ignore next -- TODO: add test */
     if (!rawRefs) {
       return null;
     }

--- a/lib/modules/datasource/gitlab-packages/index.ts
+++ b/lib/modules/datasource/gitlab-packages/index.ts
@@ -49,7 +49,7 @@ export class GitlabPackagesDatasource extends Datasource {
     registryUrl,
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/gitlab-releases/index.ts
+++ b/lib/modules/datasource/gitlab-releases/index.ts
@@ -28,7 +28,7 @@ export class GitlabReleasesDatasource extends Datasource {
     registryUrl,
     packageName,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/go/index.ts
+++ b/lib/modules/datasource/go/index.ts
@@ -129,7 +129,7 @@ export class GoDatasource extends Datasource {
       case GitlabTagsDatasource.id: {
         return this.direct.gitlab.getDigest(source, tag);
       }
-      /* v8 ignore next 3: can never happen, makes lint happy */
+      /* v8 ignore next: can never happen, makes lint happy */
       default: {
         return null;
       }

--- a/lib/modules/datasource/go/releases-direct.ts
+++ b/lib/modules/datasource/go/releases-direct.ts
@@ -130,13 +130,13 @@ export class GoDirectDatasource extends Datasource {
         res = await this.bitbucket.getReleases(source);
         break;
       }
-      /* v8 ignore next 3 -- should never happen */
+      /* v8 ignore next -- should never happen */
       default: {
         return null;
       }
     }
 
-    /* v8 ignore next 3 -- TODO: add test */
+    /* v8 ignore next -- TODO: add test */
     if (!res) {
       return null;
     }

--- a/lib/modules/datasource/golang-version/index.ts
+++ b/lib/modules/datasource/golang-version/index.ts
@@ -46,7 +46,7 @@ export class GolangVersionDatasource extends Datasource {
   private async _getReleases({
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/gradle-version/index.ts
+++ b/lib/modules/datasource/gradle-version/index.ts
@@ -31,7 +31,7 @@ export class GradleVersionDatasource extends Datasource {
   private async _getReleases({
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/helm/index.ts
+++ b/lib/modules/datasource/helm/index.ts
@@ -60,7 +60,7 @@ export class HelmDatasource extends Datasource {
     packageName,
     registryUrl: helmRepository,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!helmRepository) {
       return null;
     }

--- a/lib/modules/datasource/jenkins-plugins/index.ts
+++ b/lib/modules/datasource/jenkins-plugins/index.ts
@@ -38,7 +38,7 @@ export class JenkinsPluginsDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/jsr/index.ts
+++ b/lib/modules/datasource/jsr/index.ts
@@ -35,7 +35,7 @@ export class JsrDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/maven/index.ts
+++ b/lib/modules/datasource/maven/index.ts
@@ -26,7 +26,7 @@ import {
 } from './util.ts';
 
 function getLatestSuitableVersion(releases: Release[]): string | null {
-  /* v8 ignore next 3 -- TODO: add test */
+  /* v8 ignore next -- TODO: add test */
   if (!releases?.length) {
     return null;
   }
@@ -106,7 +106,7 @@ export class MavenDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/node-version/index.ts
+++ b/lib/modules/datasource/node-version/index.ts
@@ -30,7 +30,7 @@ export class NodeVersionDatasource extends Datasource {
   private async _getReleases({
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/npm/index.ts
+++ b/lib/modules/datasource/npm/index.ts
@@ -32,7 +32,7 @@ export class NpmDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/npm/npmrc.ts
+++ b/lib/modules/datasource/npm/npmrc.ts
@@ -17,7 +17,7 @@ let npmrcRaw = '';
 let packageRules: PackageRule[] = [];
 
 function envReplace(value: any, env = getEnv()): any {
-  /* v8 ignore next 3 -- TODO: add test */
+  /* v8 ignore next -- TODO: add test */
   if (!isString(value)) {
     return value;
   }

--- a/lib/modules/datasource/nuget/index.ts
+++ b/lib/modules/datasource/nuget/index.ts
@@ -39,7 +39,7 @@ export class NugetDatasource extends Datasource {
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     logger.trace(`nuget.getReleases(${packageName})`);
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/nuget/v3.ts
+++ b/lib/modules/datasource/nuget/v3.ts
@@ -43,7 +43,7 @@ export class NugetV3Api {
       resultCacheKey,
     );
 
-    /* v8 ignore next 3 -- TODO: add test */
+    /* v8 ignore next -- TODO: add test */
     if (cachedResult) {
       return cachedResult;
     }

--- a/lib/modules/datasource/orb/index.ts
+++ b/lib/modules/datasource/orb/index.ts
@@ -42,7 +42,7 @@ export class OrbDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/packagist/index.ts
+++ b/lib/modules/datasource/packagist/index.ts
@@ -246,7 +246,7 @@ export class PackagistDatasource extends Datasource {
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     logger.trace(`getReleases(${packageName})`);
 
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -205,7 +205,7 @@ export class PodDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/python-version/index.ts
+++ b/lib/modules/datasource/python-version/index.ts
@@ -46,7 +46,7 @@ export class PythonVersionDatasource extends Datasource {
   private async _getReleases({
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/repology/index.ts
+++ b/lib/modules/datasource/repology/index.ts
@@ -199,7 +199,7 @@ export class RepologyDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/rubygems/index.ts
+++ b/lib/modules/datasource/rubygems/index.ts
@@ -57,7 +57,7 @@ export class RubygemsDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/sbt-package/index.ts
+++ b/lib/modules/datasource/sbt-package/index.ts
@@ -363,7 +363,7 @@ export class SbtPackageDatasource extends MavenDatasource {
     config: PostprocessReleaseConfig,
     release: Release,
   ): Promise<PostprocessReleaseResult> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!config.registryUrl) {
       return release;
     }

--- a/lib/modules/datasource/sbt-plugin/index.ts
+++ b/lib/modules/datasource/sbt-plugin/index.ts
@@ -222,7 +222,7 @@ export class SbtPluginDatasource extends Datasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/terraform-module/index.ts
+++ b/lib/modules/datasource/terraform-module/index.ts
@@ -48,7 +48,7 @@ export class TerraformModuleDatasource extends TerraformDatasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }

--- a/lib/modules/datasource/terraform-provider/index.ts
+++ b/lib/modules/datasource/terraform-provider/index.ts
@@ -55,7 +55,7 @@ export class TerraformProviderDatasource extends TerraformDatasource {
     packageName,
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!registryUrl) {
       return null;
     }
@@ -305,7 +305,7 @@ export class TerraformProviderDatasource extends TerraformDatasource {
           };
           return newBuild;
         } catch (err) {
-          /* v8 ignore next 3 -- hard to test */
+          /* v8 ignore next -- hard to test */
           if (err instanceof ExternalHostError) {
             throw err;
           }
@@ -424,7 +424,7 @@ export class TerraformProviderDatasource extends TerraformDatasource {
     try {
       rawHashData = (await this.http.getText(zipHashUrl)).body;
     } catch (err) {
-      /* v8 ignore next 3 -- hard to test */
+      /* v8 ignore next -- hard to test */
       if (err instanceof ExternalHostError) {
         throw err;
       }

--- a/lib/modules/manager/gomod/update.ts
+++ b/lib/modules/manager/gomod/update.ts
@@ -25,13 +25,13 @@ export function updateDependency({
       logger.warn('gomod manager does not support replacement updates yet');
       return null;
     }
-    /* v8 ignore next 3 -- should never happen */
+    /* v8 ignore next -- should never happen */
     if (!currentName || !upgrade.managerData) {
       return null;
     }
     const currentNameNoVersion = getNameWithNoVersion(currentName);
     const lines = fileContent.split(newlineRegex);
-    /* v8 ignore next 4 -- hard to test */
+    /* v8 ignore next -- hard to test */
     if (lines.length <= upgrade.managerData.lineNumber) {
       logger.warn('go.mod current line no longer exists after update');
       return null;

--- a/lib/modules/manager/kustomize/artifacts.ts
+++ b/lib/modules/manager/kustomize/artifacts.ts
@@ -40,7 +40,7 @@ function helmRepositoryArgs(
       return `--repo ${quote(repository)} ${quote(depName)}`;
     case DockerDatasource.id:
       return quote(`oci://${repository}`);
-    /* v8 ignore next 2: should never happen */
+    /* v8 ignore next: should never happen */
     default:
       throw new Error(`Unknown datasource: ${datasource}`);
   }

--- a/lib/modules/manager/npm/extract/common/package-file.ts
+++ b/lib/modules/manager/npm/extract/common/package-file.ts
@@ -66,7 +66,7 @@ export function extractPackageJson(
           const match = regEx('^(?<name>.+)@(?<range>.+)$').exec(
             dependencies as string,
           );
-          /* v8 ignore next 3 -- needs test */
+          /* v8 ignore next -- needs test */
           if (!match?.groups) {
             break;
           }

--- a/lib/modules/manager/npm/extract/post/locked-versions.ts
+++ b/lib/modules/manager/npm/extract/post/locked-versions.ts
@@ -58,7 +58,7 @@ export async function getLockedVersions(
       if (!lockFileCache[npmLock]) {
         logger.trace(`Retrieving/parsing ${npmLock}`);
         const cache = await getNpmLock(npmLock);
-        /* v8 ignore next 4 -- needs test */
+        /* v8 ignore next -- needs test */
         if (!cache) {
           logger.warn({ npmLock }, 'Npm: unable to get lockfile');
           return;

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -112,7 +112,7 @@ export function determineLockFileDirs(
   for (const p of config.updatedPackageFiles!) {
     logger.trace(`Checking ${String(p.path)} for lock files`);
     const packageFile = getPackageFile(p.path);
-    /* v8 ignore next 3 -- needs test */
+    /* v8 ignore next -- needs test */
     if (!packageFile.managerData) {
       continue;
     }
@@ -601,7 +601,7 @@ export async function getAdditionalFiles(
         await updateYarnOffline(lockFileDir, updatedArtifacts);
       }
 
-      /* v8 ignore next 7 -- needs test */
+      /* v8 ignore next -- needs test */
       if (upgrades.some(yarn.isYarnUpdate)) {
         existingYarnrcYmlContent = await updateYarnBinary(
           lockFileDir,
@@ -611,7 +611,7 @@ export async function getAdditionalFiles(
       }
     }
     await resetNpmrcContent(lockFileDir, npmrcContent);
-    /* v8 ignore next 4 -- needs test */
+    /* v8 ignore next -- needs test */
     if (existingYarnrcYmlContent) {
       // TODO #22198
       await writeLocalFile(yarnRcYmlFilename!, existingYarnrcYmlContent);

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -228,7 +228,7 @@ export async function generateLockFile(
       ],
       docker: {},
     };
-    /* v8 ignore next 4 -- needs test */
+    /* v8 ignore next -- needs test */
     if (GlobalConfig.get('exposeAllEnv')) {
       extraEnv.NPM_AUTH = env.NPM_AUTH;
       extraEnv.NPM_EMAIL = env.NPM_EMAIL;

--- a/lib/modules/manager/npm/post-update/pnpm.ts
+++ b/lib/modules/manager/npm/post-update/pnpm.ts
@@ -88,7 +88,7 @@ export async function generateLockFile(
         pnpmToolConstraint,
       ],
     };
-    /* v8 ignore next 4 -- needs test */
+    /* v8 ignore next -- needs test */
     if (GlobalConfig.get('exposeAllEnv')) {
       extraEnv.NPM_AUTH = env.NPM_AUTH;
       extraEnv.NPM_EMAIL = env.NPM_EMAIL;

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -213,7 +213,7 @@ export async function generateLockFile(
       docker: {},
       toolConstraints,
     };
-    /* v8 ignore next 4 -- needs test */
+    /* v8 ignore next -- needs test */
     if (GlobalConfig.get('exposeAllEnv')) {
       extraEnv.NPM_AUTH = env.NPM_AUTH;
       extraEnv.NPM_EMAIL = env.NPM_EMAIL;

--- a/lib/modules/manager/npm/update/locked-dependency/package-lock/index.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/package-lock/index.ts
@@ -248,7 +248,7 @@ export async function updateLockedDependency(
       }
       newPackageJsonContent =
         parentUpdateResult.files[packageFile] || newPackageJsonContent;
-      /* v8 ignore next 2 -- hard to test */
+      /* v8 ignore next -- hard to test */
       newLockFileContent =
         parentUpdateResult.files[lockFile] || newLockFileContent;
     }

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/get-locked.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/get-locked.ts
@@ -30,7 +30,7 @@ export function getYarn1LockedDependencies(
   try {
     for (const [depNameConstraint, entry] of Object.entries(yarnLock)) {
       const parsed = parseEntry(depNameConstraint);
-      /* v8 ignore next 3 -- needs test */
+      /* v8 ignore next -- needs test */
       if (!parsed) {
         continue;
       }
@@ -59,7 +59,7 @@ export function getYarn2LockedDependencies(
       for (const subConstraint of fullConstraint.split(', ')) {
         const depNameConstraint = subConstraint;
         const parsed = parseEntry(depNameConstraint);
-        /* v8 ignore next 3 -- needs test */
+        /* v8 ignore next -- needs test */
         if (!parsed) {
           continue;
         }

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.ts
@@ -78,7 +78,7 @@ export function updateLockedDependency(
         newVersion,
       );
     }
-    /* v8 ignore next 4 -- cannot test */
+    /* v8 ignore next -- cannot test */
     if (newLockFileContent === lockFileContent) {
       logger.debug('Failed to make any changes to lock file');
       return { status: 'update-failed' };

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -60,7 +60,7 @@ export class UvProcessor extends BasePyProjectProcessor {
     // Skip sources that do not make sense to handle (e.g. path).
     if (uv.sources || defaultIndex || implicitIndexUrls) {
       for (const dep of deps) {
-        /* v8 ignore next 3 -- needs test */
+        /* v8 ignore next -- needs test */
         if (!dep.packageName) {
           continue;
         }
@@ -363,7 +363,7 @@ async function getUvIndexCredentials(
 
   for (const { name, url } of uv_indexes) {
     const parsedUrl = parseUrl(url);
-    /* v8 ignore next 3 -- needs test */
+    /* v8 ignore next -- needs test */
     if (!parsedUrl) {
       continue;
     }

--- a/lib/modules/manager/terraform/extractors/others/modules.ts
+++ b/lib/modules/manager/terraform/extractors/others/modules.ts
@@ -44,7 +44,7 @@ export class ModuleExtractor extends DependencyExtractor {
       return [];
     }
 
-    /* v8 ignore next 4 -- needs test */
+    /* v8 ignore next -- needs test */
     if (!isPlainObject(modules)) {
       logger.debug({ modules }, 'Terraform: unexpected `modules` value');
       return [];

--- a/lib/modules/manager/terraform/extractors/others/providers.ts
+++ b/lib/modules/manager/terraform/extractors/others/providers.ts
@@ -20,7 +20,7 @@ export class ProvidersExtractor extends TerraformProviderExtractor {
       return [];
     }
 
-    /* v8 ignore next 7 -- needs test */
+    /* v8 ignore next -- needs test */
     if (!isPlainObject(providerTypes)) {
       logger.debug(
         { providerTypes },

--- a/lib/modules/manager/terraform/extractors/resources/generic-docker-image-ref.ts
+++ b/lib/modules/manager/terraform/extractors/resources/generic-docker-image-ref.ts
@@ -84,7 +84,7 @@ export class GenericDockerImageRefExtractor extends DependencyExtractor {
     const dependencies: PackageDependency[] = [];
     // if there are no path elements left, we have reached the end of the path
     if (leftPath.length === 0) {
-      /* v8 ignore next 8 -- needs test */
+      /* v8 ignore next -- needs test */
       if (!isNonEmptyString(parentElement)) {
         return [
           {

--- a/lib/modules/manager/terraform/extractors/resources/helm-release.ts
+++ b/lib/modules/manager/terraform/extractors/resources/helm-release.ts
@@ -31,7 +31,7 @@ export class HelmReleaseExtractor extends DependencyExtractor {
       return [];
     }
 
-    /* v8 ignore next 7 -- needs test */
+    /* v8 ignore next -- needs test */
     if (!isPlainObject(helmReleases)) {
       logger.debug(
         { helmReleases },

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -177,7 +177,7 @@ export async function updateArtifacts({
         const updateLock = locks.find(
           (value) => value.packageName === packageName,
         );
-        /* v8 ignore next 4 -- needs test */
+        /* v8 ignore next -- needs test */
         if (!updateLock) {
           logger.debug(`Skipping. No lock found for "${packageName}"`);
           continue;

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -1269,7 +1269,7 @@ export async function getBranchLastCommitTime(
     return time.toJSDate();
   } catch (err) {
     const errChecked = checkForPlatformFailure(err);
-    /* v8 ignore next 3 -- TODO: add test */
+    /* v8 ignore next -- TODO: add test */
     if (errChecked) {
       throw errChecked;
     }

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -222,7 +222,7 @@ export async function renovateRepository(
   AbandonedPackageStats.report();
   GitOperationStats.report();
   const cloned = isCloned();
-  /* v8 ignore next 11 -- coverage not required of these `undefined` checks, as we're happy receiving an `undefined` in the logs */
+  /* v8 ignore next -- coverage not required of these `undefined` checks, as we're happy receiving an `undefined` in the logs */
   logger.info(
     {
       cloned,

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -33,13 +33,13 @@ function filterByMaxMajorIncrement(
   depName: string,
 ): Release[] {
   const currentMajor = versioningApi.getMajor(currentVersion);
-  /* v8 ignore next 3 -- shouldn't happen */
+  /* v8 ignore next -- shouldn't happen */
   if (currentMajor === null) {
     return releases;
   }
   return releases.filter((r) => {
     const releaseMajor = versioningApi.getMajor(r.version);
-    /* v8 ignore next 3 -- shouldn't happen */
+    /* v8 ignore next -- shouldn't happen */
     if (releaseMajor === null) {
       return true;
     }
@@ -64,7 +64,7 @@ export function filterVersions(
   const { ignoreUnstable, ignoreDeprecated, respectLatest, maxMajorIncrement } =
     config;
 
-  /* v8 ignore next 3 -- shouldn't happen */
+  /* v8 ignore next -- shouldn't happen */
   if (!currentVersion) {
     return [];
   }

--- a/tools/lint/rules.js
+++ b/tools/lint/rules.js
@@ -20,6 +20,7 @@ import preferNullishUtil from './rules/prefer-nullish-util.js';
 import preferPartialInSpecs from './rules/prefer-partial-in-specs.js';
 import requireRegexUtil from './rules/require-regex-util.js';
 import testRootDescribe from './rules/test-root-describe.js';
+import v8IgnoreNoCount from './rules/v8-ignore-no-count.js';
 import v8IgnoreReason from './rules/v8-ignore-reason.js';
 import validateConfigWarningsAndErrors from './rules/validate-config-warnings-and-errors.js';
 import zodSchemaLocation from './rules/zod-schema-location.js';
@@ -52,6 +53,7 @@ export default {
     'prefer-partial-in-specs': preferPartialInSpecs,
     'require-regex-util': requireRegexUtil,
     'test-root-describe': testRootDescribe,
+    'v8-ignore-no-count': v8IgnoreNoCount,
     'v8-ignore-reason': v8IgnoreReason,
     'validate-config-warnings-and-errors': validateConfigWarningsAndErrors,
     'zod-schema-location': zodSchemaLocation,

--- a/tools/lint/rules/v8-ignore-no-count.js
+++ b/tools/lint/rules/v8-ignore-no-count.js
@@ -1,0 +1,48 @@
+/**
+ * Forbids the count form `next <N>` of coverage-ignore hints.
+ *
+ * The count is not honored by the coverage provider: vitest's
+ * `ast-v8-to-istanbul` hint parser captures only the keyword
+ * (`if`/`else`/`next`/`file`), so `next` always exempts exactly the next AST
+ * node, however many lines it spans. A trailing number suggests a line range
+ * that is never applied and misleads readers about what is exempted.
+ *
+ * The fixer drops the count, which preserves the actual (keyword-only)
+ * behavior.
+ */
+const countRegex = /(v8 ignore\s+next)\s+\d+/;
+
+/** @type {import('eslint').Rule.RuleModule} */
+export default {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    messages: {
+      noCount:
+        "The count in 'v8 ignore next <N>' is not honored by V8 coverage - 'next' always exempts exactly the next AST node. Use 'v8 ignore next' (or 'if'/'else'/'file') instead.",
+    },
+  },
+  create(context) {
+    return {
+      Program() {
+        for (const comment of context.sourceCode.getAllComments()) {
+          const match = countRegex.exec(comment.value);
+          if (!match || !comment.loc || !comment.range) {
+            continue;
+          }
+          // comment.value excludes the leading `/*` or `//` (2 characters)
+          const start = comment.range[0] + 2 + match.index;
+          const end = start + match[0].length;
+          const keyword = match[1];
+          context.report({
+            loc: comment.loc,
+            messageId: 'noCount',
+            fix(fixer) {
+              return fixer.replaceTextRange([start, end], keyword);
+            },
+          });
+        }
+      },
+    };
+  },
+};

--- a/tools/lint/rules/v8-ignore-reason.js
+++ b/tools/lint/rules/v8-ignore-reason.js
@@ -5,9 +5,9 @@
  * only captures the keyword (`if`/`else`/`next`/`file`) and `next` always
  * exempts exactly the next AST node, however many lines it spans: `next 2`
  * before two sibling statements exempts only the first, while `next 1`
- * before a multi-line `if` block exempts the whole block. Existing counts
- * are inert noise and remain allowed by this rule; only a justification is
- * required.
+ * before a multi-line `if` block exempts the whole block. This rule only
+ * requires a justification; the count form itself is forbidden by the
+ * companion `v8-ignore-no-count` rule.
  *
  * A `stop` marker only terminates a region opened by `start`; the
  * justification lives on the `start` marker, so bare stops are exempt.
@@ -21,7 +21,7 @@ const bareStopRegex = /^\s*v8 ignore stop\s*$/;
 const dashReasonRegex = /v8 ignore.*?--+\s+\S/;
 
 /**
- * Legacy colon form, e.g. `v8 ignore next 3: hard to test`. Accepted because
+ * Legacy colon form, e.g. `v8 ignore next: hard to test`. Accepted because
  * it is widespread in the codebase, but the dash form is recommended.
  */
 const colonReasonRegex = /v8 ignore\s+[a-z]+(?:\s+\d+)?\s*:\s*\S/;


### PR DESCRIPTION
## Changes

Adds a new custom oxlint rule `renovate/v8-ignore-no-count` that forbids the count form of coverage-ignore comments, e.g. `/* v8 ignore next 4 -- foo */`.

The count is not honored by the coverage provider: vitest's `ast-v8-to-istanbul` hint parser captures only the keyword (`if`/`else`/`next`/`file`), so `next` always exempts exactly the next AST node, however many lines it spans. A trailing count therefore suggests a line range that is never applied and misleads readers about what is actually exempted.

Details:

- New rule `tools/lint/rules/v8-ignore-no-count.js`, enabled as `error` in `.oxlintrc.json`. It is autofixable: the fixer drops the count (e.g. `next 4` → `next`), which preserves the actual keyword-only behavior, so coverage results are unchanged.
- The autofix was applied to all 78 existing occurrences across `lib/` and `tools/`.
- Updated the note in `v8-ignore-reason.js` that previously documented counts as "allowed inert noise" to point to the new companion rule.
- Added a bullet to `docs/development/best-practices.md` advising against counts.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #44728
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The rule implementation, config wiring, and docs update were written by Claude Code (model: Claude Fable 5), which also ran the autofix over the existing occurrences. Verified via `pnpm oxlint`, `pnpm type-check`, `pnpm biome`, `pnpm prettier`, and targeted vitest runs.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
