### PR TITLE
fix(logger): only truncate `metaFields` when they're string values

### DIFF
--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -59,17 +59,12 @@ describe('logger/pretty-stdout', () => {
       { field: 'depType' },
       { field: 'dependency' },
       { field: 'branch' },
-    ])(
-      'stringifies a non-string value for the $field meta field as "[object Object]"',
-      ({ field }) => {
-        const rec = partial<BunyanRecord>({
-          [field]: { count: 1 },
-        });
-        expect(prettyStdout.getMeta(rec)).toEqual(
-          util.styleText('gray', ` (${field}=[object Object])`),
-        );
-      },
-    );
+    ])('ignores a non-string value for the $field meta field', ({ field }) => {
+      const rec = partial<BunyanRecord>({
+        [field]: { count: 1 },
+      });
+      expect(prettyStdout.getMeta(rec)).toBeEmptyString();
+    });
   });
 
   describe('getDetails(rec)', () => {
@@ -99,31 +94,15 @@ describe('logger/pretty-stdout', () => {
       { field: 'dependency' },
       { field: 'branch' },
     ])(
-      'drops the $field meta string field entirely from details',
-      ({ field }) => {
-        const rec = partial<BunyanRecord>({
-          v: 0,
-          [field]: 'value',
-        });
-        expect(prettyStdout.getDetails(rec)).toBeEmptyString();
-      },
-    );
-
-    it.each([
-      { field: 'repository' },
-      { field: 'baseBranch' },
-      { field: 'packageFile' },
-      { field: 'depType' },
-      { field: 'dependency' },
-      { field: 'branch' },
-    ])(
-      'drops the $field meta field entirely from details, even when non-string',
+      'expands the $field meta field when its value is not a string',
       ({ field }) => {
         const rec = partial<BunyanRecord>({
           v: 0,
           [field]: { count: 1 },
         });
-        expect(prettyStdout.getDetails(rec)).toBeEmptyString();
+        expect(prettyStdout.getDetails(rec)).toBe(
+          `       "${field}": {"count": 1}\n`,
+        );
       },
     );
 

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -70,15 +70,6 @@ describe('logger/pretty-stdout', () => {
         );
       },
     );
-
-    it('stringifies a non-string (array) value for the dependencies meta field via Array#toString', () => {
-      const rec = partial<BunyanRecord>({
-        dependencies: ['abc', 'def'],
-      });
-      expect(prettyStdout.getMeta(rec)).toEqual(
-        util.styleText('gray', ' (dependencies=abc,def)'),
-      );
-    });
   });
 
   describe('getDetails(rec)', () => {
@@ -106,7 +97,6 @@ describe('logger/pretty-stdout', () => {
       { field: 'packageFile' },
       { field: 'depType' },
       { field: 'dependency' },
-      { field: 'dependencies' },
       { field: 'branch' },
     ])(
       'drops the $field meta string field entirely from details',
@@ -125,7 +115,6 @@ describe('logger/pretty-stdout', () => {
       { field: 'packageFile' },
       { field: 'depType' },
       { field: 'dependency' },
-      { field: 'dependencies' },
       { field: 'branch' },
     ])(
       'drops the $field meta field entirely from details, even when non-string',

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -51,6 +51,34 @@ describe('logger/pretty-stdout', () => {
       });
       expect(prettyStdout.getMeta(rec, false)).toBe(' (repository=a/b) [test]');
     });
+
+    it.each([
+      { field: 'repository' },
+      { field: 'baseBranch' },
+      { field: 'packageFile' },
+      { field: 'depType' },
+      { field: 'dependency' },
+      { field: 'branch' },
+    ])(
+      'stringifies a non-string value for the $field meta field as "[object Object]"',
+      ({ field }) => {
+        const rec = partial<BunyanRecord>({
+          [field]: { count: 1 },
+        });
+        expect(prettyStdout.getMeta(rec)).toEqual(
+          util.styleText('gray', ` (${field}=[object Object])`),
+        );
+      },
+    );
+
+    it('stringifies a non-string (array) value for the dependencies meta field via Array#toString', () => {
+      const rec = partial<BunyanRecord>({
+        dependencies: ['abc', 'def'],
+      });
+      expect(prettyStdout.getMeta(rec)).toEqual(
+        util.styleText('gray', ' (dependencies=abc,def)'),
+      );
+    });
   });
 
   describe('getDetails(rec)', () => {
@@ -71,6 +99,44 @@ describe('logger/pretty-stdout', () => {
       });
       expect(prettyStdout.getDetails(rec)).toBeEmptyString();
     });
+
+    it.each([
+      { field: 'repository' },
+      { field: 'baseBranch' },
+      { field: 'packageFile' },
+      { field: 'depType' },
+      { field: 'dependency' },
+      { field: 'dependencies' },
+      { field: 'branch' },
+    ])(
+      'drops the $field meta string field entirely from details',
+      ({ field }) => {
+        const rec = partial<BunyanRecord>({
+          v: 0,
+          [field]: 'value',
+        });
+        expect(prettyStdout.getDetails(rec)).toBeEmptyString();
+      },
+    );
+
+    it.each([
+      { field: 'repository' },
+      { field: 'baseBranch' },
+      { field: 'packageFile' },
+      { field: 'depType' },
+      { field: 'dependency' },
+      { field: 'dependencies' },
+      { field: 'branch' },
+    ])(
+      'drops the $field meta field entirely from details, even when non-string',
+      ({ field }) => {
+        const rec = partial<BunyanRecord>({
+          v: 0,
+          [field]: { count: 1 },
+        });
+        expect(prettyStdout.getDetails(rec)).toBeEmptyString();
+      },
+    );
 
     it('supports a config', () => {
       const rec = partial<BunyanRecord>({

--- a/lib/logger/pretty-stdout.ts
+++ b/lib/logger/pretty-stdout.ts
@@ -18,6 +18,11 @@ const bunyanFields = [
   'msg',
   'start_time',
 ];
+/**
+ * If a log contains any of these meta fields in the meta, promote them up to the log line, rather than rendering them with other meta fields.
+ *
+ * This only applies when these fields have a string value, otherwise they are treated as a regular meta field.
+ */
 const metaFields = [
   'repository',
   'baseBranch',
@@ -55,7 +60,7 @@ export function getMeta(rec: BunyanRecord, colorize = true): string {
     return '';
   }
   let res = rec.module ? ` [${rec.module}]` : ``;
-  const filteredMeta = metaFields.filter((elem) => rec[elem]);
+  const filteredMeta = metaFields.filter((elem) => isString(rec[elem]));
   if (!filteredMeta.length) {
     return res;
   }
@@ -76,7 +81,7 @@ export function getDetails(rec: BunyanRecord): string {
     if (
       key === 'logContext' ||
       bunyanFields.includes(key) ||
-      metaFields.includes(key)
+      (metaFields.includes(key) && isString(recFiltered[key]))
     ) {
       delete recFiltered[key];
     }

--- a/lib/logger/pretty-stdout.ts
+++ b/lib/logger/pretty-stdout.ts
@@ -24,7 +24,6 @@ const metaFields = [
   'packageFile',
   'depType',
   'dependency',
-  'dependencies',
   'branch',
 ];
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This is the top of a stack of 3 PRs (#45476 → #45477 → #45478). Stacked on top of #45477.

When certain meta fields are logged, we pull them out of the meta fields
and into the log line, such as:

    DEBUG: Branch is not pending, removing pending upgrades (branch="renovate/express-4.x")

However, this also would affect non-string values such as:

    DEBUG: Git operations statistics (branch="[object Object]")

This only affects the "pretty" logs, but would mean no `branch` metadata
appears.

Instead, we can only include them when they're a string.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

This PR (root-cause analysis, code, tests, commit message, and PR description) was generated by Claude Sonnet 5 via Claude Code, from an investigation started by reporting the `[object Object]` log line.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
