### PR TITLE
fix(manager/sveltos): concatenate repositoryURL with chartName for OCI

### DIFF
--- a/lib/modules/manager/sveltos/extract.spec.ts
+++ b/lib/modules/manager/sveltos/extract.spec.ts
@@ -44,13 +44,13 @@ metadata:
 spec:
   syncMode: Continuous
   helmCharts:
-  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts/vault
+  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts
     repositoryName:   oci-vault
-    chartName:        oci://registry-1.docker.io/bitnamicharts/vault
+    chartName:        vault
     chartVersion:     0.7.2
-  - repositoryURL:    oci://custom-registry:443/charts/vault-sidecar
+  - repositoryURL:    oci://custom-registry:443/charts
     repositoryName:   oci-custom-vault
-    chartName:        oci://custom-registry:443/charts/vault-sidecar
+    chartName:        vault-sidecar
     chartVersion:     0.5.0
 `;
 const validClusterProfile = codeBlock`
@@ -94,13 +94,13 @@ metadata:
 spec:
   syncMode: Continuous
   helmCharts:
-  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts/vault
+  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts
     repositoryName:   oci-vault
-    chartName:        oci://registry-1.docker.io/bitnamicharts/vault
+    chartName:        vault
     chartVersion:     0.7.2
-  - repositoryURL:    oci://custom-registry:443/charts/vault-sidecar
+  - repositoryURL:    oci://custom-registry:443/charts
     repositoryName:   oci-custom-vault
-    chartName:        oci://custom-registry:443/charts/vault-sidecar
+    chartName:        vault-sidecar
     chartVersion:     0.5.0
 `;
 const validClusterProfileOCI = codeBlock`
@@ -112,9 +112,9 @@ metadata:
 spec:
   syncMode: Continuous
   helmCharts:
-  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts/vault
+  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts
     repositoryName:   oci-vault
-    chartName:        oci://registry-1.docker.io/bitnamicharts/vault
+    chartName:        vault
     chartVersion:     0.7.2
 `;
 const validEventTrigger = codeBlock`
@@ -158,13 +158,13 @@ metadata:
 spec:
   syncMode: Continuous
   helmCharts:
-  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts/vault
+  - repositoryURL:    oci://registry-1.docker.io/bitnamicharts
     repositoryName:   oci-vault
-    chartName:        oci://registry-1.docker.io/bitnamicharts/vault
+    chartName:        vault
     chartVersion:     0.7.2
-  - repositoryURL:    oci://custom-registry:443/charts/vault-sidecar
+  - repositoryURL:    oci://custom-registry:443/charts
     repositoryName:   oci-custom-vault
-    chartName:        oci://custom-registry:443/charts/vault-sidecar
+    chartName:        vault-sidecar
     chartVersion:     0.5.0
 `;
 const validClusterPromotion = codeBlock`
@@ -192,9 +192,9 @@ metadata:
 spec:
   profileSpec:
     helmCharts:
-    - repositoryURL:    oci://registry-1.docker.io/bitnamicharts/vault
+    - repositoryURL:    oci://registry-1.docker.io/bitnamicharts
       repositoryName:   oci-vault
-      chartName:        oci://registry-1.docker.io/bitnamicharts/vault
+      chartName:        vault
       chartVersion:     0.7.2
 `;
 const malformedProfiles = codeBlock`
@@ -427,14 +427,14 @@ describe('modules/manager/sveltos/extract', () => {
             currentValue: '0.7.2',
             datasource: 'docker',
             depType: 'Profile',
-            depName: 'oci://registry-1.docker.io/bitnamicharts/vault',
+            depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
           },
           {
             currentValue: '0.5.0',
             datasource: 'docker',
             depType: 'Profile',
-            depName: 'oci://custom-registry:443/charts/vault-sidecar',
+            depName: 'vault-sidecar',
             packageName: 'custom-registry:443/charts/vault-sidecar',
           },
         ],
@@ -478,14 +478,14 @@ describe('modules/manager/sveltos/extract', () => {
             currentValue: '0.7.2',
             datasource: 'docker',
             depType: 'ClusterProfile',
-            depName: 'oci://registry-1.docker.io/bitnamicharts/vault',
+            depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
           },
           {
             currentValue: '0.5.0',
             datasource: 'docker',
             depType: 'ClusterProfile',
-            depName: 'oci://custom-registry:443/charts/vault-sidecar',
+            depName: 'vault-sidecar',
             packageName: 'custom-registry:443/charts/vault-sidecar',
           },
         ],
@@ -506,7 +506,7 @@ describe('modules/manager/sveltos/extract', () => {
         deps: [
           {
             currentValue: '0.7.2',
-            depName: 'oci://registry-1.docker.io/bitnamicharts/vault',
+            depName: 'vault',
             packageName: 'docker.proxy.test/some/path/bitnamicharts/vault',
             datasource: 'docker',
             depType: 'ClusterProfile',
@@ -544,7 +544,7 @@ describe('modules/manager/sveltos/extract', () => {
             currentValue: '0.7.2',
             datasource: 'docker',
             depType: 'ClusterPromotion',
-            depName: 'oci://registry-1.docker.io/bitnamicharts/vault',
+            depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
           },
         ],
@@ -585,14 +585,14 @@ describe('modules/manager/sveltos/extract', () => {
             currentValue: '0.7.2',
             datasource: 'docker',
             depType: 'EventTrigger',
-            depName: 'oci://registry-1.docker.io/bitnamicharts/vault',
+            depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
           },
           {
             currentValue: '0.5.0',
             datasource: 'docker',
             depType: 'EventTrigger',
-            depName: 'oci://custom-registry:443/charts/vault-sidecar',
+            depName: 'vault-sidecar',
             packageName: 'custom-registry:443/charts/vault-sidecar',
           },
         ],

--- a/lib/modules/manager/sveltos/extract.ts
+++ b/lib/modules/manager/sveltos/extract.ts
@@ -54,7 +54,11 @@ function processHelmCharts(
     const image = trimTrailingSlash(removeOCIPrefix(source.repositoryURL));
 
     dep.datasource = DockerDatasource.id;
-    dep.packageName = getDep(image, false, registryAliases).packageName;
+    dep.packageName = getDep(
+      `${image}/${source.chartName}`,
+      false,
+      registryAliases,
+    ).packageName;
   } else {
     dep.packageName = removeRepositoryName(
       source.repositoryName,


### PR DESCRIPTION
## Changes

For Sveltos `helmCharts` using an OCI registry, the manager previously derived the
`packageName` from `repositoryURL` only. This produced an incorrect package name and
caused `401 Unauthorized` lookup failures.

Given this ClusterProfile spec:

```yaml
helmCharts:
  - repositoryURL: oci://docker.io/envoyproxy
    chartName: gateway-helm
    chartVersion: v1.4.1
```

- Before: `packageName: docker.io/envoyproxy`
- After: `packageName: docker.io/envoyproxy/gateway-helm`

This matches how Sveltos itself resolves OCI charts by concatenating
`repositoryURL` + `chartName` (see the [official docs](https://projectsveltos.github.io/sveltos/addons/helm_charts/#example-oci-registry)).

Test fixtures and assertions were updated to reflect the real Sveltos OCI format
(`repositoryURL` = OCI base, `chartName` = chart name only).

Related discussion: https://github.com/renovatebot/renovate/discussions/40885

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #40885 
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI (GitHub Copilot, Claude Opus 4.8) was used to implement the fix, update the unit tests.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @aamoyel will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
