### PR TITLE
fix(gomod): support cyclic module graphs with gomodTidyAll

### DIFF
--- a/lib/modules/manager/gomod/artifacts-gomodtidyall.spec.ts
+++ b/lib/modules/manager/gomod/artifacts-gomodtidyall.spec.ts
@@ -69,6 +69,12 @@ function baseConfig(
   };
 }
 
+function mockTidyAllFileContents(...passes: (string | null)[][]): void {
+  for (const content of passes.flat()) {
+    fs.readLocalFile.mockResolvedValueOnce(content);
+  }
+}
+
 describe('modules/manager/gomod/artifacts-gomodtidyall', () => {
   beforeEach(() => {
     delete process.env.GOPATH;
@@ -90,6 +96,15 @@ describe('modules/manager/gomod/artifacts-gomodtidyall', () => {
       'api/go.mod',
       'cmd/go.mod',
     ]);
+    const stableContents = [
+      'shared.mod',
+      'shared.sum',
+      'api.mod',
+      'api.sum',
+      'cmd.mod',
+      'cmd.sum',
+    ];
+    mockTidyAllFileContents(stableContents, stableContents);
     git.getRepoStatus.mockResolvedValueOnce(
       partial<StatusResult>({
         modified: ['shared/go.sum', 'api/go.sum', 'cmd/go.sum'],
@@ -135,6 +150,8 @@ describe('modules/manager/gomod/artifacts-gomodtidyall', () => {
   it('implies primary tidy when only gomodTidyAll is set', async () => {
     const execSnapshots = mockExecAll();
     packageTree.getGoModulesInTidyOrder.mockResolvedValueOnce(['api/go.mod']);
+    const stableContents = ['root.mod', 'root.sum', 'api.mod', 'api.sum'];
+    mockTidyAllFileContents(stableContents, stableContents);
     git.getRepoStatus.mockResolvedValueOnce(
       partial<StatusResult>({ modified: ['go.sum', 'api/go.sum'] }),
     );
@@ -160,6 +177,8 @@ describe('modules/manager/gomod/artifacts-gomodtidyall', () => {
   it('collects updated dependent go.mod when only that file changed', async () => {
     mockExecAll();
     packageTree.getGoModulesInTidyOrder.mockResolvedValueOnce(['api/go.mod']);
+    const stableContents = ['root.mod', 'root.sum', 'api.mod', 'api.sum'];
+    mockTidyAllFileContents(stableContents, stableContents);
     git.getRepoStatus.mockResolvedValueOnce(
       partial<StatusResult>({ modified: ['api/go.mod'] }),
     );
@@ -240,5 +259,147 @@ describe('modules/manager/gomod/artifacts-gomodtidyall', () => {
     });
 
     expect(packageTree.getGoModulesInTidyOrder).not.toHaveBeenCalled();
+  });
+
+  it('compares module contents and repeats tidy commands until stable', async () => {
+    const execSnapshots = mockExecAll();
+    packageTree.getGoModulesInTidyOrder.mockResolvedValueOnce(['api/go.mod']);
+    const initialContents = ['root-0', 'sum-0', 'api-0', 'api-sum-0'];
+    const changedContents = ['root-1', 'sum-1', 'api-1', 'api-sum-1'];
+    mockTidyAllFileContents(initialContents, changedContents, changedContents);
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({ modified: ['go.sum', 'api/go.sum'] }),
+    );
+    fs.readLocalFile.mockResolvedValueOnce('New go.sum');
+    fs.readLocalFile.mockResolvedValueOnce('New api/go.sum');
+    fs.readLocalFile.mockResolvedValueOnce(gomod1);
+
+    await gomod.updateArtifacts({
+      packageFileName: 'go.mod',
+      updatedDeps: [],
+      newPackageFileContent: gomod1,
+      config: baseConfig(),
+    });
+
+    expect(
+      execSnapshots.filter(({ cmd }) => cmd === 'go -C api mod tidy'),
+    ).toHaveLength(2);
+    expect(
+      execSnapshots.filter(({ cmd }) => cmd === 'go mod tidy'),
+    ).toHaveLength(3);
+  });
+
+  it('runs vendoring and generation after tidy commands stabilize', async () => {
+    GlobalConfig.set({
+      ...adminConfig,
+      allowedUnsafeExecutions: ['goGenerate'],
+    });
+    fs.readLocalFile.mockReset();
+    fs.readLocalFile.mockResolvedValueOnce('Current go.sum');
+    fs.readLocalFile.mockResolvedValueOnce('modules.txt content');
+    const execSnapshots = mockExecAll();
+    packageTree.getGoModulesInTidyOrder.mockResolvedValueOnce(['api/go.mod']);
+    const initialContents = ['root-0', 'sum-0', 'api-0', 'api-sum-0'];
+    const changedContents = ['root-1', 'sum-1', 'api-1', 'api-sum-1'];
+    mockTidyAllFileContents(initialContents, changedContents, changedContents);
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({ modified: ['go.sum'] }),
+    );
+    fs.readLocalFile.mockResolvedValueOnce('New go.sum');
+    fs.readLocalFile.mockResolvedValueOnce(gomod1);
+
+    await gomod.updateArtifacts({
+      packageFileName: 'go.mod',
+      updatedDeps: [],
+      newPackageFileContent: gomod1,
+      config: baseConfig({
+        postUpdateOptions: ['gomodTidyAll', 'goGenerate'],
+      }),
+    });
+
+    const commands = execSnapshots.map(({ cmd }) => cmd);
+    expect(commands.indexOf('go mod vendor')).toBeGreaterThan(
+      commands.lastIndexOf('go -C api mod tidy'),
+    );
+    expect(commands.indexOf('go generate ./...')).toBeGreaterThan(
+      commands.indexOf('go mod vendor'),
+    );
+  });
+
+  it('returns source artifacts and an error when dependent tidies do not stabilize', async () => {
+    const execSnapshots = mockExecAll();
+    packageTree.getGoModulesInTidyOrder.mockResolvedValueOnce(['api/go.mod']);
+    mockTidyAllFileContents(
+      ['root-0', 'sum-0', 'api-0', null],
+      ['root-1', 'sum-1', 'api-1', 'api-sum-1'],
+      ['root-2', 'sum-2', 'api-2', 'api-sum-2'],
+      ['root-3', 'sum-3', 'api-3', 'api-sum-3'],
+    );
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({ modified: ['go.sum'] }),
+    );
+    fs.readLocalFile.mockResolvedValueOnce('sum-1');
+    fs.readLocalFile.mockResolvedValueOnce(gomod1);
+
+    const result = await gomod.updateArtifacts({
+      packageFileName: 'go.mod',
+      updatedDeps: [],
+      newPackageFileContent: gomod1,
+      config: baseConfig(),
+    });
+
+    expect(
+      execSnapshots.filter(({ cmd }) => cmd === 'go -C api mod tidy'),
+    ).toHaveLength(3);
+    expect(result).toEqual([
+      {
+        file: {
+          type: 'addition',
+          path: 'go.sum',
+          contents: 'sum-1',
+        },
+      },
+      {
+        artifactError: {
+          fileName: 'go.sum',
+          stderr: 'go mod tidy did not stabilize after 3 passes',
+        },
+      },
+    ]);
+    expect(git.getRepoStatus).toHaveBeenCalledOnce();
+    expect(fs.writeLocalFile).toHaveBeenCalledWith('go.mod', 'root-1');
+    expect(fs.writeLocalFile).toHaveBeenCalledWith('go.sum', 'sum-1');
+    expect(fs.writeLocalFile).toHaveBeenCalledWith('api/go.mod', 'api-0');
+    expect(fs.deleteLocalFile).toHaveBeenCalledWith('api/go.sum');
+  });
+
+  it('returns an error when rollback leaves no modified module files', async () => {
+    mockExecAll();
+    packageTree.getGoModulesInTidyOrder.mockResolvedValueOnce(['api/go.mod']);
+    mockTidyAllFileContents(
+      ['root-0', 'sum-0', 'api-0', 'api-sum-0'],
+      ['root-1', 'sum-1', 'api-1', 'api-sum-1'],
+      ['root-2', 'sum-2', 'api-2', 'api-sum-2'],
+      ['root-3', 'sum-3', 'api-3', 'api-sum-3'],
+    );
+    git.getRepoStatus.mockResolvedValueOnce(
+      partial<StatusResult>({ modified: [] }),
+    );
+
+    const result = await gomod.updateArtifacts({
+      packageFileName: 'go.mod',
+      updatedDeps: [],
+      newPackageFileContent: gomod1,
+      config: baseConfig(),
+    });
+
+    expect(result).toEqual([
+      {
+        artifactError: {
+          fileName: 'go.sum',
+          stderr: 'go mod tidy did not stabilize after 3 passes',
+        },
+      },
+    ]);
   });
 });

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -10,6 +10,7 @@ import { getEnv } from '../../../util/env.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import { filterMap } from '../../../util/filter-map.ts';
 import {
+  deleteLocalFile,
   ensureCacheDir,
   findLocalSiblingOrParent,
   isValidLocalPath,
@@ -31,6 +32,7 @@ import { getGoModulesInTidyOrder } from './package-tree.ts';
 
 const { major, valid } = semver;
 const gitExec = withGitEnvironment(['go']);
+const maxTidyAllPasses = 3;
 
 function getUpdateImportPathCmds(
   updatedDeps: PackageDependency[],
@@ -302,6 +304,15 @@ export async function updateArtifacts({
     }
 
     let goWorkSumFileName = upath.join(goModDir, 'go.work.sum');
+    const postTidyCommands: string[] = [];
+    function addPostTidyCommand(command: string): void {
+      if (isGoModTidyAllRequired) {
+        postTidyCommands.push(command);
+        return;
+      }
+      execCommands.push(command);
+    }
+
     if (useVendor) {
       // If we find a go.work, then use go workspace vendoring.
       const goWorkFile = await findLocalSiblingOrParent(
@@ -317,7 +328,7 @@ export async function updateArtifacts({
 
         args = 'work vendor';
         logger.debug('using go work vendor');
-        execCommands.push(`${cmd} ${args}`);
+        addPostTidyCommand(`${cmd} ${args}`);
 
         args = 'work sync';
         logger.debug('using go work sync');
@@ -325,7 +336,7 @@ export async function updateArtifacts({
       } else {
         args = `mod vendor${modFileFlag}`;
         logger.debug('using go mod vendor');
-        execCommands.push(`${cmd} ${args}`);
+        addPostTidyCommand(`${cmd} ${args}`);
       }
 
       if (isGoModTidyRequired) {
@@ -343,12 +354,33 @@ export async function updateArtifacts({
     }
 
     let dependentModules: string[] = [];
+    let tidyAllCommands: string[] = [];
+    let tidyAllFiles: string[] = [];
+    let initialTidyAllContents: (string | null)[] = [];
+    let firstPassTidyAllContents: (string | null)[] = [];
+    let previousTidyAllContents: (string | null)[] = [];
+    let tidyAllArtifactError: string | undefined;
     if (isGoModTidyAllRequired) {
       try {
         dependentModules = await getGoModulesInTidyOrder(goModFileName);
-        for (const dependent of dependentModules) {
+        const dependentTidyCommands = dependentModules.map((dependent) => {
           const dir = upath.relative(goModDir, upath.dirname(dependent));
-          execCommands.push(`${cmd} -C ${quote(dir)} mod tidy${tidyOpts}`);
+          return `${cmd} -C ${quote(dir)} mod tidy${tidyOpts}`;
+        });
+        execCommands.push(...dependentTidyCommands);
+        if (dependentModules.length > 0) {
+          tidyAllCommands = [
+            `${cmd} mod tidy${modFileFlag}${tidyOpts}`,
+            ...dependentTidyCommands,
+          ];
+          tidyAllFiles = [goModFileName, ...dependentModules].flatMap((f) => [
+            f,
+            f.replace(regEx(/\.mod$/), '.sum'),
+          ]);
+          initialTidyAllContents = await Promise.all(
+            tidyAllFiles.map((f) => readLocalFile(f, 'utf8')),
+          );
+          previousTidyAllContents = initialTidyAllContents;
         }
         logger.debug({ dependentModules }, 'go mod tidy commands included');
       } catch (err) {
@@ -359,7 +391,7 @@ export async function updateArtifacts({
     if (useGoGenerate) {
       if (goGenerateAllowed) {
         logger.debug('go generate command included');
-        execCommands.push(`${cmd} generate ./...`);
+        addPostTidyCommand(`${cmd} generate ./...`);
       } else {
         logger.once.warn(
           `go generate command requested as a post update action, but goGenerate is not permitted in the allowedUnsafeExecutions`,
@@ -368,6 +400,48 @@ export async function updateArtifacts({
     }
 
     await gitExec(execCommands, execOptions);
+
+    if (tidyAllCommands.length > 0) {
+      for (let pass = 1; pass <= maxTidyAllPasses; pass += 1) {
+        const currentTidyAllContents = await Promise.all(
+          tidyAllFiles.map((f) => readLocalFile(f, 'utf8')),
+        );
+        if (pass === 1) {
+          firstPassTidyAllContents = currentTidyAllContents;
+        }
+        if (
+          currentTidyAllContents.every(
+            (content, index) => content === previousTidyAllContents[index],
+          )
+        ) {
+          break;
+        }
+        if (pass === maxTidyAllPasses) {
+          for (const [index, fileName] of tidyAllFiles.entries()) {
+            const restoredContent =
+              index < 2
+                ? firstPassTidyAllContents[index]
+                : initialTidyAllContents[index];
+            if (restoredContent === null) {
+              await deleteLocalFile(fileName);
+            } else {
+              await writeLocalFile(fileName, restoredContent);
+            }
+          }
+          tidyAllArtifactError = `go mod tidy did not stabilize after ${maxTidyAllPasses} passes`;
+          dependentModules = [];
+          break;
+        }
+
+        logger.debug(`go mod tidy files changed, running pass ${pass + 1}`);
+        previousTidyAllContents = currentTidyAllContents;
+        await gitExec(tidyAllCommands, execOptions);
+      }
+    }
+
+    if (!tidyAllArtifactError && postTidyCommands.length > 0) {
+      await gitExec(postTidyCommands, execOptions);
+    }
 
     const status = await getRepoStatus();
     const dependentFiles = dependentModules.flatMap((f) => [
@@ -381,6 +455,16 @@ export async function updateArtifacts({
       !status.modified.includes(goWorkSumFileName) &&
       !dependentFiles.some((f) => status.modified.includes(f))
     ) {
+      if (tidyAllArtifactError) {
+        return [
+          {
+            artifactError: {
+              fileName: sumFileName,
+              stderr: tidyAllArtifactError,
+            },
+          },
+        ];
+      }
       return null;
     }
 
@@ -525,6 +609,14 @@ export async function updateArtifacts({
           });
         }
       }
+    }
+    if (tidyAllArtifactError) {
+      res.push({
+        artifactError: {
+          fileName: sumFileName,
+          stderr: tidyAllArtifactError,
+        },
+      });
     }
     return res;
   } catch (err) {

--- a/lib/modules/manager/gomod/package-tree.spec.ts
+++ b/lib/modules/manager/gomod/package-tree.spec.ts
@@ -67,6 +67,35 @@ describe('modules/manager/gomod/package-tree', () => {
       ]);
     });
 
+    it('returns dependents when local replacements contain a cycle', async () => {
+      const cyclicMonorepo: Record<string, string> = {
+        'tooling/go.mod': codeBlock`
+          module example.com/tooling
+
+          replace example.com/service => ../service
+        `,
+        'service/go.mod': codeBlock`
+          module example.com/service
+
+          replace example.com/tooling => ../tooling
+        `,
+        'app/go.mod': codeBlock`
+          module example.com/app
+
+          replace example.com/service => ../service
+        `,
+      };
+      scm.getFileList.mockResolvedValue(Object.keys(cyclicMonorepo));
+      fs.readLocalFile.mockImplementation((f: string) =>
+        Promise.resolve(cyclicMonorepo[f]),
+      );
+
+      expect(await getGoModulesInTidyOrder('tooling/go.mod')).toEqual([
+        'service/go.mod',
+        'app/go.mod',
+      ]);
+    });
+
     it('returns empty array when the module has no dependents or is unknown', async () => {
       scm.getFileList.mockResolvedValue(['a/go.mod']);
       fs.readLocalFile.mockResolvedValue('module example.com/a\n');

--- a/lib/modules/manager/gomod/package-tree.ts
+++ b/lib/modules/manager/gomod/package-tree.ts
@@ -1,4 +1,4 @@
-import { Graph, depthFirstSearch, topologicalSort } from 'graph-data-structure';
+import { Graph, depthFirstSearch } from 'graph-data-structure';
 import upath from 'upath';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import {
@@ -61,8 +61,9 @@ async function buildDependencyGraph(): Promise<Graph> {
 
 /**
  * Get all `go.mod` files which transitively depend on `packageFileName`, ordered
- * so that a module always comes before the modules which depend on it.
- * The given `packageFileName` is not included.
+ * so that a module comes before the modules which depend on it whenever the
+ * relationship is acyclic. Cycles are tolerated and each dependent module is
+ * included once. The given `packageFileName` is not included.
  */
 export async function getGoModulesInTidyOrder(
   packageFileName: string,
@@ -72,12 +73,8 @@ export async function getGoModulesInTidyOrder(
     return [];
   }
 
-  const dependents = new Set(
-    depthFirstSearch(graph, {
-      sourceNodes: [packageFileName],
-      includeSourceNodes: false,
-    }),
-  );
-
-  return topologicalSort(graph).filter((f) => dependents.has(f));
+  return depthFirstSearch(graph, {
+    sourceNodes: [packageFileName],
+    includeSourceNodes: false,
+  }).reverse();
 }


### PR DESCRIPTION
## Changes

`gomodTidyAll` currently sorts the entire local module graph topologically. A
cycle in local `replace` relationships makes dependency discovery throw
`Cycle found`, so Renovate skips tidying dependent modules. Even an unrelated
cycle elsewhere in the repository can trigger this failure.

This change tolerates cycles while preserving the existing ordering and command
sequence for acyclic repositories. Each reachable dependent is included once.
Only a reachable cycle enables the additional resolution passes:

- After `go get` and any import-path updates, snapshot the participating
  `go.mod`/`go.sum` files and run up to three tidy-only passes, comparing file
  contents after each pass. Existing rules for skipping the source tidy still
  apply.
- If the files stabilize, continue with the normal artifact-update pass.
- If they do not stabilize, restore all snapshotted files, including removing
  sum files created during the attempts, then run the normal pass with each
  dependent visited once. Return those normal-pass artifacts together with a
  convergence error. A failed resolution command also restores the snapshot
  before returning an artifact error.
- Vendoring, workspace sync, and generation run only in the normal pass, never
  during speculative resolution. Their existing order, including the tidy after
  vendoring, is preserved. Vendor and generated artifacts therefore come from
  the settled state or the normal fallback pass, not discarded attempts.

Cyclic updates can run up to three resolution passes **plus one normal pass**.
Acyclic updates get no additional tidy passes. Vendoring and generation are not
repeated by the resolution loop.

Reproduction: https://github.com/clanky1024/renovate-gomodtidyall-graph-issue.
The original failure is recorded in this
[dry-run workflow](https://github.com/clanky1024/renovate-gomodtidyall-graph-issue/actions/runs/32473232953).

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex (GPT-5 and GPT-6) assisted with investigation, implementation,
tests, reproduction runs, and this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly.
- [x] An agent will draft replies and @mschfh will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository:
https://github.com/clanky1024/renovate-gomodtidyall-graph-issue

All eight Go-manager test files pass, with 100% scoped statement, branch, and
function coverage. TypeScript checking, oxlint, Biome, and Prettier pass. Tests
cover convergence through the third pass, skipped source tidies, rollback after
nonconvergence or a command failure, and normal-pass vendor/generated artifacts
after rollback, including workspace vendoring.

Reran commit `5aff2eb26a` against the public reproduction on 2026-09-17 using a
full GitHub dry run. It detected the cycle, stabilized after two resolution
passes, and completed the normal pass without a cycle or convergence artifact
error. The proposed update changes `go.yaml.in/yaml/v3` from v3.0.4 to v3.0.5 and
includes all six `go.mod`/`go.sum` files across `tooling`, `service`, and `app`.
The dry run exited successfully without writing a branch or PR in the
reproduction repository. Vendoring and generation are covered by unit tests;
they are not enabled in this reproduction.
