### PR TITLE
fix(manager/gomod): handle bare `../` replace paths in `gomodTidyAll`

### DIFF
--- a/lib/modules/manager/gomod/package-tree.spec.ts
+++ b/lib/modules/manager/gomod/package-tree.spec.ts
@@ -52,6 +52,17 @@ describe('modules/manager/gomod/package-tree', () => {
         parseLocalReplacePaths('// replace example.com/a => ../a\n'),
       ).toEqual([]);
     });
+
+    it('parses bare ../ and ./ replace paths pointing to a parent or current directory', () => {
+      const content = codeBlock`
+        module example.com/e2e
+
+        replace example.com/root => ../
+        replace example.com/sibling => ./
+      `;
+
+      expect(parseLocalReplacePaths(content)).toEqual(['../', './']);
+    });
   });
 
   describe('getGoModulesInTidyOrder', () => {
@@ -80,6 +91,23 @@ describe('modules/manager/gomod/package-tree', () => {
       fs.readLocalFile.mockResolvedValue(null);
 
       expect(await getGoModulesInTidyOrder('shared/go.mod')).toEqual([]);
+    });
+
+    it('traverses bare ../ replace directives pointing to a parent module', async () => {
+      const files: Record<string, string> = {
+        'go.mod': 'module example.com/root\n',
+        'e2e/go.mod': codeBlock`
+          module example.com/e2e
+
+          replace example.com/root => ../
+        `,
+      };
+      scm.getFileList.mockResolvedValue(Object.keys(files));
+      fs.readLocalFile.mockImplementation((f: string) =>
+        Promise.resolve(files[f]),
+      );
+
+      expect(await getGoModulesInTidyOrder('go.mod')).toEqual(['e2e/go.mod']);
     });
   });
 });

--- a/lib/modules/manager/gomod/package-tree.ts
+++ b/lib/modules/manager/gomod/package-tree.ts
@@ -12,7 +12,7 @@ import { scm } from '../../platform/scm.ts';
 // `[^\s/]` rules out comment lines, and lets this match the single line form as
 // well as the lines inside a `replace (...)` block.
 const localReplace = regEx(
-  /^[^\S\n]*(?:replace[^\S\n]+)?[^\s/]\S*(?:[^\S\n]+\S+)?[^\S\n]+=>[^\S\n]+(?<localPath>\.{1,2}\/\S+)/gm,
+  /^[^\S\n]*(?:replace[^\S\n]+)?[^\s/]\S*(?:[^\S\n]+\S+)?[^\S\n]+=>[^\S\n]+(?<localPath>\.{1,2}\/\S*)/gm,
 );
 
 /**


### PR DESCRIPTION

## Changes

`gomodTidyAll` silently skipped sub-modules whose `go.mod` contains a replace directive pointing to the parent with a bare trailing slash (e.g. `replace example.com/root => ../`).

The `localReplace` regex in `package-tree.ts` used `\S+` to capture the local path, which requires at least one non-whitespace character after the final `/`. A bare `../` or `./` has nothing after the slash, so it never matched — `getGoModulesInTidyOrder` returned `[]` and `go mod tidy` was never run on those sub-modules.

Fix: change `\S+` → `\S*` in the named capture group so zero trailing characters are accepted.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

<!-- ^^^ FILL IN THE CORRECT BOX — I've left a placeholder checked; only you know the true answer -->

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @prad9192 will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation 

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work 

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository