### PR TITLE
fix(platform/azure): detect hosted deployment when `deploymentType` is a string

### DIFF
--- a/lib/modules/platform/azure/azure-got-wrapper.spec.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.spec.ts
@@ -1,3 +1,4 @@
+import type { DeploymentFlags } from 'azure-devops-node-api/interfaces/common/VSSInterfaces.js';
 import { buildTestJwt } from '~test/jwt-util.ts';
 import type * as _hostRules from '../../../util/host-rules.ts';
 
@@ -165,10 +166,26 @@ describe('modules/platform/azure/azure-got-wrapper', () => {
       expect(await azure.isHosted()).toBe(true);
     });
 
+    it('returns true when deployment type is the serialized enum name', async () => {
+      vi.spyOn(sdk.WebApi.prototype, 'connect').mockResolvedValue({
+        deploymentType: 'hosted' as unknown as DeploymentFlags,
+      });
+
+      expect(await azure.isHosted()).toBe(true);
+    });
+
     it('returns false when deployment type is OnPremises', async () => {
       // DeploymentFlags.OnPremises === 2
       vi.spyOn(sdk.WebApi.prototype, 'connect').mockResolvedValue({
         deploymentType: 2,
+      });
+
+      expect(await azure.isHosted()).toBe(false);
+    });
+
+    it('returns false when deployment type is the on-premises enum name', async () => {
+      vi.spyOn(sdk.WebApi.prototype, 'connect').mockResolvedValue({
+        deploymentType: 'onPremises' as unknown as DeploymentFlags,
       });
 
       expect(await azure.isHosted()).toBe(false);

--- a/lib/modules/platform/azure/azure-got-wrapper.ts
+++ b/lib/modules/platform/azure/azure-got-wrapper.ts
@@ -69,7 +69,13 @@ export function workItemTrackingApi(): Promise<IWorkItemTrackingApi> {
 export async function isHosted(): Promise<boolean> {
   try {
     const { deploymentType } = await azureObj().connect();
-    return deploymentType === DeploymentFlags.Hosted;
+    // `connect()` returns the response body as-is, without running the SDK
+    // deserializer, so enums arrive as their name (`hosted`) instead of their
+    // numeric value. Accept both forms.
+    return (
+      deploymentType === DeploymentFlags.Hosted ||
+      String(deploymentType).toLowerCase() === 'hosted'
+    );
   } catch (err) {
     logger.debug(
       { err },


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

`isHosted()` compared `deploymentType` against the numeric `DeploymentFlags.Hosted`, but `WebApi.connect()` returns the raw `_apis/connectionData` body without running the SDK deserializer, so the field arrives as the enum name (`hosted`). The comparison never matched, every Azure DevOps Services instance was treated as on-premises, and the work item Markdown format op was dropped — dashboards render as plain text on cloud since #45237.

Now accept both the numeric and the serialized name.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Reported in discussion #45437, regression from #45237.

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5 via Claude Code: diagnosis, code and unit tests.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @RahulGautamSingh will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
