### PR TITLE
fix(http): follow GitHub cursor-based pagination past the first page

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -327,6 +327,110 @@ describe('util/http/github', () => {
       );
     });
 
+    it('paginates cursor-based endpoints which have no `last` link', async () => {
+      // Endpoints like `/repos/{owner}/{repo}/dependabot/alerts` only ever
+      // reveal the next opaque cursor, so the chain must be walked
+      const url = '/some-url?per_page=2';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a', 'b'], {
+          link: `<${githubApiHost}${url}&after=c2>; rel="next"`,
+        })
+        .get(`${url}&after=c2`)
+        .reply(200, ['c', 'd'], {
+          link: `<${githubApiHost}${url}&after=e3>; rel="next", <${githubApiHost}${url}&before=c1>; rel="prev"`,
+        })
+        .get(`${url}&after=e3`)
+        .reply(200, ['e']);
+      const res = await githubApi.getJsonUnchecked(url, { paginate: true });
+      expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
+    });
+
+    it('stops cursor pagination at the page limit', async () => {
+      const url = '/some-url?per_page=1';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a'], {
+          link: `<${githubApiHost}${url}&after=b>; rel="next"`,
+        })
+        .get(`${url}&after=b`)
+        .reply(200, ['b'], {
+          link: `<${githubApiHost}${url}&after=c>; rel="next"`,
+        });
+      const res = await githubApi.getJsonUnchecked(url, {
+        paginate: true,
+        pageLimit: 2,
+      });
+      expect(res.body).toEqual(['a', 'b']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ maxPages: 1 }),
+        'GitHub cursor pagination stopped before the last page; results are truncated. Increase `pageLimit` or use `paginate: "all"` to fetch more.',
+      );
+    });
+
+    it('ignores the page limit for cursor pagination when paginating all', async () => {
+      const url = '/some-url?per_page=1';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a'], {
+          link: `<${githubApiHost}${url}&after=b>; rel="next"`,
+        })
+        .get(`${url}&after=b`)
+        .reply(200, ['b'], {
+          link: `<${githubApiHost}${url}&after=c>; rel="next"`,
+        })
+        .get(`${url}&after=c`)
+        .reply(200, ['c']);
+      const res = await githubApi.getJsonUnchecked(url, {
+        paginate: 'all',
+        pageLimit: 1,
+      });
+      expect(res.body).toEqual(['a', 'b', 'c']);
+    });
+
+    it('stops cursor pagination when the cursor does not advance', async () => {
+      const url = '/some-url?per_page=1';
+      const link = `<${githubApiHost}${url}&after=b>; rel="next"`;
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a'], { link })
+        .get(`${url}&after=b`)
+        .reply(200, ['b'], { link });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: 'all' });
+      expect(res.body).toEqual(['a', 'b']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        expect.anything(),
+        'GitHub cursor pagination did not advance; results may be truncated.',
+      );
+    });
+
+    it('does not follow cursor pagination links to a different origin', async () => {
+      const url = '/some-url?per_page=1';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a'], {
+          link: `<${githubApiHost}${url}&after=b>; rel="next"`,
+        })
+        .get(`${url}&after=b`)
+        .reply(200, ['b'], {
+          link: `<https://attacker.example.com${url}&after=c>; rel="next"`,
+        });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: 'all' });
+      expect(res.body).toEqual(['a', 'b']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          requestHost: 'api.github.com',
+          paginationHost: 'attacker.example.com',
+        },
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+      );
+    });
+
     describe('handleGotError', () => {
       it('should log a once warning for github.com 401', async () => {
         await expect(

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -40,6 +40,7 @@ import type {
 } from './types.ts';
 
 const githubBaseUrl = 'https://api.github.com/';
+const githubApiOrigin = 'https://api.github.com';
 let baseUrl = githubBaseUrl;
 export function setBaseUrl(url: string): void {
   baseUrl = url;
@@ -249,6 +250,17 @@ function constructAcceptString(input?: unknown): string {
 
 const MAX_GRAPHQL_PAGE_SIZE = 100;
 
+/**
+ * Absolute ceiling for REST cursor pagination, applied even to
+ * `paginate: 'all'`. Unlike page-number pagination there is no
+ * server-supplied total to bound the walk, so this is the only structural
+ * limit preventing an endlessly-repeating `rel="next"` chain from looping
+ * forever.
+ */
+const MAX_CURSOR_PAGES = 1000;
+
+const DEFAULT_PAGE_LIMIT = 10;
+
 interface GraphqlPageCacheItem {
   pageLastResizedAt: string;
   pageSize: number;
@@ -331,6 +343,38 @@ function setGraphqlPageSize(fieldName: string, newPageSize: number): void {
 function replaceUrlBase(url: URL, baseUrl: string): URL {
   const relativeUrl = `${url.pathname}${url.search}`;
   return new URL(relativeUrl, baseUrl);
+}
+
+/**
+ * Resolve a pagination link into a URL we are allowed to follow, or `null` if
+ * it points to another origin. Called for every hop of a pagination chain, not
+ * just the first one, so the chain cannot escape the origin midway through.
+ */
+function resolvePaginationUrl(
+  link: string,
+  requestUrl: URL,
+  baseUrl: string | undefined,
+  rebaseLinks: boolean,
+): URL | null {
+  let pageUrl = new URL(link, baseUrl);
+  if (
+    baseUrl &&
+    rebaseLinks &&
+    // Preserve github.com URLs for use cases like release notes
+    pageUrl.origin !== githubApiOrigin
+  ) {
+    pageUrl = replaceUrlBase(pageUrl, baseUrl);
+  }
+  // Don't follow a cross-origin request, unless we've been explicitly requested to do so with `RENOVATE_X_REBASE_PAGINATION_LINKS`
+  if (pageUrl.origin !== requestUrl.origin) {
+    // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
+    logger.once.warn(
+      { requestHost: requestUrl.host, paginationHost: pageUrl.host },
+      'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+    );
+    return null;
+  }
+  return pageUrl;
 }
 
 export class GithubHttp extends HttpBase<GithubHttpOptions> {
@@ -419,40 +463,95 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
       delete httpOptions.cacheProvider;
       httpOptions.memCache = false;
       // Check if result is paginated
-      const pageLimit = httpOptions.pageLimit ?? 10;
+      const pageLimit = httpOptions.pageLimit ?? DEFAULT_PAGE_LIMIT;
       const linkHeader = parseLinkHeader(result?.headers?.link);
       const next = linkHeader?.next;
       const env = getEnv();
-      if (next?.url && linkHeader?.last?.page) {
-        let lastPage = parseInt(linkHeader.last.page, 10);
-        // v8 ignore else -- TODO: add test #40625
-        if (!env.RENOVATE_PAGINATE_ALL && httpOptions.paginate !== 'all') {
-          lastPage = Math.min(pageLimit, lastPage);
-        }
+      if (next?.url) {
+        const unlimited =
+          !!env.RENOVATE_PAGINATE_ALL || httpOptions.paginate === 'all';
         const baseUrl = httpOptions.baseUrl ?? this.baseUrl;
-        const parsedUrl = new URL(next.url, baseUrl);
-        const rebasePagination =
-          !!baseUrl &&
-          !!env.RENOVATE_X_REBASE_PAGINATION_LINKS &&
-          // Preserve github.com URLs for use cases like release notes
-          parsedUrl.origin !== 'https://api.github.com';
-        const firstPageUrl = rebasePagination
-          ? replaceUrlBase(parsedUrl, baseUrl)
-          : parsedUrl;
-        // Don't follow a cross-origin request, unless we've been explicitly requested to do so with `RENOVATE_X_REBASE_PAGINATION_LINKS`
-        if (firstPageUrl.origin === resolvedUrl.origin) {
-          const queue = [...range(2, lastPage)].map(
-            (pageNumber) => (): Promise<HttpResponse<T>> => {
-              // copy before modifying searchParams
-              const nextUrl = parseUrl(firstPageUrl.toString())!;
-              nextUrl.searchParams.set('page', String(pageNumber));
-              return super.requestJsonUnsafe<T>(method, {
-                ...opts,
-                url: nextUrl,
-              });
-            },
-          );
-          const pages = await p.all(queue);
+        const rebaseLinks = !!env.RENOVATE_X_REBASE_PAGINATION_LINKS;
+        const firstPageUrl = resolvePaginationUrl(
+          next.url,
+          resolvedUrl,
+          baseUrl,
+          rebaseLinks,
+        );
+        if (firstPageUrl) {
+          let pages: HttpResponse<T>[];
+          if (linkHeader?.last?.page) {
+            // Page-number pagination: the last page number is known up front,
+            // so the remaining pages can be fetched in parallel.
+            let lastPage = parseInt(linkHeader.last.page, 10);
+            // v8 ignore else -- TODO: add test #40625
+            if (!unlimited) {
+              lastPage = Math.min(pageLimit, lastPage);
+            }
+            const queue = [...range(2, lastPage)].map(
+              (pageNumber) => (): Promise<HttpResponse<T>> => {
+                // copy before modifying searchParams
+                const nextUrl = parseUrl(firstPageUrl.toString())!;
+                nextUrl.searchParams.set('page', String(pageNumber));
+                return super.requestJsonUnsafe<T>(method, {
+                  ...opts,
+                  url: nextUrl,
+                });
+              },
+            );
+            pages = await p.all(queue);
+          } else {
+            // Cursor pagination, used by endpoints such as
+            // `/repos/{owner}/{repo}/dependabot/alerts`. They never send
+            // `rel="last"`, and each response only reveals the next opaque
+            // cursor, so the pages must be walked sequentially rather than
+            // fanned out. Without this branch only the first page was ever
+            // fetched.
+            pages = [];
+            const maxPages = unlimited
+              ? MAX_CURSOR_PAGES
+              : Math.min(pageLimit - 1, MAX_CURSOR_PAGES);
+            const seenPageUrls = new Set<string>([firstPageUrl.href]);
+            let cursorUrl: URL | null = firstPageUrl;
+            while (cursorUrl && pages.length < maxPages) {
+              const page: HttpResponse<T> = await super.requestJsonUnsafe<T>(
+                method,
+                { ...opts, url: cursorUrl },
+              );
+              pages.push(page);
+              const nextLink = parseLinkHeader(page.headers.link)?.next?.url;
+              cursorUrl = nextLink
+                ? resolvePaginationUrl(
+                    nextLink,
+                    resolvedUrl,
+                    baseUrl,
+                    rebaseLinks,
+                  )
+                : null;
+              if (cursorUrl) {
+                // A cursor that repeats a URL we already fetched would loop
+                // forever, so stop instead of trusting the server to terminate.
+                if (seenPageUrls.has(cursorUrl.href)) {
+                  logger.once.warn(
+                    { url: resolvedUrl.href },
+                    'GitHub cursor pagination did not advance; results may be truncated.',
+                  );
+                  cursorUrl = null;
+                } else {
+                  seenPageUrls.add(cursorUrl.href);
+                }
+              }
+            }
+            // Reaching the cap with a `next` link still pending means the
+            // caller silently got partial results, which is exactly the class
+            // of bug this branch exists to fix. Say so.
+            if (cursorUrl) {
+              logger.once.warn(
+                { url: resolvedUrl.href, maxPages },
+                'GitHub cursor pagination stopped before the last page; results are truncated. Increase `pageLimit` or use `paginate: "all"` to fetch more.',
+              );
+            }
+          }
           // v8 ignore else -- TODO: add test #40625
           if (httpOptions.paginationField && isPlainObject(result.body)) {
             const paginatedResult = result.body[httpOptions.paginationField];
@@ -478,15 +577,6 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
               }
             }
           }
-        } else {
-          // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
-          logger.once.warn(
-            {
-              requestHost: resolvedUrl.host,
-              paginationHost: firstPageUrl.host,
-            },
-            'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
-          );
         }
       }
     }


### PR DESCRIPTION
Endpoints like /repos/{owner}/{repo}/dependabot/alerts never return a `rel="last"` link, only an opaque `rel="next"` cursor, so pagination silently stopped after the first page. Walk the cursor chain sequentially with a page-limit/hard cap and loop detection, reusing the existing cross-origin link protection at every hop.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->
Detect when there's no rel="last", and walk the next cursor chain sequentially (page by page, since each page only reveals the next cursor), with a hard cap (MAX_CURSOR_PAGES), loop detection for a non-advancing cursor, and the existing cross-origin link check applied at each hop.
## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
