### PR TITLE
fix(datasource/npm): don't break on non-string `homepage`

### DIFF
--- a/lib/modules/datasource/npm/schema.spec.ts
+++ b/lib/modules/datasource/npm/schema.spec.ts
@@ -126,6 +126,31 @@ describe('modules/datasource/npm/schema', () => {
     expect(result.homepage).toBeUndefined();
   });
 
+  // https://registry.npmjs.org/jsonfile — homepage: [""]
+  it('drops an invalid package-level `homepage` (e.g. an array)', () => {
+    const result = CachedPackument.parse({
+      homepage: [''],
+      versions: { '1.0.0': {} },
+    });
+    expect(result.homepage).toBeUndefined();
+  });
+
+  // https://registry.npmjs.org/jsonfile — versions 0.0.1 and 1.0.0 have `homepage: [""]`
+  it('drops a non-string `homepage` in a version entry instead of invalidating the whole cached packument', () => {
+    const result = CachedPackument.parse({
+      versions: {
+        '0.0.1': { homepage: [''] },
+        '6.2.1': {
+          homepage: 'https://github.com/jprichardson/node-jsonfile#readme',
+        },
+      },
+    });
+    expect(result.versions?.['0.0.1']?.homepage).toBeUndefined();
+    expect(result.versions?.['6.2.1']?.homepage).toBe(
+      'https://github.com/jprichardson/node-jsonfile#readme',
+    );
+  });
+
   describe('NpmResponseSchema', () => {
     it('parses a full npm registry response and preserves extra version fields', () => {
       const input = {
@@ -201,6 +226,63 @@ describe('modules/datasource/npm/schema', () => {
       };
       const result = NpmResponse.parse(input);
       expect(result.homepage).toBeUndefined();
+    });
+
+    // https://registry.npmjs.org/jsonfile — homepage: [""]
+    it('drops an invalid package-level `homepage` (e.g. an array)', () => {
+      const input = {
+        name: 'mypackage',
+        'dist-tags': { latest: '1.0.0' },
+        versions: { '1.0.0': {} },
+        homepage: [''],
+      };
+      const result = NpmResponse.parse(input);
+      expect(result.homepage).toBeUndefined();
+    });
+
+    describe('drops a non-string `homepage` in a version entry instead of invalidating the whole packument', () => {
+      // https://registry.npmjs.org/jsonfile — versions 0.0.1 and 1.0.0 have `homepage: [""]`
+      it('handles `jsonfile`, where affected versions have `homepage: [""]`', () => {
+        const input = {
+          name: 'jsonfile',
+          'dist-tags': { latest: '6.2.1' },
+          homepage: 'https://github.com/jprichardson/node-jsonfile#readme',
+          versions: {
+            '0.0.1': { homepage: [''] },
+            '1.0.0': { homepage: [''] },
+            '6.2.1': {
+              homepage: 'https://github.com/jprichardson/node-jsonfile#readme',
+            },
+          },
+        };
+        const result = NpmResponse.parse(input);
+        expect(result.versions?.['0.0.1']?.homepage).toBeUndefined();
+        expect(result.versions?.['1.0.0']?.homepage).toBeUndefined();
+        expect(result.versions?.['6.2.1']?.homepage).toBe(
+          'https://github.com/jprichardson/node-jsonfile#readme',
+        );
+      });
+
+      // https://registry.npmjs.org/fs-extra — version 0.0.1 has `homepage: ["<url>"]`
+      it('handles `fs-extra`, where affected versions have `homepage: ["<url>"]`', () => {
+        const input = {
+          name: 'fs-extra',
+          'dist-tags': { latest: '11.4.0' },
+          versions: {
+            '0.0.1': {
+              homepage: ['https://github.com/jprichardson/node-fs-extra'],
+            },
+            '11.4.0': {
+              homepage: 'https://github.com/jprichardson/node-fs-extra',
+            },
+          },
+        };
+        const result = NpmResponse.parse(input);
+        expect(result.versions?.['0.0.1']?.homepage).toBeUndefined();
+        expect(result.versions?.['11.4.0']?.homepage).toBe(
+          'https://github.com/jprichardson/node-fs-extra',
+        );
+      });
     });
 
     describe('parses a response with an array of objects for the `repository`, and returns the first element', () => {

--- a/lib/modules/datasource/npm/schema.ts
+++ b/lib/modules/datasource/npm/schema.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod/v4';
-import {
-  DeepNullish,
-  LooseRecord,
-  Nullish,
-} from '../../../util/schema-utils/index.ts';
+import { DeepNullish, LooseRecord } from '../../../util/schema-utils/index.ts';
 
 const Repository = z.union([
   z.string(),
@@ -30,7 +26,9 @@ const Distribution = z.object({
 
 export const NpmResponseVersion = z.object({
   repository: RepositoryNpmResponse.optional(),
-  homepage: Nullish(z.string().optional()),
+  // `.catch()` drops non-string entries instead of invalidating the whole
+  // packument, e.g. some old `jsonfile`/`fs-extra` versions have `homepage: [...]`.
+  homepage: z.string().optional().catch(undefined),
   deprecated: z.union([z.string(), z.boolean()]).optional(),
   gitHead: z.string().optional(),
   // `LooseRecord` drops non-string entries i.e. pre-1.0 npm's nested a full dependency tree under `devDependencies`
@@ -49,7 +47,7 @@ export const CachedPackument = DeepNullish(
   z.object({
     versions: z.record(z.string(), NpmResponseVersion).optional(),
     repository: Repository.optional(),
-    homepage: z.string().optional(),
+    homepage: z.string().optional().catch(undefined),
     // `LooseRecord` drops non-string entries (e.g. Artifactory's
     // `"unpublished": null`) instead of invalidating the whole packument.
     time: LooseRecord(z.string()).optional(),
@@ -70,7 +68,7 @@ export const NpmResponse = z.object({
   name: z.string().optional(),
   versions: z.record(z.string(), NpmResponseVersionLoose).optional(),
   repository: RepositoryNpmResponse.optional(),
-  homepage: Nullish(z.string().optional()),
+  homepage: z.string().optional().catch(undefined),
   time: LooseRecord(z.string()).optional(),
   'dist-tags': z.record(z.string(), z.string()).optional(),
 });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

fix(datasource/npm): don't break on non-string `homepage`

As reported in #45357, https://github.com/renovatebot/renovate/pull/45219 caused a regression for cases
where an npm package had `homepage: [...]`.

We should restore the `catch(undefined)` and add a test to make sure
this isn't broken in the future.




## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Sonnet 5) investigated the discussion, identified the regression, made the schema/test changes, and pulled real registry data (jsonfile, fs-extra) for the regression tests.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
