### PR TITLE
test(manager/bundler): add missing branch coverage in extract()

### DIFF
--- a/lib/modules/manager/bundler/extract.spec.ts
+++ b/lib/modules/manager/bundler/extract.spec.ts
@@ -301,4 +301,135 @@ describe('modules/manager/bundler/extract', () => {
       ],
     });
   });
+
+  it('ignores a bare source variable that is not defined', async () => {
+    const undefinedSourceGemfile = codeBlock`
+      source undefined_var
+
+      gem 'foo'
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(undefinedSourceGemfile);
+    const res = await extractPackageFile(undefinedSourceGemfile, 'Gemfile');
+    expect(res).toMatchObject({
+      registryUrls: [],
+      deps: [{ depName: 'foo' }],
+    });
+  });
+
+  it('ignores an inline gem source with no value', async () => {
+    const emptyInlineSourceGemfile = codeBlock`
+      gem 'foo', require: false, source:
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(emptyInlineSourceGemfile);
+    const res = await extractPackageFile(emptyInlineSourceGemfile, 'Gemfile');
+    expect(res).toMatchObject({
+      deps: [{ depName: 'foo' }],
+    });
+  });
+
+  it('skips sourceUrl for a non-http git ref in Gemfile', async () => {
+    const sshGitRefGemfile = codeBlock`
+      gem 'foo', git: 'git@github.com:foo/foo.git', tag: 'v1.0.0'
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(sshGitRefGemfile);
+    const res = await extractPackageFile(sshGitRefGemfile, 'Gemfile');
+    expect(res).toMatchObject({
+      deps: [
+        {
+          depName: 'foo',
+          packageName: 'git@github.com:foo/foo.git',
+          currentValue: 'v1.0.0',
+          datasource: 'git-refs',
+        },
+      ],
+    });
+    expect(res?.deps[0].sourceUrl).toBeUndefined();
+  });
+
+  it('parses a ruby version nested inside a group block', async () => {
+    const rubyInGroupGemfile = codeBlock`
+      group :test do
+        ruby '2.7.1'
+      end
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(rubyInGroupGemfile);
+    const res = await extractPackageFile(rubyInGroupGemfile, 'Gemfile');
+    expect(res?.deps).toMatchObject([
+      { depName: 'ruby', currentValue: '2.7.1' },
+    ]);
+    expect(res?.deps[0].managerData?.lineNumber).toBeNaN();
+  });
+
+  it('parses a ruby version nested inside a source block', async () => {
+    const rubyInSourceBlockGemfile = codeBlock`
+      source 'https://gems.example.com' do
+        ruby '2.7.1'
+      end
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(rubyInSourceBlockGemfile);
+    const res = await extractPackageFile(rubyInSourceBlockGemfile, 'Gemfile');
+    expect(res?.deps).toMatchObject([
+      { depName: 'ruby', currentValue: '2.7.1' },
+    ]);
+    expect(res?.deps[0].managerData?.lineNumber).toBeNaN();
+  });
+
+  it('parses a ruby version nested inside a platforms block', async () => {
+    const rubyInPlatformsGemfile = codeBlock`
+      platforms :jruby do
+        ruby '2.7.1'
+      end
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(rubyInPlatformsGemfile);
+    const res = await extractPackageFile(rubyInPlatformsGemfile, 'Gemfile');
+    expect(res?.deps).toMatchObject([
+      { depName: 'ruby', currentValue: '2.7.1' },
+    ]);
+    expect(res?.deps[0].managerData?.lineNumber).toBeNaN();
+  });
+
+  it('ignores an empty platforms block', async () => {
+    const emptyPlatformsGemfile = codeBlock`
+      gem 'foo'
+      platforms :jruby do
+      end
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(emptyPlatformsGemfile);
+    const res = await extractPackageFile(emptyPlatformsGemfile, 'Gemfile');
+    expect(res?.deps).toMatchObject([{ depName: 'foo' }]);
+  });
+
+  it('parses a ruby version nested inside an if block', async () => {
+    const rubyInIfGemfile = codeBlock`
+      if RUBY_VERSION >= '3.0'
+        ruby '2.7.1'
+      end
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(rubyInIfGemfile);
+    const res = await extractPackageFile(rubyInIfGemfile, 'Gemfile');
+    expect(res?.deps).toMatchObject([
+      { depName: 'ruby', currentValue: '2.7.1' },
+    ]);
+    expect(res?.deps[0].managerData?.lineNumber).toBeNaN();
+  });
+
+  it('ignores an empty if block', async () => {
+    const emptyIfGemfile = codeBlock`
+      gem 'foo'
+      if RUBY_VERSION >= '3.0'
+      end
+    `;
+
+    fs.readLocalFile.mockResolvedValueOnce(emptyIfGemfile);
+    const res = await extractPackageFile(emptyIfGemfile, 'Gemfile');
+    expect(res?.deps).toMatchObject([{ depName: 'foo' }]);
+  });
 });

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -172,7 +172,8 @@ export async function extractPackageFile(
           if (isHttpUrl(gitUrl)) {
             dep.sourceUrl = gitUrl.replace(regEx(/\.git$/), '');
           }
-        } else if (gitRefsMatch.repoName) {
+        } else {
+          // we always have repoName, as `gitRefsMatchRegex`'s first group requires either `gitUrl` or `repoName`
           dep.packageName = `https://github.com/${gitRefsMatch.repoName}`;
           dep.sourceUrl = dep.packageName;
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

The `else if (gitRefsMatch.repoName)` branch was unreachable, so we can
simplify this check.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Sonnet 5 wrote the new test cases and the `else if` → `else` simplification, based on branch-coverage analysis of the diff.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->

