### PR TITLE
feat(datasource/dotnet-version): support custom registry URLs

### DIFF
--- a/lib/modules/datasource/dotnet-version/index.spec.ts
+++ b/lib/modules/datasource/dotnet-version/index.spec.ts
@@ -204,5 +204,28 @@ describe('modules/datasource/dotnet-version/index', () => {
         },
       ]);
     });
+
+    it('fetches the index from a configured registry', async () => {
+      const mirror = 'https://dotnet.example.com/release-metadata';
+      httpMock
+        .scope(mirror)
+        .get('/releases-index.json')
+        .reply(200, {
+          'releases-index': [
+            { 'releases.json': `${mirror}/7.0/releases.json` },
+          ],
+        })
+        .get('/7.0/releases.json')
+        .reply(200, releases7_0);
+
+      const res = await getPkgReleases({
+        datasource: DotnetVersionDatasource.id,
+        packageName: 'dotnet-sdk',
+        registryUrls: [`${mirror}/releases-index.json`],
+      });
+
+      expect(res?.sourceUrl).toBe('https://github.com/dotnet/sdk');
+      expect(res?.releases).not.toHaveLength(0);
+    });
   });
 });

--- a/lib/modules/datasource/dotnet-version/index.ts
+++ b/lib/modules/datasource/dotnet-version/index.ts
@@ -17,7 +17,7 @@ export class DotnetVersionDatasource extends Datasource {
 
   override readonly caching = true;
 
-  override readonly customRegistrySupport = false;
+  override readonly customRegistrySupport = true;
 
   override readonly defaultRegistryUrls = [
     'https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json',
@@ -32,13 +32,18 @@ export class DotnetVersionDatasource extends Datasource {
 
   private async _getReleases({
     packageName,
+    registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     if (!(packageName === 'dotnet-sdk' || packageName === 'dotnet-runtime')) {
       return null;
     }
 
+    /* v8 ignore next -- should never happen */
+    if (!registryUrl) {
+      return null;
+    }
+
     try {
-      const registryUrl = this.defaultRegistryUrls[0];
       const { body: urls } = await this.http.getJson(
         registryUrl,
         ReleasesIndex,
@@ -66,7 +71,7 @@ export class DotnetVersionDatasource extends Datasource {
     return withCache(
       {
         namespace: `datasource-${DotnetVersionDatasource.id}`,
-        key: config.packageName,
+        key: `${config.registryUrl}:${config.packageName}`,
         ttlMinutes: 1440,
         fallback: true,
       },

--- a/lib/modules/datasource/dotnet-version/readme.md
+++ b/lib/modules/datasource/dotnet-version/readme.md
@@ -1,2 +1,6 @@
 This datasource returns releases of the .NET Runtime and SDK.
 It only accepts dependencies with the name `dotnet-sdk` or `dotnet-runtime`.
+
+By default the releases index is read from `https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/releases-index.json`.
+Set `registryUrls` to the URL of a mirrored `releases-index.json` to read it from somewhere else.
+The channel files are fetched from the URLs listed inside that index, so a mirror should point at its own copies.


### PR DESCRIPTION
## Changes

`DotnetVersionDatasource` read its releases index from `this.defaultRegistryUrls[0]` instead of the `registryUrl` it was handed, so a configured registry was accepted by config and then ignored. It now uses the URL it is passed, and `customRegistrySupport` is `true`.

Two things came with that:

- **The cache key gains the registry URL.** It was `config.packageName` alone, which was correct while every lookup hit the same index, but once a registry can be configured two of them would share one entry and one registry's releases could be served for another. It is now `${registryUrl}:${packageName}`, matching what `node-version` and `rust-version` already do. This invalidates existing entries once.
- **The readme says what a custom registry means here.** Unlike most datasources the default is a full file URL, not a host, so `registryUrls` is the URL of a mirrored `releases-index.json`. The channel files are then fetched from the URLs listed inside that index, so a mirror needs to point at its own copies — worth stating rather than leaving people to infer it.

The missing-`registryUrl` branch is unreachable in practice, since config fills it from `defaultRegistryUrls`; it carries the `/* v8 ignore next */` comment the other datasources use for the same guard.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45028
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The code, the test and this description were written by Claude Opus 5 running in Claude Code, directed by @MLuc24. The shape follows the existing `node-version` and `rust-version` datasources rather than being invented: the guard idiom, the `v8 ignore` comment and the registry-scoped cache key are all copied from them. The new test was run against unpatched `main` first to confirm it fails there.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @MLuc24 will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`fetches the index from a configured registry` mocks a mirror serving both the index and the channel file it points at, and asserts the releases come back. Because `httpMock` fails on any unmocked request, the test only passes if the mirror — and not the default host — was the one that got called.

On `main`, with only the test applied, it fails:

```
× fetches the index from a configured registry
AssertionError: expected undefined to be 'https://github.com/dotnet/sdk'
GET https://example.com/foo/bar/fail 404
```

With the change: `Tests 10 passed (10)`.

Also run on the changed files: `oxlint`, `biome check`, `prettier --check`, and `tsc --noEmit` — all clean.

I did not run this against a real repository: it would need a self-hosted mirror of the .NET release metadata to exercise the path that actually changed.
