### PR TITLE
chore(AGENTS.md): tune the PR template + PR raising etiquette

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,8 @@ Two discussion categories are available:
 
 - PRs require 100% test coverage. Use `/* v8 ignore ... */` sparingly when tests wouldn't prove anything.
 - Do not force push PR branches.
-- Follow the PR template (`.github/pull_request_template.md`).
+- Follow the PR template (`.github/pull_request_template.md`). Before running `gh pr create`, read that file in full and use its exact section structure for the PR body — do not substitute a generic Summary/Test plan format.
+- PRs should be raised as a draft PR, and only marked ready once the CLA has been signed, and the user has confirmed that the changes are ready to go
 
 ### Commands
 


### PR DESCRIPTION
## Changes

Updates `AGENTS.md` guidance for AI agents working in this repo:

- Clarifies that agents must read `.github/pull_request_template.md` in full and use its exact section structure before running `gh pr create`, rather than substituting a generic Summary/Test plan format.
- Adds a rule that PRs should be raised as drafts, only marked ready once the CLA is signed and the user has confirmed the changes are ready to go.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR itself is a documentation change dictating AI agent behaviour, drafted with Claude (Sonnet 5) based on the repo maintainer's (@jamietanna's) instructions.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>