### PR TITLE
feat(gitlab): support discussions for merge request comments

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2017,6 +2017,13 @@ If you have other bots which commit on top of Renovate PRs, and don't want Renov
 `gitIgnoredAuthors` values can be exact [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322)-compliant email strings, glob patterns, or regex patterns.
 For more details on the syntax and supported patterns, see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
 
+## `gitlabMergeRequestCommentType`
+
+By default, Renovate posts comments on GitLab merge requests as regular notes.
+Set this option to `discussion` to post new comments as resolvable discussions instead.
+GitLab can be configured to [prevent merging while threads remain unresolved](https://docs.gitlab.com/user/project/merge_requests/#prevent-merge-unless-all-threads-are-resolved).
+When this GitLab setting is enabled, Renovate discussions prevent the merge request from being merged until someone resolves them.
+
 ## `gitLabIgnoreApprovals`
 
 Ignore the default project level approval(s), so that Renovate bot can automerge its merge requests, without needing approval(s).

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2024,7 +2024,7 @@ Under the hood, it creates a MR-level approval rule where `approvals_required` i
 This option works only when `automerge=true` and either `automergeType=pr` or `automergeType=branch`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
 
-## `gitLabMergeRequestCommentType`
+## `gitlabMergeRequestCommentType`
 
 By default, Renovate posts comments on GitLab merge requests as regular notes.
 Set this option to `discussion` to post new comments as resolvable discussions instead.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2027,9 +2027,9 @@ Also, approval rules overriding should not be [prevented in GitLab settings](htt
 ## `gitlabMergeRequestCommentType`
 
 By default, Renovate posts comments on GitLab merge requests as regular notes.
-Set this option to `discussion` to post new comments as resolvable discussions instead.
+Set this option to `discussion` to post new comments as resolvable threads instead.
 GitLab can be configured to [prevent merging while threads remain unresolved](https://docs.gitlab.com/user/project/merge_requests/#prevent-merge-unless-all-threads-are-resolved).
-When this GitLab setting is enabled, Renovate discussions prevent the merge request from being merged until someone resolves them.
+When this GitLab setting is enabled, Renovate threads prevent the merge request from being merged until someone resolves them.
 
 ## `goGetDirs`
 

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2017,19 +2017,19 @@ If you have other bots which commit on top of Renovate PRs, and don't want Renov
 `gitIgnoredAuthors` values can be exact [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322)-compliant email strings, glob patterns, or regex patterns.
 For more details on the syntax and supported patterns, see Renovate's [string pattern matching documentation](./string-pattern-matching.md).
 
-## `gitlabMergeRequestCommentType`
-
-By default, Renovate posts comments on GitLab merge requests as regular notes.
-Set this option to `discussion` to post new comments as resolvable discussions instead.
-GitLab can be configured to [prevent merging while threads remain unresolved](https://docs.gitlab.com/user/project/merge_requests/#prevent-merge-unless-all-threads-are-resolved).
-When this GitLab setting is enabled, Renovate discussions prevent the merge request from being merged until someone resolves them.
-
 ## `gitLabIgnoreApprovals`
 
 Ignore the default project level approval(s), so that Renovate bot can automerge its merge requests, without needing approval(s).
 Under the hood, it creates a MR-level approval rule where `approvals_required` is set to `0`.
 This option works only when `automerge=true` and either `automergeType=pr` or `automergeType=branch`.
 Also, approval rules overriding should not be [prevented in GitLab settings](https://docs.gitlab.com/ee/user/project/merge_requests/approvals/settings.html#prevent-editing-approval-rules-in-merge-requests).
+
+## `gitLabMergeRequestCommentType`
+
+By default, Renovate posts comments on GitLab merge requests as regular notes.
+Set this option to `discussion` to post new comments as resolvable discussions instead.
+GitLab can be configured to [prevent merging while threads remain unresolved](https://docs.gitlab.com/user/project/merge_requests/#prevent-merge-unless-all-threads-are-resolved).
+When this GitLab setting is enabled, Renovate discussions prevent the merge request from being merged until someone resolves them.
 
 ## `goGetDirs`
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1281,6 +1281,16 @@ const options: Readonly<RenovateOptions>[] = [
     stage: 'repository',
   },
   {
+    name: 'gitlabMergeRequestCommentType',
+    description:
+      'Choose whether Renovate comments on GitLab merge requests are created as notes or discussions.',
+    type: 'string',
+    allowedValues: ['note', 'discussion'],
+    default: 'note',
+    stage: 'repository',
+    supportedPlatforms: ['gitlab'],
+  },
+  {
     name: 'gitTimeout',
     description:
       'Configure the timeout with a number of milliseconds to wait for a Git task.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -4,6 +4,7 @@ import type { ManagerName } from '../manager-list.generated.ts';
 import type { CustomManager } from '../modules/manager/custom/types.ts';
 import type {
   GitUrlOption,
+  GitlabMergeRequestCommentType,
   RepoSortMethod,
   SortMethod,
 } from '../modules/platform/types.ts';
@@ -408,6 +409,7 @@ export interface RenovateConfig
   forkModeDisallowMaintainerEdits?: boolean;
   forkProcessing?: 'auto' | 'enabled' | 'disabled';
   forkToken?: string;
+  gitlabMergeRequestCommentType?: GitlabMergeRequestCommentType;
 
   gitAuthor?: string;
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -151,16 +151,44 @@ describe('modules/platform/gitlab/index', () => {
   });
 
   describe('configureRepo()', () => {
-    it('uses the gitlabMergeRequestCommentType configuration if provided', () => {
-      configureRepo({
+    it('uses the gitlabMergeRequestCommentType configuration if provided', async () => {
+      const scope = await initRepo();
+      gitlab.configureRepo({
         gitlabMergeRequestCommentType: 'discussion',
-      } as any); 
-      expect(mergeRequestCommentType).toBe('discussion');
+      });
+
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200);
+
+      await expect(
+        gitlab.ensureComment({
+          number: 42,
+          topic: 'some-subject',
+          content: 'some\ncontent',
+        }),
+      ).toResolve();
     });
 
-    it('uses "note" as the default fallback value', () => {
-      configureRepo({} as any); 
-      expect(mergeRequestCommentType).toBe('note');
+    it('uses "note" as the default fallback value', async () => {
+      const scope = await initRepo();
+      gitlab.configureRepo({});
+
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200);
+
+      await expect(
+        gitlab.ensureComment({
+          number: 42,
+          topic: 'some-subject',
+          content: 'some\ncontent',
+        }),
+      ).toResolve();
     });
   });
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -150,6 +150,20 @@ describe('modules/platform/gitlab/index', () => {
     });
   });
 
+  describe('configureRepo()', () => {
+    it('uses the gitlabMergeRequestCommentType configuration if provided', () => {
+      configureRepo({
+        gitlabMergeRequestCommentType: 'discussion',
+      } as any); 
+      expect(mergeRequestCommentType).toBe('discussion');
+    });
+
+    it('uses "note" as the default fallback value', () => {
+      configureRepo({} as any); 
+      expect(mergeRequestCommentType).toBe('note');
+    });
+  });
+
   describe('getRepos', () => {
     it('should throw an error if it receives an error', async () => {
       httpMock

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -1966,6 +1966,25 @@ describe('modules/platform/gitlab/index', () => {
       ).toResolve();
     });
 
+    it('adds a comment as a discussion when configured', async () => {
+      const scope = await initRepo();
+      gitlab.configureRepo({
+        gitlabMergeRequestCommentType: 'discussion',
+      });
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_requests/42/notes')
+        .reply(200, [])
+        .post('/api/v4/projects/some%2Frepo/merge_requests/42/discussions')
+        .reply(200);
+      await expect(
+        gitlab.ensureComment({
+          number: 42,
+          topic: 'some-subject',
+          content: 'some\ncontent',
+        }),
+      ).toResolve();
+    });
+
     it('add updates comment if necessary', async () => {
       const scope = await initRepo();
       scope

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -8,6 +8,7 @@ import {
 import pMap from 'p-map';
 import semver from 'semver';
 import { GlobalConfig } from '../../../config/global.ts';
+import type { RenovateConfig } from '../../../config/types.ts';
 import {
   REPOSITORY_ACCESS_FORBIDDEN,
   REPOSITORY_ARCHIVED,
@@ -46,6 +47,7 @@ import type {
   EnsureCommentRemovalConfig,
   EnsureIssueConfig,
   FindPRConfig,
+  GitlabMergeRequestCommentType,
   Issue,
   MergePRConfig,
   PlatformParams,
@@ -104,6 +106,7 @@ let config: {
 
 export function resetPlatform(): void {
   config = {} as any;
+  mergeRequestCommentType = 'note';
   draftPrefix = DRAFT_PREFIX;
   defaults.hostType = 'gitlab';
   defaults.endpoint = 'https://gitlab.com/api/v4/';
@@ -115,6 +118,7 @@ export const id = 'gitlab';
 
 let draftPrefix = DRAFT_PREFIX;
 let botUserName: string;
+let mergeRequestCommentType: GitlabMergeRequestCommentType = 'note';
 
 export async function initPlatform({
   endpoint,
@@ -364,6 +368,12 @@ export async function initRepo({
     repoFingerprint: repoFingerprint(res.body.id, defaults.endpoint),
   };
   return repoConfig;
+}
+
+export function configureRepo({
+  gitlabMergeRequestCommentType,
+}: RenovateConfig): void {
+  mergeRequestCommentType = gitlabMergeRequestCommentType ?? 'note';
 }
 
 export function getBranchForceRebase(): Promise<boolean> {
@@ -1337,9 +1347,10 @@ async function getComments(issueNo: number): Promise<GitlabComment[]> {
 }
 
 async function addComment(issueNo: number, body: string): Promise<void> {
-  // POST projects/:owner/:repo/merge_requests/:number/notes
+  const commentType =
+    mergeRequestCommentType === 'discussion' ? 'discussions' : 'notes';
   await gitlabApi.postJson(
-    `projects/${config.repository}/merge_requests/${issueNo}/notes`,
+    `projects/${config.repository}/merge_requests/${issueNo}/${commentType}`,
     {
       body: { body },
     },

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -1,5 +1,5 @@
 import type { DateTime } from 'luxon';
-import type { MergeStrategy } from '../../config/types.ts';
+import type { MergeStrategy, RenovateConfig } from '../../config/types.ts';
 import type { BranchStatus, HostRule } from '../../types/index.ts';
 import type { CommitFilesConfig } from '../../util/git/types.ts';
 import type { LongCommitSha } from '../../util/schema-utils/git.ts';
@@ -33,6 +33,7 @@ export interface RepoResult {
 }
 
 export type GitUrlOption = 'default' | 'ssh' | 'endpoint';
+export type GitlabMergeRequestCommentType = 'note' | 'discussion';
 
 export interface RepoParams {
   repository: string;
@@ -252,6 +253,7 @@ export interface Platform {
     branchOrTag?: string,
   ): Promise<any>;
   initRepo(config: RepoParams): Promise<RepoResult>;
+  configureRepo?(config: RenovateConfig): void;
   getPrList(): Promise<Pr[]>;
   ensureIssueClosing(title: string): Promise<void>;
   ensureIssue(

--- a/lib/workers/repository/init/index.ts
+++ b/lib/workers/repository/init/index.ts
@@ -56,6 +56,7 @@ export async function initRepo(
   config = await initApis(config);
   await initializeCaches(config as WorkerPlatformConfig);
   config = await getRepoConfig(config);
+  platform.configureRepo?.(config);
   setRepositoryLogLevelRemaps(config.logLevelRemap);
   if (config.mode === 'silent') {
     logger.info(


### PR DESCRIPTION
## Changes

Adds a new `gitlabMergeRequestCommentType` repository option with `note` (default) and `discussion` values.

When configured as `discussion`, Renovate creates new GitLab merge request comments through the discussions API so that projects requiring all threads to be resolved can prevent merges while Renovate discussions remain open. The setting is applied after repository configuration resolution, and the configuration documentation explains the GitLab behavior.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #15985
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). OpenAI Codex (GPT-5) was used to implement the code, tests, and documentation.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>