### PR TITLE
fix(lint): extend `prefer-is-helpers` to catch more cases

### DIFF
--- a/lib/modules/datasource/crate/index.spec.ts
+++ b/lib/modules/datasource/crate/index.spec.ts
@@ -1,4 +1,5 @@
 import { setTimeout } from 'node:timers/promises';
+import { isUndefined } from '@sindresorhus/is';
 import fs from 'fs-extra';
 import type { SimpleGit } from 'simple-git';
 import type { DirectoryResult } from 'tmp-promise';
@@ -507,7 +508,7 @@ describe('modules/datasource/crate/index', () => {
         .mockName('clone')
         .mockImplementation(
           async (_registryUrl: string, clonePath: string, opts) => {
-            if (typeof opts !== 'undefined' && Object.hasOwn(opts, '--depth')) {
+            if (!isUndefined(opts) && Object.hasOwn(opts, '--depth')) {
               throw new Error(
                 'fatal: dumb http transport does not support shallow capabilities',
               );
@@ -553,7 +554,7 @@ describe('modules/datasource/crate/index', () => {
         .fn()
         .mockName('clone')
         .mockImplementation((_registryUrl: string, clonePath: string, opts) => {
-          if (typeof opts !== 'undefined' && Object.hasOwn(opts, '--depth')) {
+          if (!isUndefined(opts) && Object.hasOwn(opts, '--depth')) {
             return Promise.reject(
               new Error(
                 'fatal: dumb http transport does not support shallow capabilities',

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString, isString } from '@sindresorhus/is';
+import { isNonEmptyString, isString, isUndefined } from '@sindresorhus/is';
 import {
   HOST_DISABLED,
   PAGE_NOT_FOUND_ERROR,
@@ -118,9 +118,9 @@ export async function getAuthHeaders(
       }
     } else if (
       googleRegex.test(registryHost) &&
-      typeof rule.username === 'undefined' &&
-      typeof rule.password === 'undefined' &&
-      typeof rule.token === 'undefined'
+      isUndefined(rule.username) &&
+      isUndefined(rule.password) &&
+      isUndefined(rule.token)
     ) {
       logger.once.debug(`hostRules: google auth for ${registryHost}`);
       logger.trace(

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@sindresorhus/is';
 import fs from 'fs-extra';
 import { logger } from '~test/util.ts';
 import { GlobalConfig } from '../../config/global.ts';
@@ -50,7 +51,7 @@ class DummyDatasource extends Datasource {
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const fn = this.registriesMock[registryUrl!];
-    if (typeof fn === 'function') {
+    if (isFunction(fn)) {
       return Promise.resolve(fn());
     }
     return Promise.resolve(fn ?? null);
@@ -72,7 +73,7 @@ class DummyDatasource2 extends Datasource {
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const fn = this.registriesMock[registryUrl!];
-    if (typeof fn === 'function') {
+    if (isFunction(fn)) {
       return Promise.resolve(fn());
     }
     return Promise.resolve(fn ?? null);
@@ -95,7 +96,7 @@ class DummyDatasource3 extends Datasource {
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const fn = this.registriesMock[registryUrl!];
-    if (typeof fn === 'function') {
+    if (isFunction(fn)) {
       return Promise.resolve(fn());
     }
     return Promise.resolve(fn ?? null);
@@ -119,7 +120,7 @@ class DummyDatasource5 extends Datasource {
     registryUrl,
   }: GetReleasesConfig): Promise<ReleaseResult | null> {
     const fn = this.registriesMock[registryUrl!];
-    if (typeof fn === 'function') {
+    if (isFunction(fn)) {
       return Promise.resolve(fn());
     }
     return Promise.resolve(fn ?? null);

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -1,4 +1,4 @@
-import { isTruthy } from '@sindresorhus/is';
+import { isFunction, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { isSkipComment } from '../../../util/ignore.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -24,10 +24,9 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     const toolConfig = upgradeableTooling[depName];
     let toolDefinition: StaticTooling | undefined;
     if (toolConfig) {
-      toolDefinition =
-        typeof toolConfig.config === 'function'
-          ? toolConfig.config(version)
-          : toolConfig.config;
+      toolDefinition = isFunction(toolConfig.config)
+        ? toolConfig.config(version)
+        : toolConfig.config;
     }
 
     if (toolDefinition) {

--- a/lib/modules/versioning/common.ts
+++ b/lib/modules/versioning/common.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '@sindresorhus/is';
 import { regEx } from '../../util/regex.ts';
 import type { VersioningApi, VersioningApiConstructor } from './types.ts';
 
@@ -6,7 +7,7 @@ export const markdownLinkRegex = regEx(/\[[^\]]+\]\([^)]+\)/);
 export function isVersioningApiConstructor(
   obj: VersioningApi | VersioningApiConstructor,
 ): obj is VersioningApiConstructor {
-  return typeof obj === 'function';
+  return isFunction(obj);
 }
 
 export function getExcludedVersions(range: string): string[] {

--- a/lib/modules/versioning/hermit/index.ts
+++ b/lib/modules/versioning/hermit/index.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@sindresorhus/is';
 import { satisfies } from 'semver';
 import type { RegExpVersion } from '../regex/index.ts';
 import { RegExpVersioningApi } from '../regex/index.ts';
@@ -41,9 +42,9 @@ export class HermitVersioning extends RegExpVersioningApi {
     } = groups;
     const release = [
       Number.parseInt(major, 10),
-      typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
-      typeof patch === 'undefined' ? 0 : Number.parseInt(patch, 10),
-      typeof supplement === 'undefined' ? 0 : Number.parseInt(supplement, 10),
+      isUndefined(minor) ? 0 : Number.parseInt(minor, 10),
+      isUndefined(patch) ? 0 : Number.parseInt(patch, 10),
+      isUndefined(supplement) ? 0 : Number.parseInt(supplement, 10),
     ];
 
     if (build) {

--- a/lib/modules/versioning/redhat/index.ts
+++ b/lib/modules/versioning/redhat/index.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
 import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
@@ -22,14 +23,10 @@ class RedhatVersioningApi extends GenericVersioningApi {
     const { major, minor, patch, releaseMajor, releaseMinor } = matches;
     const release = [
       Number.parseInt(major, 10),
-      typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
-      typeof patch === 'undefined' ? 0 : Number.parseInt(patch, 10),
-      typeof releaseMajor === 'undefined'
-        ? 0
-        : Number.parseInt(releaseMajor, 10),
-      typeof releaseMinor === 'undefined'
-        ? 0
-        : Number.parseInt(releaseMinor, 10),
+      isUndefined(minor) ? 0 : Number.parseInt(minor, 10),
+      isUndefined(patch) ? 0 : Number.parseInt(patch, 10),
+      isUndefined(releaseMajor) ? 0 : Number.parseInt(releaseMajor, 10),
+      isUndefined(releaseMinor) ? 0 : Number.parseInt(releaseMinor, 10),
     ];
 
     return { release, prerelease: '' };

--- a/lib/modules/versioning/regex/index.ts
+++ b/lib/modules/versioning/regex/index.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@sindresorhus/is';
 import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { GenericVersion } from '../generic.ts';
@@ -64,9 +65,9 @@ export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
     const { major, minor, patch, build, revision, prerelease, compatibility } =
       groups;
     const release = [
-      typeof major === 'undefined' ? 0 : Number.parseInt(major, 10),
-      typeof minor === 'undefined' ? 0 : Number.parseInt(minor, 10),
-      typeof patch === 'undefined' ? 0 : Number.parseInt(patch, 10),
+      isUndefined(major) ? 0 : Number.parseInt(major, 10),
+      isUndefined(minor) ? 0 : Number.parseInt(minor, 10),
+      isUndefined(patch) ? 0 : Number.parseInt(patch, 10),
     ];
 
     if (build) {

--- a/lib/proxy.ts
+++ b/lib/proxy.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '@sindresorhus/is';
+import { isNonEmptyString, isUndefined } from '@sindresorhus/is';
 import { createGlobalProxyAgent } from 'global-agent';
 import { logger } from './logger/index.ts';
 import { addSecretForSanitizing } from './util/sanitize.ts';
@@ -20,8 +20,8 @@ export function bootstrap(): void {
   envVars.forEach((envVar) => {
     /* v8 ignore next -- env is case-insensitive on windows */
     if (
-      typeof process.env[envVar] === 'undefined' &&
-      typeof process.env[envVar.toLowerCase()] !== 'undefined'
+      isUndefined(process.env[envVar]) &&
+      !isUndefined(process.env[envVar.toLowerCase()])
     ) {
       process.env[envVar] = process.env[envVar.toLowerCase()];
     }

--- a/lib/util/exec/env.ts
+++ b/lib/util/exec/env.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@sindresorhus/is';
 import { GlobalConfig } from '../../config/global.ts';
 import { regEx } from '../regex.ts';
 
@@ -61,7 +62,7 @@ export function getChildProcessEnv(
   }
   const envVars = [...basicEnvVars, ...customEnvVars];
   envVars.forEach((envVar) => {
-    if (typeof process.env[envVar] !== 'undefined') {
+    if (!isUndefined(process.env[envVar])) {
       env[envVar] = process.env[envVar];
     }
   });

--- a/lib/util/fingerprint.ts
+++ b/lib/util/fingerprint.ts
@@ -1,4 +1,5 @@
 import { type Hash, createHash } from 'node:crypto';
+import { isFunction, isSymbol } from '@sindresorhus/is';
 
 // Returns true when `value` would appear in the canonical JSON produced by
 // `safe-stable-stringify`. We pre-check before emitting because objects must
@@ -8,11 +9,7 @@ import { type Hash, createHash } from 'node:crypto';
 // `cache` memoizes the result per object reference so callers that invoke
 // isEmittable just before recursing don't re-walk the toJSON chain twice.
 function isEmittable(value: unknown, cache: WeakMap<object, boolean>): boolean {
-  if (
-    value === undefined ||
-    typeof value === 'function' ||
-    typeof value === 'symbol'
-  ) {
+  if (value === undefined || isFunction(value) || isSymbol(value)) {
     return false;
   }
   // oxlint-disable-next-line renovate/prefer-is-object -- byte-exact JSON canonicalization: functions are handled explicitly above and must not take the object path
@@ -24,8 +21,9 @@ function isEmittable(value: unknown, cache: WeakMap<object, boolean>): boolean {
     return cached;
   }
   const obj = value as { toJSON?: () => unknown };
-  const result =
-    typeof obj.toJSON === 'function' ? isEmittable(obj.toJSON(), cache) : true;
+  const result = isFunction(obj.toJSON)
+    ? isEmittable(obj.toJSON(), cache)
+    : true;
   cache.set(value, result);
   return result;
 }
@@ -48,7 +46,7 @@ function fingerprintInto(
   }
 
   const obj = value as { toJSON?: () => unknown };
-  if (typeof obj.toJSON === 'function') {
+  if (isFunction(obj.toJSON)) {
     fingerprintInto(h, obj.toJSON(), seen, emittableCache);
     return;
   }

--- a/lib/util/html.ts
+++ b/lib/util/html.ts
@@ -1,10 +1,11 @@
+import { isUndefined } from '@sindresorhus/is';
 import type { HTMLElement, Options } from 'node-html-parser';
 import { parse as _parse } from 'node-html-parser';
 
 export type { HTMLElement, Options };
 
 export function parse(html: string, config?: Partial<Options>): HTMLElement {
-  if (typeof config !== 'undefined') {
+  if (!isUndefined(config)) {
     return _parse(html, config);
   }
 

--- a/lib/util/result.ts
+++ b/lib/util/result.ts
@@ -1,3 +1,4 @@
+import { isBoolean, isUndefined } from '@sindresorhus/is';
 import type { ZodError, output as ZodOutput, ZodType } from 'zod/v4';
 import { NEVER } from 'zod/v4';
 import { logger } from '../logger/index.ts';
@@ -37,17 +38,13 @@ function isZodResult<Output extends Val>(
     input === null ||
     Object.keys(input).length !== 2 ||
     !('success' in input) ||
-    typeof input.success !== 'boolean'
+    !isBoolean(input.success)
   ) {
     return false;
   }
 
   if (input.success) {
-    return (
-      'data' in input &&
-      typeof input.data !== 'undefined' &&
-      input.data !== null
-    );
+    return 'data' in input && !isUndefined(input.data) && input.data !== null;
   }
   return 'error' in input;
 }

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -1,4 +1,9 @@
-import { isArray, isNonEmptyArray, isNumber } from '@sindresorhus/is';
+import {
+  isArray,
+  isNonEmptyArray,
+  isNumber,
+  isUndefined,
+} from '@sindresorhus/is';
 import { GlobalConfig } from '../../../../config/global.ts';
 import type { RenovateConfig } from '../../../../config/types.ts';
 import {
@@ -306,7 +311,7 @@ export async function ensurePr(
     const logJSON = upgrade.logJSON;
 
     if (logJSON) {
-      if (typeof logJSON.error === 'undefined') {
+      if (isUndefined(logJSON.error)) {
         if (logJSON.project) {
           upgrade.repoName = logJSON.project.repository;
         }

--- a/tools/lint/rules/prefer-is-helpers.spec.ts
+++ b/tools/lint/rules/prefer-is-helpers.spec.ts
@@ -20,7 +20,10 @@ ruleTester.run('prefer-is-helpers', rule, {
 
     // --- typeof string ---
     `is.string(x);`,
+    // `isNumber()` also excludes `NaN`, so this isn't a safe rewrite
     `typeof x === 'number';`,
+    // `isObject()` excludes `null` and includes functions, so this isn't a
+    // safe rewrite
     `typeof x === 'object';`,
     `x === 'string';`,
     // `+` is not a comparison operator
@@ -74,24 +77,50 @@ ruleTester.run('prefer-is-helpers', rule, {
     // --- typeof string ---
     {
       code: `typeof x === 'string';`,
-      errors: [{ messageId: 'preferIsString' }],
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
     },
     {
       code: `typeof x !== 'string';`,
-      errors: [{ messageId: 'preferIsString' }],
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
     },
     {
       code: `typeof x == 'string';`,
-      errors: [{ messageId: 'preferIsString' }],
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
     },
     {
       code: `typeof x != 'string';`,
-      errors: [{ messageId: 'preferIsString' }],
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
     },
     // reversed operand order
     {
       code: `'string' === typeof x;`,
-      errors: [{ messageId: 'preferIsString' }],
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
+    },
+
+    // --- typeof boolean/function/symbol/bigint/undefined ---
+    {
+      code: `typeof x === 'boolean';`,
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
+    },
+    {
+      code: `typeof fn === 'function';`,
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
+    },
+    {
+      code: `typeof x === 'symbol';`,
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
+    },
+    {
+      code: `typeof x === 'bigint';`,
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
+    },
+    {
+      code: `typeof x === 'undefined';`,
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
+    },
+    {
+      code: `typeof x !== 'undefined';`,
+      errors: [{ messageId: 'preferIsHelperForTypeof' }],
     },
 
     // --- null/undefined comparisons ---

--- a/tools/lint/rules/prefer-is-helpers.ts
+++ b/tools/lint/rules/prefer-is-helpers.ts
@@ -109,18 +109,33 @@ function getNullishComparison(
 }
 
 /**
- * Whether `node` is `typeof <expr> ==/===/!=/!== '<literalValue>'` (either
- * operand order).
+ * `typeof` result literals that map onto an `@sindresorhus/is` helper with
+ * behaviour identical to the `typeof` comparison. Types are deliberately
+ * excluded when the helper's semantics diverge from a plain `typeof` check:
+ *
+ * - `'number'` — `isNumber()` also excludes `NaN`.
+ * - `'object'` — `isObject()` excludes `null` and includes functions.
  */
-function isTypeofComparison(
-  node: ESTree.BinaryExpression,
-  literalValue: string,
-): boolean {
+const TYPEOF_HELPERS: Record<string, string> = {
+  string: 'isString',
+  boolean: 'isBoolean',
+  function: 'isFunction',
+  symbol: 'isSymbol',
+  bigint: 'isBigint',
+  undefined: 'isUndefined',
+};
+
+/**
+ * If `node` is `typeof <expr> ==/===/!=/!== '<literalValue>'` (either operand
+ * order) for a `<literalValue>` with a matching helper in `TYPEOF_HELPERS`,
+ * return that literal value; otherwise return null.
+ */
+function getTypeofHelperLiteral(node: ESTree.BinaryExpression): string | null {
   if (
     !EQUALITY_OPERATORS.has(node.operator) &&
     !INEQUALITY_OPERATORS.has(node.operator)
   ) {
-    return false;
+    return null;
   }
   for (const [a, b] of [
     [node.left, node.right],
@@ -130,12 +145,13 @@ function isTypeofComparison(
       a.type === 'UnaryExpression' &&
       a.operator === 'typeof' &&
       b.type === 'Literal' &&
-      b.value === literalValue
+      typeof b.value === 'string' &&
+      b.value in TYPEOF_HELPERS
     ) {
-      return true;
+      return b.value;
     }
   }
-  return false;
+  return null;
 }
 
 export default defineRule({
@@ -144,8 +160,8 @@ export default defineRule({
     messages: {
       preferIsTruthy:
         'Use `.filter(isTruthy)` with `isTruthy` from `@sindresorhus/is` instead of `.filter(Boolean)` for a properly typed result.',
-      preferIsString:
-        "Use `isString()` from `@sindresorhus/is` instead of comparing `typeof` against 'string'.",
+      preferIsHelperForTypeof:
+        "Use `{{helper}}()` from `@sindresorhus/is` instead of comparing `typeof` against '{{literal}}'.",
       preferIsNullOrUndefined:
         'Use `isNullOrUndefined()` from `@sindresorhus/is` instead of comparing against both `null` and `undefined`.',
       preferNotIsNullOrUndefined:
@@ -169,9 +185,14 @@ export default defineRule({
         }
       },
       BinaryExpression(node) {
-        // `typeof x === 'string'` / `typeof x !== 'string'`
-        if (isTypeofComparison(node, 'string')) {
-          context.report({ node, messageId: 'preferIsString' });
+        // `typeof x === 'string'` / `typeof x !== 'string'` / etc.
+        const literal = getTypeofHelperLiteral(node);
+        if (literal) {
+          context.report({
+            node,
+            messageId: 'preferIsHelperForTypeof',
+            data: { helper: TYPEOF_HELPERS[literal], literal },
+          });
         }
       },
       LogicalExpression(node) {


### PR DESCRIPTION
## Changes



## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

Claude Sonnet 5 was used to extend the lint rule logic and refactor the codebase to use the type-checking helpers.

### Use of AI in replying to PR comments

- [x] @jamietanna will reply

## Documentation (please check one with an [x])

- [x] No documentation update is required

This is an internal development linting improvement with no user-facing documentation changes.

## How I've tested my work (please select one)

- [x] Newly added/modified unit tests, or
