### PR TITLE
feat(http/bitbucket): surface deprecated and removed API functionality

### DIFF
--- a/lib/modules/platform/bitbucket/__snapshots__/index.spec.ts.snap
+++ b/lib/modules/platform/bitbucket/__snapshots__/index.spec.ts.snap
@@ -6,13 +6,6 @@ exports[`modules/platform/bitbucket/index > ensureComment() > does not throw 1`]
 
 exports[`modules/platform/bitbucket/index > ensureCommentRemoval() > does not throw 1`] = `undefined`;
 
-exports[`modules/platform/bitbucket/index > findIssue() > does not throw 1`] = `
-{
-  "body": "content",
-  "number": 25,
-}
-`;
-
 exports[`modules/platform/bitbucket/index > findPr() > finds pr 1`] = `
 {
   "bodyStruct": {
@@ -39,27 +32,6 @@ exports[`modules/platform/bitbucket/index > getBranchPr() > bitbucket finds PR f
   "targetBranch": "master",
   "title": "title",
 }
-`;
-
-exports[`modules/platform/bitbucket/index > getIssueList() > get issues 1`] = `
-[
-  {
-    "content": {
-      "raw": "content",
-    },
-    "id": 25,
-    "kind": "task",
-    "title": "title",
-  },
-  {
-    "content": {
-      "raw": "content",
-    },
-    "id": 26,
-    "kind": "task",
-    "title": "title",
-  },
-]
 `;
 
 exports[`modules/platform/bitbucket/index > getPr() > canRebase > getPr(3) 1`] = `

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -591,225 +591,41 @@ describe('modules/platform/bitbucket/index', () => {
   });
 
   describe('findIssue()', () => {
-    it('does not throw', async () => {
-      httpMock.scope(baseUrl).get('/2.0/user').reply(200, { uuid: '12345' });
-      await bitbucket.initPlatform({ username: 'renovate', password: 'pass' });
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)%20AND%20reporter.uuid%3D%2212345%22',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        });
-      expect(await bitbucket.findIssue('title')).toMatchSnapshot();
-    });
-
-    it('returns null if no issues', async () => {
-      const scope = await initRepoMock(
-        {
-          repository: 'some/empty',
-        },
-        { has_issues: true },
-      );
-      scope
-        .get(
-          '/2.0/repositories/some/empty/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [],
-        });
+    it('returns null as issues are unsupported', async () => {
+      await initRepoMock();
       expect(await bitbucket.findIssue('title')).toBeNull();
+      expect(logger.logger.once.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Bitbucket Cloud has removed its issue tracker',
+        ),
+      );
     });
   });
 
   describe('ensureIssue()', () => {
-    it('updates existing issues', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        })
-        .put('/2.0/repositories/some/repo/issues/25')
-        .reply(200)
-        .put('/2.0/repositories/some/repo/issues/26')
-        .reply(200);
+    it('returns null as issues are unsupported', async () => {
+      await initRepoMock();
       expect(
         await bitbucket.ensureIssue({ title: 'title', body: 'body' }),
-      ).toBe('updated');
-    });
-
-    it('creates new issue', async () => {
-      const scope = await initRepoMock(
-        { repository: 'some/empty' },
-        { has_issues: true },
-      );
-      scope
-        .get(
-          '/2.0/repositories/some/empty/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, { values: [] })
-        .get(
-          '/2.0/repositories/some/empty/issues?q=title%3D%22old-title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, { values: [] })
-        .post('/2.0/repositories/some/empty/issues')
-        .reply(200);
-      expect(
-        await bitbucket.ensureIssue({
-          title: 'title',
-          reuseTitle: 'old-title',
-          body: 'body',
-        }),
-      ).toBe('created');
-    });
-
-    it('noop for existing issue', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        })
-        .put('/2.0/repositories/some/repo/issues/26')
-        .reply(200);
-      expect(
-        await bitbucket.ensureIssue({
-          title: 'title',
-          body: '\n content \n',
-        }),
       ).toBeNull();
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        { title: 'title' },
+        'Cannot ensure issue',
+      );
     });
   });
 
   describe('ensureIssueClosing()', () => {
-    it('does not throw for disabled issues', async () => {
-      await initRepoMock({ repository: 'some/repo' }, { has_issues: false });
-      await expect(bitbucket.ensureIssueClosing('title')).toResolve();
-    });
-
-    it('closes issue', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get(
-          '/2.0/repositories/some/repo/issues?q=title%3D%22title%22%20AND%20(state%20%3D%20%22new%22%20OR%20state%20%3D%20%22open%22)',
-        )
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        })
-        .put('/2.0/repositories/some/repo/issues/25')
-        .reply(200)
-        .put('/2.0/repositories/some/repo/issues/26')
-        .reply(200);
+    it('does not throw as issues are unsupported', async () => {
+      await initRepoMock();
       await expect(bitbucket.ensureIssueClosing('title')).toResolve();
     });
   });
 
   describe('getIssueList()', () => {
-    it('returns empty array for disabled issues', async () => {
-      await initRepoMock({ repository: 'some/repo' }, { has_issues: false });
+    it('returns empty array as issues are unsupported', async () => {
+      await initRepoMock();
       expect(await bitbucket.getIssueList()).toEqual([]);
-    });
-
-    it('get issues', async () => {
-      httpMock.scope(baseUrl).get('/2.0/user').reply(200, { uuid: '12345' });
-      await bitbucket.initPlatform({ username: 'renovate', password: 'pass' });
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get('/2.0/repositories/some/repo/issues')
-        .query({
-          q: '(state = "new" OR state = "open") AND reporter.uuid="12345"',
-        })
-        .reply(200, {
-          values: [
-            {
-              id: 25,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-            {
-              id: 26,
-              title: 'title',
-              kind: 'task',
-              content: { raw: 'content' },
-            },
-          ],
-        });
-      const issues = await bitbucket.getIssueList();
-
-      expect(issues).toHaveLength(2);
-      expect(issues).toMatchSnapshot();
-    });
-
-    it('does not throw', async () => {
-      const scope = await initRepoMock({}, { has_issues: true });
-      scope
-        .get('/2.0/repositories/some/repo/issues')
-        .query({
-          q: '(state = "new" OR state = "open")',
-        })
-        .reply(500, {});
-      const issues = await bitbucket.getIssueList();
-
-      expect(issues).toHaveLength(0);
     });
   });
 

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -39,7 +39,6 @@ import type {
 } from '../types.ts';
 import { repoFingerprint } from '../util.ts';
 import { smartTruncate } from '../utils/pr-body.ts';
-import { readOnlyIssueBody } from '../utils/read-only-issue-body.ts';
 import * as comments from './comments.ts';
 import { BitbucketPrCache } from './pr-cache.ts';
 import {
@@ -271,7 +270,6 @@ export async function initRepo({
       ...config,
       owner: info.owner,
       mergeMethod: info.mergeMethod,
-      has_issues: info.has_issues,
       is_private: info.is_private,
     };
 
@@ -584,71 +582,6 @@ export async function setBranchStatus({
   aggressiveRepoCacheProvider.markSynced('get', branchStatusesUrl, false);
 }
 
-interface BbIssue {
-  id: number;
-  title: string;
-  kind: string;
-  content?: { raw: string };
-}
-
-async function findOpenIssues(title: string): Promise<BbIssue[]> {
-  try {
-    const filters = [
-      `title=${JSON.stringify(title)}`,
-      '(state = "new" OR state = "open")',
-    ];
-    if (renovateUserUuid) {
-      filters.push(`reporter.uuid="${renovateUserUuid}"`);
-    }
-    const filter = encodeURIComponent(filters.join(' AND '));
-    // v8 ignore next -- TODO: add test #40625
-    return (
-      (
-        await bitbucketHttp.getJsonUnchecked<{ values: BbIssue[] }>(
-          `/2.0/repositories/${config.repository}/issues?q=${filter}`,
-          { cacheProvider: aggressiveRepoCacheProvider },
-        )
-      ).body.values || []
-    );
-  } catch (err) /* v8 ignore next -- defensive: issue search failures are logged and mapped to [], not simulated in specs */ {
-    logger.warn({ err }, 'Error finding issues');
-    return [];
-  }
-}
-
-export async function findIssue(title: string): Promise<Issue | null> {
-  logger.debug(`findIssue(${title})`);
-
-  /* v8 ignore next -- specs initialize repos with the issue tracker enabled */
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot findIssue');
-    return null;
-  }
-  const issues = await findOpenIssues(title);
-  if (!issues.length) {
-    return null;
-  }
-  const [issue] = issues;
-  return {
-    number: issue.id,
-    body: issue.content?.raw,
-  };
-}
-
-async function closeIssue(issueNumber: number): Promise<void> {
-  await bitbucketHttp.putJson(
-    `/2.0/repositories/${config.repository}/issues/${issueNumber}`,
-    {
-      body: { state: 'closed' },
-    },
-  );
-}
-
-/**
- * Remove or transform markdown into Bitbucket supported syntax.
- *
- * See https://bitbucket.org/tutorials/markdowndemo/src for supported markdown syntax
- */
 /**
  * Remove or transform markdown into Bitbucket supported syntax.
  *
@@ -765,115 +698,36 @@ export function maxBodyLength(): number {
   return 250000;
 }
 
-export async function ensureIssue({
+function logIssuesRemoved(): void {
+  logger.once.debug(
+    'Bitbucket Cloud has removed its issue tracker, so Renovate features which rely on issues, like the Dependency Dashboard, do not work. See https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3071',
+  );
+}
+
+export function findIssue(title: string): Promise<Issue | null> {
+  logger.debug(`findIssue(${title})`);
+  logIssuesRemoved();
+  return Promise.resolve(null);
+}
+
+export function ensureIssue({
   title,
-  reuseTitle,
-  body,
 }: EnsureIssueConfig): Promise<EnsureIssueResult | null> {
-  logger.debug(`ensureIssue()`);
-  /* v8 ignore next -- specs initialize repos with the issue tracker enabled */
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot ensureIssue');
-    logger.debug(`Failed to ensure Issue with title:${title}`);
-    return null;
-  }
-  try {
-    let issues = await findOpenIssues(title);
-    const description = massageMarkdown(sanitize(body));
-    const issueKind = 'task';
-
-    if (!issues.length && reuseTitle) {
-      issues = await findOpenIssues(reuseTitle);
-    }
-    if (issues.length) {
-      // Close any duplicates
-      for (const issue of issues.slice(1)) {
-        await closeIssue(issue.id);
-      }
-      const [issue] = issues;
-
-      if (
-        issue.title !== title ||
-        String(issue.content?.raw).trim() !== description.trim() ||
-        issue.kind !== issueKind
-      ) {
-        logger.debug('Issue updated');
-        await bitbucketHttp.putJson(
-          `/2.0/repositories/${config.repository}/issues/${issue.id}`,
-          {
-            body: {
-              kind: issueKind,
-              content: {
-                raw: readOnlyIssueBody(description),
-                markup: 'markdown',
-              },
-            },
-          },
-        );
-        return 'updated';
-      }
-    } else {
-      logger.info('Issue created');
-      await bitbucketHttp.postJson(
-        `/2.0/repositories/${config.repository}/issues`,
-        {
-          body: {
-            title,
-            kind: issueKind,
-            content: {
-              raw: readOnlyIssueBody(description),
-              markup: 'markdown',
-            },
-          },
-        },
-      );
-      return 'created';
-    }
-  } catch (err) /* v8 ignore next -- issue creation failure handling is not mocked in specs */ {
-    if (err.message.startsWith('Repository has no issue tracker.')) {
-      logger.debug(`Issues are disabled, so could not create issue: ${title}`);
-    } else {
-      logger.warn({ err }, 'Could not ensure issue');
-    }
-  }
-  return null;
+  logger.once.warn({ title }, 'Cannot ensure issue');
+  logIssuesRemoved();
+  return Promise.resolve(null);
 }
 
-/* v8 ignore next -- exercised only through the dependency dashboard flow, which specs mock at a higher level */
-export async function getIssueList(): Promise<Issue[]> {
+export function getIssueList(): Promise<Issue[]> {
   logger.debug(`getIssueList()`);
-
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot getIssueList');
-    return [];
-  }
-  try {
-    const filters = ['(state = "new" OR state = "open")'];
-    if (renovateUserUuid) {
-      filters.push(`reporter.uuid="${renovateUserUuid}"`);
-    }
-    const filter = encodeURIComponent(filters.join(' AND '));
-    const url = `/2.0/repositories/${config.repository}/issues?q=${filter}`;
-    const res = await bitbucketHttp.getJsonUnchecked<{ values: Issue[] }>(url, {
-      cacheProvider: repoCacheProvider,
-    });
-    return res.body.values || [];
-  } catch (err) {
-    logger.warn({ err }, 'Error finding issues');
-    return [];
-  }
+  logIssuesRemoved();
+  return Promise.resolve([]);
 }
 
-export async function ensureIssueClosing(title: string): Promise<void> {
-  /* v8 ignore next -- specs initialize repos with the issue tracker enabled */
-  if (!config.has_issues) {
-    logger.debug('Issues are disabled - cannot ensureIssueClosing');
-    return;
-  }
-  const issues = await findOpenIssues(title);
-  for (const issue of issues) {
-    await closeIssue(issue.id);
-  }
+export function ensureIssueClosing(title: string): Promise<void> {
+  logger.debug(`ensureIssueClosing(${title})`);
+  logIssuesRemoved();
+  return Promise.resolve();
 }
 
 export function addAssignees(

--- a/lib/modules/platform/bitbucket/readme.md
+++ b/lib/modules/platform/bitbucket/readme.md
@@ -31,8 +31,6 @@ Give the bot API token the following permission scopes:
 | [`read:pullrequest:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-pullrequest-bitbucket)   | Pull requests: Read  |
 | [`write:pullrequest:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#write-pullrequest-bitbucket) | Pull requests: Write |
 | [`read:user:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-user-bitbucket)                 | User: Read           |
-| [`read:issue:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-issue-bitbucket)               | Issues: Read         |
-| [`write:issue:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#write-issue-bitbucket)             | Issues: Write        |
 | [`read:workspace:bitbucket`](https://developer.atlassian.com/cloud/bitbucket/rest/intro/#read-workspace-bitbucket)       | Workspace: Read      |
 
 The bot also needs to validate the workspace membership status of pull-request reviewers, for that, [create a new user group](https://support.atlassian.com/bitbucket-cloud/docs/organize-workspace-members-into-groups/) in the workspace with the **Create repositories** permission and add the bot user to it.
@@ -53,3 +51,5 @@ Remember to:
 - Adding assignees to PRs not supported (does not seem to be a Bitbucket concept)
 - `automergeStrategy=rebase` not supported by Bitbucket Cloud, see [Jira issue BCLOUD-16610](https://jira.atlassian.com/browse/BCLOUD-16610)
 - Markdown support for collapsible syntax, see [Jira issue BCLOUD-20231](https://jira.atlassian.com/browse/BCLOUD-20231)
+- Issues are not supported, as Bitbucket Cloud removed its issue tracker on [2026-08-24](https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-3071).
+  This means features which rely on issues, like the [Dependency Dashboard](../../../configuration-options.md#dependencydashboard) or informing you of warnings in your Renovate config, no longer work.

--- a/lib/modules/platform/bitbucket/schema.ts
+++ b/lib/modules/platform/bitbucket/schema.ts
@@ -30,9 +30,6 @@ export const RepoInfo = z
     mainbranch: z.object({
       name: z.string(),
     }),
-    has_issues: z.boolean().catch(() => {
-      return false;
-    }),
     uuid: z.string(),
     full_name: z
       .string()
@@ -61,7 +58,6 @@ export const RepoInfo = z
       name,
       mainbranch: repoInfoBody.mainbranch.name,
       mergeMethod: 'merge',
-      has_issues: repoInfoBody.has_issues,
       uuid: repoInfoBody.uuid,
       is_private: repoInfoBody.is_private,
       projectName: repoInfoBody.project?.name,

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -10,7 +10,6 @@ export interface MergeRequestBody {
 
 export interface Config {
   defaultBranch: string;
-  has_issues: boolean;
   mergeMethod: string;
   owner: string;
   repository: string;

--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -1,4 +1,5 @@
 import * as httpMock from '~test/http-mock.ts';
+import { logger } from '~test/util.ts';
 import * as hostRules from '../host-rules.ts';
 import { range } from '../range.ts';
 import { BitbucketHttp, setBaseUrl } from './bitbucket.ts';
@@ -52,6 +53,94 @@ describe('util/http/bitbucket', () => {
       },
       statusCode: 200,
     });
+  });
+
+  it('warns about deprecated functionality', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(410, {
+        type: 'error',
+        error: {
+          message: 'CHANGE-3071 - Functionality has been deprecated',
+          detail: 'Please read the changelog entry for more details.',
+          data: {
+            announcement_url:
+              'https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071',
+          },
+        },
+      });
+
+    await expect(api.getJsonUnchecked('some-url')).rejects.toThrow(
+      'Request failed with status code 410 (Gone)',
+    );
+
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      {
+        url: `${baseUrl}/some-url`,
+        message: 'CHANGE-3071 - Functionality has been deprecated',
+        detail: 'Please read the changelog entry for more details.',
+        announcementUrl:
+          'https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071',
+      },
+      'Bitbucket API functionality has been deprecated or removed',
+    );
+  });
+
+  it('warns about deprecated functionality for non-JSON responses', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(
+        410,
+        JSON.stringify({
+          error: {
+            message: 'CHANGE-3071 - Functionality has been deprecated',
+            data: {
+              announcement_url:
+                'https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071',
+            },
+          },
+        }),
+      );
+
+    await expect(api.get('some-url')).rejects.toThrow(
+      'Request failed with status code 410 (Gone)',
+    );
+
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      {
+        url: `${baseUrl}/some-url`,
+        message: 'CHANGE-3071 - Functionality has been deprecated',
+        detail: undefined,
+        announcementUrl:
+          'https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071',
+      },
+      'Bitbucket API functionality has been deprecated or removed',
+    );
+  });
+
+  it('does not warn when the request failed without a response', async () => {
+    httpMock.scope(baseUrl).get('/some-url').replyWithError('some error');
+
+    await expect(api.getJsonUnchecked('some-url')).rejects.toThrow(
+      'some error',
+    );
+
+    expect(logger.logger.once.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn for unrelated errors', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(404, { type: 'error', error: { message: 'Not found' } });
+
+    await expect(api.getJsonUnchecked('some-url')).rejects.toThrow(
+      'Request failed with status code 404 (Not Found)',
+    );
+
+    expect(logger.logger.once.warn).not.toHaveBeenCalled();
   });
 
   it('paginates: adds default pagelen if non is present', async () => {

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -1,5 +1,9 @@
 import { isNonEmptyObject, isNullOrUndefined } from '@sindresorhus/is';
+import { RequestError } from 'got';
+import { z } from 'zod/v4';
+import { logger } from '../../logger/index.ts';
 import type { PagedResult } from '../../modules/platform/bitbucket/types.ts';
+import { Json } from '../schema-utils/index.ts';
 import { HttpBase, type InternalJsonUnsafeOptions } from './http.ts';
 import type { HttpMethod, HttpOptions, HttpResponse } from './types.ts';
 
@@ -30,6 +34,32 @@ export class BitbucketHttp extends HttpBase<BitbucketHttpOptions> {
     return super
       .extraOptions()
       .concat(['paginate', 'pagelen'] as (keyof BitbucketHttpOptions)[]);
+  }
+
+  protected override handleError(
+    url: string | URL,
+    httpOptions: HttpOptions,
+    err: Error,
+  ): never {
+    if (err instanceof RequestError && err.response) {
+      const announcement = DeprecationAnnouncementBody.safeParse(
+        err.response.body,
+      );
+      if (announcement.success) {
+        const { message, detail, data } = announcement.data.error;
+        logger.once.warn(
+          {
+            // `url` is only resolved against the base URL for JSON requests
+            url: err.response.url,
+            message,
+            detail,
+            announcementUrl: data.announcement_url,
+          },
+          'Bitbucket API functionality has been deprecated or removed',
+        );
+      }
+    }
+    return super.handleError(url, httpOptions, err);
   }
 
   protected override async requestJsonUnsafe<T>(
@@ -85,6 +115,27 @@ export class BitbucketHttp extends HttpBase<BitbucketHttpOptions> {
     return result as HttpResponse<T>;
   }
 }
+
+/**
+ * Bitbucket Cloud responds with an error body linking to the relevant changelog entry when the endpoint's functionality has been deprecated or removed.
+ *
+ * See https://developer.atlassian.com/cloud/bitbucket/changelog/
+ */
+const DeprecationAnnouncement = z.object({
+  error: z.object({
+    message: z.string(),
+    detail: z.string().optional(),
+    data: z.object({
+      announcement_url: z.string(),
+    }),
+  }),
+});
+
+/** The body is already parsed for JSON requests, but a raw string otherwise. */
+const DeprecationAnnouncementBody = z.union([
+  DeprecationAnnouncement,
+  Json.pipe(DeprecationAnnouncement),
+]);
 
 function hasPagelen(url: URL): boolean {
   return !isNullOrUndefined(url.searchParams.get('pagelen'));


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes



To surface the deprecation or removal of features by Bitbucket Cloud,
there may be an error body such as:

```json
    {
      "type": "error",
      "error": {
        "message": "CHANGE-3071 - Functionality has been deprecated",
        "detail": "Please read the changelog entry for more details.",
        "data": {
          "announcement_url": "https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071"
        }
      }
    }
```

To make it more visible to a self-hosted administrator that they're
using deprecated/removed functionality, we can elevate this to a WARN
log line, if there is an `announcement_url`.

We make sure to handle both parsed JSON response bodies and a raw string
body used for other requests.

To reduce noise to a self-hosted administrator, we can log this once per
run.

Co-authored-by: Claude Opus 5 <jamie.tanna+claude-code@mend.io>



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code, using Claude Opus 5, wrote the code and tests here, driven and reviewed by @jamietanna.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: n/a

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
