### PR TITLE
fix(github-graphql): lower shrinkPageSize floor from 25 to 5

### DIFF
--- a/lib/util/github/graphql/datasource-fetcher.spec.ts
+++ b/lib/util/github/graphql/datasource-fetcher.spec.ts
@@ -297,9 +297,11 @@ describe('util/github/graphql/datasource-fetcher', () => {
     });
 
     /**
-     * See: #16343
+     * See: #16343, discussion #45248
      */
     describe('Page shrinking', () => {
+      const pageSizes = [100, 50, 25, 10, 5];
+
       function generateItems(count: number): TestAdapterInput[] {
         const indices = [...range(1, count)].map((x) => `${x}`);
         return indices.map((idx) => ({
@@ -330,16 +332,83 @@ describe('util/github/graphql/datasource-fetcher', () => {
         return pages;
       }
 
-      it('shrinks page from 100 to 50', async () => {
-        const items = generateItems(150);
-        const pages = generatePages(items, 50);
-        const scope = httpMock
+      /**
+       * Requests that failed before the page size became small enough.
+       * Each one re-tries the very first page, hence the `null` cursor.
+       */
+      function shrinkingTrace(attempts: number): unknown[] {
+        return pageSizes.slice(0, attempts).map((size) => ({
+          body: { variables: { count: size, cursor: null } },
+        }));
+      }
+
+      function paginationTrace(pageSize: number, pageCount: number): unknown[] {
+        return [...range(1, pageCount)].map((idx) => ({
+          body: {
+            variables: {
+              count: pageSize,
+              cursor: idx === 1 ? null : `page-${idx}`,
+            },
+          },
+        }));
+      }
+
+      it.each`
+        attempts | pageSize | itemCount
+        ${1}     | ${50}    | ${150}
+        ${2}     | ${25}    | ${100}
+        ${3}     | ${10}    | ${30}
+        ${4}     | ${5}     | ${15}
+      `(
+        'shrinks page size to $pageSize after $attempts failed attempt(s)',
+        async ({
+          attempts,
+          pageSize,
+          itemCount,
+        }: {
+          attempts: number;
+          pageSize: number;
+          itemCount: number;
+        }) => {
+          const items = generateItems(itemCount);
+          const pages = generatePages(items, pageSize);
+          const scope = httpMock
+            .scope('https://api.github.com/')
+            .post('/graphql')
+            .times(attempts)
+            .reply(
+              200,
+              err('Something went wrong while executing your query.'),
+            );
+          pages.forEach((page) => {
+            scope.post('/graphql').reply(200, page);
+          });
+
+          const res = await Datasource.query(
+            { packageName: 'foo/bar' },
+            http,
+            adapter,
+          );
+
+          expect(res).toHaveLength(itemCount);
+          expect(res).toEqual(items.map(adapter.transform));
+          expect(httpMock.getTrace()).toMatchObject([
+            ...shrinkingTrace(attempts),
+            ...paginationTrace(pageSize, pages.length),
+          ]);
+        },
+      );
+
+      it('shrinks page size when a later page fails', async () => {
+        const items = generateItems(30);
+        httpMock
           .scope('https://api.github.com/')
           .post('/graphql')
-          .reply(200, err('Something went wrong while executing your query.'));
-        pages.forEach((page) => {
-          scope.post('/graphql').reply(200, page);
-        });
+          .reply(200, resp(false, items.slice(0, 20), 'page-2'))
+          .post('/graphql')
+          .reply(200, err('Something went wrong while executing your query.'))
+          .post('/graphql')
+          .reply(200, resp(false, items.slice(20)));
 
         const res = await Datasource.query(
           { packageName: 'foo/bar' },
@@ -347,43 +416,11 @@ describe('util/github/graphql/datasource-fetcher', () => {
           adapter,
         );
 
-        expect(res).toHaveLength(150);
         expect(res).toEqual(items.map(adapter.transform));
         expect(httpMock.getTrace()).toMatchObject([
           { body: { variables: { count: 100, cursor: null } } },
-          { body: { variables: { count: 50, cursor: null } } },
+          { body: { variables: { count: 100, cursor: 'page-2' } } },
           { body: { variables: { count: 50, cursor: 'page-2' } } },
-          { body: { variables: { count: 50, cursor: 'page-3' } } },
-        ]);
-      });
-
-      it('shrinks page from 50 to 25', async () => {
-        const items = generateItems(100);
-        const pages = generatePages(items, 25);
-        const scope = httpMock
-          .scope('https://api.github.com/')
-          .post('/graphql')
-          .twice()
-          .reply(200, err('Something went wrong while executing your query.'));
-        pages.forEach((page) => {
-          scope.post('/graphql').reply(200, page);
-        });
-
-        const res = await Datasource.query(
-          { packageName: 'foo/bar' },
-          http,
-          adapter,
-        );
-
-        expect(res).toHaveLength(100);
-        expect(res).toEqual(items.map(adapter.transform));
-        expect(httpMock.getTrace()).toMatchObject([
-          { body: { variables: { count: 100, cursor: null } } },
-          { body: { variables: { count: 50, cursor: null } } },
-          { body: { variables: { count: 25, cursor: null } } },
-          { body: { variables: { count: 25, cursor: 'page-2' } } },
-          { body: { variables: { count: 25, cursor: 'page-3' } } },
-          { body: { variables: { count: 25, cursor: 'page-4' } } },
         ]);
       });
 
@@ -391,18 +428,16 @@ describe('util/github/graphql/datasource-fetcher', () => {
         httpMock
           .scope('https://api.github.com/')
           .post('/graphql')
-          .thrice()
+          .times(pageSizes.length)
           .reply(200, err('Something went wrong while executing your query.'));
 
         await expect(
           Datasource.query({ packageName: 'foo/bar' }, http, adapter),
         ).rejects.toThrow('Something went wrong while executing your query.');
 
-        expect(httpMock.getTrace()).toMatchObject([
-          { body: { variables: { count: 100, cursor: null } } },
-          { body: { variables: { count: 50, cursor: null } } },
-          { body: { variables: { count: 25, cursor: null } } },
-        ]);
+        expect(httpMock.getTrace()).toMatchObject(
+          shrinkingTrace(pageSizes.length),
+        );
       });
     });
 

--- a/lib/util/github/graphql/datasource-fetcher.ts
+++ b/lib/util/github/graphql/datasource-fetcher.ts
@@ -27,6 +27,18 @@ import type {
 } from './types.ts';
 
 /**
+ * Page sizes to try, from the largest to the smallest.
+ *
+ * Repositories with many tags can exceed the GitHub GraphQL execution
+ * timeout even for small page sizes, hence the low floor.
+ *
+ * @see https://github.com/renovatebot/renovate/discussions/45248
+ */
+const pageSizes = [100, 50, 25, 10, 5] as const;
+
+type PageSize = (typeof pageSizes)[number];
+
+/**
  * We know empirically that certain type of GraphQL errors
  * can be fixed by shrinking page size.
  *
@@ -66,7 +78,7 @@ export class GithubGraphqlDatasourceFetcher<
   private readonly repoOwner: string;
   private readonly repoName: string;
 
-  private itemsPerQuery: 100 | 50 | 25 = 100;
+  private itemsPerQuery: PageSize = pageSizes[0];
 
   private queryCount = 0;
 
@@ -176,17 +188,13 @@ export class GithubGraphqlDatasourceFetcher<
   }
 
   private shrinkPageSize(): boolean {
-    if (this.itemsPerQuery === 100) {
-      this.itemsPerQuery = 50;
-      return true;
+    const nextIdx = pageSizes.indexOf(this.itemsPerQuery) + 1;
+    if (nextIdx >= pageSizes.length) {
+      return false;
     }
 
-    if (this.itemsPerQuery === 50) {
-      this.itemsPerQuery = 25;
-      return true;
-    }
-
-    return false;
+    this.itemsPerQuery = pageSizes[nextIdx];
+    return true;
   }
 
   private hasReachedQueryLimit(): boolean {


### PR DESCRIPTION
## Changes

`shrinkPageSize()` walked `100 → 50 → 25` and then gave up. For repositories with many tags, `refs(first: 25)` with nested tag / annotated-tag target resolution still exceeds GitHub's 10-second GraphQL execution limit, so the query is terminated server-side (502 / 504). The resulting `ExternalHostError` was re-thrown as an unrecoverable failure instead of being retried with a smaller page.

GitHub Support confirmed these are query *execution timeouts* — the query runs for exactly 10 seconds and is killed by their GraphQL backend — and recommended reducing the `refs(first: ...)` page size.

This PR extends the ladder to `100 → 50 → 25 → 10 → 5`. The step list is now a single `pageSizes` constant, and `shrinkPageSize()` advances through it by index rather than via a chain of `if` branches, so adding or removing a step is a one-line change.

Behaviour is unchanged for every repository that already succeeds at 25 or above — the extra steps are only reached after 25 has failed.

### Note for reviewers

`hasReachedQueryLimit()` is a flat `queryCount >= 100`, which is an *item* ceiling that varies with page size: 2,500 items at `first: 25`, but only 500 at `first: 5`. So a repository large enough to need the smallest page is also the one most likely to be truncated by the query cap.

I deliberately left that out of this PR to keep the change minimal, since it is a separate design decision. Happy to fold in either option if you have a preference:

- scale the query limit with the page size so the item budget stays roughly constant, or
- keep the flat cap and log a warning when it is hit.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussion: https://github.com/renovatebot/renovate/discussions/45248 (maintainer reply: "PR welcome")

Related: #16343, which introduced the shrink mechanism in 2022 with 25 as the floor.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5, via Claude Code, wrote the code change, the test suite, and this description. Every test was verified to fail on `main` and pass with the change (see below), and the diff was reviewed by @NickAnge before pushing.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @NickAnge will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The `Page shrinking` suite now covers every rung of the ladder instead of just the first two. It is table-driven over `attempts → resulting page size`, plus two behavioural cases:

- `shrinks page size when a later page fails` — new. Page 1 succeeds at 100, page 2 fails, and the retry reuses the same cursor at 50, so shrinking works mid-pagination too.
- `re-throws if shrinking did not help` — now derives the attempt count from the ladder instead of hard-coding three.

The three new/changed cases fail on `main` and pass with the fix:

```
# datasource-fetcher.ts reverted to main
× shrinks page size to 10 after 3 failed attempt(s)
× shrinks page size to 5 after 4 failed attempt(s)
× re-throws if shrinking did not help
Tests  3 failed | 77 passed (80)

# with the fix
Tests  80 passed (80)
```

`pnpm check --all lib/util/github/graphql` and `pnpm type-check` are clean.

These tests mock the HTTP layer, so they cover the retry logic rather than the premise that `first: 5` fits inside the 10s limit. The repository where we hit this is private, so I could not reproduce the timeout publicly. Happy to find a large enough public repo if you want that confirmed before merging.
