### PR TITLE
ci: check for `Closes #<discussion>`

### DIFF
--- a/.github/workflows/check-commit-messages.yml
+++ b/.github/workflows/check-commit-messages.yml
@@ -9,6 +9,8 @@ on:
 
 permissions:
   contents: read
+  discussions: read
+  issues: read
   statuses: write
 
 concurrency:
@@ -19,44 +21,18 @@ jobs:
   closes-issue-or-discussion:
     runs-on: ubuntu-slim
     steps:
-      - name: Check for 'Closes \#' in commit messages
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          show-progress: false
+
+      - name: Check for closing keywords that would close a Discussion
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            // Co-authored-by: Claude Sonnet 4.5 (GitHub Copilot)
-
-            // Get all commits in this PR using the GitHub API
-            const { data: commits } = await github.rest.pulls.listCommits({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number,
-            });
-
-            // Check each commit message for closing keywords
-            const violatingCommits = [];
-            // Matches: closes #123, fixes #123, closes: #123, etc.
-            const closingPattern = /(closes|fixes|resolves|fixed|closed|resolved):?\s+#\d+/i;
-
-            for (const commit of commits) {
-              const message = commit.commit.message;
-              if (closingPattern.test(message)) {
-                const shortSha = commit.sha.substring(0, 7);
-                const firstLine = message.split('\n')[0];
-                violatingCommits.push({ sha: shortSha, message: firstLine });
-              }
-            }
-
-            // Report results
-            if (violatingCommits.length > 0) {
-              let errorMessage = `Found ${violatingCommits.length} commit(s) with issue closing keywords:\n\n`;
-              for (const commit of violatingCommits) {
-                errorMessage += `- ${commit.sha}: ${commit.message}\n`;
-              }
-              errorMessage += `\nCommit messages should not contain closing keywords (closes, fixes, resolves, etc.). Use the PR description instead.`;
-              core.setFailed(errorMessage);
-            } else {
-              core.info('✓ No commits with issue closing keywords found');
-            }
+            const script = require('./tools/check-closes-discussion.cjs')
+            await script({ github, context, core })
 
   # Runs a full `semantic-release` dry-run for the state that would exist right
   # after this PR merges, and fails if it would publish a new *major* version.

--- a/.github/workflows/close-answered-discussions.yml
+++ b/.github/workflows/close-answered-discussions.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const script = require('.github/workflows/close-answered-discussions/script.cjs')
+            const script = require('./tools/close-answered-discussions.cjs')
             console.log(await script({github, context, discussionAnsweredDays: 30}))

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -398,7 +398,6 @@
     "**/.venv/",
     "tools/mkdocs/docs",
     "tools/mkdocs/site",
-    ".github/workflows/**/*.js",
     ".worktrees/**/*",
     ".markdownlint-cli2.mjs",
     "tools/mkdocs/.cache",

--- a/tools/check-closes-discussion.cjs
+++ b/tools/check-closes-discussion.cjs
@@ -1,0 +1,97 @@
+// Co-authored-by: Claude Sonnet 4.5 (GitHub Copilot)
+
+/**
+ * @param {{ github: any, context: any, core: any }} params
+ */
+module.exports = async ({ github, context, core }) => {
+  // Get all commits in this PR using the GitHub API
+  const { data: commits } = await github.rest.pulls.listCommits({
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    pull_number: context.payload.pull_request.number,
+  });
+
+  // GitHub honours closing keywords in both commit messages and the
+  // PR description. `#123` may refer to a Discussion rather than an
+  // Issue - since Issues and Discussions are numbered independently
+  // - and closing keywords must not auto-close a Discussion (see
+  // #45439, which unintentionally closed discussion #40885).
+  // Matches: closes #123, fixes #123, closes: #123, etc.
+  const closingPattern =
+    /(closes|fixes|resolves|fixed|closed|resolved):?\s+#(\d+)/gi;
+
+  // Collect every closing-keyword reference, keeping one example
+  // line per source for the error report.
+  const references = new Map(); // number -> { source, line }
+  /**
+   * @param {string} text
+   * @param {string} source
+   */
+  function collect(text, source) {
+    for (const match of text.matchAll(closingPattern)) {
+      const number = match[2];
+      if (!references.has(number)) {
+        const line = text.slice(0, match.index).split('\n').length;
+        const lineText = text.split('\n')[line - 1].trim();
+        references.set(number, { source, line: lineText });
+      }
+    }
+  }
+
+  for (const commit of commits) {
+    const shortSha = commit.sha.substring(0, 7);
+    collect(commit.commit.message, `commit ${shortSha}`);
+  }
+  collect(context.payload.pull_request.body ?? '', 'PR description');
+
+  // Only fail for references that resolve to a Discussion - an
+  // Issue reference is the intended, supported use of these
+  // keywords (see the PR template).
+  const violations = [];
+  for (const [number, { source, line }] of references) {
+    let isIssue = true;
+    try {
+      await github.rest.issues.get({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: parseInt(number, 10),
+      });
+    } catch (err) {
+      if (err.status !== 404) {
+        throw err;
+      }
+      isIssue = false;
+    }
+    if (isIssue) {
+      continue;
+    }
+
+    const { repository } = await github.graphql(
+      `query($owner: String!, $repo: String!, $number: Int!) {
+        repository(owner: $owner, name: $repo) {
+          discussion(number: $number) { id }
+        }
+      }`,
+      {
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        number: parseInt(number, 10),
+      },
+    );
+    if (repository.discussion) {
+      violations.push({ source, line });
+    }
+  }
+
+  // Report results
+  if (violations.length > 0) {
+    let errorMessage = `Found ${violations.length} closing keyword(s) referencing a Discussion:\n\n`;
+    for (const violation of violations) {
+      errorMessage += `- ${violation.source}: ${violation.line}\n`;
+    }
+    errorMessage += `\nClosing keywords (closes, fixes, resolves, etc.) must not reference a Discussion, as merging would auto-close it. Reference the discussion without a closing keyword instead, e.g. 'Related discussion: #123'.`;
+    core.setFailed(errorMessage);
+  } else {
+    core.info('✓ No closing keywords referencing a Discussion found');
+  }
+};

--- a/tools/close-answered-discussions.cjs
+++ b/tools/close-answered-discussions.cjs
@@ -1,5 +1,9 @@
 // Parses the ISO date string and checks it's past the age window
 // Co-authored-by: GPT-4.1 (GitHub Copilot)
+/**
+ * @param {string} dateString
+ * @param {number} daysAgo
+ */
 function isOlderThanDaysAgo(dateString, daysAgo) {
   const parsedDate = new Date(dateString);
   const now = new Date();
@@ -7,6 +11,9 @@ function isOlderThanDaysAgo(dateString, daysAgo) {
   return parsedDate < thresholdDate;
 }
 
+/**
+ * @param {{ github: any, context: any, discussionAnsweredDays: number }} params
+ */
 module.exports = async ({ github, context, discussionAnsweredDays }) => {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
@@ -34,6 +41,7 @@ module.exports = async ({ github, context, discussionAnsweredDays }) => {
   while (true) {
     // oxlint-disable-next-line no-console
     console.debug({ cursor }, 'Starting query');
+    /** @type {{ repository: any }} */
     const { repository } = await github.graphql(query, { cursor });
 
     // oxlint-disable-next-line no-console


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes


Due to a long-standing issue with `semantic-release` not checking if
`#...` reference is for a Discussion or Issue, if a contributor says
`Closes #<discussion>`, then our release process fails.

We can extend our existing checks to try and catch this in the PR
itself, as users may not read the big warning that says "don't add a
Discussion here".

Follow-up to https://github.com/renovatebot/renovate/pull/45439

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
