### PR TITLE
feat: implement custom registry support for python-versions

### DIFF
--- a/lib/modules/datasource/python-version/index.spec.ts
+++ b/lib/modules/datasource/python-version/index.spec.ts
@@ -178,5 +178,71 @@ describe('modules/datasource/python-version/index', () => {
         }
       });
     });
+
+    it('supports registryUrl override', async () => {
+      httpMock
+        .scope(
+          'https://artifactory.company.com/static-python-org/api/v2/downloads/release',
+        )
+        .get('')
+        .reply(200, Fixtures.get('release.json'));
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'python',
+        registryUrls: [
+          'https://artifactory.company.com/static-python-org/api/v2/downloads/release',
+        ],
+      });
+
+      expect(res?.releases).toHaveLength(2);
+    });
+
+    it('support host-level registry override', async () => {
+      httpMock
+        .scope(
+          'https://static-python-org.artifactory.company.com/api/v2/downloads/release',
+        )
+        .get('')
+        .reply(200, Fixtures.get('release.json'));
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'python',
+        registryUrls: [
+          'https://static-python-org.artifactory.company.com/api/v2/downloads/release',
+        ],
+      });
+
+      expect(res?.releases).toHaveLength(2);
+    });
+
+    it('Fall back to default registry if registryUrl is not specified', async () => {
+      httpMock
+        .scope(defaultRegistryUrl)
+        .get('')
+        .reply(200, Fixtures.get('release.json'));
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'python',
+        registryUrls: [],
+      });
+
+      expect(res?.releases).toHaveLength(2);
+    });
+
+    it('error when registry URL is invalid', async () => {
+      // consume the global EOL mock which is set in beforeEach
+      await new PythonVersionDatasource().getEolReleases();
+
+      const res = await getPkgReleases({
+        datasource,
+        packageName: 'python',
+        registryUrls: ['this/is-an;invalid$url'],
+      });
+
+      expect(res).toBeNull();
+    });
   });
 });

--- a/lib/modules/datasource/python-version/index.ts
+++ b/lib/modules/datasource/python-version/index.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { HttpError } from '../../../util/http/index.ts';
+import { parseUrl } from '../../../util/url.ts';
 import { id as versioning } from '../../versioning/python/index.ts';
 import { Datasource } from '../datasource.ts';
 import { registryUrl as eolRegistryUrl } from '../endoflife-date/common.ts';
@@ -21,8 +22,7 @@ export class PythonVersionDatasource extends Datasource {
     this.pythonEolDatasource = new EndoflifeDateDatasource();
   }
 
-  override readonly customRegistrySupport = false;
-
+  override readonly customRegistrySupport = true;
   override readonly defaultRegistryUrls = [defaultRegistryUrl];
 
   override readonly defaultVersioning = versioning;
@@ -50,6 +50,16 @@ export class PythonVersionDatasource extends Datasource {
     if (!registryUrl) {
       return null;
     }
+
+    const parsedUrl = parseUrl(registryUrl);
+    if (!parsedUrl) {
+      logger.warn(
+        { registryUrl },
+        'python-version datasource: Invalid registryUrl',
+      );
+      return null;
+    }
+
     const pythonPrebuildReleases = await this.getPrebuildReleases();
     const pythonPrebuildVersions = new Set<string>(
       pythonPrebuildReleases?.releases.map((release) => release.version),

--- a/lib/modules/datasource/rust-version/index.ts
+++ b/lib/modules/datasource/rust-version/index.ts
@@ -9,8 +9,6 @@ import { type ParsedManifestUrl, parseManifestUrl } from './parse.ts';
 export class RustVersionDatasource extends Datasource {
   static readonly id = 'rust-version';
 
-  override readonly customRegistrySupport = false;
-
   override readonly defaultRegistryUrls = ['https://static.rust-lang.org'];
 
   override readonly defaultVersioning = rustVersioning.id;

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -386,7 +386,7 @@ export abstract class HttpBase<
   }
 
   private resolveArgs<ResT = unknown>(
-    arg1: string,
+    arg1: string | URL,
     arg2: JSONOpts | ZodType<ResT> | undefined,
     arg3: ZodType<ResT> | undefined,
   ): InternalJsonOptions<JSONOpts, ResT> {
@@ -526,16 +526,16 @@ export abstract class HttpBase<
    * @param schema Zod schema for the response
    */
   getJson<Schema extends ZodType<any, any, any>>(
-    url: string,
+    url: string | URL,
     schema: Schema,
   ): Promise<HttpResponse<z.infer<Schema>>>;
   getJson<Schema extends ZodType<any, any, any>>(
-    url: string,
+    url: string | URL,
     options: JSONOpts,
     schema: Schema,
   ): Promise<HttpResponse<z.infer<Schema>>>;
   getJson<Schema extends ZodType<any, any, any>>(
-    arg1: string,
+    arg1: string | URL,
     arg2?: JSONOpts | Schema,
     arg3?: Schema,
   ): Promise<HttpResponse<z.infer<Schema>>> {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes
Implement custom registry support for python-versions, Also adds `| URL` to getJson and `resolveArgs` so I could use `parseUrl` to ensure custom registries are validated.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45025
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
