### PR TITLE
feat(pr): add changelogsLocation to post changelogs as a PR comment

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -710,6 +710,26 @@ For example:
 
 This name will appear in Renovate logs, making it easier to debug or trace specific rules.
 
+## `changelogsLocation`
+
+Use this option to control where Renovate puts the changelogs/release notes of an update.
+The available options are:
+
+- `body`(default) - the changelogs are part of the pull request body
+- `comment` - the changelogs are posted as a comment on the pull request, and the body links to that comment
+
+Set `changelogsLocation=comment` if your platform seeds the squash commit message from the pull request body, and you don't want the changelogs in your repository history.
+
+```json
+{
+  "changelogsLocation": "comment"
+}
+```
+
+The comment is kept up-to-date the same way the pull request body is.
+The `{{{changelogs}}}` template field then holds a short notice pointing to the comment, so a custom `prBodyTemplate` needs no changes.
+This option has no effect when there are no changelogs to show, like when `fetchChangeLogs=off`.
+
 ## `cloneSubmodules`
 
 Enabling this option will mean that detected Git submodules will be cloned at time of repository clone.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3302,6 +3302,15 @@ const options: Readonly<RenovateOptions>[] = [
     parents: ['.', 'packageRules'],
   },
   {
+    name: 'changelogsLocation',
+    description:
+      'Controls whether changelogs/release notes are put in the PR body or in a PR comment.',
+    type: 'string',
+    allowedValues: ['body', 'comment'],
+    default: 'body',
+    cli: false,
+  },
+  {
     name: 'cloneSubmodules',
     description:
       'Set to `true` to initialize submodules during repository clone.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -471,6 +471,7 @@ export interface RenovateConfig
   customDatasources?: Record<string, CustomDatasourceConfig>;
 
   fetchChangeLogs?: FetchChangeLogsOptions;
+  changelogsLocation?: ChangelogsLocation;
   secrets?: Record<string, string>;
   variables?: Record<string, string>;
 
@@ -571,6 +572,8 @@ export const UpdateTypesOptions = [
 export type UpdateTypeOptions = (typeof UpdateTypesOptions)[number];
 
 export type FetchChangeLogsOptions = 'off' | 'branch' | 'pr';
+
+export type ChangelogsLocation = 'body' | 'comment';
 
 export type MatchStringsStrategy = 'any' | 'recursive' | 'combination';
 

--- a/lib/workers/repository/update/pr/body/changelogs.spec.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.spec.ts
@@ -1,6 +1,6 @@
 import * as _template from '../../../../../util/template/index.ts';
 import type { BranchConfig } from '../../../../types.ts';
-import { getChangelogs } from './changelogs.ts';
+import { getChangelogs, getChangelogsCommentNotice } from './changelogs.ts';
 
 vi.mock('../../../../../util/template/index.ts');
 const template = vi.mocked(_template);
@@ -78,5 +78,39 @@ describe('workers/repository/update/pr/body/changelogs', () => {
 
       "
     `);
+  });
+
+  describe('getChangelogsCommentNotice', () => {
+    it('returns empty string when there is no release notes', () => {
+      const res = getChangelogsCommentNotice({
+        manager: 'some-manager',
+        branchName: 'some-branch',
+        baseBranch: 'base',
+        upgrades: [],
+        hasReleaseNotes: false,
+      });
+
+      expect(res).toBe('');
+    });
+
+    it('returns a notice pointing to the comment', () => {
+      const res = getChangelogsCommentNotice({
+        manager: 'some-manager',
+        branchName: 'some-branch',
+        baseBranch: 'base',
+        upgrades: [],
+        hasReleaseNotes: true,
+      });
+
+      expect(res).toMatchInlineSnapshot(`
+        "
+
+        ---
+
+        Release notes for this update are in a comment on this PR.
+
+        "
+      `);
+    });
   });
 });

--- a/lib/workers/repository/update/pr/body/changelogs.spec.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.spec.ts
@@ -106,15 +106,9 @@ describe('workers/repository/update/pr/body/changelogs', () => {
         hasReleaseNotes: true,
       });
 
-      expect(res).toMatchInlineSnapshot(`
-        "
-
-        ---
-
-        Release notes for this update are in a comment on this PR.
-
-        "
-      `);
+      expect(res).toBe(
+        '\n\n---\n\nRelease notes for this update are in a comment on this PR.\n\n',
+      );
     });
   });
   describe('getChangelogsCommentContent', () => {

--- a/lib/workers/repository/update/pr/body/changelogs.spec.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.spec.ts
@@ -1,6 +1,10 @@
 import * as _template from '../../../../../util/template/index.ts';
 import type { BranchConfig } from '../../../../types.ts';
-import { getChangelogs, getChangelogsCommentNotice } from './changelogs.ts';
+import {
+  getChangelogs,
+  getChangelogsCommentContent,
+  getChangelogsCommentNotice,
+} from './changelogs.ts';
 
 vi.mock('../../../../../util/template/index.ts');
 const template = vi.mocked(_template);
@@ -111,6 +115,44 @@ describe('workers/repository/update/pr/body/changelogs', () => {
 
         "
       `);
+    });
+  });
+  describe('getChangelogsCommentContent', () => {
+    it('returns empty string when there is no release notes', () => {
+      const res = getChangelogsCommentContent({
+        manager: 'some-manager',
+        branchName: 'some-branch',
+        baseBranch: 'base',
+        upgrades: [],
+        hasReleaseNotes: false,
+      });
+
+      expect(res).toBe('');
+      expect(template.compile).not.toHaveBeenCalled();
+    });
+
+    it('drops the heading which the comment topic already provides', () => {
+      template.compile.mockImplementationOnce(
+        (): string => '### Release Notes\n\nsome/repo (dep-1)',
+      );
+
+      const res = getChangelogsCommentContent({
+        manager: 'some-manager',
+        branchName: 'some-branch',
+        baseBranch: 'base',
+        upgrades: [
+          {
+            manager: 'some-manager',
+            depName: 'dep-1',
+            repoName: 'some/repo',
+            branchName: 'some-branch',
+            hasReleaseNotes: true,
+          },
+        ],
+        hasReleaseNotes: true,
+      });
+
+      expect(res).toBe('some/repo (dep-1)');
     });
   });
 });

--- a/lib/workers/repository/update/pr/body/changelogs.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.ts
@@ -26,3 +26,18 @@ export function getChangelogs(config: BranchConfig): string {
 
   return releaseNotes;
 }
+
+export const changelogsCommentTopic = 'Release Notes';
+
+/**
+ * Used in place of the release notes when they are posted as a PR comment, so
+ * that platforms which seed the squash commit message from the PR body don't
+ * put the whole changelog into the repository history.
+ */
+export function getChangelogsCommentNotice(config: BranchConfig): string {
+  if (!config.hasReleaseNotes) {
+    return '';
+  }
+
+  return '\n\n---\n\nRelease notes for this update are in a comment on this PR.\n\n';
+}

--- a/lib/workers/repository/update/pr/body/changelogs.ts
+++ b/lib/workers/repository/update/pr/body/changelogs.ts
@@ -5,12 +5,7 @@ import * as template from '../../../../../util/template/index.ts';
 import type { BranchConfig } from '../../../../types.ts';
 import releaseNotesHbs from '../changelog/hbs-template.ts';
 
-export function getChangelogs(config: BranchConfig): string {
-  let releaseNotes = '';
-  if (!config.hasReleaseNotes) {
-    return releaseNotes;
-  }
-
+function renderChangelogs(config: BranchConfig): string {
   for (const upgrade of config.upgrades) {
     if (upgrade.hasReleaseNotes && upgrade.repoName) {
       upgrade.releaseNotesSummaryTitle = `${
@@ -19,7 +14,7 @@ export function getChangelogs(config: BranchConfig): string {
     }
   }
 
-  releaseNotes += `\n\n---\n\n${template.compile(releaseNotesHbs, config, false)}\n\n`;
+  let releaseNotes = template.compile(releaseNotesHbs, config, false);
   releaseNotes = releaseNotes.replace(regEx(/### \[`vv/g), '### [`v');
   releaseNotes = sanitizeMarkdown(releaseNotes);
   releaseNotes = unemojify(releaseNotes);
@@ -27,7 +22,27 @@ export function getChangelogs(config: BranchConfig): string {
   return releaseNotes;
 }
 
+export function getChangelogs(config: BranchConfig): string {
+  if (!config.hasReleaseNotes) {
+    return '';
+  }
+
+  return `\n\n---\n\n${renderChangelogs(config)}\n\n`;
+}
+
 export const changelogsCommentTopic = 'Release Notes';
+
+/**
+ * The release notes as they are posted in a PR comment.
+ * The heading is dropped, because the comment topic already provides one.
+ */
+export function getChangelogsCommentContent(config: BranchConfig): string {
+  if (!config.hasReleaseNotes) {
+    return '';
+  }
+
+  return renderChangelogs(config).replace(regEx(/^### Release Notes\n+/), '');
+}
 
 /**
  * Used in place of the release notes when they are posted as a PR comment, so

--- a/lib/workers/repository/update/pr/body/index.spec.ts
+++ b/lib/workers/repository/update/pr/body/index.spec.ts
@@ -378,5 +378,37 @@ describe('workers/repository/update/pr/body/index', () => {
         'Please check the Dependency Dashboard for more information\n\n---';
       expect(res).toBe(expected);
     });
+
+    it('replaces changelogs with a notice when they are commented', () => {
+      changelogs.getChangelogsCommentNotice.mockReturnValueOnce(
+        'getChangelogsCommentNotice',
+      );
+      platform.massageMarkdown.mockImplementation((x) => x);
+      template.compile.mockImplementation(
+        (_, config) => (config as { changelogs: string }).changelogs,
+      );
+
+      const res = getPrBody(
+        {
+          manager: 'some-manager',
+          branchName: 'some-branch',
+          baseBranch: 'base',
+          upgrades: [],
+          changelogsLocation: 'comment',
+          prBodyTemplate: '{{{changelogs}}}',
+        },
+        {
+          debugData: {
+            updatedInVer: '1.2.3',
+            createdInVer: '1.2.3',
+            targetBranch: 'base',
+          },
+        },
+        {},
+      );
+
+      expect(res).toContain('getChangelogsCommentNotice');
+      expect(changelogs.getChangelogs).not.toHaveBeenCalled();
+    });
   });
 });

--- a/lib/workers/repository/update/pr/body/index.ts
+++ b/lib/workers/repository/update/pr/body/index.ts
@@ -8,7 +8,7 @@ import * as template from '../../../../../util/template/index.ts';
 import { joinUrlParts } from '../../../../../util/url.ts';
 import type { BranchConfig } from '../../../../types.ts';
 import { getDepWarningsPR, getWarnings } from '../../../errors-warnings.ts';
-import { getChangelogs } from './changelogs.ts';
+import { getChangelogs, getChangelogsCommentNotice } from './changelogs.ts';
 import { getPrConfigDescription } from './config-description.ts';
 import { getControls } from './controls.ts';
 import { getPrFooter } from './footer.ts';
@@ -119,7 +119,10 @@ export function getPrBody(
     table: getPrUpdatesTable(branchConfig),
     warnings,
     notes: getPrNotes(branchConfig) + getPrExtraNotes(branchConfig),
-    changelogs: getChangelogs(branchConfig),
+    changelogs:
+      branchConfig.changelogsLocation === 'comment'
+        ? getChangelogsCommentNotice(branchConfig)
+        : getChangelogs(branchConfig),
     configDescription: getPrConfigDescription(branchConfig),
     controls: getControls(),
     footer: getPrFooter(branchConfig),

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -1000,6 +1000,73 @@ describe('workers/repository/update/pr/index', () => {
         const [[bodyConfig]] = prBody.getPrBody.mock.calls;
         expect(bodyConfig.upgrades).toHaveLength(3);
       });
+
+      describe('changelogsLocation=comment', () => {
+        beforeEach(() => {
+          vi.spyOn(platform, 'massageMarkdown').mockImplementation((x) => x);
+        });
+
+        it('comments the changelogs on a created PR', async () => {
+          platform.createPr.mockResolvedValueOnce(pr);
+
+          const res = await ensurePr({
+            ...config,
+            changelogsLocation: 'comment',
+            upgrades: [dummyUpgrade],
+          });
+
+          expect(res).toEqual({ type: 'with-pr', pr });
+          expect(comment.ensureComment).toHaveBeenCalledExactlyOnceWith({
+            number,
+            topic: 'Release Notes',
+            content: expect.stringContaining('some/repo'),
+          });
+        });
+
+        it('comments the changelogs on an unchanged PR', async () => {
+          platform.getBranchPr.mockResolvedValueOnce(pr);
+
+          const res = await ensurePr({
+            ...config,
+            changelogsLocation: 'comment',
+            upgrades: [dummyUpgrade],
+          });
+
+          expect(res).toEqual({ type: 'with-pr', pr });
+          expect(platform.updatePr).not.toHaveBeenCalled();
+          expect(comment.ensureComment).toHaveBeenCalledExactlyOnceWith({
+            number,
+            topic: 'Release Notes',
+            content: expect.stringContaining('some/repo'),
+          });
+        });
+
+        it('does not comment when there are no changelogs', async () => {
+          platform.createPr.mockResolvedValueOnce(pr);
+
+          const res = await ensurePr({
+            ...config,
+            changelogsLocation: 'comment',
+            upgrades: [],
+          });
+
+          expect(res).toEqual({ type: 'with-pr', pr });
+          expect(comment.ensureComment).not.toHaveBeenCalled();
+        });
+
+        it('does not comment on dry run', async () => {
+          GlobalConfig.set({ dryRun: 'full' });
+
+          const res = await ensurePr({
+            ...config,
+            changelogsLocation: 'comment',
+            upgrades: [dummyUpgrade],
+          });
+
+          expect(res).toEqual({ type: 'with-pr', pr: { number: 0 } });
+          expect(comment.ensureComment).not.toHaveBeenCalled();
+        });
+      });
     });
 
     describe('Warnings', () => {

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -35,7 +35,10 @@ import type {
 } from '../../../types.ts';
 import { embedChangelogs } from '../../changelog/index.ts';
 import { resolveBranchStatus } from '../branch/status-checks.ts';
-import { changelogsCommentTopic, getChangelogs } from './body/changelogs.ts';
+import {
+  changelogsCommentTopic,
+  getChangelogsCommentContent,
+} from './body/changelogs.ts';
 import { getPrBody } from './body/index.ts';
 import {
   getChangedLabels,
@@ -161,7 +164,7 @@ async function ensureChangelogsComment(
   }
 
   const content = platform.massageMarkdown(
-    getChangelogs(config),
+    getChangelogsCommentContent(config),
     config.rebaseLabel,
   );
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -35,6 +35,7 @@ import type {
 } from '../../../types.ts';
 import { embedChangelogs } from '../../changelog/index.ts';
 import { resolveBranchStatus } from '../branch/status-checks.ts';
+import { changelogsCommentTopic, getChangelogs } from './body/changelogs.ts';
 import { getPrBody } from './body/index.ts';
 import {
   getChangedLabels,
@@ -149,6 +150,32 @@ function addPullRequestNoteIfAttestationHasBeenLost(
       ].join('\n'),
     );
   }
+}
+
+async function ensureChangelogsComment(
+  config: BranchConfig,
+  prNumber: number,
+): Promise<void> {
+  if (config.changelogsLocation !== 'comment' || !config.hasReleaseNotes) {
+    return;
+  }
+
+  const content = platform.massageMarkdown(
+    getChangelogs(config),
+    config.rebaseLabel,
+  );
+
+  if (GlobalConfig.get('dryRun')) {
+    logger.info(`DRY-RUN: Would add release notes comment to PR #${prNumber}`);
+    return;
+  }
+
+  logger.debug(`Adding release notes comment to PR #${prNumber}`);
+  await ensureComment({
+    number: prNumber,
+    topic: changelogsCommentTopic,
+    content,
+  });
 }
 
 // Ensures that PR exists with matching title/body
@@ -387,6 +414,10 @@ export async function ensurePr(
     if (existingPr) {
       logger.debug('Processing existing PR');
 
+      // Done before the "does not need updating" check below, because the PR
+      // body only holds a static notice when the release notes are commented
+      await ensureChangelogsComment(config, existingPr.number);
+
       if (
         !existingPr.hasAssignees &&
         !hasNotIgnoredReviewers(existingPr, config) &&
@@ -599,6 +630,7 @@ export async function ensurePr(
     }
     // Skip assign and review if automerging PR
     if (pr) {
+      await ensureChangelogsComment(config, pr.number);
       if (
         config.automerge &&
         !config.assignAutomerge &&


### PR DESCRIPTION
## Changes

Adds a new `changelogsLocation` config option with two values:

- `body` (default): unchanged behavior, the changelogs/release notes are part of the PR body.
- `comment`: the changelogs are posted as a PR comment instead, and the `{{{changelogs}}}` field of the PR body holds a short notice pointing at the comment.

Implementation notes:

- `getPrBody()` swaps `getChangelogs()` for `getChangelogsCommentNotice()` when `changelogsLocation=comment`, so a custom `prBodyTemplate` needs no changes.
- The comment is ensured under the topic `Release Notes` via `platform/comment.ts`, which already hashes content in the repo cache, so an unchanged changelog costs no API call.
- It is ensured *before* the "PR does not need updating" early return, because with the changelogs in a comment the PR body no longer changes when the release notes do.
- No-ops when there are no release notes (e.g. `fetchChangeLogs=off`), and logs instead of commenting under `--dry-run`.

## Context

Motivation: GitHub (and other platforms) seed the squash commit message from the PR body, so today every Renovate PR that carries release notes dumps the whole changelog into the repository history.
In our monorepo we worked around this with a GitHub Actions workflow that lifts the Release Notes section out of the PR body after the fact and re-posts it as a comment.
This option makes that workaround unnecessary.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Happy to open a Discussion first, or to rename the option / change its values, if you'd prefer that.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, unit tests and docs were drafted with Claude Code (Claude Opus 5) and reviewed by me.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly.
- [x] An agent will draft replies and @jasonwbarnett will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
