### PR TITLE
ci: add commit hook for BREAKING CHANGE

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,12 +1,26 @@
 #!/bin/sh
-if git stripspace --strip-comments <"$1" |
-  grep -Eiq '(closes|fixes|resolves|fixed|closed|resolved):?[[:space:]]+#[0-9]+'; then
+msg=$(git stripspace --strip-comments <"$1")
+
+abort() {
   echo
   echo "Aborting commit."
-  echo "The commit message contains an issue closing keyword (closes, fixes, resolves, ...)."
-  echo "Put it in the pull request description instead, otherwise CI fails."
+  echo "$1"
+  echo "$2"
   echo
   echo "If you're sure you want to keep it, run git commit with the --no-verify flag."
   echo
   exit 1
+}
+
+if printf '%s\n' "$msg" |
+  grep -Eiq '(closes|fixes|resolves|fixed|closed|resolved):?[[:space:]]+#[0-9]+'; then
+  abort "The commit message contains an issue closing keyword (closes, fixes, resolves, ...)." \
+    "Put it in the pull request description instead, otherwise CI fails."
+fi
+
+# A 'BREAKING CHANGE' footer makes semantic-release publish a major version,
+# see .releaserc.json.
+if printf '%s\n' "$msg" | grep -Eiq '^[[:space:]*]*BREAKING[ -]CHANGE[:[:space:]]'; then
+  abort "The commit message contains a 'BREAKING CHANGE:' footer." \
+    "This triggers a major release, which we prepare deliberately, see docs/development/major-release.md."
 fi


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Checks for breaking change markers in the commit message, to prevent these things to surface at earliest in the CI 

## Context

https://github.com/renovatebot/renovate/pull/45290#pullrequestreview-4962798626

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
