### PR TITLE
feat(manager/pep621): specify newVersion in uv lock --upgrade-package

### DIFF
--- a/lib/modules/manager/pep621/processors/uv.spec.ts
+++ b/lib/modules/manager/pep621/processors/uv.spec.ts
@@ -420,7 +420,7 @@ describe('modules/manager/pep621/processors/uv', () => {
         releases: [{ version: '0.2.35' }, { version: '0.2.28' }],
       });
 
-      const updatedDeps = [{ packageName: 'dep1' }];
+      const updatedDeps = [{ packageName: 'dep1', newVersion: '0.1.0' }];
       const pyproject = parsePyProject(codeBlock`
         [project]
         requires-python = "==3.11.1"
@@ -459,7 +459,7 @@ describe('modules/manager/pep621/processors/uv', () => {
             '&& ' +
             'install-tool uv 0.2.35 ' +
             '&& ' +
-            'uv lock --upgrade-package dep1' +
+            'uv lock --upgrade-package dep1==0.1.0' +
             "'",
         },
       ]);
@@ -505,13 +505,41 @@ describe('modules/manager/pep621/processors/uv', () => {
       });
 
       const updatedDeps = [
-        { packageName: 'dep1', depType: depTypes.dependencies },
-        { packageName: 'dep2', depType: depTypes.dependencies },
-        { depName: 'dep3', depType: depTypes.optionalDependencies },
-        { depName: 'dep4', depType: depTypes.optionalDependencies },
-        { depName: 'dep5', depType: depTypes.uvDevDependencies },
-        { depName: 'dep6', depType: depTypes.uvDevDependencies },
-        { depName: 'dep7', depType: depTypes.buildSystemRequires },
+        {
+          packageName: 'dep1',
+          newVersion: '0.1.0',
+          depType: depTypes.dependencies,
+        },
+        {
+          packageName: 'dep2',
+          newVersion: '0.2.0',
+          depType: depTypes.dependencies,
+        },
+        {
+          depName: 'dep3',
+          newVersion: '0.3.0',
+          depType: depTypes.optionalDependencies,
+        },
+        {
+          depName: 'dep4',
+          newVersion: '0.4.0',
+          depType: depTypes.optionalDependencies,
+        },
+        {
+          depName: 'dep5',
+          newVersion: '0.5.0',
+          depType: depTypes.uvDevDependencies,
+        },
+        {
+          depName: 'dep6',
+          newVersion: '0.6.0',
+          depType: depTypes.uvDevDependencies,
+        },
+        {
+          depName: 'dep7',
+          newVersion: '0.7.0',
+          depType: depTypes.buildSystemRequires,
+        },
       ];
       const result = await processor.updateArtifacts(
         {
@@ -535,7 +563,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3 --upgrade-package dep4 --upgrade-package dep5 --upgrade-package dep6',
+          cmd: 'uv lock --upgrade-package dep1==0.1.0 --upgrade-package dep2==0.2.0 --upgrade-package dep3==0.3.0 --upgrade-package dep4==0.4.0 --upgrade-package dep5==0.5.0 --upgrade-package dep6==0.6.0',
         },
       ]);
     });
@@ -576,30 +604,35 @@ describe('modules/manager/pep621/processors/uv', () => {
       const updatedDeps = [
         {
           packageName: 'dep1',
+          newVersion: '0.1.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['https://foobar.com'],
         },
         {
           packageName: 'dep2',
+          newVersion: '0.2.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['https://example.com'],
         },
         {
           packageName: 'dep3',
+          newVersion: '0.3.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['invalidurl'],
         },
         {
           packageName: 'dep4',
+          newVersion: '0.4.0',
           depType: depTypes.dependencies,
           datasource: GithubTagsDatasource.id,
           registryUrls: ['https://github.com'],
         },
         {
           packageName: 'dep5',
+          newVersion: '0.5.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: [
@@ -608,12 +641,14 @@ describe('modules/manager/pep621/processors/uv', () => {
         },
         {
           packageName: 'dep6',
+          newVersion: '0.6.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['https://pinned.com/simple'],
         },
         {
           packageName: 'dep7',
+          newVersion: '0.7.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['https://unnamed.com/simple'],
@@ -655,7 +690,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3 --upgrade-package dep4 --upgrade-package dep5 --upgrade-package dep6 --upgrade-package dep7',
+          cmd: 'uv lock --upgrade-package dep1==0.1.0 --upgrade-package dep2==0.2.0 --upgrade-package dep3==0.3.0 --upgrade-package dep4==0.4.0 --upgrade-package dep5==0.5.0 --upgrade-package dep6==0.6.0 --upgrade-package dep7==0.7.0',
           options: {
             env: {
               GIT_CONFIG_COUNT: '6',
@@ -716,18 +751,21 @@ describe('modules/manager/pep621/processors/uv', () => {
       const updatedDeps = [
         {
           packageName: 'dep1',
+          newVersion: '1.0.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['https://example.com/simple'],
         },
         {
           packageName: 'dep2',
+          newVersion: '2.0.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: ['https://pinned.com/simple'],
         },
         {
           packageName: 'dep3',
+          newVersion: '3.0.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: [
@@ -773,7 +811,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'uv lock --upgrade-package dep1 --upgrade-package dep2 --upgrade-package dep3',
+          cmd: 'uv lock --upgrade-package dep1==1.0.0 --upgrade-package dep2==2.0.0 --upgrade-package dep3==3.0.0',
           options: {
             env: {
               UV_EXTRA_INDEX_URL: 'https://user:pass@example.com/simple',
@@ -813,6 +851,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       const updatedDeps = [
         {
           packageName: 'dep',
+          newVersion: '1.0.0',
           depType: depTypes.dependencies,
           datasource: PypiDatasource.id,
           registryUrls: [
@@ -840,7 +879,7 @@ describe('modules/manager/pep621/processors/uv', () => {
       ]);
       expect(execSnapshots).toMatchObject([
         {
-          cmd: 'uv lock --upgrade-package dep',
+          cmd: 'uv lock --upgrade-package dep==1.0.0',
           options: {
             env: {
               UV_EXTRA_INDEX_URL:

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -256,19 +256,19 @@ function generateCMD(updatedDeps: Upgrade[]): string {
   for (const dep of updatedDeps) {
     switch (dep.depType) {
       case depTypes.optionalDependencies: {
-        deps.push(dep.depName!);
+        deps.push(`${dep.depName!}==${dep.newVersion!}`);
         break;
       }
       case depTypes.uvDevDependencies:
       case depTypes.uvSources: {
-        deps.push(dep.depName!);
+        deps.push(`${dep.depName!}==${dep.newVersion!}`);
         break;
       }
       case depTypes.buildSystemRequires:
         // build requirements are not locked in the lock files, no need to update.
         break;
       default: {
-        deps.push(dep.packageName!);
+        deps.push(`${dep.packageName!}==${dep.newVersion!}`);
       }
     }
   }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41626
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @schlamar will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/schlamar/renovate-demo/pull/4

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
