### PR TITLE
fix(lint): enforce use of `stringify` utils

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -223,7 +223,8 @@
         "renovate/no-hardcoded-docs-url": "error",
         "renovate/no-unquoted-exec-interpolation": "error",
         "renovate/prefer-fs-util": "error",
-        "renovate/prefer-luxon": "error"
+        "renovate/prefer-luxon": "error",
+        "renovate/prefer-stringify-util": "error"
       }
     },
     {
@@ -279,6 +280,18 @@
       ],
       "rules": {
         "renovate/prefer-luxon": "off"
+      }
+    },
+    {
+      "files": ["lib/util/fingerprint.ts"],
+      "rules": {
+        "renovate/prefer-stringify-util": "off"
+      }
+    },
+    {
+      "files": ["lib/util/cache/**"],
+      "rules": {
+        "renovate/prefer-stringify-util": "off"
       }
     },
     {

--- a/lib/config-validator.ts
+++ b/lib/config-validator.ts
@@ -70,7 +70,9 @@ async function validate(
       'Config migration necessary',
     );
     const changedObjects = diffLines(
+      // oxlint-disable-next-line renovate/prefer-stringify-util -- diff display: must match plain JSON.stringify formatting exactly, not the util's stable-stringify output
       JSON.stringify(config, null, 2),
+      // oxlint-disable-next-line renovate/prefer-stringify-util -- diff display: must match plain JSON.stringify formatting exactly, not the util's stable-stringify output
       JSON.stringify(migratedConfig, null, 2),
       { ignoreWhitespace: false, newlineIsToken: false },
     );

--- a/lib/config/parse.ts
+++ b/lib/config/parse.ts
@@ -5,6 +5,7 @@ import upath from 'upath';
 import { logger } from '../logger/index.ts';
 import { parseJson } from '../util/common.ts';
 import { regEx } from '../util/regex.ts';
+import { quickStringify } from '../util/stringify.ts';
 
 export function parseFileConfig(
   fileName: string,
@@ -59,7 +60,7 @@ export function parseFileConfig(
     );
     if (jsonValidationError) {
       const validationError = 'Duplicate keys in JSON';
-      const validationMessage = JSON.stringify(jsonValidationError);
+      const validationMessage = quickStringify(jsonValidationError);
       return {
         success: false,
         validationError,

--- a/lib/config/validation-helpers/utils.ts
+++ b/lib/config/validation-helpers/utils.ts
@@ -9,6 +9,7 @@ import { logger } from '../../logger/index.ts';
 import type { RegexManagerTemplates } from '../../modules/manager/custom/regex/types.ts';
 import type { CustomManager } from '../../modules/manager/custom/types.ts';
 import { regEx } from '../../util/regex.ts';
+import { quickStringify } from '../../util/stringify.ts';
 import type { ValidationMessage } from '../types.ts';
 import { ConfigValidationTopic } from './types.ts';
 
@@ -52,7 +53,7 @@ export function validateNumber(
   } else {
     errors.push({
       topic: ConfigValidationTopic.Error,
-      message: `Configuration option \`${path}\` should be an integer. Found: ${JSON.stringify(
+      message: `Configuration option \`${path}\` should be an integer. Found: ${quickStringify(
         val,
       )} (${typeof val}).`,
     });

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -32,6 +32,7 @@ import {
   isRegexMatch,
   matchRegexOrGlobList,
 } from '../util/string-match.ts';
+import { quickStringify } from '../util/stringify.ts';
 import * as template from '../util/template/index.ts';
 import { parseUrl } from '../util/url.ts';
 import {
@@ -254,7 +255,7 @@ export async function validateConfig(
   parentPath?: string,
 ): Promise<ValidationResult> {
   return instrument(
-    `validateConfig(${configType}, ${JSON.stringify(parentPath)})`,
+    `validateConfig(${configType}, ${quickStringify(parentPath)})`,
     async () => {
       initOptions();
 
@@ -423,7 +424,7 @@ export async function validateConfig(
               if (val !== true && val !== false) {
                 errors.push({
                   topic: ConfigValidationTopic.Error,
-                  message: `Configuration option \`${currentPath}\` should be boolean. Found: ${JSON.stringify(
+                  message: `Configuration option \`${currentPath}\` should be boolean. Found: ${quickStringify(
                     val,
                   )} (${typeof val})`,
                 });
@@ -512,7 +513,7 @@ export async function validateConfig(
                     if (!isValidCommitTrailer(subval)) {
                       errors.push({
                         topic: ConfigValidationTopic.Error,
-                        message: `Invalid commit trailer: \`${JSON.stringify(
+                        message: `Invalid commit trailer: \`${quickStringify(
                           subval,
                         )}\`. Must be a single-line string in the form \`Key: value\`, where the key contains only letters, digits and \`-\`.`,
                       });
@@ -567,7 +568,7 @@ export async function validateConfig(
                         if (hasRelativePresets) {
                           // the stripped relative preset may still provide the
                           // missing selectors, so this cannot be an error
-                          const message = `${currentPath}[${subIndex}]: this rule extends a relative preset that cannot be resolved during validation, so its selectors could not be checked. Rule: ${JSON.stringify(
+                          const message = `${currentPath}[${subIndex}]: this rule extends a relative preset that cannot be resolved during validation, so its selectors could not be checked. Rule: ${quickStringify(
                             packageRule,
                           )}`;
                           warnings.push({
@@ -575,7 +576,7 @@ export async function validateConfig(
                             message,
                           });
                         } else {
-                          const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one match* or exclude* selector. Rule: ${JSON.stringify(
+                          const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one match* or exclude* selector. Rule: ${quickStringify(
                             packageRule,
                           )}`;
                           errors.push({
@@ -590,7 +591,7 @@ export async function validateConfig(
                         !hasRelativePresets &&
                         selectorLength === Object.keys(resolvedRule).length
                       ) {
-                        const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one non-match* or non-exclude* field. Rule: ${JSON.stringify(
+                        const message = `${currentPath}[${subIndex}]: Each packageRule must contain at least one non-match* or non-exclude* field. Rule: ${quickStringify(
                           packageRule,
                         )}`;
                         warnings.push({
@@ -618,7 +619,7 @@ export async function validateConfig(
                       if (isNonEmptyArray(resolvedRule.matchUpdateTypes)) {
                         for (const option of preLookupOptions) {
                           if (resolvedRule[option] !== undefined) {
-                            const message = `${currentPath}[${subIndex}]: packageRules cannot combine both matchUpdateTypes and ${option}. Rule: ${JSON.stringify(
+                            const message = `${currentPath}[${subIndex}]: packageRules cannot combine both matchUpdateTypes and ${option}. Rule: ${quickStringify(
                               packageRule,
                             )}`;
                             errors.push({
@@ -1191,7 +1192,7 @@ async function validateGlobalConfig(
       if (val !== true && val !== false) {
         warnings.push({
           topic: ConfigValidationTopic.Error,
-          message: `Configuration option \`${currentPath}\` should be a boolean. Found: ${JSON.stringify(
+          message: `Configuration option \`${currentPath}\` should be a boolean. Found: ${quickStringify(
             val,
           )} (${typeof val}).`,
         });

--- a/lib/instrumentation/reporting.ts
+++ b/lib/instrumentation/reporting.ts
@@ -79,6 +79,7 @@ export function finalizeReport(): void {
 }
 
 async function getReportBody(config: RenovateConfig): Promise<string> {
+  // oxlint-disable-next-line renovate/prefer-stringify-util -- keep this consistently created
   const json = JSON.stringify(report);
   if (!config.reportFormatting) {
     return json;

--- a/lib/modules/datasource/common.ts
+++ b/lib/modules/datasource/common.ts
@@ -9,6 +9,7 @@ import {
 } from '../../util/exec/types.ts';
 import { filterMap } from '../../util/filter-map.ts';
 import { regEx } from '../../util/regex.ts';
+import { quickStringify } from '../../util/stringify.ts';
 import * as allVersioning from '../versioning/index.ts';
 import { defaultVersioning } from '../versioning/index.ts';
 import datasources from './api.ts';
@@ -271,7 +272,7 @@ export function applyConstraintsFiltering<
           release,
           versioning: constraintVersioningName,
         },
-        `applyConstraintsFiltering(${release.version}): releaseConstraints[${name}]=${JSON.stringify(constraint)}`,
+        `applyConstraintsFiltering(${release.version}): releaseConstraints[${name}]=${quickStringify(constraint)}`,
       );
       if (!isNonEmptyArray(constraint)) {
         // A release with no constraints is OK

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -106,6 +106,7 @@ function getAuthJson(): string | null {
     }
   }
 
+  // oxlint-disable-next-line renovate/prefer-stringify-util -- external composer auth.json format: must match plain JSON.stringify output exactly
   return isEmptyObject(authJson) ? null : JSON.stringify(authJson);
 }
 

--- a/lib/modules/manager/npm/extract/common/package-file.ts
+++ b/lib/modules/manager/npm/extract/common/package-file.ts
@@ -9,6 +9,7 @@ import {
 import { CONFIG_VALIDATION } from '../../../../../constants/error-messages.ts';
 import { logger } from '../../../../../logger/index.ts';
 import { regEx } from '../../../../../util/regex.ts';
+import { quickStringify } from '../../../../../util/stringify.ts';
 import type { PackageDependency, PackageFileContent } from '../../../types.ts';
 import type { NpmManagerData } from '../../types.ts';
 import { loadPackageJson } from '../../utils.ts';
@@ -41,7 +42,7 @@ export function extractPackageJson(
   }
   const packageJsonName = packageJson.name;
   logger.debug(
-    `npm file ${packageFile} has name ${JSON.stringify(packageJsonName)}`,
+    `npm file ${packageFile} has name ${quickStringify(packageJsonName)}`,
   );
   const packageFileVersion = packageJson.version;
 

--- a/lib/modules/manager/npm/update/locked-dependency/package-lock/dep-constraints.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/package-lock/dep-constraints.ts
@@ -1,6 +1,7 @@
 import type { PackageJson } from 'type-fest';
 import { logger } from '../../../../../../logger/index.ts';
 import { regEx } from '../../../../../../util/regex.ts';
+import { quickStringify } from '../../../../../../util/stringify.ts';
 import { api as semver } from '../../../../../versioning/npm/index.ts';
 import type { PackageLockOrEntry, ParentDependency } from './types.ts';
 
@@ -77,8 +78,8 @@ export function findDepConstraints(
   // dedupe
   const res: ParentDependency[] = [];
   for (const req of parents) {
-    const reqStringified = JSON.stringify(req);
-    if (!res.find((i) => JSON.stringify(i) === reqStringified)) {
+    const reqStringified = quickStringify(req);
+    if (!res.find((i) => quickStringify(i) === reqStringified)) {
       res.push(req);
     }
   }

--- a/lib/modules/manager/npm/update/locked-dependency/package-lock/index.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/package-lock/index.ts
@@ -221,6 +221,7 @@ export async function updateLockedDependency(
       delete dependency.resolved;
       delete dependency.integrity;
     }
+    // oxlint-disable-next-line renovate/prefer-stringify-util -- lockfile content committed to the PR diff: must match plain JSON.stringify formatting exactly
     let newLockFileContent = JSON.stringify(
       packageLockJson,
       null,

--- a/lib/modules/manager/npm/utils.ts
+++ b/lib/modules/manager/npm/utils.ts
@@ -6,7 +6,6 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-
 import { PackageJson } from './schema.ts';
 import type { LockFile, ParseLockFileResult } from './types.ts';
 
@@ -24,6 +23,7 @@ export function parseLockFile(lockFile: string): ParseLockFileResult {
 }
 
 export function composeLockFile(lockFile: LockFile, indent: string): string {
+  // oxlint-disable-next-line renovate/prefer-stringify-util -- lockfile content committed to the PR diff: must match plain JSON.stringify formatting exactly
   return `${JSON.stringify(lockFile, null, indent)}\n`;
 }
 

--- a/lib/modules/manager/pip-compile/artifacts.ts
+++ b/lib/modules/manager/pip-compile/artifacts.ts
@@ -10,6 +10,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
+import { quickStringify } from '../../../util/stringify.ts';
 import { parseUrl } from '../../../util/url.ts';
 import { extractPackageFileFlags as extractRequirementsFileFlags } from '../pip_requirements/common.ts';
 import type {
@@ -99,7 +100,7 @@ export async function updateArtifacts({
     return null;
   }
   logger.debug(
-    `pipCompile.updateArtifacts(${inputFileName}->${JSON.stringify(
+    `pipCompile.updateArtifacts(${inputFileName}->${quickStringify(
       config.lockFiles,
     )})`,
   );

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -28,6 +28,7 @@ import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { sampleSize } from '../../../util/sample.ts';
 import { sanitize } from '../../../util/sanitize.ts';
 import { isEmailAdress } from '../../../util/schema-utils/index.ts';
+import { quickStringify } from '../../../util/stringify.ts';
 import { ensureTrailingSlash, getQueryString } from '../../../util/url.ts';
 import type {
   BranchStatusConfig,
@@ -253,7 +254,7 @@ export async function initRepo({
   cloneSubmodulesFilter,
   gitUrl,
 }: RepoParams): Promise<RepoResult> {
-  logger.debug(`initRepo("${JSON.stringify({ repository }, null, 2)}")`);
+  logger.debug(`initRepo("${quickStringify({ repository }, null, 2)}")`);
   const opts = hostRules.find({
     hostType: defaults.hostType,
     url: defaults.endpoint,

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -18,6 +18,7 @@ import * as promises from '../../../util/promises.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
 import { UUIDRegex, matchRegexOrGlobList } from '../../../util/string-match.ts';
+import { quickStringify } from '../../../util/stringify.ts';
 import { parseUrl } from '../../../util/url.ts';
 import type {
   AutodiscoverConfig,
@@ -594,7 +595,7 @@ interface BbIssue {
 async function findOpenIssues(title: string): Promise<BbIssue[]> {
   try {
     const filters = [
-      `title=${JSON.stringify(title)}`,
+      `title=${quickStringify(title)}`,
       '(state = "new" OR state = "open")',
     ];
     if (renovateUserUuid) {

--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -16,6 +16,7 @@ import { parseJson } from '../../../util/common.ts';
 import * as git from '../../../util/git/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
+import { quickStringify } from '../../../util/stringify.ts';
 import type {
   BranchStatusConfig,
   CreatePRConfig,
@@ -532,7 +533,7 @@ export async function addReviewers(
   reviewers: string[],
 ): Promise<void> {
   const numberOfApprovers = reviewers.length;
-  const approvalRuleContents = `{"Version":"2018-11-08","Statements": [{"Type": "Approvers","NumberOfApprovalsNeeded":${numberOfApprovers},"ApprovalPoolMembers": ${JSON.stringify(
+  const approvalRuleContents = `{"Version":"2018-11-08","Statements": [{"Type": "Approvers","NumberOfApprovalsNeeded":${numberOfApprovers},"ApprovalPoolMembers": ${quickStringify(
     reviewers,
   )}}]}`;
   const res = await client.createPrApprovalRule(

--- a/lib/util/git/semantic.ts
+++ b/lib/util/git/semantic.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../logger/index.ts';
 import { getCache } from '../../util/cache/repository/index.ts';
 import { regEx } from '../regex.ts';
+import { quickStringify } from '../stringify.ts';
 import { getCommitMessages } from './index.ts';
 
 type DetectedSemanticCommit = 'enabled' | 'disabled';
@@ -15,7 +16,7 @@ export async function detectSemanticCommits(): Promise<DetectedSemanticCommit> {
     return cache.semanticCommits;
   }
   const commitMessages = await getCommitMessages();
-  logger.trace(`commitMessages=${JSON.stringify(commitMessages)}`);
+  logger.trace(`commitMessages=${quickStringify(commitMessages)}`);
   const score = detectSemanticCommitScore(commitMessages);
   logger.debug(`semanticCommits: score=${score}`);
   if (score > 0) {

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -15,6 +15,7 @@ import { acquireLock } from '../mutex.ts';
 import { type AsyncResult, Result } from '../result.ts';
 import { Toml } from '../schema-utils/index.ts';
 import { ObsoleteCacheHitLogger } from '../stats.ts';
+import { quickStringify } from '../stringify.ts';
 import { compile } from '../template/index.ts';
 import { isHttpUrl, parseUrl, resolveBaseUrl } from '../url.ts';
 import { parseSingleYaml } from '../yaml.ts';
@@ -168,7 +169,7 @@ export abstract class HttpBase<
       options.memCache !== false &&
       isReadMethod
         ? hash(
-            `got-${JSON.stringify({
+            `got-${quickStringify({
               url,
               headers: options.headers,
               method,

--- a/lib/util/json-writer/json-writer.ts
+++ b/lib/util/json-writer/json-writer.ts
@@ -12,6 +12,7 @@ export class JSONWriter {
   }
 
   public write(json: unknown, newLineAtTheEnd = true): string {
+    // oxlint-disable-next-line renovate/prefer-stringify-util -- onboarding/migration output committed to the PR diff: must match plain JSON.stringify formatting exactly
     let content = JSON.stringify(json, null, this.indentation);
 
     if (newLineAtTheEnd) {

--- a/lib/util/minimatch.spec.ts
+++ b/lib/util/minimatch.spec.ts
@@ -39,5 +39,13 @@ describe('util/minimatch', () => {
       expect(filterFunc('test.js')).toBe(true);
       expect(filterFunc('test.txt')).toBe(false);
     });
+
+    it('should correctly match filenames with options', () => {
+      const filterFunc = minimatchFilter('*.js', { dot: true });
+      expect(filterFunc('test.js')).toBe(true);
+      expect(filterFunc('test.txt')).toBe(false);
+      // second call hits the cache for the same pattern+options key
+      expect(minimatchFilter('*.js', { dot: true })('test.js')).toBe(true);
+    });
   });
 });

--- a/lib/util/minimatch.ts
+++ b/lib/util/minimatch.ts
@@ -1,5 +1,6 @@
 import type { MinimatchOptions } from 'minimatch';
 import { Minimatch } from 'minimatch';
+import { quickStringify } from './stringify.ts';
 
 const cache = new Map<string, Minimatch>();
 
@@ -8,7 +9,7 @@ export function minimatch(
   options?: MinimatchOptions,
   useCache = true,
 ): Minimatch {
-  const key = options ? `${pattern}:${JSON.stringify(options)}` : pattern;
+  const key = options ? `${pattern}:${quickStringify(options)}` : pattern;
 
   if (useCache) {
     const cachedResult = cache.get(key);
@@ -29,7 +30,7 @@ export function minimatchFilter(
   options?: MinimatchOptions,
   useCache = true,
 ): (fileName: string) => boolean {
-  const key = options ? `${pattern}:${JSON.stringify(options)}` : pattern;
+  const key = options ? `${pattern}:${quickStringify(options)}` : pattern;
 
   if (useCache) {
     const cachedResult = cache.get(key);

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -12,6 +12,7 @@ import { logger } from '../../logger/index.ts';
 import { toArray } from '../array.ts';
 import { getChildEnv } from '../exec/utils.ts';
 import { regEx } from '../regex.ts';
+import { quickStringify } from '../stringify.ts';
 
 // Missing in handlebars
 type Options = HelperOptions & {
@@ -24,7 +25,9 @@ const helpers: Record<string, handlebars.HelperDelegate> = {
   encodeBase64: (str: string) => Buffer.from(str ?? '').toString('base64'),
   decodeBase64: (str: string) => Buffer.from(str ?? '', 'base64').toString(),
   stringToPrettyJSON: (input: string): string =>
+    // oxlint-disable-next-line renovate/prefer-stringify-util -- user-facing template helper: output can land in commit messages/PR bodies and must match plain JSON.stringify formatting exactly
     JSON.stringify(JSON.parse(input), null, 2),
+  // oxlint-disable-next-line renovate/prefer-stringify-util -- user-facing template helper: output can land in commit messages/PR bodies and must match plain JSON.stringify formatting exactly
   toJSON: (input: unknown): string => JSON.stringify(input),
   toArray: (...args: unknown[]): unknown[] => {
     // Need to remove the 'options', as the last parameter
@@ -88,7 +91,7 @@ const helpers: Record<string, handlebars.HelperDelegate> = {
     const seen = new Set<string>();
 
     return toArray(obj).filter((value) => {
-      const str = JSON.stringify(value);
+      const str = quickStringify(value)!;
 
       if (seen.has(str)) {
         return false;

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -40,6 +40,7 @@ import * as throttle from '../../util/http/throttle.ts';
 import { regexEngineStatus } from '../../util/regex.ts';
 import { addSecretForSanitizing } from '../../util/sanitize.ts';
 import { coerceString } from '../../util/string.ts';
+import { quickStringify } from '../../util/stringify.ts';
 import * as repositoryWorker from '../repository/index.ts';
 import type { RepositoryWorkerConfig } from '../repository/init/types.ts';
 import { autodiscoverRepositories } from './autodiscover.ts';
@@ -208,7 +209,7 @@ export async function start(): Promise<number> {
     );
 
     if (isNonEmptyString(config.writeDiscoveredRepos)) {
-      const content = JSON.stringify(config.repositories);
+      const content = quickStringify(config.repositories)!;
       await fs.writeFile(config.writeDiscoveredRepos, content);
       logger.info(
         `Written discovered repositories to ${config.writeDiscoveredRepos}`,

--- a/lib/workers/repository/config-migration/branch/create.ts
+++ b/lib/workers/repository/config-migration/branch/create.ts
@@ -59,6 +59,7 @@ export async function createConfigMigrationBranch(
     }
     const pJsonContent = await applyPrettierFormatting(
       'package.json',
+      // oxlint-disable-next-line renovate/prefer-stringify-util -- migration output committed to the PR diff: must match plain JSON.stringify formatting exactly
       JSON.stringify(pJson, undefined, migratedConfigData.indent.indent),
       'json',
       migratedConfigData.indent,

--- a/lib/workers/repository/config-migration/branch/migrated-data.ts
+++ b/lib/workers/repository/config-migration/branch/migrated-data.ts
@@ -164,9 +164,11 @@ export class MigratedDataFactory {
             { err },
             'Error weaving JSONC to preserve comments, falling back to JSON.stringify',
           );
+          // oxlint-disable-next-line renovate/prefer-stringify-util -- migration output committed to the PR diff: must match plain JSON.stringify formatting exactly
           content = JSON.stringify(migratedConfig, undefined, indentSpace);
         }
       } else {
+        // oxlint-disable-next-line renovate/prefer-stringify-util -- migration output committed to the PR diff: must match plain JSON.stringify formatting exactly
         content = JSON.stringify(migratedConfig, undefined, indentSpace);
       }
 

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -15,6 +15,7 @@ import { coerceArray } from '../../util/array.ts';
 import { emojify } from '../../util/emoji.ts';
 import { regEx } from '../../util/regex.ts';
 import { coerceString } from '../../util/string.ts';
+import { quickStringify } from '../../util/stringify.ts';
 import * as template from '../../util/template/index.ts';
 import type { BranchConfig, SelectAllConfig } from '../types.ts';
 import { extractRepoProblems, replacementAlreadyExists } from './common.ts';
@@ -182,7 +183,7 @@ export async function readDashboardBody(
     dependencyDashboardAllPending: false,
     dependencyDashboardAllRateLimited: false,
   };
-  const stringifiedConfig = JSON.stringify(config);
+  const stringifiedConfig = quickStringify(config);
   if (
     config.dependencyDashboard === true ||
     stringifiedConfig.includes('"dependencyDashboardApproval":true') ||

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -37,6 +37,7 @@ import { maskToken } from '../../../util/mask.ts';
 import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { coerceString } from '../../../util/string.ts';
+import { quickStringify } from '../../../util/stringify.ts';
 import { getOnboardingConfig } from '../onboarding/branch/config.ts';
 import {
   getOnboardingConfigFromCache,
@@ -125,7 +126,7 @@ export async function detectRepoFileConfig(
     const cachedConfig = getOnboardingConfigFromCache();
     const parsedConfig = cachedConfig ? JSON.parse(cachedConfig) : undefined;
     if (parsedConfig) {
-      setOnboardingConfigDetails(configFileName, JSON.stringify(parsedConfig));
+      setOnboardingConfigDetails(configFileName, quickStringify(parsedConfig)!);
       return { configFileName, configFileParsed: parsedConfig };
     }
   }
@@ -171,7 +172,7 @@ export async function detectRepoFileConfig(
     );
   }
 
-  setOnboardingConfigDetails(configFileName, JSON.stringify(configFileParsed));
+  setOnboardingConfigDetails(configFileName, quickStringify(configFileParsed)!);
   return { configFileName, configFileParsed };
 }
 

--- a/lib/workers/repository/onboarding/pr/pr-list.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.ts
@@ -8,6 +8,7 @@ import { logger } from '../../../../logger/index.ts';
 import { emojify } from '../../../../util/emoji.ts';
 import { coerceNumber } from '../../../../util/number.ts';
 import { regEx } from '../../../../util/regex.ts';
+import { quickStringify } from '../../../../util/stringify.ts';
 import type { BranchConfig } from '../../../types.ts';
 
 /**
@@ -51,7 +52,7 @@ export function getExpectedPrList(
       '@&#8203;$1',
     )}</summary>\n\n`;
     if (branch.schedule?.length) {
-      prDesc += `  - Schedule: ${JSON.stringify(branch.schedule)}\n`;
+      prDesc += `  - Schedule: ${quickStringify(branch.schedule)}\n`;
     }
     prDesc += `  - Branch name: \`${branch.branchName}\`\n`;
     prDesc += branch.baseBranch

--- a/lib/workers/repository/process/lookup/filter.ts
+++ b/lib/workers/repository/process/lookup/filter.ts
@@ -7,6 +7,7 @@ import * as npmVersioning from '../../../../modules/versioning/npm/index.ts';
 import * as pep440 from '../../../../modules/versioning/pep440/index.ts';
 import * as poetryVersioning from '../../../../modules/versioning/poetry/index.ts';
 import { getRegexPredicate } from '../../../../util/string-match.ts';
+import { quickStringify } from '../../../../util/stringify.ts';
 import * as template from '../../../../util/template/index.ts';
 import type { FilterConfig } from './types.ts';
 
@@ -161,7 +162,7 @@ export function filterVersions(
       const error = new Error(CONFIG_VALIDATION);
       error.validationSource = 'config';
       error.validationError = 'Invalid `allowedVersions`';
-      error.validationMessage = `The following allowedVersions does not parse as a valid version or range with versioning=${JSON.stringify(config.versioning)}: ${JSON.stringify(allowedVersions)}`;
+      error.validationMessage = `The following allowedVersions does not parse as a valid version or range with versioning=${quickStringify(config.versioning)}: ${quickStringify(allowedVersions)}`;
       throw error;
     }
   }

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -31,6 +31,7 @@ import { checkMinimumReleaseAge } from '../../../../util/minimum-release-age.ts'
 import { applyPackageRules } from '../../../../util/package-rules/index.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { Result } from '../../../../util/result.ts';
+import { quickStringify } from '../../../../util/stringify.ts';
 import type { Timestamp } from '../../../../util/timestamp.ts';
 import { calculateAbandonment } from './abandonment.ts';
 import { getBucket } from './bucket.ts';
@@ -214,7 +215,7 @@ export async function lookupUpdates(
       // v8 ignore else -- TODO: add test #40625
       if (config.currentValue) {
         logger.debug(
-          `Invalid currentValue for ${config.packageName}: ${JSON.stringify(config.currentValue)} (${typeof config.currentValue})`,
+          `Invalid currentValue for ${config.packageName}: ${quickStringify(config.currentValue)} (${typeof config.currentValue})`,
         );
       }
       res.skipReason = 'invalid-value';

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -40,6 +40,7 @@ import {
 } from '../../../../util/merge-confidence/index.ts';
 import { coerceNumber } from '../../../../util/number.ts';
 import { toMs } from '../../../../util/pretty-time.ts';
+import { quickStringify } from '../../../../util/stringify.ts';
 import * as template from '../../../../util/template/index.ts';
 import { getCount, isLimitReached } from '../../../global/limits.ts';
 import type {
@@ -749,7 +750,7 @@ export async function processBranch(
           },
         )}`;
 
-        logger.trace(`commitMessage: ${JSON.stringify(config.commitMessage)}`);
+        logger.trace(`commitMessage: ${quickStringify(config.commitMessage)}`);
       }
 
       if (config.commitTrailers) {
@@ -760,7 +761,7 @@ export async function processBranch(
           ),
         );
         logger.trace(
-          `commitTrailers: ${JSON.stringify(config.commitTrailers)}`,
+          `commitTrailers: ${quickStringify(config.commitTrailers)}`,
         );
       }
 

--- a/lib/workers/repository/update/pr/body/index.ts
+++ b/lib/workers/repository/update/pr/body/index.ts
@@ -4,6 +4,7 @@ import { platform } from '../../../../../modules/platform/index.ts';
 import { detectPlatform } from '../../../../../util/common.ts';
 import { regEx } from '../../../../../util/regex.ts';
 import { toBase64 } from '../../../../../util/string.ts';
+import { quickStringify } from '../../../../../util/stringify.ts';
 import * as template from '../../../../../util/template/index.ts';
 import { joinUrlParts } from '../../../../../util/url.ts';
 import type { BranchConfig } from '../../../../types.ts';
@@ -131,7 +132,7 @@ export function getPrBody(
     prBody = template.compile(prBodyTemplate, content, false);
     prBody = prBody.trim();
     prBody = prBody.replace(regEx(/\n\n\n+/g), '\n\n');
-    const prDebugData64 = toBase64(JSON.stringify(prBodyConfig.debugData));
+    const prDebugData64 = toBase64(quickStringify(prBodyConfig.debugData));
     prBody += `\n<!--renovate-debug:${prDebugData64}-->\n`;
     prBody = platform.massageMarkdown(prBody, config.rebaseLabel);
 

--- a/lib/workers/repository/update/pr/code-owners.ts
+++ b/lib/workers/repository/update/pr/code-owners.ts
@@ -9,6 +9,7 @@ import {
   getBranchFilesFromCommit,
 } from '../../../../util/git/index.ts';
 import { newlineRegex, regEx } from '../../../../util/regex.ts';
+import { quickStringify } from '../../../../util/stringify.ts';
 
 interface FileOwnersScore {
   file: string;
@@ -166,7 +167,7 @@ export async function codeOwnersForPr(pr: Pr): Promise<string[]> {
       .sort((a, b) => b.score - a.score);
 
     logger.debug(
-      `CODEOWNERS matched the following users: ${JSON.stringify(userScore)}`,
+      `CODEOWNERS matched the following users: ${quickStringify(userScore)}`,
     );
 
     return userScore.map((u) => u.user);

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -112,7 +112,7 @@ function compileCommitMessage(upgrade: BranchUpgradeConfig): string {
     upgrade.commitMessage = splitMessage.join('\n');
   }
 
-  logger.trace(`commitMessage: ${JSON.stringify(upgrade.commitMessage)}`);
+  logger.trace(`commitMessage: ${safeStringify(upgrade.commitMessage)}`);
   return upgrade.commitMessage;
 }
 
@@ -165,7 +165,7 @@ function compilePrTitle(
   }
   // Compile again to allow for nested templates
   upgrade.prTitle = template.compile(upgrade.prTitle, upgrade);
-  logger.trace(`prTitle: ${JSON.stringify(upgrade.prTitle)}`);
+  logger.trace(`prTitle: ${safeStringify(upgrade.prTitle)}`);
 }
 
 function getMinimumGroupSize(upgrades: BranchUpgradeConfig[]): number {

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -19,6 +19,7 @@ import preferJsonPipe from './rules/prefer-json-pipe.ts';
 import preferLuxon from './rules/prefer-luxon.ts';
 import preferNullishUtil from './rules/prefer-nullish-util.ts';
 import preferPartialInSpecs from './rules/prefer-partial-in-specs.ts';
+import preferStringifyUtil from './rules/prefer-stringify-util.ts';
 import requireRegexUtil from './rules/require-regex-util.ts';
 import testRootDescribe from './rules/test-root-describe.ts';
 import v8IgnoreReason from './rules/v8-ignore-reason.ts';
@@ -51,6 +52,7 @@ export default definePlugin({
     'prefer-is-object': preferIsObject,
     'prefer-nullish-util': preferNullishUtil,
     'prefer-partial-in-specs': preferPartialInSpecs,
+    'prefer-stringify-util': preferStringifyUtil,
     'require-regex-util': requireRegexUtil,
     'test-root-describe': testRootDescribe,
     'v8-ignore-reason': v8IgnoreReason,

--- a/tools/lint/rules/prefer-stringify-util.spec.ts
+++ b/tools/lint/rules/prefer-stringify-util.spec.ts
@@ -1,0 +1,39 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './prefer-stringify-util.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+});
+
+ruleTester.run('prefer-stringify-util', rule, {
+  valid: [
+    // already using the util helpers
+    `safeStringify(value);`,
+    `quickStringify(value);`,
+    // other JSON methods are not checked
+    `JSON.parse(value);`,
+    // member callee is not the `JSON` global
+    `foo.JSON.stringify(value);`,
+    // computed member call
+    `JSON['stringify'](value);`,
+    // callee is not a member expression
+    `stringify(value);`,
+  ],
+  invalid: [
+    {
+      code: `JSON.stringify(value);`,
+      errors: [{ messageId: 'preferStringifyUtil' }],
+    },
+    {
+      code: `JSON.stringify(value, null, 2);`,
+      errors: [{ messageId: 'preferStringifyUtil' }],
+    },
+    {
+      code: `const s = \`prefix-\${JSON.stringify(value)}\`;`,
+      errors: [{ messageId: 'preferStringifyUtil' }],
+    },
+  ],
+});

--- a/tools/lint/rules/prefer-stringify-util.ts
+++ b/tools/lint/rules/prefer-stringify-util.ts
@@ -1,0 +1,27 @@
+import { defineRule } from '@oxlint/plugins';
+
+export default defineRule({
+  meta: {
+    type: 'suggestion',
+    messages: {
+      preferStringifyUtil:
+        "Use safeStringify() or quickStringify() from 'lib/util/stringify.ts' instead of JSON.stringify(): they handle circular references and non-serializable values safely. Additionally, they are more performant than `JSON.stringify`",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'MemberExpression' &&
+          !node.callee.computed &&
+          node.callee.object.type === 'Identifier' &&
+          node.callee.object.name === 'JSON' &&
+          node.callee.property.type === 'Identifier' &&
+          node.callee.property.name === 'stringify'
+        ) {
+          context.report({ node, messageId: 'preferStringifyUtil' });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Changes



We generally prefer to avoid `JSON.stringify`, due to performance
reasons, and instead prefer our internal stringify utils.

We can add a linting rule, and convert unnecessary usages of
`JSON.stringify` to our use a stringify util.

Unchanged tests indicate existing functionality is unaffected, but we can
release this as `fix` to get early feedback.





## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Sonnet 5 (via Claude Code) wrote the lint rule and its tests, migrated the call sites, and drafted this PR description.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
