### PR TITLE
fix(datasource/pypi): use the earliest `upload_time` of a version

### DIFF
--- a/lib/modules/datasource/pypi/__fixtures__/numpy.json
+++ b/lib/modules/datasource/pypi/__fixtures__/numpy.json
@@ -1,0 +1,198 @@
+{
+  "info": {
+    "name": "numpy",
+    "home_page": null,
+    "project_urls": {
+      "documentation": "https://numpy.org/doc/",
+      "download": "https://pypi.org/project/numpy/#files",
+      "homepage": "https://numpy.org",
+      "release notes": "https://numpy.org/doc/stable/release",
+      "source": "https://github.com/numpy/numpy",
+      "tracker": "https://github.com/numpy/numpy/issues"
+    }
+  },
+  "releases": {
+    "1.5.0": [
+      {
+        "comment_text": "",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "f47eee0605be5f922a85f798bf8ff1849d4d043b08229b026e55527110384c6d",
+          "md5": "3a8bfdc434df782d647161c48943ee09",
+          "sha256": "06d2181c884c5937c7c475103dd55de4fe4842a9d91bab1ed0965dd973a4661a"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.0.tar.gz",
+        "has_sig": false,
+        "md5_digest": "3a8bfdc434df782d647161c48943ee09",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 2276377,
+        "upload_time": "2010-09-15T14:44:53",
+        "upload_time_iso_8601": "2010-09-15T14:44:53.723687Z",
+        "url": "https://files.pythonhosted.org/packages/f4/7e/ee0605be5f922a85f798bf8ff1849d4d043b08229b026e55527110384c6d/numpy-1.5.0.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "bdbd20b14b780f26876796fa7d33ac4e7d59adcd462c8c08006f5aeb11e67a10",
+          "md5": "95fd147bb761ca8e2baf34a153586358",
+          "sha256": "ba4d6b5d59e0646b6b82098db087ee2f9aedeca968354492f125ebb62f091f69"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.0.win32-py2.6.exe",
+        "has_sig": false,
+        "md5_digest": "95fd147bb761ca8e2baf34a153586358",
+        "packagetype": "bdist_wininst",
+        "python_version": "2.6",
+        "requires_python": null,
+        "size": 2338968,
+        "upload_time": "2010-08-31T18:15:09",
+        "upload_time_iso_8601": "2010-08-31T18:15:09.478131Z",
+        "url": "https://files.pythonhosted.org/packages/bd/bd/20b14b780f26876796fa7d33ac4e7d59adcd462c8c08006f5aeb11e67a10/numpy-1.5.0.win32-py2.6.exe",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ],
+    "1.5.1": [
+      {
+        "comment_text": "",
+        "core-metadata": {
+          "sha256": "e3e359893ffc9080f1fd2b8f140cefea87e033744504e87f926a637216783fbd"
+        },
+        "digests": {
+          "blake2b_256": "add60cee332656a0633ff062c13408734dc3c617d5d45d174c491033063668eb",
+          "md5": "78ccd7fc7bd4667969fa77634e1f2210",
+          "sha256": "2d19469a94eadd002b1596cb0ec22e4f27f4f96dd6c83391220d0e187041bd36"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.1-cp27-none-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.whl",
+        "has_sig": false,
+        "md5_digest": "78ccd7fc7bd4667969fa77634e1f2210",
+        "packagetype": "bdist_wheel",
+        "python_version": "cp27",
+        "requires_python": null,
+        "size": 10720015,
+        "upload_time": "2014-07-30T22:27:08",
+        "upload_time_iso_8601": "2014-07-30T22:27:08.796621Z",
+        "url": "https://files.pythonhosted.org/packages/ad/d6/0cee332656a0633ff062c13408734dc3c617d5d45d174c491033063668eb/numpy-1.5.1-cp27-none-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.whl",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "73e188932bb0420a0fbe1547ee96d4e7332de5c1ed5a846a6c96ea422c6bf753",
+          "md5": "376ef150df41b5353944ab742145352d",
+          "sha256": "c36789ec381fec09f519249744ea36a77e5534b69446a59ee73b06cac29542eb"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.1.tar.gz",
+        "has_sig": false,
+        "md5_digest": "376ef150df41b5353944ab742145352d",
+        "packagetype": "sdist",
+        "python_version": "source",
+        "requires_python": null,
+        "size": 2280220,
+        "upload_time": "2010-11-18T14:16:58",
+        "upload_time_iso_8601": "2010-11-18T14:16:58.801332Z",
+        "url": "https://files.pythonhosted.org/packages/73/e1/88932bb0420a0fbe1547ee96d4e7332de5c1ed5a846a6c96ea422c6bf753/numpy-1.5.1.tar.gz",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "Simple installer, no SSE instructions.",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "8b8ee20ca84e30db2d93d85370ba23efbe54037bb45348dd6496185e7bbb15fa",
+          "md5": "bfcb66706ebdece6a9680f79f2b643ca",
+          "sha256": "e45623a65625a22e8c59d5feacc02bdc360eed4ab9f01f3dc619dc58c56336ad"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.1.win32-py2.5-nosse.exe",
+        "has_sig": false,
+        "md5_digest": "bfcb66706ebdece6a9680f79f2b643ca",
+        "packagetype": "bdist_wininst",
+        "python_version": "2.5",
+        "requires_python": null,
+        "size": 2881052,
+        "upload_time": "2011-01-28T15:33:59",
+        "upload_time_iso_8601": "2011-01-28T15:33:59.749000Z",
+        "url": "https://files.pythonhosted.org/packages/8b/8e/e20ca84e30db2d93d85370ba23efbe54037bb45348dd6496185e7bbb15fa/numpy-1.5.1.win32-py2.5-nosse.exe",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "Simple installer, no SSE instructions.",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "d2fe2d765a8f923db9a2254f398af2cafdd777b39611e90ac28d5fc3b8fd9cfa",
+          "md5": "267627e760277e5f6a74a83772a4f1d0",
+          "sha256": "bea35acebd89855529f52e418f2b5d5976b50982651a7e1b97d4d6b68ba83130"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.1.win32-py2.6-nosse.exe",
+        "has_sig": false,
+        "md5_digest": "267627e760277e5f6a74a83772a4f1d0",
+        "packagetype": "bdist_wininst",
+        "python_version": "2.6",
+        "requires_python": null,
+        "size": 2342045,
+        "upload_time": "2011-01-28T15:31:25",
+        "upload_time_iso_8601": "2011-01-28T15:31:25.757819Z",
+        "url": "https://files.pythonhosted.org/packages/d2/fe/2d765a8f923db9a2254f398af2cafdd777b39611e90ac28d5fc3b8fd9cfa/numpy-1.5.1.win32-py2.6-nosse.exe",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "Simple installer, no SSE instructions.",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "eba9af5807aeefbc05d574e103212cfc71423ac255ad326de651ed01ddf7f995",
+          "md5": "7d6e48b35570c3d83db4cd0a4346b6c1",
+          "sha256": "37d8363be1e76b855ef27eb140caccd00e250244a6a3536dce9cd06a1e56ddbb"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.1.win32-py2.7-nosse.exe",
+        "has_sig": false,
+        "md5_digest": "7d6e48b35570c3d83db4cd0a4346b6c1",
+        "packagetype": "bdist_wininst",
+        "python_version": "2.7",
+        "requires_python": null,
+        "size": 2341138,
+        "upload_time": "2011-01-28T15:25:56",
+        "upload_time_iso_8601": "2011-01-28T15:25:56.453527Z",
+        "url": "https://files.pythonhosted.org/packages/eb/a9/af5807aeefbc05d574e103212cfc71423ac255ad326de651ed01ddf7f995/numpy-1.5.1.win32-py2.7-nosse.exe",
+        "yanked": false,
+        "yanked_reason": null
+      },
+      {
+        "comment_text": "Simple installer, no SSE instructions.",
+        "core-metadata": false,
+        "digests": {
+          "blake2b_256": "3fc92aa4f6426c7b8e4a227834ecb10da666c35791510bc1ae11bf6e87398c18",
+          "md5": "13c5ebdd920f2c756602358135fd7196",
+          "sha256": "8821b7d0c926858e81d11b13336edd6e0d4569d0179c9568ae08011658912823"
+        },
+        "downloads": -1,
+        "filename": "numpy-1.5.1.win32-py3.1-nosse.exe",
+        "has_sig": false,
+        "md5_digest": "13c5ebdd920f2c756602358135fd7196",
+        "packagetype": "bdist_wininst",
+        "python_version": "3.1",
+        "requires_python": null,
+        "size": 2496332,
+        "upload_time": "2011-01-28T15:32:39",
+        "upload_time_iso_8601": "2011-01-28T15:32:39.341520Z",
+        "url": "https://files.pythonhosted.org/packages/3f/c9/2aa4f6426c7b8e4a227834ecb10da666c35791510bc1ae11bf6e87398c18/numpy-1.5.1.win32-py3.1-nosse.exe",
+        "yanked": false,
+        "yanked_reason": null
+      }
+    ]
+  }
+}

--- a/lib/modules/datasource/pypi/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/datasource/pypi/__snapshots__/index.spec.ts.snap
@@ -126,7 +126,7 @@ exports[`modules/datasource/pypi/index > getReleases > processes real data 1`] =
   "registryUrl": "https://pypi.org/pypi",
   "releases": [
     {
-      "releaseTimestamp": "2017-04-03T16:55:14.000Z",
+      "releaseTimestamp": "2017-04-03T16:55:08.000Z",
       "version": "0.0.1",
     },
     {
@@ -134,7 +134,7 @@ exports[`modules/datasource/pypi/index > getReleases > processes real data 1`] =
       "version": "0.0.2",
     },
     {
-      "releaseTimestamp": "2017-04-28T21:18:54.000Z",
+      "releaseTimestamp": "2017-04-28T21:18:47.000Z",
       "version": "0.0.3",
     },
     {
@@ -146,7 +146,7 @@ exports[`modules/datasource/pypi/index > getReleases > processes real data 1`] =
       "version": "0.0.5",
     },
     {
-      "releaseTimestamp": "2017-06-13T22:21:05.000Z",
+      "releaseTimestamp": "2017-06-13T22:20:58.000Z",
       "version": "0.0.6",
     },
     {
@@ -154,15 +154,15 @@ exports[`modules/datasource/pypi/index > getReleases > processes real data 1`] =
       "version": "0.0.7",
     },
     {
-      "releaseTimestamp": "2017-07-07T16:22:26.000Z",
+      "releaseTimestamp": "2017-07-07T16:22:24.000Z",
       "version": "0.0.8",
     },
     {
-      "releaseTimestamp": "2017-08-28T20:14:33.000Z",
+      "releaseTimestamp": "2017-08-28T20:14:31.000Z",
       "version": "0.0.9",
     },
     {
-      "releaseTimestamp": "2017-09-22T23:47:59.000Z",
+      "releaseTimestamp": "2017-09-22T23:47:54.000Z",
       "version": "0.0.10",
     },
     {
@@ -241,7 +241,7 @@ exports[`modules/datasource/pypi/index > uses https://pypi.org/pypi/ instead of 
   "registryUrl": "https://pypi.org/simple",
   "releases": [
     {
-      "releaseTimestamp": "2017-04-03T16:55:14.000Z",
+      "releaseTimestamp": "2017-04-03T16:55:08.000Z",
       "version": "0.0.1",
     },
     {
@@ -249,7 +249,7 @@ exports[`modules/datasource/pypi/index > uses https://pypi.org/pypi/ instead of 
       "version": "0.0.2",
     },
     {
-      "releaseTimestamp": "2017-04-28T21:18:54.000Z",
+      "releaseTimestamp": "2017-04-28T21:18:47.000Z",
       "version": "0.0.3",
     },
     {
@@ -261,7 +261,7 @@ exports[`modules/datasource/pypi/index > uses https://pypi.org/pypi/ instead of 
       "version": "0.0.5",
     },
     {
-      "releaseTimestamp": "2017-06-13T22:21:05.000Z",
+      "releaseTimestamp": "2017-06-13T22:20:58.000Z",
       "version": "0.0.6",
     },
     {
@@ -269,15 +269,15 @@ exports[`modules/datasource/pypi/index > uses https://pypi.org/pypi/ instead of 
       "version": "0.0.7",
     },
     {
-      "releaseTimestamp": "2017-07-07T16:22:26.000Z",
+      "releaseTimestamp": "2017-07-07T16:22:24.000Z",
       "version": "0.0.8",
     },
     {
-      "releaseTimestamp": "2017-08-28T20:14:33.000Z",
+      "releaseTimestamp": "2017-08-28T20:14:31.000Z",
       "version": "0.0.9",
     },
     {
-      "releaseTimestamp": "2017-09-22T23:47:59.000Z",
+      "releaseTimestamp": "2017-09-22T23:47:54.000Z",
       "version": "0.0.10",
     },
     {

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -18,16 +18,16 @@ const mixedCaseResponse = Fixtures.get('versions-html-mixed-case.html');
 const withPeriodsResponse = Fixtures.get('versions-html-with-periods.html');
 
 const azureCliMonitorReleases = [
-  { releaseTimestamp: '2017-04-03T16:55:14.000Z', version: '0.0.1' },
+  { releaseTimestamp: '2017-04-03T16:55:08.000Z', version: '0.0.1' },
   { releaseTimestamp: '2017-04-17T20:32:30.000Z', version: '0.0.2' },
-  { releaseTimestamp: '2017-04-28T21:18:54.000Z', version: '0.0.3' },
+  { releaseTimestamp: '2017-04-28T21:18:47.000Z', version: '0.0.3' },
   { releaseTimestamp: '2017-05-09T21:36:51.000Z', version: '0.0.4' },
   { releaseTimestamp: '2017-05-30T23:13:49.000Z', version: '0.0.5' },
-  { releaseTimestamp: '2017-06-13T22:21:05.000Z', version: '0.0.6' },
+  { releaseTimestamp: '2017-06-13T22:20:58.000Z', version: '0.0.6' },
   { releaseTimestamp: '2017-06-21T22:12:36.000Z', version: '0.0.7' },
-  { releaseTimestamp: '2017-07-07T16:22:26.000Z', version: '0.0.8' },
-  { releaseTimestamp: '2017-08-28T20:14:33.000Z', version: '0.0.9' },
-  { releaseTimestamp: '2017-09-22T23:47:59.000Z', version: '0.0.10' },
+  { releaseTimestamp: '2017-07-07T16:22:24.000Z', version: '0.0.8' },
+  { releaseTimestamp: '2017-08-28T20:14:31.000Z', version: '0.0.9' },
+  { releaseTimestamp: '2017-09-22T23:47:54.000Z', version: '0.0.10' },
   { releaseTimestamp: '2017-10-24T02:14:07.000Z', version: '0.0.11' },
   { releaseTimestamp: '2017-11-14T18:31:57.000Z', version: '0.0.12' },
   { releaseTimestamp: '2017-12-05T18:57:54.000Z', version: '0.0.13' },
@@ -110,9 +110,9 @@ describe('modules/datasource/pypi/index', () => {
       ).toMatchSnapshot();
     });
 
-    it('uses the upload_time of the first file of a version', async () => {
-      // The wheel is listed first, but was uploaded a week after the sdist,
-      // so the timestamp we report depends on the order of the files
+    it('uses the earliest upload_time of the files of a version', async () => {
+      // The order of the files is not meaningful, so the timestamp must not
+      // depend on it: the wheel is listed first, but uploaded a week later
       const json = codeBlock`
         {
           "info": { "name": "foo" },
@@ -136,13 +136,12 @@ describe('modules/datasource/pypi/index', () => {
 
       expect(res?.releases).toEqual([
         {
-          releaseTimestamp: '2024-01-08T00:00:00.000Z',
+          releaseTimestamp: '2024-01-01T00:00:00.000Z',
           version: '1.0.0',
         },
       ]);
     });
 
-    // NOTE that this is incorrect, and being fixed as a follow-up
     it('uses the upload_time of the first file of real world data', async () => {
       // `numpy` shows how far off that can be:
       // - `1.5.1` was released in 2010
@@ -153,9 +152,8 @@ describe('modules/datasource/pypi/index', () => {
       const res = await getPkgReleases({ datasource, packageName: 'numpy' });
 
       expect(res?.releases).toEqual([
-        { releaseTimestamp: '2010-09-15T14:44:53.000Z', version: '1.5.0' },
-        // NOTE that this is incorrect, and being fixed as a follow-up
-        { releaseTimestamp: '2014-07-30T22:27:08.000Z', version: '1.5.1' },
+        { releaseTimestamp: '2010-08-31T18:15:09.000Z', version: '1.5.0' },
+        { releaseTimestamp: '2010-11-18T14:16:58.000Z', version: '1.5.1' },
       ]);
     });
 

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -12,6 +12,7 @@ vi.mock('google-auth-library');
 const googleAuth = vi.mocked(_googleAuth);
 
 const res1 = Fixtures.get('azure-cli-monitor.json');
+const numpyResponse = Fixtures.get('numpy.json');
 const htmlResponse = Fixtures.get('versions-html.html');
 const mixedCaseResponse = Fixtures.get('versions-html-mixed-case.html');
 const withPeriodsResponse = Fixtures.get('versions-html-with-periods.html');
@@ -107,6 +108,55 @@ describe('modules/datasource/pypi/index', () => {
           packageName: 'azure-cli-monitor',
         }),
       ).toMatchSnapshot();
+    });
+
+    it('uses the upload_time of the first file of a version', async () => {
+      // The wheel is listed first, but was uploaded a week after the sdist,
+      // so the timestamp we report depends on the order of the files
+      const json = codeBlock`
+        {
+          "info": { "name": "foo" },
+          "releases": {
+            "1.0.0": [
+              {
+                "filename": "foo-1.0.0-py3-none-any.whl",
+                "upload_time": "2024-01-08T00:00:00"
+              },
+              {
+                "filename": "foo-1.0.0.tar.gz",
+                "upload_time": "2024-01-01T00:00:00"
+              }
+            ]
+          }
+        }
+      `;
+      httpMock.scope(baseUrl).get('/foo/json').reply(200, json);
+
+      const res = await getPkgReleases({ datasource, packageName: 'foo' });
+
+      expect(res?.releases).toEqual([
+        {
+          releaseTimestamp: '2024-01-08T00:00:00.000Z',
+          version: '1.0.0',
+        },
+      ]);
+    });
+
+    // NOTE that this is incorrect, and being fixed as a follow-up
+    it('uses the upload_time of the first file of real world data', async () => {
+      // `numpy` shows how far off that can be:
+      // - `1.5.1` was released in 2010
+      // - `1.5.1` gained a wheel in 2014, which PyPI lists first
+      // - `1.5.0` lists its sdist first, even though a Windows installer was uploaded earlier
+      httpMock.scope(baseUrl).get('/numpy/json').reply(200, numpyResponse);
+
+      const res = await getPkgReleases({ datasource, packageName: 'numpy' });
+
+      expect(res?.releases).toEqual([
+        { releaseTimestamp: '2010-09-15T14:44:53.000Z', version: '1.5.0' },
+        // NOTE that this is incorrect, and being fixed as a follow-up
+        { releaseTimestamp: '2014-07-30T22:27:08.000Z', version: '1.5.1' },
+      ]);
     });
 
     it('supports custom datasource url', async () => {

--- a/lib/modules/datasource/pypi/index.ts
+++ b/lib/modules/datasource/pypi/index.ts
@@ -6,6 +6,7 @@ import { getEnv } from '../../../util/env.ts';
 import { parse } from '../../../util/html.ts';
 import type { OutgoingHttpHeaders } from '../../../util/http/types.ts';
 import { regEx } from '../../../util/regex.ts';
+import type { Timestamp } from '../../../util/timestamp.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
 import { ensureTrailingSlash, parseUrl } from '../../../util/url.ts';
 import * as pep440 from '../../versioning/pep440/index.ts';
@@ -38,7 +39,7 @@ export class PypiDatasource extends Datasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'The relase timestamp is determined from the `upload_time` field in the results. This field is not available when using the simple API.';
+    'The release timestamp is determined from the earliest `upload_time` field of the files of a version. This field is not available when using the simple API.';
   override readonly sourceUrlSupport = 'release';
   override readonly sourceUrlNote =
     'The source URL is determined from the `homepage` field if it is a github repository, else we use the `project_urls` field.';
@@ -188,11 +189,10 @@ export class PypiDatasource extends Datasource {
       const versions = Object.keys(dep.releases);
       dependency.releases = versions.map((version) => {
         const releases = coerceArray(dep.releases?.[version]);
-        const { upload_time: releaseTimestamp } = releases[0] || {};
         const isDeprecated = releases.some(({ yanked }) => yanked);
         const result: Release = {
           version,
-          releaseTimestamp: asTimestamp(releaseTimestamp),
+          releaseTimestamp: PypiDatasource.getEarliestTimestamp(releases),
         };
         if (isDeprecated) {
           result.isDeprecated = isDeprecated;
@@ -208,6 +208,20 @@ export class PypiDatasource extends Datasource {
       });
     }
     return dependency;
+  }
+
+  private static getEarliestTimestamp(
+    releases: PypiRelease[],
+  ): Timestamp | null {
+    let earliest: Timestamp | null = null;
+    for (const { upload_time } of releases) {
+      const timestamp = asTimestamp(upload_time);
+      // `asTimestamp` normalizes to UTC ISO 8601, so comparing the strings compares the instants
+      if (timestamp && (!earliest || timestamp < earliest)) {
+        earliest = timestamp;
+      }
+    }
+    return earliest;
   }
 
   private static extractVersionFromLinkText(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes



When calculating the `releaseTimestamp` for the PyPI datasource, we've
been looking at the first entry in the response, which isn't always
the first time this package existed.

In the case that a Wheel is uploaded after the package first was
released - for instance, to support a new version of Python, at an
existing pinned version of the package - this would lead to a
potentially incorrect calculation for the `releaseTimestamp`.

This can lead to Renovate seeing a package as newer than it is, which
can mean that i.e. `minimumReleaseAge` can show as pending for a package
that shouldn't be.

As part of upstream changes[0], this should be less frequent in the
ecosystem, but existing packages still exist with this behaviour.

To fix this, we can make sure that we filter a given Release's
to find the earliest `upload_time`.

[0]: https://blog.pypi.org/posts/2026-07-22-releases-now-reject-new-files-after-14-days/
<!-- Describe what behavior is changed by this PR. -->

This is split into two commits for ease of reviewing.

Split from https://github.com/renovatebot/renovate/pull/44222

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
