### PR TITLE
fix(vulnerabilities): scope Go stdlib OSV remediation to the `toolchain` directive

### DIFF
--- a/lib/workers/repository/process/types.ts
+++ b/lib/workers/repository/process/types.ts
@@ -7,6 +7,7 @@ export interface Vulnerability {
   packageFileConfig: RenovateConfig & PackageFile;
   packageName: string;
   osvPackageName: string;
+  depType?: string;
   depVersion: string;
   fixedVersion: string | null;
   datasource: string;

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -4,7 +4,9 @@ import { mockFn } from 'vitest-mock-extended';
 import type { RenovateConfig } from '~test/util.ts';
 import { logger } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
+import type { PackageRuleInputConfig } from '../../../config/types.ts';
 import type { PackageFile } from '../../../modules/manager/types.ts';
+import { applyPackageRules } from '../../../util/package-rules/index.ts';
 import { Vulnerabilities } from './vulnerabilities.ts';
 
 const getVulnerabilitiesMock =
@@ -1280,10 +1282,103 @@ describe('workers/repository/process/vulnerabilities', () => {
           matchDatasources: ['golang-version'],
           matchPackageNames: ['go'],
           matchCurrentVersion: '1.23.6',
+          matchDepTypes: ['toolchain'],
           allowedVersions: '>= 1.23.8',
           isVulnerabilityAlert: true,
         },
       ]);
+    });
+
+    it('does not apply go stdlib toolchain remediation to the module go directive', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        gomod: [
+          {
+            deps: [
+              {
+                depName: 'go',
+                depType: 'golang',
+                currentValue: '1.26.0',
+                datasource: 'golang-version',
+                versioning: 'go-mod-directive',
+              },
+              {
+                depName: 'go',
+                depType: 'toolchain',
+                currentValue: '1.26.5',
+                datasource: 'golang-version',
+              },
+            ],
+            packageFile: 'go.mod',
+          },
+        ],
+      };
+
+      getVulnerabilitiesMock.mockResolvedValueOnce([
+        {
+          id: 'GO-2026-0001',
+          modified: '',
+          aliases: ['CVE-2026-0001'],
+          affected: [
+            {
+              package: {
+                name: 'stdlib',
+                ecosystem: 'Go',
+                purl: 'pkg:golang/stdlib',
+              },
+              ranges: [
+                {
+                  type: 'SEMVER',
+                  events: [{ introduced: '1.26.0' }, { fixed: '1.26.6' }],
+                },
+              ],
+            },
+          ],
+        },
+      ]);
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+
+      expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules).toMatchObject([
+        {
+          matchDatasources: ['golang-version'],
+          matchPackageNames: ['go'],
+          matchCurrentVersion: '1.26.5',
+          matchDepTypes: ['toolchain'],
+          allowedVersions: '>= 1.26.6',
+          isVulnerabilityAlert: true,
+        },
+      ]);
+
+      const toolchainDep: PackageRuleInputConfig & {
+        allowedVersions?: string;
+      } = await applyPackageRules({
+        packageRules: config.packageRules,
+        depName: 'go',
+        packageName: 'go',
+        depType: 'toolchain',
+        currentValue: '1.26.5',
+        datasource: 'golang-version',
+        versioning: 'semver',
+      });
+      expect(toolchainDep.allowedVersions).toBe('>= 1.26.6');
+      expect(toolchainDep.isVulnerabilityAlert).toBe(true);
+
+      const golangDep: PackageRuleInputConfig & { allowedVersions?: string } =
+        await applyPackageRules({
+          packageRules: config.packageRules,
+          depName: 'go',
+          packageName: 'go',
+          depType: 'golang',
+          currentValue: '1.26.0',
+          datasource: 'golang-version',
+          versioning: 'go-mod-directive',
+        });
+      expect(golangDep.allowedVersions).toBeUndefined();
+      expect(golangDep.isVulnerabilityAlert).toBeUndefined();
     });
 
     it('skips vulnerability lookup for go module directive', async () => {

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1406,7 +1406,7 @@ describe('workers/repository/process/vulnerabilities', () => {
       expect(config.packageRules).toHaveLength(0);
     });
 
-    it('scopes remediation package rules to the vulnerable dependency depType', async () => {
+    it('does not scope npm remediation rules by depType', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         npm: [
           {
@@ -1430,11 +1430,11 @@ describe('workers/repository/process/vulnerabilities', () => {
       );
 
       expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules?.[0]).not.toHaveProperty('matchDepTypes');
       expect(config.packageRules).toMatchObject([
         {
           matchDatasources: ['npm'],
           matchPackageNames: ['lodash'],
-          matchDepTypes: ['dependencies'],
           matchCurrentVersion: '4.17.10',
           allowedVersions: '>= 4.17.11',
           isVulnerabilityAlert: true,

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1406,6 +1406,42 @@ describe('workers/repository/process/vulnerabilities', () => {
       expect(config.packageRules).toHaveLength(0);
     });
 
+    it('scopes remediation package rules to the vulnerable dependency depType', async () => {
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            deps: [
+              {
+                depName: 'lodash',
+                depType: 'dependencies',
+                currentValue: '4.17.10',
+                datasource: 'npm',
+              },
+            ],
+            packageFile: 'package.json',
+          },
+        ],
+      };
+      getVulnerabilitiesMock.mockResolvedValueOnce([lodashVulnerability]);
+
+      await vulnerabilities.appendVulnerabilityPackageRules(
+        config,
+        packageFiles,
+      );
+
+      expect(config.packageRules).toHaveLength(1);
+      expect(config.packageRules).toMatchObject([
+        {
+          matchDatasources: ['npm'],
+          matchPackageNames: ['lodash'],
+          matchDepTypes: ['dependencies'],
+          matchCurrentVersion: '4.17.10',
+          allowedVersions: '>= 4.17.11',
+          isVulnerabilityAlert: true,
+        },
+      ]);
+    });
+
     it('sets default datasource versioning to align with allowedVersions on packageRule', async () => {
       const packageFiles: Record<string, PackageFile[]> = {
         gomod: [

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -601,9 +601,10 @@ export class Vulnerabilities {
       affected,
     );
 
-    const packageRule: PackageRule = {
+    return {
       matchDatasources: [datasource],
       matchPackageNames: [packageName],
+      ...(depType ? { matchDepTypes: [depType] } : {}),
       matchCurrentVersion: depVersion,
       versioning,
       allowedVersions: fixedVersion,
@@ -614,16 +615,6 @@ export class Vulnerabilities {
         ...packageFileConfig.vulnerabilityAlerts,
       },
     };
-
-    // The Go module `go` directive shares datasource `golang-version` and
-    // packageName `go` with the toolchain, and `go-mod-directive` versioning
-    // treats `1.x.0` as `^1.x.0`, so `matchCurrentVersion` of the toolchain
-    // still matches the module directive. Scope remediation to the toolchain.
-    if (packageName === 'go' && depType === 'toolchain') {
-      packageRule.matchDepTypes = ['toolchain'];
-    }
-
-    return packageRule;
   }
 
   static evaluateCvssVector(vector: string): [string, string] {

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -264,6 +264,7 @@ export class Vulnerabilities {
             osvPackageName,
             vulnerability: osvVulnerability,
             affected,
+            depType: dep.depType,
             depVersion,
             fixedVersion,
             datasource: dep.datasource!,
@@ -570,6 +571,7 @@ export class Vulnerabilities {
       vulnerability,
       affected,
       packageName,
+      depType,
       depVersion,
       fixedVersion,
       datasource,
@@ -599,7 +601,7 @@ export class Vulnerabilities {
       affected,
     );
 
-    return {
+    const packageRule: PackageRule = {
       matchDatasources: [datasource],
       matchPackageNames: [packageName],
       matchCurrentVersion: depVersion,
@@ -612,6 +614,16 @@ export class Vulnerabilities {
         ...packageFileConfig.vulnerabilityAlerts,
       },
     };
+
+    // The Go module `go` directive shares datasource `golang-version` and
+    // packageName `go` with the toolchain, and `go-mod-directive` versioning
+    // treats `1.x.0` as `^1.x.0`, so `matchCurrentVersion` of the toolchain
+    // still matches the module directive. Scope remediation to the toolchain.
+    if (packageName === 'go' && depType === 'toolchain') {
+      packageRule.matchDepTypes = ['toolchain'];
+    }
+
+    return packageRule;
   }
 
   static evaluateCvssVector(vector: string): [string, string] {

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -170,6 +170,7 @@ export class Vulnerabilities {
 
     const packageName = dep.packageName ?? dep.depName!;
     let osvPackageName = packageName;
+    let depType: string | undefined;
     if (ecosystem === 'PyPI') {
       // https://peps.python.org/pep-0503/#normalized-names
       osvPackageName = osvPackageName
@@ -181,6 +182,7 @@ export class Vulnerabilities {
         return null;
       }
       osvPackageName = 'stdlib';
+      depType = dep.depType;
     }
 
     try {
@@ -264,7 +266,7 @@ export class Vulnerabilities {
             osvPackageName,
             vulnerability: osvVulnerability,
             affected,
-            depType: dep.depType,
+            depType,
             depVersion,
             fixedVersion,
             datasource: dep.datasource!,


### PR DESCRIPTION
## Changes

When `osvVulnerabilityAlerts` fires for a Go `toolchain` directive, Renovate also bumped the unrelated module `go` directive (`depType: golang`) onto a non-vulnerability branch.

The OSV lookup already skipped the module `go` line (`depType !== 'toolchain'`), but `vulnerabilityToPackageRules()` emitted a remediation rule with only `matchDatasources` and `matchPackageNames`. Both directives share `datasource: golang-version` and `packageName: go`, so the toolchain's `allowedVersions` also applied to the module line.

`matchCurrentVersion` of the toolchain (e.g. `1.26.5`) does not exclude `go 1.26.0` because `go-mod-directive` versioning treats `1.26.0` as `^1.26.0`.

Vulnerability rules are generated per dependency. This PR copies that dep's `depType` onto the rule as `matchDepTypes` when present, so the rule cannot match a different dep that happens to share datasource and package name. The Go toolchain still updates on the vulnerability branch; the module `go` directive is left alone.

### Reproduction

`go.mod` / `go.work`:

```
go 1.26.0
toolchain go1.26.5
```

with an active Go stdlib OSV advisory affecting 1.26.5, fixed in 1.26.6.

**Before:** three updates (`go`, `go`, `go`) — toolchain 1.26.5→1.26.6 on `renovate/…-go-vulnerability`, plus the module `go` directive 1.26.0→1.26.6 on `renovate/go-1.x`.

**After:** only the toolchain update on the vulnerability branch.

Reproduced on Renovate 44.29.5 and 44.32.6 (present on current main).

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

This PR was written primarily by Cursor Grok 4.6. The bug, root cause, and fix direction were specified by the author; the agent implemented the change, added the unit tests, and drafted this description.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests, or