### PR TITLE
refactor(config): use constants for config validation topics

### DIFF
--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -23,6 +23,7 @@ import type {
 import type { GitNoVerifyOption } from '../util/git/types.ts';
 import type { MergeConfidence } from '../util/merge-confidence/types.ts';
 import type { Timestamp } from '../util/timestamp.ts';
+import type { ConfigValidationTopic } from './validation-helpers/types.ts';
 
 export type RenovateConfigStage =
   | 'global'
@@ -625,7 +626,8 @@ export interface PackageRule
 }
 
 export interface ValidationMessage {
-  topic: string;
+  // Topic is either the known list of topics, or a dynamically generated one
+  topic: ConfigValidationTopic | (string & {});
   message: string;
 }
 

--- a/lib/config/validation-helpers/match-base-branches.ts
+++ b/lib/config/validation-helpers/match-base-branches.ts
@@ -1,6 +1,6 @@
 import { isNonEmptyArray } from '@sindresorhus/is';
 import type { ValidationMessage } from '../types.ts';
-import type { CheckBaseBranchesArgs } from './types.ts';
+import { type CheckBaseBranchesArgs, ConfigValidationTopic } from './types.ts';
 
 /**
  * Only if type condition or context condition violated then errors array will be mutated to store metadata
@@ -16,7 +16,7 @@ export function check({
     !isNonEmptyArray(baseBranchPatterns)
   ) {
     warnings.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: `${currentPath}: You must configure baseBranchPatterns in order to use them inside matchBaseBranches.`,
     });
   }

--- a/lib/config/validation-helpers/regex-glob-matchers.ts
+++ b/lib/config/validation-helpers/regex-glob-matchers.ts
@@ -1,7 +1,7 @@
 import { isArray, isString } from '@sindresorhus/is';
 import { getRegexPredicate, isRegexMatch } from '../../util/string-match.ts';
 import type { ValidationMessage } from '../types.ts';
-import type { CheckMatcherArgs } from './types.ts';
+import { type CheckMatcherArgs, ConfigValidationTopic } from './types.ts';
 
 /**
  * Only if type condition or context condition violated then errors array will be mutated to store metadata
@@ -18,7 +18,7 @@ export function check({
       matchers.length > 1
     ) {
       res.push({
-        topic: 'Configuration Error',
+        topic: ConfigValidationTopic.Error,
         message: `${currentPath}: Your input contains * or ** along with other patterns. Please remove them, as * or ** matches all patterns.`,
       });
     }
@@ -28,14 +28,14 @@ export function check({
       // minimatch allows any string as glob
       if (isRegexMatch(matcher) && !getRegexPredicate(matcher)) {
         res.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Failed to parse regex pattern for ${currentPath}: ${matcher}`,
         });
       }
     }
   } else {
     res.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: `${currentPath}: should be an array of strings. You have included ${typeof matchers}.`,
     });
   }

--- a/lib/config/validation-helpers/types.ts
+++ b/lib/config/validation-helpers/types.ts
@@ -1,5 +1,20 @@
 import type { PackageRule } from '../types.ts';
 
+/**
+ * Known `topic`s for Config Validation errors.
+ *
+ * This is particularly important for `Security`, which callers use to decide that a violation must always fail validation.
+ */
+export const ConfigValidationTopic = {
+  Error: 'Configuration Error',
+  Warning: 'Configuration Warning',
+  Deprecation: 'Deprecation Warning',
+  Security: 'Config security error',
+} as const;
+
+export type ConfigValidationTopic =
+  (typeof ConfigValidationTopic)[keyof typeof ConfigValidationTopic];
+
 export interface CheckManagerArgs {
   resolvedRule: PackageRule;
   currentPath: string;

--- a/lib/config/validation-helpers/utils.ts
+++ b/lib/config/validation-helpers/utils.ts
@@ -10,6 +10,7 @@ import type { RegexManagerTemplates } from '../../modules/manager/custom/regex/t
 import type { CustomManager } from '../../modules/manager/custom/types.ts';
 import { regEx } from '../../util/regex.ts';
 import type { ValidationMessage } from '../types.ts';
+import { ConfigValidationTopic } from './types.ts';
 
 export function getParentName(parentPath: string | undefined): string {
   return parentPath
@@ -44,13 +45,13 @@ export function validateNumber(
   if (isNumber(val)) {
     if (val < 0 && !allowsNegative) {
       errors.push({
-        topic: 'Configuration Error',
+        topic: ConfigValidationTopic.Error,
         message: `Configuration option \`${path}\` should be a positive integer. Found negative value instead.`,
       });
     }
   } else {
     errors.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: `Configuration option \`${path}\` should be an integer. Found: ${JSON.stringify(
         val,
       )} (${typeof val}).`,
@@ -109,14 +110,14 @@ export function validateRegexManagerFields(
           'customManager.matchStrings regEx validation error',
         );
         errors.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Invalid regExp for ${currentPath}: \`${matchString}\``,
         });
       }
     }
   } else {
     errors.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message:
         'Each Custom Manager `matchStrings` array must have at least one item.',
     });
@@ -126,7 +127,7 @@ export function validateRegexManagerFields(
   for (const field of mandatoryFields) {
     if (!hasField(customManager, field)) {
       errors.push({
-        topic: 'Configuration Error',
+        topic: ConfigValidationTopic.Error,
         message: `Regex Managers must contain ${field}Template configuration or regex group named ${field}`,
       });
     }
@@ -135,7 +136,7 @@ export function validateRegexManagerFields(
   const nameFields = ['depName', 'packageName'];
   if (!nameFields.some((field) => hasField(customManager, field))) {
     errors.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: `Regex Managers must contain depName or packageName regex groups or templates`,
     });
   }
@@ -148,7 +149,7 @@ export function validateJSONataManagerFields(
 ): void {
   if (!isNonEmptyString(customManager.fileFormat)) {
     errors.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: 'Each JSONata manager must contain a fileFormat field.',
     });
   }
@@ -163,14 +164,14 @@ export function validateJSONataManagerFields(
           'customManager.matchStrings JSONata query validation error',
         );
         errors.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Invalid JSONata query for ${currentPath}: \`${matchString}\``,
         });
       }
     }
   } else {
     errors.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: `Each Custom Manager must contain a non-empty matchStrings array`,
     });
   }
@@ -179,7 +180,7 @@ export function validateJSONataManagerFields(
   for (const field of mandatoryFields) {
     if (!hasField(customManager, field)) {
       errors.push({
-        topic: 'Configuration Error',
+        topic: ConfigValidationTopic.Error,
         message: `JSONata Managers must contain ${field}Template configuration or ${field} in the query `,
       });
     }
@@ -188,7 +189,7 @@ export function validateJSONataManagerFields(
   const nameFields = ['depName', 'packageName'];
   if (!nameFields.some((field) => hasField(customManager, field))) {
     errors.push({
-      topic: 'Configuration Error',
+      topic: ConfigValidationTopic.Error,
       message: `JSONata Managers must contain depName or packageName in the query or their templates`,
     });
   }

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -61,6 +61,7 @@ import type {
 import { allowedStatusCheckStrings } from './types.ts';
 import * as matchBaseBranchesValidator from './validation-helpers/match-base-branches.ts';
 import * as regexOrGlobValidator from './validation-helpers/regex-glob-matchers.ts';
+import { ConfigValidationTopic } from './validation-helpers/types.ts';
 import {
   getParentName,
   isFalseGlobal,
@@ -265,7 +266,7 @@ export async function validateConfig(
         /* v8 ignore next 7 -- TODO: add test */
         if (key === '__proto__') {
           errors.push({
-            topic: 'Config security error',
+            topic: ConfigValidationTopic.Security,
             message: '__proto__',
           });
           continue;
@@ -277,7 +278,7 @@ export async function validateConfig(
           topLevelObjects.includes(key)
         ) {
           errors.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `The "${key}" object can only be configured at the top level of a config but was found inside "${parentPath}"`,
           });
         }
@@ -299,7 +300,7 @@ export async function validateConfig(
             !(configType === 'inherit' && isInhertConfigOption(key))
           ) {
             warnings.push({
-              topic: 'Configuration Error',
+              topic: ConfigValidationTopic.Error,
               message: `The "${key}" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file.`,
             });
             continue;
@@ -311,7 +312,7 @@ export async function validateConfig(
           );
           if (isNonEmptyArray(unsupportedManagers)) {
             errors.push({
-              topic: 'Configuration Error',
+              topic: ConfigValidationTopic.Error,
               message: `The following managers configured in enabledManagers are not supported: "${unsupportedManagers.join(
                 ', ',
               )}"`,
@@ -320,7 +321,7 @@ export async function validateConfig(
         }
         if (key === 'registryUrls' && !parentPath && isNonEmptyArray(val)) {
           warnings.push({
-            topic: 'Configuration Warning',
+            topic: ConfigValidationTopic.Warning,
             message:
               'Setting `registryUrls` at the top level of your config will apply it to all managers and datasources, which can cause the wrong registry URL to be used for some packages. Use `registryUrls` inside `packageRules` to target specific managers or packages.',
           });
@@ -331,7 +332,7 @@ export async function validateConfig(
           isNonEmptyArray(val)
         ) {
           warnings.push({
-            topic: 'Configuration Warning',
+            topic: ConfigValidationTopic.Warning,
             message:
               'Setting `defaultRegistryUrls` at the top level of your config will apply it to all managers and datasources, which can cause the wrong registry URL to be used for some packages. Use `defaultRegistryUrls` inside `packageRules` to target specific managers or packages.',
           });
@@ -342,7 +343,7 @@ export async function validateConfig(
         ) {
           if (getDeprecationMessage(key)) {
             warnings.push({
-              topic: 'Deprecation Warning',
+              topic: ConfigValidationTopic.Deprecation,
               message: getDeprecationMessage(key)!,
             });
           }
@@ -352,7 +353,7 @@ export async function validateConfig(
               template.validate((val as string).toString());
             } catch {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `Invalid template in config path: ${currentPath}`,
               });
             }
@@ -378,7 +379,7 @@ export async function validateConfig(
           // v8 ignore else -- intentionally unhandled - if we knew what was to be covered here, we'd add validation
           if (!optionTypes[key]) {
             errors.push({
-              topic: 'Configuration Error',
+              topic: ConfigValidationTopic.Error,
               message: `Invalid configuration option: ${currentPath}`,
             });
           } else if (key === 'schedule') {
@@ -387,7 +388,7 @@ export async function validateConfig(
             );
             if (!validSchedule) {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `Invalid ${currentPath}: \`${errorMessage}\``,
               });
             }
@@ -402,7 +403,7 @@ export async function validateConfig(
           ) {
             if (!getRegexPredicate(val)) {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `Invalid regExp for ${currentPath}: \`${val}\``,
               });
             }
@@ -412,7 +413,7 @@ export async function validateConfig(
             );
             if (!validTimezone) {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `${currentPath}: ${errorMessage}`,
               });
             }
@@ -421,7 +422,7 @@ export async function validateConfig(
             if (type === 'boolean') {
               if (val !== true && val !== false) {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `Configuration option \`${currentPath}\` should be boolean. Found: ${JSON.stringify(
                     val,
                   )} (${typeof val})`,
@@ -462,7 +463,7 @@ export async function validateConfig(
                         subval.startsWith('global:')
                       ) {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `${currentPath}: you cannot extend from "global:" presets in a repository config's "extends"`,
                         });
                       }
@@ -472,7 +473,7 @@ export async function validateConfig(
                         subval.startsWith('group:')
                       ) {
                         warnings.push({
-                          topic: 'Configuration Warning',
+                          topic: ConfigValidationTopic.Warning,
                           message: `${currentPath}: you should not extend "group:" presets`,
                         });
                       }
@@ -482,7 +483,7 @@ export async function validateConfig(
                           hasValidTimezone(timezone);
                         if (!validTimezone) {
                           errors.push({
-                            topic: 'Configuration Error',
+                            topic: ConfigValidationTopic.Error,
                             message: `${currentPath}: ${errorMessage}`,
                           });
                         }
@@ -492,14 +493,14 @@ export async function validateConfig(
                           parsePreset(subval);
                         } catch {
                           errors.push({
-                            topic: 'Configuration Error',
+                            topic: ConfigValidationTopic.Error,
                             message: `${currentPath}: preset "${subval}" is not valid`,
                           });
                         }
                       }
                     } else {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `${currentPath}: preset value is not a string`,
                       });
                     }
@@ -510,7 +511,7 @@ export async function validateConfig(
                   for (const subval of val) {
                     if (!isValidCommitTrailer(subval)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid commit trailer: \`${JSON.stringify(
                           subval,
                         )}\`. Must be a single-line string in the form \`Key: value\`, where the key contains only letters, digits and \`-\`.`,
@@ -570,7 +571,7 @@ export async function validateConfig(
                             packageRule,
                           )}`;
                           warnings.push({
-                            topic: 'Configuration Error',
+                            topic: ConfigValidationTopic.Error,
                             message,
                           });
                         } else {
@@ -578,7 +579,7 @@ export async function validateConfig(
                             packageRule,
                           )}`;
                           errors.push({
-                            topic: 'Configuration Error',
+                            topic: ConfigValidationTopic.Error,
                             message,
                           });
                         }
@@ -593,7 +594,7 @@ export async function validateConfig(
                           packageRule,
                         )}`;
                         warnings.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message,
                         });
                       }
@@ -621,7 +622,7 @@ export async function validateConfig(
                               packageRule,
                             )}`;
                             errors.push({
-                              topic: 'Configuration Error',
+                              topic: ConfigValidationTopic.Error,
                               message,
                             });
                           }
@@ -629,7 +630,7 @@ export async function validateConfig(
                       }
                     } else {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `${currentPath} must contain JSON objects`,
                       });
                     }
@@ -663,7 +664,7 @@ export async function validateConfig(
                         (k) => !allowedKeys.includes(k),
                       );
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Custom Manager contains disallowed fields: ${disallowedKeys.join(
                           ', ',
                         )}`,
@@ -691,7 +692,7 @@ export async function validateConfig(
                         }
                       } else {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Each Custom Manager must contain a non-empty managerFilePatterns array`,
                         });
                       }
@@ -701,12 +702,12 @@ export async function validateConfig(
                         isUndefined(customManager.customType)
                       ) {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Each Custom Manager must contain a non-empty customType string`,
                         });
                       } else {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Invalid customType: ${customManager.customType}. Key is not a custom manager`,
                         });
                       }
@@ -726,7 +727,7 @@ export async function validateConfig(
                         regEx(pattern.replace(startPattern, '/'));
                       } catch {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Invalid regExp for ${currentPath}: \`${pattern}\``,
                         });
                       }
@@ -740,7 +741,7 @@ export async function validateConfig(
                       !getRegexPredicate(baseBranchPattern)
                     ) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid regExp for ${currentPath}: \`${baseBranchPattern}\``,
                       });
                     }
@@ -755,20 +756,20 @@ export async function validateConfig(
                   (isString(parentPath) || !isPreset) // top level in a preset
                 ) {
                   errors.push({
-                    topic: 'Configuration Error',
+                    topic: ConfigValidationTopic.Error,
                     message: `${currentPath}: ${key} should be inside a \`packageRule\` only`,
                   });
                 }
               } else {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `Configuration option \`${currentPath}\` should be a list (Array)`,
                 });
               }
             } else if (type === 'string') {
               if (!isString(val)) {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `Configuration option \`${currentPath}\` should be a string`,
                 });
               }
@@ -778,7 +779,7 @@ export async function validateConfig(
                   const res = validatePlainObject(val);
                   if (res !== true) {
                     errors.push({
-                      topic: 'Configuration Error',
+                      topic: ConfigValidationTopic.Error,
                       message: `Invalid \`${currentPath}.${key}.${res}\` configuration: value is not a string`,
                     });
                   }
@@ -790,13 +791,13 @@ export async function validateConfig(
                   for (const [envVarName, envVarValue] of Object.entries(val)) {
                     if (!isString(envVarValue)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid env variable value: \`${currentPath}.${envVarName}\` must be a string.`,
                       });
                     }
                     if (!matchRegexOrGlobList(envVarName, allowedEnvVars)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Env variable name \`${envVarName}\` is not allowed by this bot's \`allowedEnv\`.`,
                       });
                     }
@@ -812,7 +813,7 @@ export async function validateConfig(
                       )
                     ) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid \`${currentPath}.${key}.${statusCheckKey}\` configuration: key is not allowed.`,
                       });
                     }
@@ -820,7 +821,7 @@ export async function validateConfig(
                       !(isString(statusCheckValue) || null === statusCheckValue)
                     ) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid \`${currentPath}.${statusCheckKey}\` configuration: status check is not a string.`,
                       });
                       continue;
@@ -838,7 +839,7 @@ export async function validateConfig(
                       )
                     ) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid \`${currentPath}.${key}.${statusCheckKey}\` configuration: key is not allowed.`,
                       });
                     }
@@ -847,7 +848,7 @@ export async function validateConfig(
                       !allowedWhenValues.includes(statusCheckValue)
                     ) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid \`${currentPath}.${statusCheckKey}\` configuration: value must be one of "always", "never", or "failed".`,
                       });
                       continue;
@@ -866,7 +867,7 @@ export async function validateConfig(
                   ] of Object.entries(val)) {
                     if (!isPlainObject(customDatasourceValue)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid \`${currentPath}.${customDatasourceName}\` configuration: customDatasource is not an object`,
                       });
                       continue;
@@ -876,13 +877,13 @@ export async function validateConfig(
                     )) {
                       if (!allowedKeys.includes(subKey)) {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Invalid \`${currentPath}.${subKey}\` configuration: key is not allowed`,
                         });
                       } else if (subKey === 'transformTemplates') {
                         if (!isArray(subValue, isString)) {
                           errors.push({
-                            topic: 'Configuration Error',
+                            topic: ConfigValidationTopic.Error,
                             message: `Invalid \`${currentPath}.${subKey}\` configuration: is not an array of string`,
                           });
                         }
@@ -891,13 +892,13 @@ export async function validateConfig(
                           !(isString(subValue) || isArray(subValue, isString))
                         ) {
                           errors.push({
-                            topic: 'Configuration Error',
+                            topic: ConfigValidationTopic.Error,
                             message: `Invalid \`${currentPath}.${subKey}\` configuration: is not an array of strings`,
                           });
                         }
                       } else if (!isString(subValue)) {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Invalid \`${currentPath}.${subKey}\` configuration: is a string`,
                         });
                       }
@@ -907,7 +908,7 @@ export async function validateConfig(
                   for (const toolName of Object.keys(val)) {
                     if (!isToolName(toolName)) {
                       warnings.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Invalid \`${currentPath}.${toolName}\` configuration: not a valid tool name.`,
                       });
                     }
@@ -918,7 +919,7 @@ export async function validateConfig(
                   for (const [k, v] of Object.entries(val)) {
                     if (!isString(v)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Configuration option \`${currentPath}.${k}\` should be an object of key-value pairs of constraints and their value`,
                       });
                       break;
@@ -926,7 +927,7 @@ export async function validateConfig(
 
                     if (!isConstraintName(k)) {
                       warnings.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Configuration option \`${currentPath}.${k}\`: \`${k}\` is not a supported constraint name`,
                       });
                     } else if (isToolName(k)) {
@@ -935,7 +936,7 @@ export async function validateConfig(
                       const versioning = getVersioning(versioningId);
                       if (!versioning.isValid(v)) {
                         warnings.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Configuration option \`${currentPath}.${k}=${v}\` is not a valid tool version constraint, according to \`${versioningId}\` versioning`,
                         });
                       }
@@ -945,7 +946,7 @@ export async function validateConfig(
                   for (const [k, v] of Object.entries(val)) {
                     if (!isString(v)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Configuration option \`${currentPath}.${k}\` should be an object of key-value pairs of additional constraint names and their versioning`,
                       });
                       break;
@@ -953,7 +954,7 @@ export async function validateConfig(
 
                     if (isToolName(k)) {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Configuration option \`${currentPath}.${k}\` is not a valid additional constraint name, as \`${k}\` is a tool name, and \`constraintsVersioning\` can only override the versioning for a non-tool constraint`,
                       });
                     } else if (isConstraintName(k)) {
@@ -964,13 +965,13 @@ export async function validateConfig(
                         )
                       ) {
                         errors.push({
-                          topic: 'Configuration Error',
+                          topic: ConfigValidationTopic.Error,
                           message: `Configuration option \`${currentPath}.${k}=${v}\`: \`${v}\` is not a valid versioning scheme`,
                         });
                       }
                     } else {
                       errors.push({
-                        topic: 'Configuration Error',
+                        topic: ConfigValidationTopic.Error,
                         message: `Configuration option \`${currentPath}.${k}\`: \`${k}\` is not a known additional constraint name`,
                       });
                     }
@@ -992,7 +993,7 @@ export async function validateConfig(
                 }
               } else {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `Configuration option \`${currentPath}\` should be a json object`,
                 });
               }
@@ -1018,13 +1019,13 @@ export async function validateConfig(
                 parseUrl(rule.matchHost) === null
               ) {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `hostRules matchHost \`${rule.matchHost}\` is not a valid URL.`,
                 });
               }
             } else if (isEmptyString(rule.matchHost)) {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message:
                   'Invalid value for hostRules matchHost. It cannot be an empty string.',
               });
@@ -1036,13 +1037,13 @@ export async function validateConfig(
             for (const [header, value] of Object.entries(rule.headers)) {
               if (!isString(value)) {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `Invalid hostRules headers value configuration: header must be a string.`,
                 });
               }
               if (!matchRegexOrGlobList(header, allowedHeaders)) {
                 errors.push({
-                  topic: 'Configuration Error',
+                  topic: ConfigValidationTopic.Error,
                   message: `hostRules header \`${header}\` is not allowed by this bot's \`allowedHeaders\`.`,
                 });
               }
@@ -1055,7 +1056,7 @@ export async function validateConfig(
             const res = getExpression(expression);
             if (res instanceof Error) {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `Invalid JSONata expression for ${currentPath}: ${res.message}`,
               });
             }
@@ -1092,14 +1093,14 @@ async function validateGlobalConfig(
   /* v8 ignore next 5 -- not testable yet */
   if (getDeprecationMessage(key)) {
     warnings.push({
-      topic: 'Deprecation Warning',
+      topic: ConfigValidationTopic.Deprecation,
       message: getDeprecationMessage(key)!,
     });
   }
 
   if (key === 'binarySource' && val === 'docker') {
     warnings.push({
-      topic: 'Deprecation Warning',
+      topic: ConfigValidationTopic.Deprecation,
       message:
         'Usage of `binarySource=docker` is deprecated, and will be removed in the future. Please migrate to `binarySource=install`. Feedback on the usage of `binarySource=docker` is welcome at https://github.com/renovatebot/renovate/discussions/40742',
     });
@@ -1117,7 +1118,7 @@ async function validateGlobalConfig(
           }).includes(val)
         ) {
           warnings.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${getPossibleConfigFileNames(
               {
                 configFileNames: config.configFileNames,
@@ -1130,7 +1131,7 @@ async function validateGlobalConfig(
           !['enabled', 'disabled', 'reset'].includes(val)
         ) {
           warnings.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['enabled', 'disabled', 'reset'].join(', ')}.`,
           });
         } else if (
@@ -1138,7 +1139,7 @@ async function validateGlobalConfig(
           !['extract', 'lookup', 'full'].includes(val)
         ) {
           warnings.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['extract', 'lookup', 'full'].join(', ')}.`,
           });
         } else if (
@@ -1146,7 +1147,7 @@ async function validateGlobalConfig(
           !['docker', 'global', 'install', 'hermit'].includes(val)
         ) {
           warnings.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['docker', 'global', 'install', 'hermit'].join(', ')}.`,
           });
         } else if (
@@ -1154,7 +1155,7 @@ async function validateGlobalConfig(
           !['required', 'optional', 'ignored'].includes(val)
         ) {
           warnings.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['required', 'optional', 'ignored'].join(', ')}.`,
           });
         } else if (
@@ -1162,7 +1163,7 @@ async function validateGlobalConfig(
           !['default', 'ssh', 'endpoint'].includes(val)
         ) {
           warnings.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `Invalid value \`${val}\` for \`${currentPath}\`. The allowed values are ${['default', 'ssh', 'endpoint'].join(', ')}.`,
           });
         }
@@ -1173,13 +1174,13 @@ async function validateGlobalConfig(
           !isString(config.reportPath)
         ) {
           errors.push({
-            topic: 'Configuration Error',
+            topic: ConfigValidationTopic.Error,
             message: `reportType '${val}' requires a configured reportPath`,
           });
         }
       } else {
         warnings.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Configuration option \`${currentPath}\` should be a string.`,
         });
       }
@@ -1189,7 +1190,7 @@ async function validateGlobalConfig(
     } else if (type === 'boolean') {
       if (val !== true && val !== false) {
         warnings.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Configuration option \`${currentPath}\` should be a boolean. Found: ${JSON.stringify(
             val,
           )} (${typeof val}).`,
@@ -1224,7 +1225,7 @@ async function validateGlobalConfig(
             // v8 ignore else -- TODO: add test #40625
             if (!allowedValues.includes(value)) {
               warnings.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `Invalid value for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
               });
             }
@@ -1236,7 +1237,7 @@ async function validateGlobalConfig(
             // v8 ignore else -- TODO: add test #40625
             if (!allowedValues.includes(value)) {
               warnings.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `Invalid value \`${value}\` for \`${currentPath}\`. The allowed values are ${allowedValues.join(', ')}.`,
               });
             }
@@ -1247,7 +1248,7 @@ async function validateGlobalConfig(
           if (isPlainObject(subval)) {
             if (!isNonEmptyString(subval.repository)) {
               errors.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `${currentPath}[${subIndex}]: each repository object entry must have a \`repository\` string property`,
               });
             }
@@ -1271,20 +1272,20 @@ async function validateGlobalConfig(
           } else if (isString(subval)) {
             if (!isNonEmptyStringAndNotWhitespace(subval)) {
               warnings.push({
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
                 message: `${currentPath}[${subIndex}]: each repository string entry entry must be a non-empty string`,
               });
             }
           } else {
             warnings.push({
-              topic: 'Configuration Error',
+              topic: ConfigValidationTopic.Error,
               message: `${currentPath}[${subIndex}]: invalid type, should be either a string or an object`,
             });
           }
         }
       } else {
         warnings.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Configuration option \`${currentPath}\` should be a list (Array).`,
         });
       }
@@ -1326,7 +1327,7 @@ async function validateGlobalConfig(
             ) {
               errors.push({
                 message: `${currentPath}: namespace \`${subKey}\` does not exist`,
-                topic: 'Configuration Error',
+                topic: ConfigValidationTopic.Error,
               });
             }
           }
@@ -1334,14 +1335,14 @@ async function validateGlobalConfig(
           const res = validatePlainObject(val);
           if (res !== true) {
             warnings.push({
-              topic: 'Configuration Error',
+              topic: ConfigValidationTopic.Error,
               message: `Invalid \`${currentPath}.${res}\` configuration: value must be a string.`,
             });
           }
         }
       } else {
         warnings.push({
-          topic: 'Configuration Error',
+          topic: ConfigValidationTopic.Error,
           message: `Configuration option \`${currentPath}\` should be a JSON object.`,
         });
       }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
When reporting config validation issues, we generally use the same
constants for our validation errors/warnings.

Instead of having these strings duplicated everywhere, we can refactor
these into constants, making it clearer when reading the code.

We can retain a "soft" union for cases where we use a dynamically
generated topic, which we won't know ahead of time.



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
