### PR TITLE
refactor(logger): remove unused `dependencies` as a stringified `metaField`

### DIFF
--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -70,15 +70,6 @@ describe('logger/pretty-stdout', () => {
         );
       },
     );
-
-    it('stringifies a non-string (array) value for the dependencies meta field via Array#toString', () => {
-      const rec = partial<BunyanRecord>({
-        dependencies: ['abc', 'def'],
-      });
-      expect(prettyStdout.getMeta(rec)).toEqual(
-        util.styleText('gray', ' (dependencies=abc,def)'),
-      );
-    });
   });
 
   describe('getDetails(rec)', () => {
@@ -106,7 +97,6 @@ describe('logger/pretty-stdout', () => {
       { field: 'packageFile' },
       { field: 'depType' },
       { field: 'dependency' },
-      { field: 'dependencies' },
       { field: 'branch' },
     ])(
       'drops the $field meta string field entirely from details',
@@ -125,7 +115,6 @@ describe('logger/pretty-stdout', () => {
       { field: 'packageFile' },
       { field: 'depType' },
       { field: 'dependency' },
-      { field: 'dependencies' },
       { field: 'branch' },
     ])(
       'drops the $field meta field entirely from details, even when non-string',

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -51,6 +51,34 @@ describe('logger/pretty-stdout', () => {
       });
       expect(prettyStdout.getMeta(rec, false)).toBe(' (repository=a/b) [test]');
     });
+
+    it.each([
+      { field: 'repository' },
+      { field: 'baseBranch' },
+      { field: 'packageFile' },
+      { field: 'depType' },
+      { field: 'dependency' },
+      { field: 'branch' },
+    ])(
+      'stringifies a non-string value for the $field meta field as "[object Object]"',
+      ({ field }) => {
+        const rec = partial<BunyanRecord>({
+          [field]: { count: 1 },
+        });
+        expect(prettyStdout.getMeta(rec)).toEqual(
+          util.styleText('gray', ` (${field}=[object Object])`),
+        );
+      },
+    );
+
+    it('stringifies a non-string (array) value for the dependencies meta field via Array#toString', () => {
+      const rec = partial<BunyanRecord>({
+        dependencies: ['abc', 'def'],
+      });
+      expect(prettyStdout.getMeta(rec)).toEqual(
+        util.styleText('gray', ' (dependencies=abc,def)'),
+      );
+    });
   });
 
   describe('getDetails(rec)', () => {
@@ -71,6 +99,44 @@ describe('logger/pretty-stdout', () => {
       });
       expect(prettyStdout.getDetails(rec)).toBeEmptyString();
     });
+
+    it.each([
+      { field: 'repository' },
+      { field: 'baseBranch' },
+      { field: 'packageFile' },
+      { field: 'depType' },
+      { field: 'dependency' },
+      { field: 'dependencies' },
+      { field: 'branch' },
+    ])(
+      'drops the $field meta string field entirely from details',
+      ({ field }) => {
+        const rec = partial<BunyanRecord>({
+          v: 0,
+          [field]: 'value',
+        });
+        expect(prettyStdout.getDetails(rec)).toBeEmptyString();
+      },
+    );
+
+    it.each([
+      { field: 'repository' },
+      { field: 'baseBranch' },
+      { field: 'packageFile' },
+      { field: 'depType' },
+      { field: 'dependency' },
+      { field: 'dependencies' },
+      { field: 'branch' },
+    ])(
+      'drops the $field meta field entirely from details, even when non-string',
+      ({ field }) => {
+        const rec = partial<BunyanRecord>({
+          v: 0,
+          [field]: { count: 1 },
+        });
+        expect(prettyStdout.getDetails(rec)).toBeEmptyString();
+      },
+    );
 
     it('supports a config', () => {
       const rec = partial<BunyanRecord>({

--- a/lib/logger/pretty-stdout.ts
+++ b/lib/logger/pretty-stdout.ts
@@ -24,7 +24,6 @@ const metaFields = [
   'packageFile',
   'depType',
   'dependency',
-  'dependencies',
   'branch',
 ];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This is the middle of a stack of 3 PRs (#45476 → #45477 → #45478). Stacked on top of #45476.

As part of future changes, we need to correct the stringification logic
when `branch` is an object.

While looking at this, we noticed that `dependencies` is - likely - an
array of items being handled by `.toString()`ing them.

However, there's no existing cases in the codebase of this behaviour, so
we can remove it from `metaFields`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR (code, tests, commit message, and PR description) was generated by Claude Sonnet 5 via Claude Code, which identified this dead field while investigating a related logger bug.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
