### PR TITLE
fix(datasource/go): prefer later `releaseTimestamp` from GitHub Releases

### DIFF
--- a/lib/modules/datasource/go/index.ts
+++ b/lib/modules/datasource/go/index.ts
@@ -40,7 +40,7 @@ export class GoDatasource extends Datasource {
 
   override readonly releaseTimestampSupport = true;
   override readonly releaseTimestampNote =
-    'If the release timestamp is not returned from the respective datasoure used to fetch the releases, then Renovate uses the `Time` field in the results instead.';
+    'If the release timestamp is not returned from the respective datasoure used to fetch the releases, then Renovate uses the `Time` field in the results instead. For modules hosted on GitHub, a later GitHub Release publication time takes precedence over both.';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
     'The source URL is determined from the `packageName` and `registryUrl`.';

--- a/lib/modules/datasource/go/readme.md
+++ b/lib/modules/datasource/go/readme.md
@@ -21,6 +21,22 @@ Therefore Renovate will also query `@v2/list` just in case there also exists a v
 Similarly, if the dependency is already on a higher version such as `v5`, Renovate will check in case higher major versions exist.
 You do not need to be worried about any 403/404 responses which result from such checks - they are the only way for Renovate to know if newer major releases exist.
 
+## Release timestamps
+
+A Go proxy reports the commit time of the tagged commit as a version's `Time`, which can be different to when the release first existed.
+This inconsistency can lead to `minimumReleaseAge` being applied incorrectly to the Go module's updates.
+
+!!! note
+  For modules hosted on GitHub, Renovate will look up if there is a GitHub Release on the repository, and if so, use the Release's publication time, if it's later than the timestamp reported by the Go proxy.
+  <br><br>
+  This lookup needs a GitHub token to be configured, and is skipped if the lookup fails, leaving the timestamp reported by the Go proxy in place.
+
+For example, this happens when:
+
+- an infrequently updated repository prepares a GitHub Release by creating a draft release
+- some time passes, and the maintainers publish the Release
+- no new commits are pushed to the release branch (i.e. `main`) in that time
+
 ## Fallback to direct lookups
 
 If no result is found from Go proxy lookups then Renovate will fall back to direct lookups.

--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -1,10 +1,13 @@
 import { codeBlock } from 'common-tags';
+import type { MockInstance } from 'vitest';
 import { Fixtures } from '~test/fixtures.ts';
 import { hostRules } from '~test/host-rules.ts';
 import * as httpMock from '~test/http-mock.ts';
+import * as githubGraphql from '../../../util/github/graphql/index.ts';
+import type { Timestamp } from '../../../util/timestamp.ts';
 import { GithubReleasesDatasource } from '../github-releases/index.ts';
 import { GithubTagsDatasource } from '../github-tags/index.ts';
-import { GoProxyDatasource } from './releases-goproxy.ts';
+import { GoProxyDatasource, getTagPrefix } from './releases-goproxy.ts';
 
 const datasource = new GoProxyDatasource();
 
@@ -21,6 +24,36 @@ describe('modules/datasource/go/releases-goproxy', () => {
     expect(datasource.encodeCase('Foo')).toBe('!foo');
     expect(datasource.encodeCase('FOO')).toBe('!f!o!o');
   });
+
+  it.each`
+    goModule                                          | tags                                          | expected
+    ${'github.com/stretchr/testify'}                  | ${['v1.11.1', 'v1.12.0']}                     | ${''}
+    ${'github.com/google/btree/v2'}                   | ${['v2.0.0']}                                 | ${''}
+    ${'github.com/aws/aws-sdk-go-v2/service/s3'}      | ${['service/s3/v1.100.0', 'v1.30.0']}         | ${'service/s3/'}
+    ${'github.com/aws/aws-sdk-go-v2/service/s3/v2'}   | ${['service/s3/v2.0.0']}                      | ${'service/s3/'}
+    ${'sigs.k8s.io/controller-runtime/tools/envtest'} | ${['tools/envtest/v0.19.0']}                  | ${'tools/envtest/'}
+    ${'cloud.google.com/go/storage'}                  | ${['storage/v1.40.0', 'v0.110.0']}            | ${'storage/'}
+    ${'gopkg.in/yaml.v3'}                             | ${['v3.0.1']}                                 | ${''}
+    ${'k8s.io/api'}                                   | ${['v0.36.3']}                                | ${''}
+    ${'github.com/prometheus/prometheus'}             | ${['v3.5.0']}                                 | ${''}
+    ${'github.com/containerd/containerd/v2'}          | ${['v2.0.0']}                                 | ${''}
+    ${'github.com/traefik/traefik/v3'}                | ${['v3.1.0']}                                 | ${''}
+    ${'github.com/foo/bar/baz'}                       | ${[]}                                         | ${''}
+    ${'github.com/foo/bar/baz'}                       | ${['baz/not-a-version', 'baz/prefix/v1.0.0']} | ${''}
+  `(
+    'getTagPrefix($goModule) === "$expected"',
+    ({
+      goModule,
+      tags,
+      expected,
+    }: {
+      goModule: string;
+      tags: string[];
+      expected: string;
+    }) => {
+      expect(getTagPrefix(goModule, tags)).toBe(expected);
+    },
+  );
 
   describe('requests', () => {
     const baseUrl = 'https://proxy.golang.org';
@@ -59,6 +92,13 @@ describe('modules/datasource/go/releases-goproxy', () => {
 
   describe('getReleases', () => {
     const baseUrl = 'https://proxy.golang.org';
+
+    let githubQueryReleases: MockInstance<typeof githubGraphql.queryReleases>;
+
+    beforeEach(() => {
+      githubQueryReleases = vi.spyOn(githubGraphql, 'queryReleases');
+      githubQueryReleases.mockResolvedValue([]);
+    });
 
     afterEach(() => {
       delete process.env.GOPROXY;
@@ -202,6 +242,230 @@ describe('modules/datasource/go/releases-goproxy', () => {
         ],
         sourceUrl: 'https://github.com/kubernetes/api',
         tags: { latest: 'v0.36.3' },
+      });
+    });
+
+    it('prefers the GitHub Release timestamp over the commit timestamp', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/github.com/stretchr/testify`)
+        .get('/@v/list')
+        .reply(
+          200,
+          codeBlock`
+            v1.11.1 2026-05-01T10:00:00Z
+            v1.12.0 2026-06-10T14:10:43Z
+          `,
+        )
+        .get('/@latest')
+        .reply(200, { Version: 'v1.12.0' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      githubQueryReleases.mockResolvedValueOnce([
+        {
+          version: 'v1.12.0',
+          releaseTimestamp: '2026-08-17T09:00:00.000Z' as Timestamp,
+          url: 'https://github.com/stretchr/testify/releases/tag/v1.12.0',
+        },
+      ]);
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/stretchr/testify',
+      });
+
+      expect(githubQueryReleases).toHaveBeenCalledWith(
+        { packageName: 'stretchr/testify', registryUrl: 'https://github.com' },
+        expect.anything(),
+      );
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v1.11.1',
+            releaseTimestamp: '2026-05-01T10:00:00.000Z',
+          },
+          {
+            version: 'v1.12.0',
+            releaseTimestamp: '2026-08-17T09:00:00.000Z',
+          },
+        ],
+        sourceUrl: 'https://github.com/stretchr/testify',
+        tags: { latest: 'v1.12.0' },
+      });
+    });
+
+    it('keeps the commit timestamp when the GitHub Release is older', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/github.com/google/btree`)
+        .get('/@v/list')
+        .reply(200, 'v1.0.0 2018-08-13T15:31:12Z')
+        .get('/@latest')
+        .reply(200, { Version: 'v1.0.0' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      githubQueryReleases.mockResolvedValueOnce([
+        {
+          version: 'v1.0.0',
+          releaseTimestamp: '2018-08-13T15:00:00.000Z' as Timestamp,
+          url: 'https://github.com/google/btree/releases/tag/v1.0.0',
+        },
+        {
+          version: 'v0.9.0',
+          releaseTimestamp: '2026-08-17T09:00:00.000Z' as Timestamp,
+          url: 'https://github.com/google/btree/releases/tag/v0.9.0',
+        },
+      ]);
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/google/btree',
+      });
+
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v1.0.0',
+            releaseTimestamp: '2018-08-13T15:31:12.000Z',
+          },
+        ],
+        sourceUrl: 'https://github.com/google/btree',
+        tags: { latest: 'v1.0.0' },
+      });
+    });
+
+    it('matches GitHub Releases of modules in a subdirectory', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/github.com/aws/aws-sdk-go-v2/service/s3`)
+        .get('/@v/list')
+        .reply(200, 'v1.100.0')
+        .get('/@v/v1.100.0.info')
+        .reply(410)
+        .get('/@latest')
+        .reply(200, { Version: 'v1.100.0' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      githubQueryReleases.mockResolvedValueOnce([
+        {
+          version: 'service/s3/v1.100.0',
+          releaseTimestamp: '2026-08-17T09:00:00.000Z' as Timestamp,
+          url: 'https://github.com/aws/aws-sdk-go-v2/releases/tag/service/s3/v1.100.0',
+        },
+      ]);
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/aws/aws-sdk-go-v2/service/s3',
+      });
+
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v1.100.0',
+            releaseTimestamp: '2026-08-17T09:00:00.000Z',
+          },
+        ],
+        sourceUrl: 'https://github.com/aws/aws-sdk-go-v2',
+        tags: { latest: 'v1.100.0' },
+      });
+    });
+
+    it('matches GitHub Releases of `+incompatible` versions', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/github.com/docker/docker`)
+        .get('/@v/list')
+        .reply(200, 'v28.0.0+incompatible 2026-06-10T14:10:43Z')
+        .get('/@latest')
+        .reply(200, { Version: 'v28.0.0+incompatible' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      githubQueryReleases.mockResolvedValueOnce([
+        {
+          version: 'v28.0.0',
+          releaseTimestamp: '2026-08-17T09:00:00.000Z' as Timestamp,
+          url: 'https://github.com/docker/docker/releases/tag/v28.0.0',
+        },
+      ]);
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/docker/docker',
+      });
+
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v28.0.0+incompatible',
+            releaseTimestamp: '2026-08-17T09:00:00.000Z',
+          },
+        ],
+        sourceUrl: 'https://github.com/docker/docker',
+        tags: { latest: 'v28.0.0+incompatible' },
+      });
+    });
+
+    it('skips GitHub Releases lookup for non-GitHub source URLs', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/bitbucket.org/library/go-lib`)
+        .get('/@v/list')
+        .reply(200, 'v1.0.0 2026-06-10T14:10:43Z')
+        .get('/@latest')
+        .reply(200, { Version: 'v1.0.0' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      const res = await datasource.getReleases({
+        packageName: 'bitbucket.org/library/go-lib',
+      });
+
+      expect(githubQueryReleases).not.toHaveBeenCalled();
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v1.0.0',
+            releaseTimestamp: '2026-06-10T14:10:43.000Z',
+          },
+        ],
+        sourceUrl: 'https://bitbucket.org/library/go-lib',
+        tags: { latest: 'v1.0.0' },
+      });
+    });
+
+    it('handles GitHub Releases fetch errors', async () => {
+      process.env.GOPROXY = baseUrl;
+
+      httpMock
+        .scope(`${baseUrl}/github.com/google/btree`)
+        .get('/@v/list')
+        .reply(200, 'v1.0.0 2018-08-13T15:31:12Z')
+        .get('/@latest')
+        .reply(200, { Version: 'v1.0.0' })
+        .get('/v2/@v/list')
+        .reply(404);
+
+      githubQueryReleases.mockRejectedValueOnce(new Error('unknown'));
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/google/btree',
+      });
+
+      expect(res).toEqual({
+        releases: [
+          {
+            version: 'v1.0.0',
+            releaseTimestamp: '2018-08-13T15:31:12.000Z',
+          },
+        ],
+        sourceUrl: 'https://github.com/google/btree',
+        tags: { latest: 'v1.0.0' },
       });
     });
 

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -7,15 +7,25 @@ import type { ConstraintsFilter } from '../../../config/types.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { detectPlatform } from '../../../util/common.ts';
 import { getEnv } from '../../../util/env.ts';
 import { filterMap } from '../../../util/filter-map.ts';
+import { queryReleases } from '../../../util/github/graphql/index.ts';
+import { GithubHttp } from '../../../util/http/github.ts';
 import { HttpError } from '../../../util/http/index.ts';
 import * as p from '../../../util/promises.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
+import type { Timestamp } from '../../../util/timestamp.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
-import { joinUrlParts } from '../../../util/url.ts';
+import {
+  joinUrlParts,
+  parseUrl,
+  trimLeadingSlash,
+  trimTrailingSlash,
+} from '../../../util/url.ts';
 import goVersioning from '../../versioning/go-mod-directive/index.ts';
 import { Datasource } from '../datasource.ts';
+import { GithubReleasesDatasource } from '../github-releases/index.ts';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
 import { BaseGoDatasource } from './base.ts';
 import { getSourceUrl } from './common.ts';
@@ -27,6 +37,15 @@ import { VersionInfo } from './schema.ts';
 const goVersionRegex = regEx(/^\s*go\s+(?<version>[^\s]+)\s*$/);
 
 const modRegex = regEx(/^(?<baseMod>.*?)(?:[./]v(?<majorVersion>\d+))?$/);
+
+const versionTagRegex = regEx(/^v\d/);
+
+/**
+ * Modules with a major version of v2 or above which have no `go.mod` are reported by a Go proxy with a `+incompatible` suffix, which is absent from the tag they were published as.
+ *
+ * @see https://go.dev/ref/mod#non-module-compat
+ */
+const incompatibleSuffixRegex = regEx(/\+incompatible$/);
 
 /**
  * @see https://go.dev/ref/mod#pseudo-versions
@@ -51,6 +70,38 @@ export function pseudoVersionToRelease(pseudoVersion: string): Release | null {
   };
 }
 
+/**
+ * A Go module which lives in a subdirectory of its repository is tagged with that subdirectory as a prefix, so `github.com/aws/aws-sdk-go-v2/service/s3` publishes `v1.2.3` as the tag `service/s3/v1.2.3`.
+ *
+ * @see https://go.dev/ref/mod#vcs-version
+ *
+ * Because we can't tell from the module path alone where the repository ends and the subdirectory begins, we try each candidate prefix - longest first - against the tags we actually found, in the same way as `filterByPrefix` does for direct lookups.
+ */
+export function getTagPrefix(goModule: string, tags: Iterable<string>): string {
+  const nameParts = goModule
+    .replace(regEx(/\/v\d+$/), '')
+    .split('/')
+    .slice(1);
+  const tagNames = [...tags];
+
+  while (nameParts.length) {
+    const prefix = `${nameParts.join('/')}/`;
+
+    const isUsed = tagNames.some(
+      (tag) =>
+        tag.startsWith(prefix) &&
+        versionTagRegex.test(tag.slice(prefix.length)),
+    );
+    if (isUsed) {
+      return prefix;
+    }
+
+    nameParts.shift();
+  }
+
+  return '';
+}
+
 export class GoProxyDatasource extends Datasource {
   static readonly id = 'go-proxy';
 
@@ -59,6 +110,8 @@ export class GoProxyDatasource extends Datasource {
   }
 
   readonly direct = new GoDirectDatasource();
+
+  private readonly githubHttp = new GithubHttp(GithubReleasesDatasource.id);
 
   private async _getReleases(
     config: GetReleasesConfig,
@@ -73,6 +126,7 @@ export class GoProxyDatasource extends Datasource {
     const noproxy = parseNoproxy();
 
     let result: ReleaseResult | null = null;
+    let servedByProxy = false;
 
     if (noproxy?.test(packageName)) {
       logger.debug(`Fetching ${packageName} via GONOPROXY match`);
@@ -96,6 +150,7 @@ export class GoProxyDatasource extends Datasource {
         );
         if (res.releases.length) {
           result = res;
+          servedByProxy = true;
           break;
         }
       } catch (err) {
@@ -126,7 +181,73 @@ export class GoProxyDatasource extends Datasource {
       }
     }
 
+    if (result?.sourceUrl && servedByProxy) {
+      await this.addGithubReleaseTimestamps(
+        packageName,
+        result.sourceUrl,
+        result.releases,
+      );
+    }
+
     return result;
+  }
+
+  /**
+   * A Go proxy reports the commit time of the tagged commit as a version's `Time`, which can be much earlier than the point at which that version was released.
+   *
+   * When the module is hosted on GitHub and the version has a GitHub Release, the Release's publication time is a better indicator of when the version became available.
+   */
+  async addGithubReleaseTimestamps(
+    packageName: string,
+    sourceUrl: string,
+    releases: Release[],
+  ): Promise<void> {
+    if (detectPlatform(sourceUrl) !== 'github') {
+      return;
+    }
+
+    const parsedUrl = parseUrl(sourceUrl);
+    /* v8 ignore next 3 -- detectPlatform only returns a platform for parseable URLs */
+    if (!parsedUrl) {
+      return;
+    }
+
+    const repository = trimTrailingSlash(
+      trimLeadingSlash(parsedUrl.pathname),
+    ).replace(regEx(/\.git$/), '');
+
+    try {
+      const githubReleases = await queryReleases(
+        {
+          packageName: repository,
+          registryUrl: parsedUrl.origin,
+        },
+        this.githubHttp,
+      );
+
+      const timestamps = new Map<string, Timestamp>();
+      for (const { version, releaseTimestamp } of githubReleases) {
+        timestamps.set(version, releaseTimestamp);
+      }
+
+      const tagPrefix = getTagPrefix(packageName, timestamps.keys());
+      for (const release of releases) {
+        const version = release.version.replace(incompatibleSuffixRegex, '');
+        const releaseTimestamp = timestamps.get(`${tagPrefix}${version}`);
+        if (
+          releaseTimestamp &&
+          (!release.releaseTimestamp ||
+            releaseTimestamp > release.releaseTimestamp)
+        ) {
+          release.releaseTimestamp = releaseTimestamp;
+        }
+      }
+    } catch (err) {
+      logger.debug(
+        { err, packageName },
+        'Error fetching GitHub Releases for Go module',
+      );
+    }
   }
 
   getReleases(config: GetReleasesConfig): Promise<ReleaseResult | null> {

--- a/lib/modules/manager/gomod/integration.spec.ts
+++ b/lib/modules/manager/gomod/integration.spec.ts
@@ -2,6 +2,7 @@ import { codeBlock } from 'common-tags';
 import * as httpMock from '~test/http-mock.ts';
 import { partial } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
+import * as githubGraphql from '../../../util/github/graphql/index.ts';
 import { fetchUpdates } from '../../../workers/repository/process/fetch.ts';
 import type { LookupUpdateConfig } from '../../../workers/repository/process/lookup/types.ts';
 import type { PackageFile } from '../types.ts';
@@ -15,6 +16,7 @@ describe('modules/manager/gomod/integration', () => {
     baseConfig = partial<LookupUpdateConfig>(getConfig() as never);
     baseConfig.manager = 'gomod';
     baseConfig.constraintsFiltering = 'strict';
+    vi.spyOn(githubGraphql, 'queryReleases').mockResolvedValue([]);
   });
 
   describe('when constraintsFiltering=strict', () => {


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes



As noted in #45314, there are cases where we may see as similar case to
the GitHub Releases datasource in #43451, where a Go module's published
`Time` matches the time that the commit the Git tag points to was
committed, rather than the time that the release was created.

If we do have a GitHub repository, we can look up the GitHub Releases
(or we'll get the Git Tags, if no Releases are present) and use the date
if it's _newer_





<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->

After:

```json
               {
                 "datasource": "go",
                 "depType": "require",
                 "depName": "github.com/stretchr/testify",
                 "currentValue": "v1.11.1",
                 "managerData": {"multiLine": true, "lineNumber": 8},
                 "updates": [
                   {
                     "bucket": "non-major",
                     "newVersion": "v1.12.0",
                     "newValue": "v1.12.0",
                     "releaseTimestamp": "2026-08-17T08:09:38.000Z",
                     "newVersionAgeInDays": 0,
                     "newMajor": 1,
                     "newMinor": 12,
                     "newPatch": 0,
                     "updateType": "minor",
                     "isBreaking": false,
                     "pendingChecks": true,
                     "libYears": 0.9722472095383055,
                     "branchName": "renovate/github.com-stretchr-testify-1.x"
                   }
                 ],
                 "packageName": "github.com/stretchr/testify",
                 "versioning": "semver",
                 "warnings": [],
                 "sourceUrl": "https://github.com/stretchr/testify",
                 "mostRecentTimestamp": "2026-08-17T08:09:38.000Z",
                 "currentVersion": "v1.11.1",
                 "currentVersionTimestamp": "2025-08-27T11:16:30.000Z",
                 "currentVersionAgeInDays": 355,
                 "isSingleVersion": true,
                 "fixedVersion": "v1.11.1"
               },
```