### PR TITLE
fix(datasource/docker): prevent private tag cache poisoning

### DIFF
--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -9,6 +9,7 @@ import { logger, partial } from '~test/util.ts';
 import { range } from '../../../../lib/util/range.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages.ts';
+import * as packageCache from '../../../util/cache/package/index.ts';
 import { getDigest, getPkgReleases } from '../index.ts';
 import { DockerHubCache } from './dockerhub-cache.ts';
 import { DockerDatasource } from './index.ts';
@@ -1731,6 +1732,67 @@ describe('modules/datasource/docker/index', () => {
           currentDigest,
         ),
       ).toBe('amd64');
+    });
+  });
+
+  describe('getTags', () => {
+    it('does not cache private registry tags by default', async () => {
+      const datasource = new DockerDatasource();
+      const registryHost = 'https://no-cache.registry.example.com';
+      const dockerRepository = 'node';
+      const cacheGet = vi.spyOn(packageCache, 'get');
+      const cacheSet = vi.spyOn(packageCache, 'setWithRawTtl');
+
+      httpMock
+        .scope(`${registryHost}/v2`)
+        .get('/node/tags/list?n=10000')
+        .reply(200, '')
+        .get('/node/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] });
+
+      expect(await datasource.getTags(registryHost, dockerRepository)).toEqual([
+        '1.0.0',
+      ]);
+      expect(cacheGet).not.toHaveBeenCalled();
+      expect(cacheSet).not.toHaveBeenCalled();
+    });
+
+    it('does not cache failed private registry tag lookups', async () => {
+      GlobalConfig.set({ cachePrivatePackages: true });
+      const datasource = new DockerDatasource();
+      const registryHost = 'https://failed-cache.registry.example.com';
+      const dockerRepository = 'node';
+      const cacheSet = vi.spyOn(packageCache, 'setWithRawTtl');
+
+      httpMock
+        .scope(`${registryHost}/v2`)
+        .get('/node/tags/list?n=10000')
+        .reply(403);
+
+      expect(
+        await datasource.getTags(registryHost, dockerRepository),
+      ).toBeNull();
+      expect(cacheSet).not.toHaveBeenCalled();
+    });
+
+    it('caches successful private registry tag lookups when enabled', async () => {
+      GlobalConfig.set({ cachePrivatePackages: true });
+      const datasource = new DockerDatasource();
+      const registryHost = 'https://cached.registry.example.com';
+      const dockerRepository = 'node';
+      const cacheSet = vi.spyOn(packageCache, 'setWithRawTtl');
+
+      httpMock
+        .scope(`${registryHost}/v2`)
+        .get('/node/tags/list?n=10000')
+        .reply(200, '')
+        .get('/node/tags/list?n=10000')
+        .reply(200, { tags: ['1.0.0'] });
+
+      expect(await datasource.getTags(registryHost, dockerRepository)).toEqual([
+        '1.0.0',
+      ]);
+      expect(cacheSet).toHaveBeenCalledOnce();
     });
   });
 

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '@sindresorhus/is';
+import { isArray, isNonEmptyString } from '@sindresorhus/is';
 import { GlobalConfig } from '../../../config/global.ts';
 import { PAGE_NOT_FOUND_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
@@ -926,6 +926,8 @@ export class DockerDatasource extends Datasource {
       {
         namespace: 'datasource-docker-tags',
         key: `${registryHost}:${dockerRepository}`,
+        cacheable: registryHost === DOCKER_HUB,
+        shouldCacheResult: isArray,
       },
       () => this._getTags(registryHost, dockerRepository),
     );


### PR DESCRIPTION
## Changes

- Treat nested Docker tag lookups as private by default for registries other than Docker Hub, matching the existing release-cache behavior.
- Cache only successful tag arrays, so a transient authentication failure returning `null` cannot poison a shared cache. Explicit `cachePrivatePackages=true` still caches successful private-registry results.
- Add regression tests for the default private-cache behavior and both failed and successful lookups when private-package caching is enabled.

The tests were added but not run locally because the pinned pnpm toolchain was unavailable in the development environment. The changes were checked by code inspection and `git diff --check`.

Related discussion: https://github.com/renovatebot/renovate/discussions/45249

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Codex (GPT-5) analyzed the reported cache behavior and generated the code, regression tests, and pull request text.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
