### PR TITLE
feat(platform/local): support dryRun=full to preview changes

### DIFF
--- a/lib/modules/platform/local/index.spec.ts
+++ b/lib/modules/platform/local/index.spec.ts
@@ -1,6 +1,17 @@
+import { partial } from '~test/util.ts';
+import { GlobalConfig } from '../../../config/global.ts';
+import { rawExec as _rawExec } from '../../../util/exec/common.ts';
+import type { ExecResult } from '../../../util/exec/types.ts';
 import * as platform from './index.ts';
 
+vi.mock('../../../util/exec/common.ts');
+const rawExec = vi.mocked(_rawExec);
+
 describe('modules/platform/local/index', () => {
+  afterEach(() => {
+    GlobalConfig.reset();
+  });
+
   describe('initPlatform', () => {
     it('returns input', async () => {
       expect(await platform.initPlatform({})).toMatchInlineSnapshot(`
@@ -26,17 +37,25 @@ describe('modules/platform/local/index', () => {
       });
     });
 
-    it('falls back to lookup when dryRun=full is requested', async () => {
+    it('preserves an explicit dryRun=full override', async () => {
       await expect(
         platform.initPlatform({
           dryRun: 'full',
         }),
       ).resolves.toEqual({
-        dryRun: 'lookup',
+        dryRun: 'full',
         endpoint: 'local',
         persistRepoData: true,
         requireConfig: 'optional',
       });
+    });
+
+    it('falls back to lookup for unsupported dryRun values', async () => {
+      await expect(
+        platform.initPlatform({
+          dryRun: 'silent',
+        }),
+      ).resolves.toMatchObject({ dryRun: 'lookup' });
     });
   });
 
@@ -55,6 +74,37 @@ describe('modules/platform/local/index', () => {
           "repoFingerprint": "",
         }
       `);
+      expect(rawExec).not.toHaveBeenCalled();
+    });
+
+    it('allows dryRun=full on a clean work tree', async () => {
+      GlobalConfig.set({ dryRun: 'full', localDir: '/tmp/foo' });
+      rawExec.mockResolvedValueOnce(partial<ExecResult>({ stdout: '\n' }));
+      await expect(platform.initRepo()).resolves.toMatchObject({
+        defaultBranch: '',
+      });
+      expect(rawExec).toHaveBeenCalledExactlyOnceWith(
+        'git status --porcelain',
+        {
+          cwd: '/tmp/foo',
+        },
+      );
+    });
+
+    it('throws on dryRun=full with a dirty work tree', async () => {
+      GlobalConfig.set({ dryRun: 'full', localDir: '/tmp/foo' });
+      rawExec.mockResolvedValueOnce(
+        partial<ExecResult>({ stdout: ' M Dockerfile\n' }),
+      );
+      await expect(platform.initRepo()).rejects.toThrow('uncommitted changes');
+    });
+
+    it('warns on dryRun=full outside a git repository', async () => {
+      GlobalConfig.set({ dryRun: 'full', localDir: '/tmp/foo' });
+      rawExec.mockRejectedValueOnce(new Error('not a git repository'));
+      await expect(platform.initRepo()).resolves.toMatchObject({
+        defaultBranch: '',
+      });
     });
   });
 

--- a/lib/modules/platform/local/index.ts
+++ b/lib/modules/platform/local/index.ts
@@ -1,4 +1,7 @@
+import { GlobalConfig } from '../../../config/global.ts';
+import { logger } from '../../../logger/index.ts';
 import type { BranchStatus } from '../../../types/index.ts';
+import { rawExec } from '../../../util/exec/common.ts';
 import type {
   Issue,
   PlatformParams,
@@ -11,7 +14,17 @@ export const id = 'local';
 export const experimental = true;
 
 export function initPlatform(params: PlatformParams): Promise<PlatformResult> {
-  const dryRun = params.dryRun === 'extract' ? 'extract' : 'lookup';
+  // Default to `lookup`, but allow opting in to `extract` or `full`.
+  // `extract` stops after dependency extraction.
+  // `full` additionally computes the file changes Renovate would make and
+  // applies them to the working directory (so the result can be inspected),
+  // but never commits, pushes, or opens a PR.
+  // Other values (such as `null`, which would imply committing changes) fall
+  // back to `lookup`.
+  const dryRun =
+    params.dryRun === 'extract' || params.dryRun === 'full'
+      ? params.dryRun
+      : 'lookup';
   return Promise.resolve({
     dryRun,
     endpoint: 'local',
@@ -24,12 +37,42 @@ export function getRepos(): Promise<string[]> {
   return Promise.resolve([]);
 }
 
-export function initRepo(): Promise<RepoResult> {
-  return Promise.resolve({
+/**
+ * When running in `dryRun=full`, Renovate writes the updated package files to
+ * the working directory so the proposed changes can be inspected. Because the
+ * local platform operates on the user's current directory, refuse to run if a
+ * git work tree is present and dirty, so that every change Renovate makes stays
+ * revertable via `git checkout .`. When the directory is not a git repository
+ * we cannot offer that safety net, so warn instead.
+ */
+async function ensureRevertableWorkTree(): Promise<void> {
+  if (GlobalConfig.get('dryRun') !== 'full') {
+    return;
+  }
+  const cwd = GlobalConfig.get('localDir');
+  let status: string;
+  try {
+    status = (await rawExec('git status --porcelain', { cwd })).stdout;
+  } catch {
+    logger.warn(
+      'Running `--platform=local --dry-run=full` outside a git repository. Renovate will modify files in the current directory and these changes cannot be reverted automatically.',
+    );
+    return;
+  }
+  if (status.trim()) {
+    throw new Error(
+      'The git work tree has uncommitted changes. Commit or stash them before running `--platform=local --dry-run=full`, so that the changes Renovate makes can be reverted with `git checkout .`.',
+    );
+  }
+}
+
+export async function initRepo(): Promise<RepoResult> {
+  await ensureRevertableWorkTree();
+  return {
     defaultBranch: '',
     isFork: false,
     repoFingerprint: '',
-  });
+  };
 }
 
 export function findIssue(): Promise<null> {

--- a/lib/modules/platform/local/readme.md
+++ b/lib/modules/platform/local/readme.md
@@ -7,8 +7,20 @@ This can be handy when testing a new Renovate configuration for example.
 
 Run the `renovate --platform=local` command in the directory you want Renovate to run in.
 In this mode, Renovate defaults to `dryRun=lookup`.
-You can override this by passing `--dry-run=extract` to stop after the extract phase.
-Other `dryRun` values (such as `full`) are not supported on the local platform and fall back to `lookup`.
+
+You can override `dryRun` with one of:
+
+- `--dry-run=extract`: stop after the extract phase, to see which dependencies Renovate detects.
+- `--dry-run=full`: additionally compute the file changes Renovate would make and write them to the working directory, so you can inspect (for example with `git diff`) exactly what Renovate would change. Renovate never commits, pushes, or opens a pull request in this mode.
+
+Any other `dryRun` value (such as `null`, which would imply committing changes) falls back to `lookup`.
+
+### `dry-run=full` and your working directory
+
+Because the local platform operates on your _current working directory_, `--dry-run=full` modifies the files in place.
+To keep this safe, Renovate refuses to run `--dry-run=full` when the git work tree has uncommitted changes, so that you can always undo Renovate's changes with `git checkout .`.
+Commit or stash your changes first, run Renovate, inspect the result, then revert with `git checkout .` once you're done.
+If you run `--dry-run=full` in a directory that is not a git repository, Renovate warns you that its changes cannot be reverted automatically.
 
 Avoid giving "repositories" arguments, as this command can only run in a _single_ directory, and it can only run in the _current working_ directory.
 

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -961,6 +961,19 @@ describe('util/git/index', { timeout: 30000 }, () => {
       expect(await git.getFile('some-path', 'some-branch')).toBeNull();
     });
 
+    it('reads from the working directory when platform=local', async () => {
+      GlobalConfig.set({ platform: 'local', localDir: tmpDir.path });
+      await fs.outputFile(`${tmpDir.path}/local_file`, 'local contents');
+
+      expect(await git.getFile('local_file')).toBe('local contents');
+    });
+
+    it('returns null for a missing file when platform=local', async () => {
+      GlobalConfig.set({ platform: 'local', localDir: tmpDir.path });
+
+      expect(await git.getFile('missing_file')).toBeNull();
+    });
+
     it('logs a warning if hidden Unciode characters are found', async () => {
       await git.getFile('Dockerfile', 'renovate/hidden-unicode');
 

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -41,6 +41,7 @@ import { getCache } from '../cache/repository/index.ts';
 import { getEnv } from '../env.ts';
 import type { ExtraEnv } from '../exec/types.ts';
 import { getChildEnv } from '../exec/utils.ts';
+import { readLocalFile } from '../fs/index.ts';
 import { newlineRegex, regEx } from '../regex.ts';
 import type { LongCommitSha } from '../schema-utils/git.ts';
 import { toLongCommitSha } from '../schema-utils/git.ts';
@@ -1310,6 +1311,11 @@ export async function getFile(
   filePath: string,
   branchName?: string,
 ): Promise<string | null> {
+  // The local platform has no git branches to read from, so read the file
+  // straight from the working directory instead of syncing git.
+  if (GlobalConfig.get('platform') === 'local') {
+    return readLocalFile(filePath, 'utf8');
+  }
   await syncGit();
   try {
     const content = await git.show([


### PR DESCRIPTION
## Changes

The `local` platform previously only allowed `dryRun=lookup` or `dryRun=extract`, so users could never see the actual file changes Renovate would make. Attempting `dryRun=full` crashed with "Cannot sync git when platform=local" because `getFile` always synced git, which the local platform never initializes.

This PR:

- reads files straight from the working directory in `getFile` when `platform=local`, instead of syncing git (fixes the crash discussed in #37869)
- allows opting in to `dryRun=full` (default stays `lookup`), which applies the computed changes to the working directory so they can be inspected with `git diff`, without committing, pushing, or opening a PR
- guards `dryRun=full` against clobbering work: it refuses to run when the git work tree is dirty (so changes are revertable with `git checkout .`) and warns when run outside a git repository

This implements the `dryRun=full` roadmap item from discussion #40970, where the approach was described and has since drawn interest from other users wanting a fast local config-iteration loop: put files + config in a clean checkout, run `renovate --platform=local --dry-run=full`, inspect with `git diff`, revert, tweak, repeat.

Happy to rework this toward the `local` / `local-git` platform split suggested by @secustor in that discussion if that is the preferred direction; the dirty-work-tree guard slots into whichever platform ends up owning "writes to the local directory".

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, tests, and docs were developed with Claude Code (Claude Opus 4.8 during initial development; Claude Fable 5 for the rebase and PR preparation), directed and reviewed by @virzak, and verified end to end locally and against real repositories (see below).

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @virzak will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/lareeth/choco-podman-cli

This branch's `--platform=local --dry-run=full` loop was used to develop and validate the Renovate config for that repo (regex manager + `github-release-attachments` checksums); the local `git diff` output matched what the hosted bot later produced on its first real update PRs. It was also used the same way to validate https://github.com/zompinc/lattice-ecp5-toolchain's config (git-refs digest tracking) before onboarding.
