### PR TITLE
fix(exec): supress unhandled promise rehection from execa timeout

### DIFF
--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -155,7 +155,7 @@ function getSpawnStub(args: StubArgs): any {
     unref,
     kill,
     pid,
-    catch: (fn) => fn(new Error('mock')),
+    catch: (fn: (err: Error) => void) => fn(new Error('mock')),
   };
 }
 

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -155,6 +155,7 @@ function getSpawnStub(args: StubArgs): any {
     unref,
     kill,
     pid,
+    catch: (fn) => fn(new Error('mock')),
   };
 }
 

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -136,9 +136,10 @@ export function exec(
     // Suppress execa's internal promise rejection (e.g., from timeout).
     // We handle all exit scenarios via 'exit' and 'error' event listeners below,
     // so the promise rejection would otherwise surface as an unhandledRejection.
-    // v8 ignore next -- execa returns a thenable in production but not in mocked tests
     if (isFunction(cp.catch)) {
-      cp.catch(() => undefined);
+      cp.catch((err) =>
+        logger.warn({ err }, 'execa promise rejection suppressed'),
+      );
     }
 
     // handle streams

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -1,6 +1,6 @@
 import type { ChildProcess } from 'node:child_process';
 import type { Readable } from 'node:stream';
-import { isNullOrUndefined } from '@sindresorhus/is';
+import { isFunction, isNullOrUndefined } from '@sindresorhus/is';
 import { execa } from 'execa';
 import { join, split } from 'shlex';
 import { instrument } from '../../instrumentation/index.ts';
@@ -136,8 +136,8 @@ export function exec(
     // Suppress execa's internal promise rejection (e.g., from timeout).
     // We handle all exit scenarios via 'exit' and 'error' event listeners below,
     // so the promise rejection would otherwise surface as an unhandledRejection.
-    // v8 ignore next 3 -- execa returns a thenable in production but not in mocked tests
-    if (typeof cp.catch === 'function') {
+    // v8 ignore next -- execa returns a thenable in production but not in mocked tests
+    if (isFunction(cp.catch)) {
       cp.catch(() => undefined);
     }
 

--- a/lib/util/exec/common.ts
+++ b/lib/util/exec/common.ts
@@ -133,6 +133,14 @@ export function exec(
       extendEnv: false,
     });
 
+    // Suppress execa's internal promise rejection (e.g., from timeout).
+    // We handle all exit scenarios via 'exit' and 'error' event listeners below,
+    // so the promise rejection would otherwise surface as an unhandledRejection.
+    // v8 ignore next 3 -- execa returns a thenable in production but not in mocked tests
+    if (typeof cp.catch === 'function') {
+      cp.catch(() => undefined);
+    }
+
     // handle streams
     const [stdout, stderr] = initStreamListeners(cp, {
       ...opts,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When a command (like pipenv lock in my case) exceeds the configured executionTimeout, Renovate already handles this correctly by marking the repository as temporary-error and moves on. However, the execa library also throws a separate "Timed out" error internally. This second error is not caught by anyone, so it triggers the global unhandledRejection handler, which
logs it at ERROR level and causes the entire Renovate run to exit with a failure code even though every other repository was
processed successfully.

This fix catches and discards that duplicate error, since the timeout is already handled through the normal code path.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
