### PR TITLE
feat(manager/github-actions): add `workflow` depType for reusable workflow calls

### DIFF
--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -335,11 +335,11 @@ describe('config/presets/index', () => {
 
       expect(res.packageRules).toEqual([
         {
-          matchDepTypes: ['action'],
+          matchDepTypes: ['action', 'workflow'],
           pinDigests: true,
         },
         {
-          matchDepTypes: ['action'],
+          matchDepTypes: ['action', 'workflow'],
           extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
           versioning:
             'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -119,7 +119,8 @@ export const presets: Record<string, Preset> = {
     description: 'Pin `github-action` digests.',
     packageRules: [
       {
-        matchDepTypes: ['action'],
+        // `workflow` is a reusable workflow call, which was also a depType of `action` before it was split out
+        matchDepTypes: ['action', 'workflow'],
         pinDigests: true,
       },
     ],
@@ -130,7 +131,7 @@ export const presets: Record<string, Preset> = {
     packageRules: [
       {
         extractVersion: '^(?<version>v?\\d+\\.\\d+\\.\\d+)$',
-        matchDepTypes: ['action'],
+        matchDepTypes: ['action', 'workflow'],
         versioning:
           'regex:^v?(?<major>\\d+)(\\.(?<minor>\\d+)\\.(?<patch>\\d+))?$',
       },

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -119,7 +119,6 @@ export const presets: Record<string, Preset> = {
     description: 'Pin `github-action` digests.',
     packageRules: [
       {
-        // `workflow` is a reusable workflow call, which was also a depType of `action` before it was split out
         matchDepTypes: ['action', 'workflow'],
         pinDigests: true,
       },

--- a/lib/modules/manager/github-actions/artifacts.spec.ts
+++ b/lib/modules/manager/github-actions/artifacts.spec.ts
@@ -281,6 +281,22 @@ describe('modules/manager/github-actions/artifacts', () => {
       expect(execSnapshots).toHaveLength(2);
     });
 
+    it('runs for a reusable workflow call', async () => {
+      const execSnapshots = mockExecAll();
+      mockLockfileRegenerated();
+
+      // the lockfile records `OWNER/REPO@REF` pins, and a reusable workflow call is one
+      const res = await updateActionsLockfile(
+        makeConfig({
+          upgrades: [{ ...checkoutUpgrade, depType: 'workflow' }],
+        }),
+        packageFiles,
+      );
+
+      expect(res.updatedArtifacts).toHaveLength(1);
+      expect(execSnapshots).toHaveLength(2);
+    });
+
     it('runs for a `docker://` uses dep', async () => {
       const execSnapshots = mockExecAll();
       mockLockfileRegenerated();

--- a/lib/modules/manager/github-actions/artifacts.ts
+++ b/lib/modules/manager/github-actions/artifacts.ts
@@ -22,7 +22,7 @@ import type { ActionsLockfileResult, OnboardedWorkflows } from './types.ts';
 const extensionName = 'github/gh-actions-lock';
 
 /** The `uses:` dep types the lockfile graph is built from. */
-const lockedDepTypes = ['action', 'docker'];
+const lockedDepTypes = ['action', 'workflow', 'docker'];
 
 function findToken(url: string): string | undefined {
   return findGithubToken(hostRules.find({ hostType: 'github', url }));

--- a/lib/modules/manager/github-actions/dep-types.ts
+++ b/lib/modules/manager/github-actions/dep-types.ts
@@ -7,6 +7,11 @@ export const knownDepTypes = [
       'A repository-based action reference in a `uses:` field (e.g. `actions/checkout@v4`)',
   },
   {
+    depType: 'workflow',
+    description:
+      'A reusable workflow referenced in a job-level `uses:` field (e.g. `owner/repo/.github/workflows/release.yml@v1`)',
+  },
+  {
     depType: 'docker',
     description:
       'A Docker image reference in a `uses:` field (e.g. `uses: docker://alpine:3`)',

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -579,6 +579,58 @@ describe('modules/manager/github-actions/extract', () => {
       });
     });
 
+    it('extracts a reusable workflow call as a workflow', async () => {
+      const res = await extractPackageFile(
+        codeBlock`
+        jobs:
+          release:
+            uses: some-org/some-repo/.github/workflows/release.yml@v1.2.3
+        `,
+        '.github/workflows/ci.yml',
+      );
+
+      expect(res?.deps).toMatchObject([
+        {
+          depName: 'some-org/some-repo',
+          currentValue: 'v1.2.3',
+          datasource: 'github-tags',
+          versioning: 'github-actions',
+          depType: 'workflow',
+          replaceString:
+            'some-org/some-repo/.github/workflows/release.yml@v1.2.3',
+          autoReplaceStringTemplate:
+            '{{depName}}/.github/workflows/release.yml@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}',
+        },
+      ]);
+    });
+
+    it.each`
+      uses                                                            | depType
+      ${'some-org/some-repo/.github/workflows/release.yml@v1'}        | ${'workflow'}
+      ${'some-org/some-repo/.github/workflows/release.yaml@v1'}       | ${'workflow'}
+      ${'actions/checkout@v4'}                                        | ${'action'}
+      ${'github/codeql-action/init@v3'}                               | ${'action'}
+      ${'some-org/some-repo/.github/workflows/sub/release.yml@v1'}    | ${'action'}
+      ${'some-org/some-repo/.github/workflows@v1'}                    | ${'action'}
+      ${'some-org/some-repo/.github/workflows/release.json@v1'}       | ${'action'}
+      ${'some-org/some-repo/nested/.github/workflows/release.yml@v1'} | ${'action'}
+    `(
+      'gives $uses the depType $depType',
+      async ({ uses, depType }: { uses: string; depType: string }) => {
+        const res = await extractPackageFile(
+          codeBlock`
+          jobs:
+            build:
+              steps:
+                - uses: ${uses}
+          `,
+          '.github/workflows/ci.yml',
+        );
+
+        expect(res?.deps[0]).toMatchObject({ depType });
+      },
+    );
+
     it('disables naked SHA pins without version comment', async () => {
       const res = await extractPackageFile(
         codeBlock`
@@ -2311,6 +2363,23 @@ describe('modules/manager/github-actions/extract', () => {
       ]);
       // the lockfile only records `OWNER/REPO@REF` pins, so a `docker://` image is still ours to pin
       expect(res?.deps[1]).not.toHaveProperty('digestManagedExternally');
+    });
+
+    it('marks a reusable workflow call, which the lockfile records too', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(lockfile);
+
+      const res = await extractPackageFile(
+        codeBlock`
+          jobs:
+            release:
+              uses: some-org/some-repo/.github/workflows/release.yml@v1
+        `,
+        '.github/workflows/ci.yml',
+      );
+
+      expect(res?.deps).toMatchObject([
+        { depType: 'workflow', digestManagedExternally: true },
+      ]);
     });
 
     it('leaves a workflow which is not onboarded alone', async () => {

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -66,6 +66,14 @@ function extractDockerAction(
   return dep;
 }
 
+/**
+ * Matches the sub-path of a reusable workflow call, relative to the referenced repository's root.
+ *
+ * GitHub only resolves a reusable workflow at `.github/workflows/<file>.yml`, so exactly one path segment, and only a job-level `uses:` may reference one.
+ * Anything else below the repository root is an action.
+ */
+const reusableWorkflowPathRe = regEx(/^\.github\/workflows\/[^/]+\.ya?ml$/);
+
 function extractRepositoryAction(
   actionRef: RepositoryReference,
   parsed: ReturnType<typeof parseUsesLine> & object,
@@ -91,12 +99,13 @@ function extractRepositoryAction(
   const depName = `${registryUrl}${packageName}`;
   const pathSuffix = subPath ? `/${subPath}` : '';
   const commentWs = commentPrecedingWhitespace || ' ';
+  const isReusableWorkflow = !!subPath && reusableWorkflowPathRe.test(subPath);
 
   const dep: PackageDependency = {
     depName,
     commitMessageTopic: '{{{depName}}} action',
     versioning: githubActionsVersioning.id,
-    depType: 'action',
+    depType: isReusableWorkflow ? 'workflow' : 'action',
     replaceString: valueString,
     autoReplaceStringTemplate: `${quote}{{depName}}${pathSuffix}@{{#if newDigest}}{{newDigest}}${quote}{{#if newValue}}${commentWs}# {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}${quote}{{/unless}}`,
     ...(isExplicitHostname
@@ -430,7 +439,7 @@ export async function extractPackageFile(
     // Deliberately no `lockFiles`: nothing here goes through `updateArtifacts`, and `matchFileNames` also tests `lockFiles`, so declaring it would make a negated rule such as `!.github/workflows/release.yml` match every workflow through the lock file path.
     for (const dep of deps) {
       // The lock file only records `OWNER/REPO@REF` pins, so a `docker://` image in a `uses:` is still ours to pin.
-      if (dep.depType === 'action') {
+      if (dep.depType === 'action' || dep.depType === 'workflow') {
         dep.digestManagedExternally = true;
       }
     }

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -66,12 +66,6 @@ function extractDockerAction(
   return dep;
 }
 
-/**
- * Matches the sub-path of a reusable workflow call, relative to the referenced repository's root.
- *
- * GitHub only resolves a reusable workflow at `.github/workflows/<file>.yml`, so exactly one path segment, and only a job-level `uses:` may reference one.
- * Anything else below the repository root is an action.
- */
 const reusableWorkflowPathRe = regEx(/^\.github\/workflows\/[^/]+\.ya?ml$/);
 
 function extractRepositoryAction(

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -42,6 +42,28 @@ If you want to automatically pin action digests add the `helpers:pinGitHubAction
 Actions pinned to a bare SHA without a version comment are disabled by default, because Renovate cannot determine which branch or tag the SHA belongs to.
 To enable updates, add a tag or branch name as a version comment, as shown above.
 
+### Reusable workflows
+
+A job-level `uses:` which points at `owner/repo/.github/workflows/<file>.yml@<ref>` calls a [reusable workflow](https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows) instead of running an action, so Renovate gives it the `workflow` `depType`.
+Every other `uses:` reference to a repository keeps the `action` `depType`, including an action in a subdirectory such as `github/codeql-action/init@v3`.
+
+Use `matchDepTypes` to configure the two separately.
+For example, to keep pinning action digests but leave reusable workflow calls on their tag:
+
+```json
+{
+  "extends": ["helpers:pinGitHubActionDigests"],
+  "packageRules": [
+    {
+      "matchDepTypes": ["workflow"],
+      "pinDigests": false
+    }
+  ]
+}
+```
+
+This is useful when an AWS IAM role trust policy, or another OIDC consumer, matches on the `job_workflow_ref` claim: that claim contains the ref the workflow was called with, so pinning the call to a digest changes the claim and breaks the policy.
+
 ### GitHub Actions lockfile (`actions.lock`)
 
 !!! warning "This feature is flagged as experimental"

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -62,8 +62,6 @@ For example, to keep pinning action digests but leave reusable workflow calls on
 }
 ```
 
-This is useful when an AWS IAM role trust policy, or another OIDC consumer, matches on the `job_workflow_ref` claim: that claim contains the ref the workflow was called with, so pinning the call to a digest changes the claim and breaks the policy.
-
 ### GitHub Actions lockfile (`actions.lock`)
 
 !!! warning "This feature is flagged as experimental"


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Give a reference whose sub-path is exactly `.github/workflows/<file>.yml|.yaml` the new `workflow` depType. Every other sub-path, such as `github/codeql-action/init`, stays an action.

The existing depType-keyed sites now accept both values, so nothing else changes behaviour: the `actions.lock` file records reusable workflow calls too, and `helpers:pinGitHubActionDigests` pinned them before this split.

## Context

A job-level `uses:` pointing at `owner/repo/.github/workflows/<file>.yml@<ref>` calls a reusable workflow rather than running an action, but both got the `action` depType, so `matchDepTypes` could not tell them apart.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
