### PR TITLE
feat(presets): add @oxlint/* packages to packages:linters and monorepo:oxlint

### DIFF
--- a/lib/config/presets/__snapshots__/index.spec.ts.snap
+++ b/lib/config/presets/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,7 @@ exports[`config/presets/index > getPreset > gets linters 1`] = `
     "packages:tslint",
   ],
   "matchPackageNames": [
+    "@oxlint/**",
     "oxlint",
     "prettier",
     "remark-lint",
@@ -186,6 +187,7 @@ exports[`config/presets/index > resolveConfigPresets > resolves linters 1`] = `
     "stylelint**",
     "codelyzer",
     "/\\btslint\\b/",
+    "@oxlint/**",
     "oxlint",
     "prettier",
     "remark-lint",
@@ -224,6 +226,7 @@ exports[`config/presets/index > resolveConfigPresets > resolves nested groups 1`
         "stylelint**",
         "codelyzer",
         "/\\btslint\\b/",
+        "@oxlint/**",
         "oxlint",
         "prettier",
         "remark-lint",

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -360,7 +360,7 @@ describe('config/presets/index', () => {
       const { config: res } = await presets.resolveConfigPresets(config);
       expect(res).toMatchSnapshot();
       // @ts-expect-error -- partial config
-      expect(res.matchPackageNames).toHaveLength(22);
+      expect(res.matchPackageNames).toHaveLength(23);
     });
 
     it('resolves nested groups', async () => {
@@ -369,7 +369,7 @@ describe('config/presets/index', () => {
       expect(res).toMatchSnapshot();
       const rule = res.packageRules![0];
       expect(rule.automerge).toBeTrue();
-      expect(rule.matchPackageNames).toHaveLength(22);
+      expect(rule.matchPackageNames).toHaveLength(23);
     });
 
     it('migrates automerge in presets', async () => {
@@ -1493,7 +1493,7 @@ describe('config/presets/index', () => {
       const res = await presets.getPreset('packages:linters', {});
       expect(res).toMatchSnapshot();
       // @ts-expect-error -- partial config
-      expect(res.matchPackageNames).toHaveLength(4);
+      expect(res.matchPackageNames).toHaveLength(5);
       expect(res.extends).toHaveLength(5);
     });
 

--- a/lib/config/presets/internal/packages.preset.ts
+++ b/lib/config/presets/internal/packages.preset.ts
@@ -104,7 +104,13 @@ export const presets: Record<string, Preset> = {
       'packages:stylelint',
       'packages:tslint',
     ],
-    matchPackageNames: ['oxlint', 'prettier', 'remark-lint', 'standard'],
+    matchPackageNames: [
+      '@oxlint/**',
+      'oxlint',
+      'prettier',
+      'remark-lint',
+      'standard',
+    ],
   },
   mapbox: {
     description: 'All Mapbox-related packages.',

--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -27,7 +27,7 @@
       "/^com.oracle.database.jdbc:/",
       "/^com.oracle.database.nls:/"
     ],
-    "oxlint": ["oxlint", "eslint-plugin-oxlint"],
+    "oxlint": ["oxlint", "@oxlint/plugins", "eslint-plugin-oxlint"],
     "prometheus-simpleclient": "/^io.prometheus:simpleclient/",
     "russh": ["/^russh$/", "/^russh-keys$/"],
     "solid": [


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Groups oxlint plugin packages together with oxlint itself.

## Context

These two need to be updated together: 
https://github.com/renovatebot/renovate/pull/45456
https://github.com/renovatebot/renovate/pull/44542

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor  will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
