### PR TITLE
fix(github-actions): update component-prefixed tags

### DIFF
--- a/lib/modules/manager/github-actions/__fixtures__/workflow_4.yml
+++ b/lib/modules/manager/github-actions/__fixtures__/workflow_4.yml
@@ -22,4 +22,4 @@ jobs:
       - uses: actions/checkout@689fcce700ae7ffc576f2b029b51b2ffb66d3abd # ratchet:exclude
       - uses: actions-runner-controller/execute-assert-arc-e2e@f1d7c52253b89f0beae60141f8465d9495cdc2cf # actions-runner-controller-0.23.5
       - uses: grafana/writers-toolkit@4b1248585248751e3b12fd020cf7ac91540ca09c # prettier/v2.0.1
-
+      - uses: grafana/shared-workflows/actions/lint-pr-title@823ed150196915a86971ab4beb899b0c80d835fe # lint-pr-title/v1.2.3

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -511,6 +511,12 @@ describe('modules/manager/github-actions/extract', () => {
           replaceString:
             'grafana/writers-toolkit@4b1248585248751e3b12fd020cf7ac91540ca09c # prettier/v2.0.1',
         },
+        {
+          currentDigest: '823ed150196915a86971ab4beb899b0c80d835fe',
+          currentValue: 'lint-pr-title/v1.2.3',
+          replaceString:
+            'grafana/shared-workflows/actions/lint-pr-title@823ed150196915a86971ab4beb899b0c80d835fe # lint-pr-title/v1.2.3',
+        },
       ]);
       expect(res!.deps[14]).not.toHaveProperty('skipReason');
     });

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -204,7 +204,7 @@ const pinTokenRe = regEx(
   /^\s*(?:(?:renovate\s*:\s*)?(?:pin\s+|tag\s*=\s*)?|(?:ratchet:[\w-]+\/[.\w-]+(?:\/[.\w-]+)*))?@?(?<version>([\w-]*[-/])?v?\d+(?:\.\d+(?:\.\d+)?)?(?:-[a-zA-Z0-9.]+)?)/,
 );
 
-export const versionLikeRe = regEx(/^v?\d+/);
+export const versionLikeRe = regEx(/^(?:[\w-]*[-/])?v?\d+/);
 
 const bareTokenRe = regEx(/^\s*(?<token>\S+)\s*$/);
 

--- a/lib/modules/versioning/github-actions/index.spec.ts
+++ b/lib/modules/versioning/github-actions/index.spec.ts
@@ -160,6 +160,15 @@ describe('modules/versioning/github-actions/index', () => {
         false,
       );
     });
+
+    it('matches only tags with the same component prefix', () => {
+      expect(
+        githubActions.matches('lint-pr-title/v1.2.3', 'lint-pr-title/v1.2.3'),
+      ).toBe(true);
+      expect(
+        githubActions.matches('other/v1.2.3', 'lint-pr-title/v1.2.3'),
+      ).toBe(false);
+    });
   });
 
   describe('.getSatisfyingVersion()', () => {
@@ -196,6 +205,15 @@ describe('modules/versioning/github-actions/index', () => {
         );
       },
     );
+
+    it('selects the newest tag from the current component', () => {
+      expect(
+        githubActions.getSatisfyingVersion(
+          ['lint-pr-title/v1.2.3', 'other/v9.0.0', 'lint-pr-title/v1.2.4'],
+          'lint-pr-title/v1',
+        ),
+      ).toBe('lint-pr-title/v1.2.4');
+    });
   });
 
   describe('.minSatisfyingVersion()', () => {
@@ -281,6 +299,12 @@ describe('modules/versioning/github-actions/index', () => {
         expect(githubActions.equals(version, other)).toBe(expected);
       },
     );
+
+    it('does not equate tags from different components', () => {
+      expect(githubActions.equals('lint-pr-title/v1.2.3', 'other/v1.2.3')).toBe(
+        false,
+      );
+    });
   });
 
   describe('.getMajor()', () => {
@@ -358,6 +382,12 @@ describe('modules/versioning/github-actions/index', () => {
         expect(githubActions.isGreaterThan(version, other)).toBe(expected);
       },
     );
+
+    it('does not order tags from different components', () => {
+      expect(
+        githubActions.isGreaterThan('lint-pr-title/v1.2.4', 'other/v1.2.3'),
+      ).toBe(false);
+    });
   });
 
   describe('.sortVersions()', () => {
@@ -416,6 +446,12 @@ describe('modules/versioning/github-actions/index', () => {
         expect(githubActions.isBreaking!(version, current)).toBe(expected);
       },
     );
+
+    it('does not compare tags from different components', () => {
+      expect(
+        githubActions.isBreaking!('lint-pr-title/v2.0.0', 'other/v1.0.0'),
+      ).toBe(false);
+    });
   });
 
   describe('.isCompatible()', () => {
@@ -429,6 +465,18 @@ describe('modules/versioning/github-actions/index', () => {
       ${'invalid'} | ${false}
     `('isCompatible("$version") === $expected', ({ version, expected }) => {
       expect(githubActions.isCompatible(version)).toBe(expected);
+    });
+
+    it('does not compare different component prefixes', () => {
+      expect(
+        githubActions.isCompatible('other/v1.2.4', 'lint-pr-title/v1.2.3'),
+      ).toBe(false);
+      expect(
+        githubActions.isCompatible(
+          'lint-pr-title/v1.2.4',
+          'lint-pr-title/v1.2.3',
+        ),
+      ).toBe(true);
     });
   });
 

--- a/lib/modules/versioning/github-actions/index.ts
+++ b/lib/modules/versioning/github-actions/index.ts
@@ -15,9 +15,30 @@ export const supportedRangeStrategies = ['pin', 'replace'];
 
 const floatingMinorTagRegex = regEx(/^\d+(\.\d+)?$/);
 const majorOnlyRegex = regEx(/^\d+$/);
+const componentPrefixRegex = regEx(/^(?<compatibility>[\w-]*[-/])v?\d+/);
+
+function splitComponentPrefix(input: string): {
+  compatibility: string;
+  version: string;
+} {
+  const trimmed = input.trim();
+  const compatibility =
+    componentPrefixRegex.exec(trimmed)?.groups?.compatibility ?? '';
+  return { compatibility, version: trimmed.slice(compatibility.length) };
+}
+
+function hasCompatibleComponentPrefix(
+  version: string,
+  current: string,
+): boolean {
+  return (
+    splitComponentPrefix(version).compatibility ===
+    splitComponentPrefix(current).compatibility
+  );
+}
 
 function massageValue(input: string): string {
-  return input.trim().replace(regEx(/^v/i), '');
+  return splitComponentPrefix(input).version.replace(regEx(/^v/i), '');
 }
 
 function parseVersion(input: string): SemVer | null {
@@ -130,6 +151,9 @@ function sortVersions(x: string, y: string): number {
 }
 
 function equals(x: string, y: string): boolean {
+  if (!hasCompatibleComponentPrefix(x, y)) {
+    return false;
+  }
   const a = parseVersionCoerced(x);
   const b = parseVersionCoerced(y);
   if (!a || !b) {
@@ -139,6 +163,9 @@ function equals(x: string, y: string): boolean {
 }
 
 function isGreaterThan(x: string, y: string): boolean {
+  if (!hasCompatibleComponentPrefix(x, y)) {
+    return false;
+  }
   const a = parseVersionCoerced(x);
   const b = parseVersionCoerced(y);
   if (!a || !b) {
@@ -148,6 +175,10 @@ function isGreaterThan(x: string, y: string): boolean {
 }
 
 function matches(version: string, range: string): boolean {
+  if (!hasCompatibleComponentPrefix(version, range)) {
+    return false;
+  }
+
   // if we have a valid floating tag provided, and it's the same as the range, treat it as the same
   if (
     parseVersionCoerced(version) &&
@@ -354,11 +385,17 @@ function getShortestMatchingVersion(
   return null;
 }
 
-function isCompatible(version: string): boolean {
-  return isValid(version);
+function isCompatible(version: string, current?: string): boolean {
+  return (
+    isValid(version) &&
+    (!current || hasCompatibleComponentPrefix(version, current))
+  );
 }
 
 function isBreaking(version: string, current: string): boolean {
+  if (!hasCompatibleComponentPrefix(version, current)) {
+    return false;
+  }
   const versionParsed = parseVersion(version);
   const currentParsed = parseVersion(current);
 


### PR DESCRIPTION
## Changes

- Recognize component-prefixed GitHub Action tags as version-like.
- Preserve the component prefix as compatibility when comparing action tags.
- Cover digest-pinned component-prefixed actions and cross-component filtering.

Addresses the behavior described in [discussion #45418](https://github.com/renovatebot/renovate/discussions/45418). Maintainer agreement on built-in support versus configuration-only handling is still requested.

Validation recorded during implementation:
- Scoped `pnpm check` passed for the changed TypeScript files.
- `pnpm vitest lib/modules/manager/github-actions lib/modules/versioning/github-actions --coverage=false` — 564 tests passed.
- `pnpm test` was attempted locally, but repository-wide `biome check .` exited before tests because its configuration ignored `.` (no files processed).
- Existing upstream lint and test checks passed. Coverage checks were skipped; coverage is not yet confirmed. These checks have not been rerun as part of this description update.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI assistance was used for code, tests, and the original PR description, with local review recorded at implementation time. OpenAI Codex assisted with this description and status update. The exact model identifiers for the original implementation and current session are not available in this session.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @zeitlinger will read and reply directly.
- [ ] An agent will draft replies and @zeitlinger will read them before they are posted.
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/prometheus/client_java (original reproduction; not claimed as an end-to-end run of this patch).
