### PR TITLE
feat(http/bitbucket): warn when an endpoint announces a deprecation

### DIFF
--- a/lib/util/http/bitbucket.spec.ts
+++ b/lib/util/http/bitbucket.spec.ts
@@ -55,6 +55,93 @@ describe('util/http/bitbucket', () => {
     });
   });
 
+  it('warns when an endpoint announces a deprecation', async () => {
+    httpMock.scope(baseUrl).get('/some-url').reply(
+      200,
+      {},
+      {
+        deprecation: '@1771545600',
+        sunset: 'Fri, 21 Aug 2026 00:00:00 UTC',
+        link: '<https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071>; rel="deprecation"; type="text/html"',
+      },
+    );
+
+    await api.getJsonUnchecked('some-url');
+
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      {
+        url: `${baseUrl}/some-url`,
+        deprecation: '2026-02-20T00:00:00.000Z',
+        sunset: '2026-08-21T00:00:00.000Z',
+        announcementUrl:
+          'https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071',
+      },
+      'Bitbucket API endpoint has been marked as deprecated',
+    );
+  });
+
+  it('warns when only a sunset is announced', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(200, {}, { sunset: 'Fri, 21 Aug 2026 00:00:00 UTC' });
+
+    await api.getJsonUnchecked('some-url');
+
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      {
+        url: `${baseUrl}/some-url`,
+        deprecation: undefined,
+        sunset: '2026-08-21T00:00:00.000Z',
+        announcementUrl: undefined,
+      },
+      'Bitbucket API endpoint has been marked as deprecated',
+    );
+  });
+
+  it('formats HTTP dates which are already spec compliant', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(200, {}, { deprecation: 'Sun, 11 Nov 2018 23:59:59 GMT' });
+
+    await api.getJsonUnchecked('some-url');
+
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ deprecation: '2018-11-11T23:59:59.000Z' }),
+      'Bitbucket API endpoint has been marked as deprecated',
+    );
+  });
+
+  it('passes through values it cannot format', async () => {
+    httpMock
+      .scope(baseUrl)
+      .get('/some-url')
+      .reply(200, {}, { deprecation: '@99999999999999999999' })
+      .get('/other-url')
+      .reply(200, {}, { sunset: 'not a date' });
+
+    await api.getJsonUnchecked('some-url');
+    await api.getJsonUnchecked('other-url');
+
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ deprecation: '@99999999999999999999' }),
+      'Bitbucket API endpoint has been marked as deprecated',
+    );
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      expect.objectContaining({ sunset: 'not a date' }),
+      'Bitbucket API endpoint has been marked as deprecated',
+    );
+  });
+
+  it('does not warn when no deprecation is announced', async () => {
+    httpMock.scope(baseUrl).get('/some-url').reply(200, {});
+
+    await api.getJsonUnchecked('some-url');
+
+    expect(logger.logger.once.warn).not.toHaveBeenCalled();
+  });
+
   it('warns about deprecated functionality', async () => {
     httpMock
       .scope(baseUrl)

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -1,9 +1,16 @@
-import { isNonEmptyObject, isNullOrUndefined } from '@sindresorhus/is';
+import {
+  isNonEmptyObject,
+  isNullOrUndefined,
+  isString,
+} from '@sindresorhus/is';
 import { RequestError } from 'got';
+import { DateTime } from 'luxon';
 import { z } from 'zod/v4';
 import { logger } from '../../logger/index.ts';
 import type { PagedResult } from '../../modules/platform/bitbucket/types.ts';
+import { regEx } from '../regex.ts';
 import { Json } from '../schema-utils/index.ts';
+import { parseLinkHeader } from '../url.ts';
 import { HttpBase, type InternalJsonUnsafeOptions } from './http.ts';
 import type { HttpMethod, HttpOptions, HttpResponse } from './types.ts';
 
@@ -60,6 +67,29 @@ export class BitbucketHttp extends HttpBase<BitbucketHttpOptions> {
       }
     }
     return super.handleError(url, httpOptions, err);
+  }
+
+  protected override handleResponse(
+    url: URL,
+    res: HttpResponse<unknown>,
+  ): void {
+    const { deprecation, sunset, link } = res.headers;
+    if (!isString(deprecation) && !isString(sunset)) {
+      return;
+    }
+
+    logger.once.warn(
+      {
+        url: url.toString(),
+        deprecation: isString(deprecation)
+          ? formatDate(deprecation)
+          : undefined,
+        sunset: isString(sunset) ? formatDate(sunset) : undefined,
+        announcementUrl: parseLinkHeader(isString(link) ? link : undefined)
+          ?.deprecation?.url,
+      },
+      'Bitbucket API endpoint has been marked as deprecated',
+    );
   }
 
   protected override async requestJsonUnsafe<T>(
@@ -136,6 +166,24 @@ const DeprecationAnnouncementBody = z.union([
   DeprecationAnnouncement,
   Json.pipe(DeprecationAnnouncement),
 ]);
+
+/**
+ * Format a `Deprecation` or `Sunset` header as ISO 8601, falling back to the raw value when it cannot be parsed.
+ *
+ * `Sunset` is an HTTP date, and `Deprecation` is either an HTTP date or an `@`-prefixed Unix timestamp.
+ */
+function formatDate(value: string): string {
+  const seconds = regEx(/^@(?<seconds>\d+)$/).exec(value)?.groups?.seconds;
+  if (seconds) {
+    return (
+      DateTime.fromSeconds(Number(seconds), { zone: 'utc' }).toISO() ?? value
+    );
+  }
+
+  // Bitbucket Cloud sends `UTC` timezone, whereas RFC8594 requires `GMT`, so we can manually work around this to parse correctly
+  const httpDate = value.replace(regEx(/ UTC$/), ' GMT');
+  return DateTime.fromHTTP(httpDate, { zone: 'utc' }).toISO() ?? value;
+}
 
 function hasPagelen(url: URL): boolean {
   return !isNullOrUndefined(url.searchParams.get('pagelen'));

--- a/lib/util/http/bitbucket.ts
+++ b/lib/util/http/bitbucket.ts
@@ -176,7 +176,8 @@ function formatDate(value: string): string {
   const seconds = regEx(/^@(?<seconds>\d+)$/).exec(value)?.groups?.seconds;
   if (seconds) {
     return (
-      DateTime.fromSeconds(Number(seconds), { zone: 'utc' }).toISO() ?? value
+      DateTime.fromSeconds(parseInt(seconds, 10), { zone: 'utc' }).toISO() ??
+      value
     );
   }
 

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -242,6 +242,8 @@ export abstract class HttpBase<
       const resCopy = copyResponse(res, deepCopyNeeded);
       resCopy.authorization = !!options?.headers?.authorization;
 
+      this.handleResponse(resolvedUrl, resCopy);
+
       if (cacheProvider) {
         return await cacheProvider.wrapServerResponse(method, url, resCopy);
       }
@@ -292,6 +294,10 @@ export abstract class HttpBase<
     err: Error,
   ): never {
     throw err;
+  }
+
+  protected handleResponse(_url: URL, _res: HttpResponse<unknown>): void {
+    // noop
   }
 
   resolveUrl(requestUrl: string | URL, options?: HttpOptions): URL {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes



To highlight to a self-hosted administrator when they are using
deprecated/removed functionality, we can look for i.e.

    sunset: Fri, 21 Aug 2026 00:00:00 UTC
    deprecation: @1771545600
    link: <https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-3071>; rel="deprecation"; type="text/html"

This provides visibility into a soon-to-be-removed piece of
functionality, and should allow us to catch these deprecations more
centrally.

We make sure to log them - as a WARN - once, and with ISO8601 dates for
readability.

If we can't parse either `sunset` or `deprecation`, we log them as-is,
so we don't accidentally remove any necessary context.

Co-authored-by: Claude Opus 5 <jamie.tanna+claude-code@mend.io>



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code, using Claude Opus 5, wrote the code and tests here, driven and reviewed by @jamietanna.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: n/a

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
