### PR TITLE
fix(manager/helmfile): keep OCI charts that carry a digest

### DIFF
--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -363,6 +363,34 @@ describe('modules/manager/helmfile/extract', () => {
       });
     });
 
+    it('splits the digest out of an OCI chart reference', async () => {
+      const content = `
+      releases:
+        - name: grafana
+          chart: oci://ghcr.io/grafana/helm-charts/grafana@sha256:3d75dc3173c3fb07eaa8853283f38558c7c27259f7ed00cf8c096173667426a1
+          version: 10.5.15
+      `;
+      const fileName = 'helmfile.yaml';
+      const result = await extractPackageFile(content, fileName, {});
+      expect(result).toStrictEqual({
+        datasource: 'helm',
+        deps: [
+          {
+            currentValue: '10.5.15',
+            currentDigest:
+              'sha256:3d75dc3173c3fb07eaa8853283f38558c7c27259f7ed00cf8c096173667426a1',
+            depName: 'ghcr.io/grafana/helm-charts/grafana',
+            datasource: 'docker',
+            packageName: 'ghcr.io/grafana/helm-charts/grafana',
+            replaceString:
+              'oci://ghcr.io/grafana/helm-charts/grafana@sha256:3d75dc3173c3fb07eaa8853283f38558c7c27259f7ed00cf8c096173667426a1',
+            autoReplaceStringTemplate:
+              'oci://{{depName}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          },
+        ],
+      });
+    });
+
     it('allows OCI chart names containing forward slashes', async () => {
       const content = `
       repositories:

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -74,6 +74,7 @@ export async function extractPackageFile(
       let depName = dep.chart;
       let packageName: string | null = null;
       let repoName: string | null = null;
+      let currentDigest: string | undefined;
 
       // If it starts with ./ ../ or / then it's a local path
       if (isLocalPath(dep.chart)) {
@@ -91,7 +92,13 @@ export async function extractPackageFile(
       }
 
       if (isOCIRegistry(dep.chart)) {
-        packageName = depName = removeOCIPrefix(dep.chart);
+        // An OCI reference may carry a digest, e.g. oci://ghcr.io/org/chart@sha256:abc.
+        // Keep it out of the name, otherwise the chart name validation below rejects it.
+        const [chartWithoutDigest, digest] = removeOCIPrefix(dep.chart).split(
+          '@',
+        );
+        packageName = depName = chartWithoutDigest;
+        currentDigest = digest;
       } else {
         if (dep.chart.includes('/')) {
           const v = dep.chart.split('/');
@@ -121,6 +128,12 @@ export async function extractPackageFile(
         depName,
         currentValue: dep.version,
       };
+      if (currentDigest) {
+        res.currentDigest = currentDigest;
+        res.replaceString = dep.chart;
+        res.autoReplaceStringTemplate =
+          'oci://{{depName}}{{#if newDigest}}@{{newDigest}}{{/if}}';
+      }
       if (kustomizationsKeysUsed(dep)) {
         needKustomize = true;
       }


### PR DESCRIPTION
## Changes

The helmfile manager dropped any release whose `chart:` carried an inline digest:

```yaml
releases:
  - name: grafana
    chart: oci://ghcr.io/grafana/helm-charts/grafana@sha256:3d75dc31…
    version: 10.5.15
```

`removeOCIPrefix` left the digest attached to the name, so `isValidChartName` saw `grafana@sha256:…` in the last path segment, rejected it on the `@`, and the dep was skipped as `unsupported-chart-type` before any lookup ran.

The digest is now split off the reference: the name keeps only the chart, and the digest goes into `currentDigest`. `replaceString` and `autoReplaceStringTemplate` are set alongside it, so the digest in `chart:` can be rewritten rather than only read.

Checked against the reporter's case with `--platform=local`:

```json
"depName": "ghcr.io/grafana/helm-charts/grafana",
"currentValue": "10.5.15",
"currentDigest": "sha256:3d75dc3173c3fb07eaa8853283f38558c7c27259f7ed00cf8c096173667426a1",
"replaceString": "oci://ghcr.io/grafana/helm-charts/grafana@sha256:3d75dc31…",
"datasource": "docker",
"currentVersion": "10.5.15"
```

No skip reason, and the lookup resolves as it does for digest-free OCI charts.

Tests, `tsc --noEmit`, oxlint and prettier run clean locally.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45341
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):
