### PR TITLE
fix(lint): use `parseInt` over `Number`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -78,6 +78,7 @@
     "unicorn/no-lonely-if": "error",
 
     "renovate/enforce-ts-extension": "error",
+    "renovate/no-number-constructor": "error",
     "renovate/prefer-json-pipe": "error",
     "renovate/prefer-nullish-util": "error",
     "renovate/require-regex-util": "error",

--- a/lib/modules/datasource/azure-pipelines-tasks/index.spec.ts
+++ b/lib/modules/datasource/azure-pipelines-tasks/index.spec.ts
@@ -233,9 +233,9 @@ describe('modules/datasource/azure-pipelines-tasks/index', () => {
         const version =
           splitted.length === 3
             ? {
-                major: Number(splitted[0]),
-                minor: Number(splitted[1]),
-                patch: Number(splitted[2]),
+                major: parseInt(splitted[0], 10),
+                minor: parseInt(splitted[1], 10),
+                patch: parseInt(splitted[2], 10),
               }
             : null;
 

--- a/lib/modules/manager/bundler/extract.ts
+++ b/lib/modules/manager/bundler/extract.ts
@@ -78,7 +78,7 @@ export async function extractPackageFile(
               depTypes,
               managerData: {
                 lineNumber:
-                  Number(dep.managerData?.lineNumber) + groupLineNumber + 1,
+                  (dep.managerData?.lineNumber ?? NaN) + groupLineNumber + 1,
               },
             };
             if (repositoryUrl) {
@@ -238,7 +238,7 @@ export async function extractPackageFile(
               registryUrls: [repositoryUrl],
               managerData: {
                 lineNumber:
-                  Number(dep.managerData?.lineNumber) + sourceLineNumber + 1,
+                  (dep.managerData?.lineNumber ?? NaN) + sourceLineNumber + 1,
               },
             })),
           );
@@ -272,7 +272,7 @@ export async function extractPackageFile(
             ...dep,
             managerData: {
               lineNumber:
-                Number(dep.managerData?.lineNumber) + platformsLineNumber + 1,
+                (dep.managerData?.lineNumber ?? NaN) + platformsLineNumber + 1,
             },
           })),
         );
@@ -305,7 +305,7 @@ export async function extractPackageFile(
             ...dep,
             managerData: {
               lineNumber:
-                Number(dep.managerData?.lineNumber) + ifLineNumber + 1,
+                (dep.managerData?.lineNumber ?? NaN) + ifLineNumber + 1,
             },
           })),
         );

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -385,6 +385,7 @@ export function extractPackageFile(
           { image: copyFromMatch.groups.image },
           'Skipping alias COPY --from',
         );
+        // oxlint-disable-next-line renovate/no-number-constructor -- must reject strings that aren't entirely numeric (e.g. `0abc`), which parseInt() would silently accept as a stage index
       } else if (Number.isNaN(Number(copyFromMatch.groups.image))) {
         const dep = getDep(
           copyFromMatch.groups.image,

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -1,4 +1,8 @@
-import { isNonEmptyStringAndNotWhitespace, isString } from '@sindresorhus/is';
+import {
+  isNonEmptyStringAndNotWhitespace,
+  isNumericString,
+  isString,
+} from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
@@ -385,8 +389,12 @@ export function extractPackageFile(
           { image: copyFromMatch.groups.image },
           'Skipping alias COPY --from',
         );
-        // oxlint-disable-next-line renovate/no-number-constructor -- must reject strings that aren't entirely numeric (e.g. `0abc`), which parseInt() would silently accept as a stage index
-      } else if (Number.isNaN(Number(copyFromMatch.groups.image))) {
+      } else if (isNumericString(copyFromMatch.groups.image)) {
+        logger.debug(
+          { image: copyFromMatch.groups.image },
+          'Skipping index reference COPY --from',
+        );
+      } else {
         const dep = getDep(
           copyFromMatch.groups.image,
           true,
@@ -405,11 +413,6 @@ export function extractPackageFile(
           'Dockerfile COPY --from',
         );
         deps.push(dep);
-      } else {
-        logger.debug(
-          { image: copyFromMatch.groups.image },
-          'Skipping index reference COPY --from',
-        );
       }
     }
 

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -154,7 +154,7 @@ export class GerritScm extends DefaultGitScm {
  */
 export function nextPatchSetRef(currentRef: string): string {
   const lastSlash = currentRef.lastIndexOf('/');
-  const patchSet = Number(currentRef.slice(lastSlash + 1));
+  const patchSet = parseInt(currentRef.slice(lastSlash + 1), 10);
   return `${currentRef.slice(0, lastSlash + 1)}${patchSet + 1}`;
 }
 

--- a/lib/modules/versioning/conan/range.ts
+++ b/lib/modules/versioning/conan/range.ts
@@ -21,7 +21,7 @@ export function getMajor(version: string): null | number {
   options.includePrerelease = true;
   const cleanerVersion = makeVersion(cleanedVersion, options);
   if (isString(cleanerVersion)) {
-    return Number(cleanerVersion.split('.')[0]);
+    return parseInt(cleanerVersion.split('.')[0], 10);
   }
   return null;
 }
@@ -33,7 +33,7 @@ export function getMinor(version: string): null | number {
   options.includePrerelease = true;
   const cleanerVersion = makeVersion(cleanedVersion, options);
   if (isString(cleanerVersion)) {
-    return Number(cleanerVersion.split('.')[1]);
+    return parseInt(cleanerVersion.split('.')[1], 10);
   }
   return null;
 }
@@ -52,7 +52,8 @@ export function getPatch(version: string): null | number {
       }),
       options,
     );
-    return Number(newVersion?.split('.')[2]);
+    /* v8 ignore next -- newVersion always has a patch segment once cleanerVersion is a valid, coercible semver string */
+    return parseInt(newVersion?.split('.')[2] ?? '', 10);
   }
   return null;
 }

--- a/lib/modules/versioning/conan/range.ts
+++ b/lib/modules/versioning/conan/range.ts
@@ -53,7 +53,7 @@ export function getPatch(version: string): null | number {
       options,
     );
     /* v8 ignore next -- newVersion always has a patch segment once cleanerVersion is a valid, coercible semver string */
-    return parseInt(newVersion?.split('.')[2] ?? '', 10);
+    return parseInt(coerceString(newVersion).split('.')[2] ?? '', 10);
   }
   return null;
 }

--- a/lib/modules/versioning/pvp/index.ts
+++ b/lib/modules/versioning/pvp/index.ts
@@ -33,8 +33,7 @@ function getMajor(version: string): number | null {
   if (parts === null) {
     return null;
   }
-  // oxlint-disable-next-line renovate/no-number-constructor -- must preserve decimal precision (e.g. `1.10` vs `1.1`), which parseInt() would truncate
-  return Number(parts.major.join('.'));
+  return parseFloat(parts.major.join('.'));
 }
 
 function getMinor(version: string): number | null {

--- a/lib/modules/versioning/pvp/index.ts
+++ b/lib/modules/versioning/pvp/index.ts
@@ -33,6 +33,7 @@ function getMajor(version: string): number | null {
   if (parts === null) {
     return null;
   }
+  // oxlint-disable-next-line renovate/no-number-constructor -- must preserve decimal precision (e.g. `1.10` vs `1.1`), which parseInt() would truncate
   return Number(parts.major.join('.'));
 }
 
@@ -41,6 +42,7 @@ function getMinor(version: string): number | null {
   if (parts === null || parts.minor.length === 0) {
     return null;
   }
+  // oxlint-disable-next-line renovate/no-number-constructor -- must preserve decimal precision (e.g. `1.10` vs `1.1`), which parseInt() would truncate
   return Number(parts.minor.join('.'));
 }
 
@@ -49,6 +51,7 @@ function getPatch(version: string): number | null {
   if (parts === null || parts.patch.length === 0) {
     return null;
   }
+  // oxlint-disable-next-line renovate/no-number-constructor -- must preserve decimal precision (e.g. `1.10` vs `1.1`), which parseInt() would truncate
   return Number(`${parts.patch[0]}.${parts.patch.slice(1).join('')}`);
 }
 

--- a/lib/modules/versioning/pvp/index.ts
+++ b/lib/modules/versioning/pvp/index.ts
@@ -41,8 +41,7 @@ function getMinor(version: string): number | null {
   if (parts === null || parts.minor.length === 0) {
     return null;
   }
-  // oxlint-disable-next-line renovate/no-number-constructor -- must preserve decimal precision (e.g. `1.10` vs `1.1`), which parseInt() would truncate
-  return Number(parts.minor.join('.'));
+  return parseFloat(parts.minor.join('.'));
 }
 
 function getPatch(version: string): number | null {
@@ -50,8 +49,7 @@ function getPatch(version: string): number | null {
   if (parts === null || parts.patch.length === 0) {
     return null;
   }
-  // oxlint-disable-next-line renovate/no-number-constructor -- must preserve decimal precision (e.g. `1.10` vs `1.1`), which parseInt() would truncate
-  return Number(`${parts.patch[0]}.${parts.patch.slice(1).join('')}`);
+  return parseFloat(`${parts.patch[0]}.${parts.patch.slice(1).join('')}`);
 }
 
 function matches(version: string, range: string): boolean {

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -39,9 +39,9 @@ export class EditorConfig {
   }
 
   private static getIndentationSize(knownProps: Props): number | undefined {
-    const indentSize = Number(knownProps.indent_size);
+    const { indent_size: indentSize } = knownProps;
 
-    if (!Number.isNaN(indentSize) && Number.isInteger(indentSize)) {
+    if (typeof indentSize === 'number' && Number.isInteger(indentSize)) {
       return indentSize;
     }
 

--- a/lib/util/json-writer/editor-config.ts
+++ b/lib/util/json-writer/editor-config.ts
@@ -1,3 +1,4 @@
+import { isNumber } from '@sindresorhus/is';
 import type { Props } from 'editorconfig';
 import { parse } from 'editorconfig';
 import upath from 'upath';
@@ -41,7 +42,7 @@ export class EditorConfig {
   private static getIndentationSize(knownProps: Props): number | undefined {
     const { indent_size: indentSize } = knownProps;
 
-    if (typeof indentSize === 'number' && Number.isInteger(indentSize)) {
+    if (isNumber(indentSize) && Number.isInteger(indentSize)) {
       return indentSize;
     }
 

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -6,6 +6,7 @@ import noExecShellOption from './rules/no-exec-shell-option.ts';
 import noHardcodedDocsUrl from './rules/no-hardcoded-docs-url.ts';
 import noHostRulesMock from './rules/no-host-rules-mock.ts';
 import noNewUrl from './rules/no-new-url.ts';
+import noNumberConstructor from './rules/no-number-constructor.ts';
 import noRedundantMockReset from './rules/no-redundant-mock-reset.ts';
 import noStatefulGlobalRegex from './rules/no-stateful-global-regex.ts';
 import noToolsImport from './rules/no-tools-import.ts';
@@ -39,6 +40,7 @@ export default definePlugin({
     'no-hardcoded-docs-url': noHardcodedDocsUrl,
     'no-host-rules-mock': noHostRulesMock,
     'no-new-url': noNewUrl,
+    'no-number-constructor': noNumberConstructor,
     'no-redundant-mock-reset': noRedundantMockReset,
     'no-stateful-global-regex': noStatefulGlobalRegex,
     'no-tools-import': noToolsImport,

--- a/tools/lint/rules/no-number-constructor.spec.ts
+++ b/tools/lint/rules/no-number-constructor.spec.ts
@@ -1,0 +1,34 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './no-number-constructor.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+});
+
+ruleTester.run('no-number-constructor', rule, {
+  valid: [
+    `parseInt('42', 10);`,
+    // other globals with a similar name are unaffected
+    `NumberFormat('42');`,
+    // member expression callee, e.g. Number.isNaN, Number.parseInt
+    `Number.isNaN(value);`,
+    `Number.parseInt('42', 10);`,
+  ],
+  invalid: [
+    {
+      code: `Number('42');`,
+      errors: [{ messageId: 'noNumberConstructor' }],
+    },
+    {
+      code: `const x = Number(someString);`,
+      errors: [{ messageId: 'noNumberConstructor' }],
+    },
+    {
+      code: `new Number('42');`,
+      errors: [{ messageId: 'noNumberConstructor' }],
+    },
+  ],
+});

--- a/tools/lint/rules/no-number-constructor.ts
+++ b/tools/lint/rules/no-number-constructor.ts
@@ -1,0 +1,31 @@
+import { defineRule } from '@oxlint/plugins';
+
+export default defineRule({
+  meta: {
+    type: 'problem',
+    messages: {
+      noNumberConstructor:
+        "Use parseInt(x, 10) instead of the 'Number' constructor.",
+    },
+  },
+  createOnce(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'Number'
+        ) {
+          context.report({ node, messageId: 'noNumberConstructor' });
+        }
+      },
+      NewExpression(node) {
+        if (
+          node.callee.type === 'Identifier' &&
+          node.callee.name === 'Number'
+        ) {
+          context.report({ node, messageId: 'noNumberConstructor' });
+        }
+      },
+    };
+  },
+});

--- a/tools/prettier/plugins/mkdocs-admonitions/index.mjs
+++ b/tools/prettier/plugins/mkdocs-admonitions/index.mjs
@@ -153,7 +153,7 @@ function unmaskAdmonitions(ast, placeholders) {
     if (node.type === 'html') {
       const match = PLACEHOLDER_RE.exec(node.value);
       if (match?.groups) {
-        node.value = placeholders[Number(match.groups.index)];
+        node.value = placeholders[parseInt(match.groups.index, 10)];
       }
       return;
     }


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

As a code review comment that comes up every so often, we can add a
linting rule to enforce this check.

This also fixes any existing usages.

As this could be breaking, we can release it as a `fix`.

Re-raised https://github.com/renovatebot/renovate/pull/45453 because the Stacked PRs + Merge Queue doesn't seem to like merging the last PR

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->


