### PR TITLE
refactor(linters): add prefer-coerce-array rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -212,6 +212,7 @@
         "renovate/no-new-url": "error",
         "renovate/no-stateful-global-regex": "error",
         "renovate/no-tools-import": "error",
+        "renovate/prefer-coerce-array": "error",
         "renovate/prefer-is-helpers": "error",
         "renovate/prefer-is-object": "error"
       }

--- a/lib/config/massage.ts
+++ b/lib/config/massage.ts
@@ -1,4 +1,5 @@
 import { isArray, isNonEmptyArray, isObject, isString } from '@sindresorhus/is';
+import { coerceArray } from '../util/array.ts';
 import { clone } from '../util/clone.ts';
 import { toMs } from '../util/pretty-time.ts';
 import { getOptions } from './options/index.ts';
@@ -66,7 +67,7 @@ export function massageConfig(config: RenovateConfig): RenovateConfig {
               delete newRule[newKey];
             }
           });
-          newRule.matchUpdateTypes = rule.matchUpdateTypes ?? [];
+          newRule.matchUpdateTypes = coerceArray(rule.matchUpdateTypes);
           newRule.matchUpdateTypes.push(key);
           newRule = { ...newRule, ...val };
           newRules.push(newRule);

--- a/lib/config/migrate-validate.ts
+++ b/lib/config/migrate-validate.ts
@@ -1,6 +1,7 @@
 import { isNonEmptyArray } from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { logger } from '../logger/index.ts';
+import { coerceArray } from '../util/array.ts';
 import * as configMassage from './massage.ts';
 import * as configMigration from './migration.ts';
 import type { RenovateConfig, ValidationMessage } from './types.ts';
@@ -40,9 +41,9 @@ export async function migrateAndValidate(
     if (isNonEmptyArray(errors)) {
       logger.info({ errors }, 'Found renovate config errors');
     }
-    massagedConfig.errors = (config.errors ?? []).concat(errors);
+    massagedConfig.errors = coerceArray(config.errors).concat(errors);
     if (!config.repoIsOnboarded) {
-      massagedConfig.warnings = (config.warnings ?? []).concat(warnings);
+      massagedConfig.warnings = coerceArray(config.warnings).concat(warnings);
     }
     return massagedConfig;
   } catch (err) {

--- a/lib/config/migrations/custom/base-branch-migration.ts
+++ b/lib/config/migrations/custom/base-branch-migration.ts
@@ -1,4 +1,5 @@
 import { isArray, isString } from '@sindresorhus/is';
+import { coerceArray } from '../../../util/array.ts';
 import { AbstractMigration } from '../base/abstract-migration.ts';
 
 export class BaseBranchMigration extends AbstractMigration {
@@ -6,7 +7,7 @@ export class BaseBranchMigration extends AbstractMigration {
   override readonly propertyName = 'baseBranch';
 
   override run(value: unknown): void {
-    const baseBranchPatterns = this.get('baseBranchPatterns') ?? [];
+    const baseBranchPatterns = coerceArray(this.get('baseBranchPatterns'));
     if (isArray<string>(value)) {
       this.setHard('baseBranchPatterns', baseBranchPatterns.concat(value));
     }

--- a/lib/config/migrations/custom/dep-types-migration.ts
+++ b/lib/config/migrations/custom/dep-types-migration.ts
@@ -1,4 +1,5 @@
 import { isArray, isNonEmptyObject, isObject } from '@sindresorhus/is';
+import { coerceArray } from '../../../util/array.ts';
 import type { PackageRule } from '../../types.ts';
 import { AbstractMigration } from '../base/abstract-migration.ts';
 
@@ -13,7 +14,7 @@ export class DepTypesMigration extends AbstractMigration {
     /^(?:(?:d|devD|optionalD|peerD)ependencies|engines|depTypes)$/;
 
   override run(value: unknown, key: string): void {
-    const packageRules: PackageRule[] = this.get('packageRules') ?? [];
+    const packageRules: PackageRule[] = coerceArray(this.get('packageRules'));
     if (isNonEmptyObject(value) && !isArray(value)) {
       packageRules.push({
         matchDepTypes: [key],

--- a/lib/config/migrations/custom/file-match-migration.ts
+++ b/lib/config/migrations/custom/file-match-migration.ts
@@ -1,4 +1,5 @@
 import { isArray, isString } from '@sindresorhus/is';
+import { coerceArray } from '../../../util/array.ts';
 import { AbstractMigration } from '../base/abstract-migration.ts';
 
 export class FileMatchMigration extends AbstractMigration {
@@ -10,7 +11,7 @@ export class FileMatchMigration extends AbstractMigration {
     if (isString(value) || isArray(value, isString)) {
       const fileMatch = isArray(value) ? value : [value];
 
-      let managerFilePatterns = this.get('managerFilePatterns') ?? [];
+      let managerFilePatterns = coerceArray(this.get('managerFilePatterns'));
       managerFilePatterns = managerFilePatterns.concat(
         fileMatch.map((match) => `/${match}/`),
       );

--- a/lib/config/migrations/custom/package-files-migration.ts
+++ b/lib/config/migrations/custom/package-files-migration.ts
@@ -1,4 +1,5 @@
 import { isArray, isNonEmptyObject, isString } from '@sindresorhus/is';
+import { coerceArray } from '../../../util/array.ts';
 import type { PackageRule } from '../../types.ts';
 import { AbstractMigration } from '../base/abstract-migration.ts';
 
@@ -7,7 +8,7 @@ export class PackageFilesMigration extends AbstractMigration {
   override readonly propertyName = 'packageFiles';
 
   override run(value: unknown): void {
-    const packageRules: PackageRule[] = this.get('packageRules') ?? [];
+    const packageRules: PackageRule[] = coerceArray(this.get('packageRules'));
     // v8 ignore else -- TODO: add test #40625
     if (isArray(value)) {
       const fileList: string[] = [];

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -10,6 +10,7 @@ import {
 } from '../../constants/error-messages.ts';
 import { logger } from '../../logger/index.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
+import { coerceArray } from '../../util/array.ts';
 import * as memCache from '../../util/cache/memory/index.ts';
 import { clone } from '../../util/clone.ts';
 import { regEx } from '../../util/regex.ts';
@@ -242,7 +243,7 @@ export async function resolveConfigPresets(
 
   let ignorePresets = clone(_ignorePresets);
   if (!ignorePresets || ignorePresets.length === 0) {
-    ignorePresets = inputConfig.ignorePresets ?? [];
+    ignorePresets = coerceArray(inputConfig.ignorePresets);
   }
   logger.trace(
     { config: inputConfig, existingPresets, mergeInternalPresets },

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -19,6 +19,7 @@ import {
 import { isCustomManager } from '../modules/manager/custom/index.ts';
 import type { CustomManager } from '../modules/manager/custom/types.ts';
 import type { HostRule } from '../types/index.ts';
+import { coerceArray } from '../util/array.ts';
 import { packageCacheNamespaces } from '../util/cache/package/namespaces.ts';
 import { clone } from '../util/clone.ts';
 import { getToolConfig } from '../util/exec/containerbase.ts';
@@ -786,7 +787,7 @@ export async function validateConfig(
                 } else if (key === 'env') {
                   const allowedEnvVars =
                     configType === 'global'
-                      ? (config.allowedEnv ?? [])
+                      ? coerceArray(config.allowedEnv)
                       : GlobalConfig.get('allowedEnv');
                   for (const [envVarName, envVarValue] of Object.entries(val)) {
                     if (!isString(envVarValue)) {
@@ -1010,7 +1011,7 @@ export async function validateConfig(
         if (key === 'hostRules' && isArray(val)) {
           const allowedHeaders =
             configType === 'global'
-              ? (config.allowedHeaders ?? [])
+              ? coerceArray(config.allowedHeaders)
               : GlobalConfig.get('allowedHeaders');
           for (const rule of val as HostRule[]) {
             if (isNonEmptyString(rule.matchHost)) {

--- a/lib/data/index.spec.ts
+++ b/lib/data/index.spec.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { isPlainObject } from '@sindresorhus/is';
+import { coerceArray } from '../util/array.ts';
 
 interface FileConfig {
   /** Top-level keys that must appear first, in the given order. */
@@ -24,7 +25,7 @@ function checkKeysSorted(
   firstKeys?: string[],
 ): void {
   let keys = Object.keys(obj);
-  const expectedFirst = depth === 0 ? (firstKeys ?? []) : [];
+  const expectedFirst = depth === 0 ? coerceArray(firstKeys) : [];
   expect(
     keys.slice(0, expectedFirst.length),
     `${path} should start with [${expectedFirst.join(', ')}]`,

--- a/lib/modules/datasource/aws-machine-image/index.ts
+++ b/lib/modules/datasource/aws-machine-image/index.ts
@@ -1,6 +1,7 @@
 import type { Filter, Image } from '@aws-sdk/client-ec2';
 import { DescribeImagesCommand, EC2Client } from '@aws-sdk/client-ec2';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
+import { coerceArray } from '../../../util/array.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
@@ -95,7 +96,7 @@ export class AwsMachineImageDatasource extends Datasource {
     const amiFilterCmd = this.getAmiFilterCommand(amiFilter);
     const ec2Client = this.getEC2Client(clientConfig);
     const matchingImages = await ec2Client.send(amiFilterCmd);
-    matchingImages.Images = matchingImages.Images ?? [];
+    matchingImages.Images = coerceArray(matchingImages.Images);
     return matchingImages.Images.sort((image1, image2) => {
       const ts1 = image1.CreationDate
         ? Date.parse(image1.CreationDate)

--- a/lib/modules/datasource/aws-rds/index.ts
+++ b/lib/modules/datasource/aws-rds/index.ts
@@ -2,6 +2,7 @@ import {
   DescribeDBEngineVersionsCommand,
   RDSClient,
 } from '@aws-sdk/client-rds';
+import { coerceArray } from '../../../util/array.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { Lazy } from '../../../util/lazy.ts';
 import { Datasource } from '../datasource.ts';
@@ -26,7 +27,7 @@ export class AwsRdsDatasource extends Datasource {
       Filters: JSON.parse(serializedFilter),
     });
     const response = await this.rds.getValue().send(cmd);
-    const versions = response.DBEngineVersions ?? [];
+    const versions = coerceArray(response.DBEngineVersions);
     return {
       releases: versions
         .filter((version) => version.EngineVersion)

--- a/lib/modules/datasource/azure-bicep-resource/schema.ts
+++ b/lib/modules/datasource/azure-bicep-resource/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { coerceArray } from '../../../util/array.ts';
 
 export const BicepResourceVersionIndex = z
   .object({
@@ -9,7 +10,7 @@ export const BicepResourceVersionIndex = z
 
     for (const resourceReference of Object.keys(resources)) {
       const [type, version] = resourceReference.toLowerCase().split('@', 2);
-      const versions = releaseMap.get(type) ?? [];
+      const versions = coerceArray(releaseMap.get(type));
       versions.push(version);
       releaseMap.set(type, versions);
     }

--- a/lib/modules/datasource/custom/utils.ts
+++ b/lib/modules/datasource/custom/utils.ts
@@ -1,6 +1,7 @@
 import { isNonEmptyString, isNullOrUndefined } from '@sindresorhus/is';
 import type { CustomDatasourceConfig } from '../../../config/types.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as template from '../../../util/template/index.ts';
 import type { GetReleasesConfig } from '../types.ts';
 
@@ -32,7 +33,7 @@ export function massageCustomDatasourceConfig(
   }
   const registryUrl = template.compile(registryUrlTemplate, templateInput);
 
-  const transformTemplates = customDatasource.transformTemplates ?? [];
+  const transformTemplates = coerceArray(customDatasource.transformTemplates);
   const transform: string[] = [];
   for (const transformTemplate of transformTemplates) {
     const templated = template.compile(transformTemplate, templateInput);

--- a/lib/modules/datasource/glasskube-packages/index.ts
+++ b/lib/modules/datasource/glasskube-packages/index.ts
@@ -1,3 +1,4 @@
+import { coerceArray } from '../../../util/array.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { joinUrlParts } from '../../../util/url.ts';
 import * as glasskubeVersioning from '../../versioning/glasskube/index.ts';
@@ -61,7 +62,7 @@ export class GlasskubePackagesDatasource extends Datasource {
       this.handleGenericErrors(latestManifestErr);
     }
 
-    for (const ref of latestManifest?.references ?? []) {
+    for (const ref of coerceArray(latestManifest?.references)) {
       if (ref.label.toLowerCase() === 'github') {
         result.sourceUrl = ref.url;
       } else if (ref.label.toLowerCase() === 'website') {

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -336,7 +336,7 @@ function resolveRegistryUrls(
     }
     return isFunction(datasource.defaultRegistryUrls)
       ? datasource.defaultRegistryUrls()
-      : (datasource.defaultRegistryUrls ?? []);
+      : coerceArray(datasource.defaultRegistryUrls);
   }
   const customUrls = registryUrls?.filter(isTruthy);
   let resolvedUrls: string[] = [];
@@ -344,13 +344,13 @@ function resolveRegistryUrls(
     resolvedUrls = [...customUrls];
   } else if (isNonEmptyArray(defaultRegistryUrls)) {
     resolvedUrls = [...defaultRegistryUrls];
-    resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
+    resolvedUrls = resolvedUrls.concat(coerceArray(additionalRegistryUrls));
   } else if (isFunction(datasource.defaultRegistryUrls)) {
     resolvedUrls = [...datasource.defaultRegistryUrls()];
-    resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
+    resolvedUrls = resolvedUrls.concat(coerceArray(additionalRegistryUrls));
   } else if (isNonEmptyArray(datasource.defaultRegistryUrls)) {
     resolvedUrls = [...datasource.defaultRegistryUrls];
-    resolvedUrls = resolvedUrls.concat(additionalRegistryUrls ?? []);
+    resolvedUrls = resolvedUrls.concat(coerceArray(additionalRegistryUrls));
   }
   return massageRegistryUrls(resolvedUrls);
 }

--- a/lib/modules/datasource/maven/schema.ts
+++ b/lib/modules/datasource/maven/schema.ts
@@ -1,5 +1,6 @@
 import { XmlDocument, type XmlElement } from 'xmldoc';
 import { z } from 'zod/v4';
+import { coerceArray } from '../../../util/array.ts';
 
 const xmlHeader = '<?xml version="1.0" encoding="UTF-8"?>';
 
@@ -102,11 +103,12 @@ function trimMetadataXml(metadata: XmlDocument, input: string): string {
   const version = metadata.descendantWithPath('version')?.val;
   const latest = metadata.descendantWithPath('versioning.latest')?.val;
   const release = metadata.descendantWithPath('versioning.release')?.val;
-  const versions =
+  const versions = coerceArray(
     metadata
       .descendantWithPath('versioning.versions')
       ?.childrenNamed('version')
-      .map((child) => child.val) ?? [];
+      .map((child) => child.val),
+  );
   const snapshot = metadata.descendantWithPath('versioning.snapshot');
   const timestamp = snapshot?.childNamed('timestamp')?.val;
   const buildNumber = snapshot?.childNamed('buildNumber')?.val;

--- a/lib/modules/datasource/python-version/index.spec.ts
+++ b/lib/modules/datasource/python-version/index.spec.ts
@@ -2,6 +2,7 @@ import { satisfies } from '@renovatebot/pep440';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
 import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as githubGraphql from '../../../util/github/graphql/index.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { registryUrl as eolRegistryUrl } from '../endoflife-date/common.ts';
@@ -150,7 +151,7 @@ describe('modules/datasource/python-version/index', () => {
           packageName: 'python',
         });
         expect(res?.releases).toHaveLength(2);
-        for (const release of res?.releases ?? []) {
+        for (const release of coerceArray(res?.releases)) {
           expect(release.isStable).toBeTrue();
         }
       });
@@ -173,7 +174,7 @@ describe('modules/datasource/python-version/index', () => {
           packageName: 'python',
         });
         expect(res?.releases).toHaveLength(2);
-        for (const release of res?.releases ?? []) {
+        for (const release of coerceArray(res?.releases)) {
           expect(release.isDeprecated).toBeBoolean();
         }
       });

--- a/lib/modules/datasource/python-version/index.ts
+++ b/lib/modules/datasource/python-version/index.ts
@@ -1,4 +1,5 @@
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { HttpError } from '../../../util/http/index.ts';
 import { id as versioning } from '../../versioning/python/index.ts';
@@ -82,7 +83,7 @@ export class PythonVersionDatasource extends Datasource {
           { err },
           'Rate limited by python.org, using prebuild releases',
         );
-        result.releases.push(...(pythonPrebuildReleases?.releases ?? []));
+        result.releases.push(...coerceArray(pythonPrebuildReleases?.releases));
       } else {
         this.handleGenericErrors(err);
       }

--- a/lib/modules/datasource/ruby-version/index.ts
+++ b/lib/modules/datasource/ruby-version/index.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { parse } from '../../../util/html.ts';
 import type { HttpError } from '../../../util/http/index.ts';
@@ -45,8 +46,9 @@ export class RubyVersionDatasource extends Datasource {
       const response = await this.http.getText(rubyVersionsUrl);
 
       const root = parse(response.body);
-      const rows =
-        root.querySelector('.release-list')?.querySelectorAll('tr') ?? [];
+      const rows = coerceArray(
+        root.querySelector('.release-list')?.querySelectorAll('tr'),
+      );
       rows.forEach((row) => {
         const tds = row.querySelectorAll('td');
         const columns: string[] = [];

--- a/lib/modules/datasource/rubygems/versions-endpoint-cache.ts
+++ b/lib/modules/datasource/rubygems/versions-endpoint-cache.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { getElapsedMinutes } from '../../../util/date.ts';
 import type { Http } from '../../../util/http/index.ts';
 import { HttpError } from '../../../util/http/index.ts';
@@ -42,7 +43,7 @@ function reconcilePackageVersions(
 ): PackageVersions {
   for (const line of versionLines) {
     const packageName = copystr(line.packageName);
-    let versions = packageVersions.get(packageName) ?? [];
+    let versions = coerceArray(packageVersions.get(packageName));
 
     const { deletedVersions, addedVersions } = line;
 

--- a/lib/modules/manager/bazel-module/parser/index.ts
+++ b/lib/modules/manager/bazel-module/parser/index.ts
@@ -1,4 +1,5 @@
 import { lang, query as q } from '@renovatebot/good-enough-parser';
+import { coerceArray } from '../../../../util/array.ts';
 import { Ctx } from './context.ts';
 import { extensionTags } from './extension-tags.ts';
 import type { ResultFragment } from './fragments.ts';
@@ -28,5 +29,5 @@ export function parse(input: string): ResultFragment[] {
   clearRepoRuleVariables();
 
   const parsedResult = starlarkLang.query(input, query, new Ctx(input));
-  return parsedResult?.results ?? [];
+  return coerceArray(parsedResult?.results);
 }

--- a/lib/modules/manager/bazel-module/rules.ts
+++ b/lib/modules/manager/bazel-module/rules.ts
@@ -3,6 +3,7 @@ import parseGithubUrl from 'github-url-from-git';
 import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
 import type { SkipReason } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { clone } from '../../../util/clone.ts';
 import { regEx } from '../../../util/regex.ts';
 import { BazelDatasource } from '../../datasource/bazel/index.ts';
@@ -187,7 +188,7 @@ function collectByModule(
 ): BazelModulePackageDep[][] {
   const rulesByModule = new Map<string, BasePackageDep[]>();
   for (const pkgDep of packageDeps) {
-    const bmi = rulesByModule.get(pkgDep.depName) ?? [];
+    const bmi = coerceArray(rulesByModule.get(pkgDep.depName));
     bmi.push(pkgDep);
     rulesByModule.set(pkgDep.depName, bmi);
   }

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -12,6 +12,7 @@ import {
   BUNDLER_INVALID_CREDENTIALS,
   TEMPORARY_ERROR,
 } from '../../../constants/error-messages.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as docker from '../../../util/exec/docker/index.ts';
 import { ExecError } from '../../../util/exec/exec-error.ts';
 import type { StatusResult } from '../../../util/git/types.ts';
@@ -197,7 +198,7 @@ describe('modules/manager/bundler/artifacts', () => {
             ...config,
             updateType: 'patch',
             postUpdateOptions: [
-              ...(config.postUpdateOptions ?? []),
+              ...coerceArray(config.postUpdateOptions),
               'bundlerConservative',
             ],
           },

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -6,6 +6,7 @@ import {
   TEMPORARY_ERROR,
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import {
   findGithubToken,
   takePersonalAccessTokenIfPossible,
@@ -84,7 +85,7 @@ function getAuthJson(): string | null {
       // https://getcomposer.org/doc/articles/authentication-for-private-packages.md#gitlab-token
       authJson['gitlab-domains'] = [
         host,
-        ...(authJson['gitlab-domains'] ?? []),
+        ...coerceArray(authJson['gitlab-domains']),
       ];
     }
   }

--- a/lib/modules/manager/composer/schema.ts
+++ b/lib/modules/manager/composer/schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod/v4';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import {
@@ -261,12 +262,12 @@ export const ComposerExtract = z
       {
         depType: 'require',
         req: require,
-        locked: lockfile?.packages ?? [],
+        locked: coerceArray(lockfile?.packages),
       },
       {
         depType: 'require-dev',
         req: requireDev,
-        locked: lockfile?.packagesDev ?? [],
+        locked: coerceArray(lockfile?.packagesDev),
       },
     ];
 

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -3,6 +3,7 @@ import pMap from 'p-map';
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
 import {
@@ -173,8 +174,8 @@ export async function updateArtifacts({
     if (isTruthy(isUpdateOptionAddChartArchives)) {
       const chartsPath = getSiblingFileName(packageFileName, 'charts');
       const status = await getRepoStatus();
-      const chartsAddition = status.not_added ?? [];
-      const chartsDeletion = status.deleted ?? [];
+      const chartsAddition = coerceArray(status.not_added);
+      const chartsDeletion = coerceArray(status.deleted);
 
       for (const file of chartsAddition) {
         // only add artifacts in the chart sub path

--- a/lib/modules/manager/kustomize/artifacts.ts
+++ b/lib/modules/manager/kustomize/artifacts.ts
@@ -3,6 +3,7 @@ import { quote } from 'shlex';
 import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
 import {
@@ -186,8 +187,8 @@ export async function updateArtifacts({
     }
 
     const status = await getRepoStatus();
-    const chartsAddition = status?.not_added ?? [];
-    const chartsDeletion = status?.deleted ?? [];
+    const chartsAddition = coerceArray(status?.not_added);
+    const chartsDeletion = coerceArray(status?.deleted);
 
     const fileChanges: UpdateArtifactsResult[] = [];
 

--- a/lib/modules/manager/maven/extract.ts
+++ b/lib/modules/manager/maven/extract.ts
@@ -3,6 +3,7 @@ import upath from 'upath';
 import type { XmlElement } from 'xmldoc';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { MAVEN_REPO } from '../../datasource/maven/common.ts';
@@ -127,9 +128,9 @@ function getAllCNBDependencies(
   node: XmlDocument,
   config: ExtractConfig,
 ): PackageDependency[] | null {
-  const pluginNodes =
-    node.childNamed('build')?.childNamed('plugins')?.childrenNamed('plugin') ??
-    [];
+  const pluginNodes = coerceArray(
+    node.childNamed('build')?.childNamed('plugins')?.childrenNamed('plugin'),
+  );
 
   const pluginNode = pluginNodes.find((pluginNode) => {
     return (
@@ -157,7 +158,7 @@ function getAllCNBDependencies(
     config,
   );
   const buildpacks = getCNBDependencies(
-    imageNode.childNamed('buildpacks')?.childrenNamed('buildpack') ?? [],
+    coerceArray(imageNode.childNamed('buildpacks')?.childrenNamed('buildpack')),
     config,
   );
   deps.push(...builder, ...runImage, ...buildpacks);
@@ -560,7 +561,7 @@ export function resolveParents(packages: PackageFile[]): PackageFile[] {
     const pkg = extractedPackages[name];
     pkg.deps.forEach((rawDep) => {
       const urlsSet = new Set([
-        ...(rawDep.registryUrls ?? []),
+        ...coerceArray(rawDep.registryUrls),
         ...registryUrls[name],
       ]);
       rawDep.registryUrls = [...urlsSet];

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -1,4 +1,5 @@
 import miseRegistry from '../../../data/mise-registry.json' with { type: 'json' };
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
@@ -577,5 +578,5 @@ export const parsedMiseRegistry: MiseRegistryData = Object.freeze(
 export function getOrderedMiseRegistryBackends(
   toolName: string,
 ): Record<string, string> {
-  return parsedMiseRegistry.tools[toolName] ?? [];
+  return coerceObject(parsedMiseRegistry.tools[toolName]);
 }

--- a/lib/modules/manager/npm/extract/common/dependency.ts
+++ b/lib/modules/manager/npm/extract/common/dependency.ts
@@ -1,6 +1,7 @@
 import { isString } from '@sindresorhus/is';
 import validateNpmPackageName from 'validate-npm-package-name';
 import { logger } from '../../../../../logger/index.ts';
+import { coerceArray } from '../../../../../util/array.ts';
 import type { ConstraintName } from '../../../../../util/exec/types.ts';
 import { isConstraintName } from '../../../../../util/exec/types.ts';
 import { regEx } from '../../../../../util/regex.ts';
@@ -42,8 +43,9 @@ export function parseDepName(depType: string, key: string): string {
   }
 
   const lastSegment = segments.at(-1);
-  const [, depName] =
-    regEx(/^((?:@[^/]+\/)?[^@]+)/).exec(lastSegment ?? '') ?? [];
+  const [, depName] = coerceArray(
+    regEx(/^((?:@[^/]+\/)?[^@]+)/).exec(lastSegment ?? ''),
+  );
   return depName;
 }
 

--- a/lib/modules/manager/nuget/artifacts.ts
+++ b/lib/modules/manager/nuget/artifacts.ts
@@ -3,6 +3,7 @@ import { quote } from 'shlex';
 import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
@@ -47,7 +48,7 @@ async function createCachedNuGetConfigFile(
   const updatedDepsRegistries: Registry[] = Array.from(
     new Set(
       updatedDeps
-        .flatMap((dep) => dep.registryUrls ?? [])
+        .flatMap((dep) => coerceArray(dep.registryUrls))
         .filter(isNonEmptyString),
     ),
     (url) => ({ url }),

--- a/lib/modules/manager/osgi/extract.ts
+++ b/lib/modules/manager/osgi/extract.ts
@@ -2,6 +2,7 @@ import { isArray, isNullOrUndefined, isString } from '@sindresorhus/is';
 import json5 from 'json5';
 import { coerce, satisfies } from 'semver';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 import { MavenDatasource } from '../../datasource/maven/index.ts';
 import type {
@@ -41,7 +42,7 @@ export function extractPackageFile(
   }
 
   // OSGi Compendium R8 159.4: bundles entry
-  const allBundles = featureModel.bundles ?? [];
+  const allBundles = coerceArray(featureModel.bundles);
 
   // The 'execution-environment' key is supported by the Sling/OSGi feature model implementation
   const execEnvFramework =

--- a/lib/modules/manager/pep621/processors/uv.ts
+++ b/lib/modules/manager/pep621/processors/uv.ts
@@ -3,6 +3,7 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../../constants/error-messages.ts';
 import { logger } from '../../../../logger/index.ts';
 import type { HostRule } from '../../../../types/index.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import type {
   ExecOptions,
   ToolConstraint,
@@ -315,8 +316,9 @@ async function getUvExtraIndexUrl(
     .filter(isString)
     .filter((registryUrl) => {
       // Check if the registry URL is not the default one and not already configured
-      const configuredIndexUrls =
-        project.tool?.uv?.index?.map(({ url }) => url) ?? [];
+      const configuredIndexUrls = coerceArray(
+        project.tool?.uv?.index?.map(({ url }) => url),
+      );
       return (
         registryUrl !== PypiDatasource.defaultURL &&
         !configuredIndexUrls.includes(registryUrl)

--- a/lib/modules/manager/pep723/schema.ts
+++ b/lib/modules/manager/pep723/schema.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyString } from '@sindresorhus/is';
 import { z } from 'zod/v4';
+import { coerceArray } from '../../../util/array.ts';
 import { Toml } from '../../../util/schema-utils/index.ts';
 import { depTypes, pep508ToPackageDependency } from '../pep621/utils.ts';
 import type { PackageFileContent } from '../types.ts';
@@ -18,7 +19,7 @@ export const Pep723 = Toml.pipe(
         .optional(),
     })
     .transform(({ 'requires-python': requiresPython, dependencies }) => {
-      const res: PackageFileContent = { deps: dependencies ?? [] };
+      const res: PackageFileContent = { deps: coerceArray(dependencies) };
 
       if (isNonEmptyString(requiresPython)) {
         res.extractedConstraints = { python: requiresPython };

--- a/lib/modules/manager/pip-compile/common.ts
+++ b/lib/modules/manager/pip-compile/common.ts
@@ -2,7 +2,7 @@ import { isString } from '@sindresorhus/is';
 import { split } from 'shlex';
 import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
-import { isNotNullOrUndefined } from '../../../util/array.ts';
+import { coerceArray, isNotNullOrUndefined } from '../../../util/array.ts';
 import type {
   ExecOptions,
   ExtraEnv,
@@ -229,17 +229,17 @@ export function extractHeaderCommand(
     if (arg.includes('=')) {
       const [option, value] = arg.split('=');
       if (option === '--extra') {
-        result.extra = result.extra ?? [];
+        result.extra = coerceArray(result.extra);
         result.extra.push(value);
       } else if (option === '--extra-index-url') {
-        result.extraIndexUrl = result.extraIndexUrl ?? [];
+        result.extraIndexUrl = coerceArray(result.extraIndexUrl);
         result.extraIndexUrl.push(value);
         // TODO: add to secrets? next PR
       } else if (['--constraint', '--constraints'].includes(option)) {
-        result.constraintsFiles = result.constraintsFiles ?? [];
+        result.constraintsFiles = coerceArray(result.constraintsFiles);
         result.constraintsFiles.push(value);
       } else if (['--override', '--overrides'].includes(option)) {
-        result.overridesFiles = result.overridesFiles ?? [];
+        result.overridesFiles = coerceArray(result.overridesFiles);
         result.overridesFiles.push(value);
       } else if (option === '--output-file') {
         if (result.outputFile) {
@@ -375,8 +375,8 @@ export function getRegistryCredVarsFromPackageFiles(
   const urls: string[] = [];
   for (const packageFile of packageFiles) {
     urls.push(
-      ...(packageFile.registryUrls ?? []),
-      ...(packageFile.additionalRegistryUrls ?? []),
+      ...coerceArray(packageFile.registryUrls),
+      ...coerceArray(packageFile.additionalRegistryUrls),
     );
   }
   logger.debug(urls, 'Extracted registry URLs from package files');

--- a/lib/modules/manager/pip-compile/extract.ts
+++ b/lib/modules/manager/pip-compile/extract.ts
@@ -133,7 +133,7 @@ export async function extractAllPackageFiles(
         const existingPackageFile = packageFiles.get(packageFile)!;
         existingPackageFile.lockFiles!.push(matchedFile);
         extendWithIndirectDeps(existingPackageFile, lockedDeps);
-        const source = lockFileSources.get(matchedFile) ?? [];
+        const source = coerceArray(lockFileSources.get(matchedFile));
         source.push(existingPackageFile);
         lockFileSources.set(matchedFile, source);
         continue;
@@ -197,7 +197,7 @@ export async function extractAllPackageFiles(
           packageFile,
         };
         packageFiles.set(packageFile, newPackageFile);
-        const source = lockFileSources.get(matchedFile) ?? [];
+        const source = coerceArray(lockFileSources.get(matchedFile));
         source.push(newPackageFile);
         lockFileSources.set(matchedFile, source);
       } else {
@@ -218,7 +218,9 @@ export async function extractAllPackageFiles(
 
   // This needs to go in reverse order to handle transitive dependencies
   for (const packageFile of [...result].reverse()) {
-    for (const reqFile of packageFile.managerData?.requirementsFiles ?? []) {
+    for (const reqFile of coerceArray<string>(
+      packageFile.managerData?.requirementsFiles,
+    )) {
       let sourceFiles: PackageFile[] | undefined = undefined;
       if (matchedFiles.includes(reqFile)) {
         sourceFiles = lockFileSources.get(reqFile);

--- a/lib/modules/manager/pipenv/artifacts.ts
+++ b/lib/modules/manager/pipenv/artifacts.ts
@@ -6,6 +6,7 @@ import {
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { HostRule } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ExtraEnv, Opt } from '../../../util/exec/types.ts';
 import {
@@ -43,11 +44,11 @@ async function findPipfileSourceUrlsWithCredentials(
 ): Promise<URL[]> {
   const pipfile = await extractPackageFile(pipfileContent, pipfileName);
 
-  return (
+  return coerceArray(
     pipfile?.registryUrls
       ?.map(parseUrl)
       .filter(isUrlInstance)
-      .filter((url) => isNonEmptyStringAndNotWhitespace(url.username)) ?? []
+      .filter((url) => isNonEmptyStringAndNotWhitespace(url.username)),
   );
 }
 

--- a/lib/modules/manager/poetry/artifacts.ts
+++ b/lib/modules/manager/poetry/artifacts.ts
@@ -9,6 +9,7 @@ import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { HostRule } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   deleteLocalFile,
@@ -118,7 +119,7 @@ function getPoetrySources(content: string, fileName: string): PoetrySource[] {
     return [];
   }
 
-  const sources = pyprojectFile.tool?.poetry?.source ?? [];
+  const sources = coerceArray(pyprojectFile.tool?.poetry?.source);
   const sourceArray: PoetrySource[] = [];
   for (const source of sources) {
     if (source.name && source.url) {

--- a/lib/modules/manager/pre-commit/extract.ts
+++ b/lib/modules/manager/pre-commit/extract.ts
@@ -5,6 +5,7 @@ import {
 } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import type { SkipReason } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { detectPlatform } from '../../../util/common.ts';
 import { find } from '../../../util/host-rules.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
@@ -198,7 +199,7 @@ function findDependencies(
   for (const item of precommitFile.repos) {
     // meta hooks is defined from pre-commit and doesn't support `additional_dependencies`
     if (item.repo !== 'meta') {
-      for (const hook of item.hooks ?? []) {
+      for (const hook of coerceArray(item.hooks)) {
         // normally language are not defined in yaml
         // only support it when it's explicitly defined.
         // this avoid to parse hooks from pre-commit-hooks.yaml from git repo

--- a/lib/modules/manager/renovate-config/extract.ts
+++ b/lib/modules/manager/renovate-config/extract.ts
@@ -2,6 +2,7 @@ import { isNonEmptyArray, isNullOrUndefined } from '@sindresorhus/is';
 import { parsePreset } from '../../../config/presets/parse.ts';
 import type { ParsedPreset } from '../../../config/presets/types.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { getToolConfig } from '../../../util/exec/containerbase.ts';
 import { isToolName } from '../../../util/exec/types.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
@@ -29,7 +30,7 @@ export function extractPackageFile(
 
   const deps: PackageDependency[] = [];
 
-  for (const preset of config.data.extends ?? []) {
+  for (const preset of coerceArray(config.data.extends)) {
     if (preset.includes('{{')) {
       // templated presets are only resolvable at runtime
       continue;
@@ -100,7 +101,7 @@ export function extractPackageFile(
     }
   }
 
-  for (const packageRule of config.data.packageRules ?? []) {
+  for (const packageRule of coerceArray(config.data.packageRules)) {
     for (const [constraint, value] of Object.entries(
       packageRule.constraints ?? {},
     )) {

--- a/lib/modules/manager/setup-cfg/extract.ts
+++ b/lib/modules/manager/setup-cfg/extract.ts
@@ -2,18 +2,21 @@
 import { RANGE_PATTERN } from '@renovatebot/pep440';
 import { logger } from '../../../logger/index.ts';
 import type { MaybePromise } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { normalizePythonDepName } from '../../datasource/pypi/common.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
 
 function getSectionName(str: string): string {
-  const [, sectionName] = regEx(/^\[\s*([^\s]+)\s*]\s*$/).exec(str) ?? [];
+  const [, sectionName] = coerceArray(
+    regEx(/^\[\s*([^\s]+)\s*]\s*$/).exec(str),
+  );
   return sectionName;
 }
 
 function getSectionRecord(str: string): string {
-  const [, sectionRecord] = regEx(/^([^\s]+)\s*=/).exec(str) ?? [];
+  const [, sectionRecord] = coerceArray(regEx(/^([^\s]+)\s*=/).exec(str));
   return sectionRecord;
 }
 

--- a/lib/modules/manager/swift/extract.spec.ts
+++ b/lib/modules/manager/swift/extract.spec.ts
@@ -1,5 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { extractPackageFile } from './extract.ts';
 
 describe('modules/manager/swift/extract', () => {
@@ -278,8 +279,9 @@ describe('modules/manager/swift/extract', () => {
 
       expect(result?.deps).toHaveLength(10);
 
-      const githubDeps =
-        result?.deps.filter((dep) => dep.datasource === 'github-tags') ?? [];
+      const githubDeps = coerceArray(
+        result?.deps.filter((dep) => dep.datasource === 'github-tags'),
+      );
       expect(githubDeps).toHaveLength(10);
 
       expect(result?.deps).toContainEqual({

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -1,5 +1,6 @@
 import { isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../../logger/index.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import * as p from '../../../../util/promises.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { getDefaultVersioning } from '../../../datasource/common.ts';
@@ -55,12 +56,13 @@ async function updateAllLocks(
       const update: ProviderLockUpdate = {
         newVersion,
         newConstraint: lock.constraints,
-        newHashes:
-          (await TerraformProviderHash.createHashes(
+        newHashes: coerceArray(
+          await TerraformProviderHash.createHashes(
             lock.registryUrl,
             lock.packageName,
             newVersion,
-          )) ?? [],
+          ),
+        ),
         ...lock,
       };
       return update;
@@ -205,12 +207,13 @@ export async function updateArtifacts({
           // TODO #22198
           newVersion: newVersion!,
           newConstraint: newConstraint!,
-          newHashes:
-            (await TerraformProviderHash.createHashes(
+          newHashes: coerceArray(
+            await TerraformProviderHash.createHashes(
               registryUrl,
               updateLock.packageName,
               newVersion!,
-            )) ?? /* v8 ignore next: needs test */ [],
+            ),
+          ),
           ...updateLock,
         };
         updates.push(update);

--- a/lib/modules/manager/tflint-plugin/plugins.ts
+++ b/lib/modules/manager/tflint-plugin/plugins.ts
@@ -1,5 +1,6 @@
 import { isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 import type { PackageDependency } from '../types.ts';
@@ -31,8 +32,8 @@ export function extractTFLintPlugin(
     if (isString(line)) {
       // `{` will be counted with +1 and `}` with -1.
       // Therefore if we reach braceCounter == 0 then we found the end of the tflint configuration block.
-      const openBrackets = (line.match(regEx(/\{/g)) ?? []).length;
-      const closedBrackets = (line.match(regEx(/\}/g)) ?? []).length;
+      const openBrackets = coerceArray(line.match(regEx(/\{/g))).length;
+      const closedBrackets = coerceArray(line.match(regEx(/\}/g))).length;
       braceCounter = braceCounter + openBrackets - closedBrackets;
 
       // only update fields inside the root block

--- a/lib/modules/manager/vendir/artifacts.ts
+++ b/lib/modules/manager/vendir/artifacts.ts
@@ -1,5 +1,6 @@
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
   getParentDir,
@@ -67,9 +68,9 @@ export async function updateArtifacts({
     const vendorDir = getParentDir(packageFileName);
     const status = await getRepoStatus();
     if (status) {
-      const modifiedFiles = status.modified ?? [];
+      const modifiedFiles = coerceArray(status.modified);
       const notAddedFiles = status.not_added;
-      const deletedFiles = status.deleted ?? [];
+      const deletedFiles = coerceArray(status.deleted);
 
       for (const f of modifiedFiles.concat(notAddedFiles)) {
         const isFileInVendorDir = f.startsWith(vendorDir);

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -4,6 +4,7 @@ import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages.ts
 import { logger } from '../../../logger/index.ts';
 import type { GitOptions, GitProtocol } from '../../../types/git.ts';
 import type { HostRule } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as git from '../../../util/git/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { ensureTrailingSlash, parseUrl } from '../../../util/url.ts';
@@ -52,7 +53,7 @@ export interface BitbucketStatus {
 }
 
 export function isInvalidReviewersResponse(err: BitbucketError): boolean {
-  const errors = err?.response?.body?.errors ?? [];
+  const errors = coerceArray(err?.response?.body?.errors);
   return (
     errors.length > 0 &&
     errors.every(
@@ -62,15 +63,17 @@ export function isInvalidReviewersResponse(err: BitbucketError): boolean {
 }
 
 export function getInvalidReviewers(err: BitbucketError): string[] {
-  const errors = err?.response?.body?.errors ?? [];
+  const errors = coerceArray(err?.response?.body?.errors);
   let invalidReviewers: string[] = [];
   for (const error of errors) {
     // v8 ignore else -- TODO: add test #40625
     if (error.exceptionName === BITBUCKET_INVALID_REVIEWERS_EXCEPTION) {
       invalidReviewers = invalidReviewers.concat(
-        error.reviewerErrors
-          ?.map(({ context }) => context)
-          .filter(isNonEmptyString) ?? [],
+        coerceArray(
+          error.reviewerErrors
+            ?.map(({ context }) => context)
+            .filter(isNonEmptyString),
+        ),
       );
     }
   }

--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -416,7 +416,7 @@ export async function updatePr({
   logger.debug(`updatePr(${prNo}, ${title}, body)`);
 
   let cachedPr: CodeCommitPr | undefined = undefined;
-  const cachedPrs = config.prList ?? [];
+  const cachedPrs = coerceArray(config.prList);
   for (const p of cachedPrs) {
     // v8 ignore else -- TODO: add test #40625
     if (p.number === prNo) {

--- a/lib/modules/platform/forgejo/index.ts
+++ b/lib/modules/platform/forgejo/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { BranchStatus } from '../../../types/index.ts';
-import { deduplicateArray } from '../../../util/array.ts';
+import { coerceArray, deduplicateArray } from '../../../util/array.ts';
 import { parseJson } from '../../../util/common.ts';
 import { getEnv } from '../../../util/env.ts';
 import * as git from '../../../util/git/index.ts';
@@ -893,7 +893,7 @@ const platform: Platform = {
           );
 
           // Test whether the issues need to be updated
-          const existingLabelIds = (existingIssue.labels ?? []).map(
+          const existingLabelIds = coerceArray(existingIssue.labels).map(
             (label) => label.id,
           );
           if (

--- a/lib/modules/platform/gerrit/scm.ts
+++ b/lib/modules/platform/gerrit/scm.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { isNonEmptyArray, isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as git from '../../../util/git/index.ts';
 import type { CommitFilesConfig, FileChange } from '../../../util/git/types.ts';
 import { hash } from '../../../util/hash.ts';
@@ -100,7 +101,7 @@ export class GerritScm extends DefaultGitScm {
     const changeId = existingChange?.change_id ?? generateChangeId();
     commit.message = message;
     commit.trailers = [
-      ...(commit.trailers ?? []).filter(
+      ...coerceArray(commit.trailers).filter(
         (trailer) =>
           !trailer.startsWith('Renovate-Branch:') &&
           !trailer.startsWith('Change-Id:'),

--- a/lib/modules/platform/gerrit/utils.ts
+++ b/lib/modules/platform/gerrit/utils.ts
@@ -1,6 +1,7 @@
 import { CONFIG_GIT_URL_UNAVAILABLE } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { BranchStatus, PrState } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
 import { toLongCommitSha } from '../../../util/schema-utils/git.ts';
@@ -113,8 +114,9 @@ export function mapGerritChangeToPr(
     title: change.subject,
     createdAt: convertGerritDateToISO(change.created),
     labels: change.hashtags,
-    reviewers:
-      change.reviewers?.REVIEWER?.map((reviewer) => reviewer.username!) ?? [],
+    reviewers: coerceArray(
+      change.reviewers?.REVIEWER?.map((reviewer) => reviewer.username!),
+    ),
     bodyStruct: {
       hash: hashBody(knownProperties?.prBody ?? findPullRequestBody(change)),
     },
@@ -152,7 +154,7 @@ export function extractSourceBranch(change: GerritChange): string | undefined {
 }
 
 export function findPullRequestBody(change: GerritChange): string | undefined {
-  const msg = Array.from(change.messages ?? [])
+  const msg = Array.from(coerceArray(change.messages))
     .reverse()
     .find((msg) => msg.tag === TAG_PULL_REQUEST_BODY);
   if (msg) {

--- a/lib/modules/platform/gitea/index.ts
+++ b/lib/modules/platform/gitea/index.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import type { BranchStatus } from '../../../types/index.ts';
-import { deduplicateArray } from '../../../util/array.ts';
+import { coerceArray, deduplicateArray } from '../../../util/array.ts';
 import { parseJson } from '../../../util/common.ts';
 import { getEnv } from '../../../util/env.ts';
 import * as git from '../../../util/git/index.ts';
@@ -901,7 +901,7 @@ const platform: Platform = {
           );
 
           // Test whether the issues need to be updated
-          const existingLabelIds = (existingIssue.labels ?? []).map(
+          const existingLabelIds = coerceArray(existingIssue.labels).map(
             (label) => label.id,
           );
           if (

--- a/lib/modules/platform/gitea/utils.ts
+++ b/lib/modules/platform/gitea/utils.ts
@@ -5,6 +5,7 @@ import {
   REPOSITORY_BLOCKED,
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
 import { parseUrl } from '../../../util/url.ts';
@@ -124,7 +125,7 @@ export function toRenovatePR(data: PR, author: string | null): Pr | null {
     title = title.substring(DRAFT_PREFIX.length);
     isDraft = true;
   }
-  const labels = (data?.labels ?? []).map((l) => l.name);
+  const labels = coerceArray(data?.labels).map((l) => l.name);
 
   return {
     labels,

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -148,12 +148,11 @@ export async function detectGhe(token: string): Promise<void> {
     const gheHeaderKey = 'x-github-enterprise-version';
     const gheQueryRes = await githubApi.headJson('/', { token });
     const gheHeaders = coerceObject(gheQueryRes?.headers);
-    const [, gheVersion] = coerceArray(
-      Object.entries(gheHeaders).find(
-        ([k]) => k.toLowerCase() === gheHeaderKey,
-      ),
+    const gheVersionHeader = Object.entries(gheHeaders).find(
+      ([k]) => k.toLowerCase() === gheHeaderKey,
     );
-    platformConfig.gheVersion = semver.valid(gheVersion as string) ?? null;
+    platformConfig.gheVersion =
+      semver.valid(gheVersionHeader?.[1] as string) ?? null;
     logger.debug(
       `Detected GitHub Enterprise Server, version: ${platformConfig.gheVersion}`,
     );

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -24,6 +24,7 @@ import { instrument } from '../../../instrumentation/index.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import type { BranchStatus } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { isGithubFineGrainedPersonalAccessToken } from '../../../util/check-token.ts';
 import { coerceToNull } from '../../../util/coerce.ts';
 import { parseJson } from '../../../util/common.ts';
@@ -147,10 +148,11 @@ export async function detectGhe(token: string): Promise<void> {
     const gheHeaderKey = 'x-github-enterprise-version';
     const gheQueryRes = await githubApi.headJson('/', { token });
     const gheHeaders = coerceObject(gheQueryRes?.headers);
-    const [, gheVersion] =
+    const [, gheVersion] = coerceArray(
       Object.entries(gheHeaders).find(
         ([k]) => k.toLowerCase() === gheHeaderKey,
-      ) ?? [];
+      ),
+    );
     platformConfig.gheVersion = semver.valid(gheVersion as string) ?? null;
     logger.debug(
       `Detected GitHub Enterprise Server, version: ${platformConfig.gheVersion}`,
@@ -1531,7 +1533,7 @@ export async function ensureIssue({
         body: {
           title,
           body,
-          labels: labels ?? [],
+          labels: coerceArray(labels),
         },
       },
       Issue,
@@ -2345,7 +2347,7 @@ export async function getVulnerabilityAlerts(): Promise<GithubVulnerabilityAlert
   } catch (err) /* v8 ignore next -- defensive: processing already-parsed alerts does not throw in specs */ {
     logger.error({ err }, 'Error processing vulnerabity alerts');
   }
-  return vulnerabilityAlerts ?? [];
+  return coerceArray(vulnerabilityAlerts);
 }
 
 async function pushFiles(

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -743,7 +743,7 @@ export async function createPr({
         remove_source_branch: true,
         title,
         description,
-        labels: (labels ?? []).join(','),
+        labels: coerceArray(labels).join(','),
         squash: config.squash,
       },
     },
@@ -1167,7 +1167,7 @@ export async function ensureIssue({
             body: {
               title,
               description,
-              labels: (labels ?? issue.labels ?? []).join(','),
+              labels: coerceArray(labels ?? issue.labels).join(','),
               confidential: confidential ?? false,
             },
           },
@@ -1179,7 +1179,7 @@ export async function ensureIssue({
         body: {
           title,
           description,
-          labels: (labels ?? []).join(','),
+          labels: coerceArray(labels).join(','),
           confidential: confidential ?? false,
         },
       });

--- a/lib/modules/platform/index.ts
+++ b/lib/modules/platform/index.ts
@@ -3,6 +3,7 @@ import { PLATFORM_NOT_FOUND } from '../../constants/error-messages.ts';
 import type { PlatformId } from '../../constants/index.ts';
 import { logger } from '../../logger/index.ts';
 import type { HostRule } from '../../types/index.ts';
+import { coerceArray } from '../../util/array.ts';
 import {
   setGitAuthor,
   setNoVerify,
@@ -47,7 +48,7 @@ export function setPlatformApi(name: PlatformId): void {
 
 export async function initPlatform(config: AllConfig): Promise<AllConfig> {
   setPrivateKey(config.gitPrivateKey, config.gitPrivateKeyPassphrase);
-  setNoVerify(config.gitNoVerify ?? []);
+  setNoVerify(coerceArray(config.gitNoVerify));
   // TODO: `platform` (#22198)
   setPlatformApi(config.platform!);
   // TODO: types
@@ -56,8 +57,8 @@ export async function initPlatform(config: AllConfig): Promise<AllConfig> {
     ...config,
     ...platformInfo,
     hostRules: [
-      ...(platformInfo?.hostRules ?? []),
-      ...(config.hostRules ?? []),
+      ...coerceArray(platformInfo?.hostRules),
+      ...coerceArray(config.hostRules),
     ],
   };
   // v8 ignore else -- TODO: add test #40625

--- a/lib/modules/platform/scm-manager/index.ts
+++ b/lib/modules/platform/scm-manager/index.ts
@@ -1,6 +1,7 @@
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import type { BranchStatus } from '../../../types/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import * as git from '../../../util/git/index.ts';
 import { getBaseUrl, setBaseUrl } from '../../../util/http/scm-manager.ts';
 import { sanitize } from '../../../util/sanitize.ts';
@@ -179,7 +180,7 @@ export async function getPrList(): Promise<Pr[]> {
     }
   }
 
-  return config.prList ?? [];
+  return coerceArray(config.prList);
 }
 
 export async function createPr({

--- a/lib/modules/platform/scm-manager/mapper.ts
+++ b/lib/modules/platform/scm-manager/mapper.ts
@@ -1,3 +1,4 @@
+import { coerceArray } from '../../../util/array.ts';
 import type { Pr } from '../types.ts';
 import type { PrState, PullRequest } from './schema.ts';
 
@@ -17,7 +18,7 @@ export function mapPrFromScmToRenovate(pr: PullRequest): Pr {
     hasAssignees: !!pr.reviewer?.length,
     labels: pr.labels,
     number: parseInt(pr.id, 10),
-    reviewers: pr.reviewer?.map((review) => review.displayName) ?? [],
+    reviewers: coerceArray(pr.reviewer?.map((review) => review.displayName)),
     state: PR_STATE_MAP[pr.status],
     title: pr.title,
     isDraft: pr.status === 'DRAFT',

--- a/lib/modules/versioning/gradle/compare.ts
+++ b/lib/modules/versioning/gradle/compare.ts
@@ -1,4 +1,5 @@
 import { isString } from '@sindresorhus/is';
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 
 export const TokenType = {
@@ -179,8 +180,8 @@ function tokenCmp(left: Token | null, right: Token | null): number {
 }
 
 export function compare(left: string, right: string): number {
-  const leftTokens = tokenize(left) ?? [];
-  const rightTokens = tokenize(right) ?? [];
+  const leftTokens = coerceArray(tokenize(left));
+  const rightTokens = coerceArray(tokenize(right));
   const length = Math.max(leftTokens.length, rightTokens.length);
   for (let idx = 0; idx < length; idx += 1) {
     const leftToken = leftTokens[idx] || null;

--- a/lib/modules/versioning/perl/index.ts
+++ b/lib/modules/versioning/perl/index.ts
@@ -1,3 +1,4 @@
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
@@ -29,7 +30,7 @@ class PerlVersioningApi extends GenericVersioningApi {
     const [, intPart, decimalPart] = matches;
     const prerelease = decimalPart.includes('_') ? 'alpha' : '';
 
-    const decimalComponents =
+    const decimalComponents = coerceArray(
       decimalPart
         .replace(regEx(/_/g), '')
         .match(regEx(/.{1,3}/g))
@@ -39,7 +40,8 @@ class PerlVersioningApi extends GenericVersioningApi {
             component += '0';
           }
           return Number.parseInt(component, 10);
-        }) ?? /* istanbul ignore next */ [];
+        }),
+    );
     const release = [Number.parseInt(intPart, 10), ...decimalComponents];
     return { release, prerelease };
   }

--- a/lib/modules/versioning/rpm/index.ts
+++ b/lib/modules/versioning/rpm/index.ts
@@ -1,4 +1,5 @@
 import { isNumericString } from '@sindresorhus/is';
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
@@ -159,8 +160,8 @@ class RpmVersioningApi extends GenericVersioningApi {
       return 0;
     }
 
-    const matchesv1 = v1.match(alphaNumPattern) ?? [];
-    const matchesv2 = v2.match(alphaNumPattern) ?? [];
+    const matchesv1 = coerceArray(v1.match(alphaNumPattern));
+    const matchesv2 = coerceArray(v2.match(alphaNumPattern));
     const matches = Math.min(matchesv1.length, matchesv2.length);
 
     for (let i = 0; i < matches; i++) {

--- a/lib/modules/versioning/ruby/version.ts
+++ b/lib/modules/versioning/ruby/version.ts
@@ -1,6 +1,7 @@
 import { eq, major, minor, patch, prerelease } from '@renovatebot/ruby-semver';
 import type { SegmentElement } from '@renovatebot/ruby-semver/dist/ruby/version.js';
 import { create } from '@renovatebot/ruby-semver/dist/ruby/version.js';
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 
 interface RubyVersion {
@@ -104,13 +105,17 @@ function increment(from: string, to: string): string {
     return regEx(/^[0-9.-/]+$/).test(x);
   }
   if (major(from) !== major(adapted)) {
-    nextVersion = [incrementMajor(maj, min, ptch, pre ?? []), 0, 0].join('.');
+    nextVersion = [incrementMajor(maj, min, ptch, coerceArray(pre)), 0, 0].join(
+      '.',
+    );
   } else if (minor(from) !== minor(adapted)) {
-    nextVersion = [maj, incrementMinor(min, ptch, pre ?? []), 0].join('.');
+    nextVersion = [maj, incrementMinor(min, ptch, coerceArray(pre)), 0].join(
+      '.',
+    );
   } else if (patch(from) !== patch(adapted)) {
-    nextVersion = [maj, min, incrementPatch(ptch, pre ?? [])].join('.');
+    nextVersion = [maj, min, incrementPatch(ptch, coerceArray(pre))].join('.');
   } else if (isStable(from) && isStable(adapted)) {
-    nextVersion = [maj, min, incrementPatch(ptch, pre ?? [])].join('.');
+    nextVersion = [maj, min, incrementPatch(ptch, coerceArray(pre))].join('.');
   } else {
     nextVersion = [maj, min, ptch].join('.');
   }

--- a/lib/util/exec/containerbase.ts
+++ b/lib/util/exec/containerbase.ts
@@ -4,6 +4,7 @@ import { GlobalConfig } from '../../config/global.ts';
 import { logger } from '../../logger/index.ts';
 import type { ReleaseResult } from '../../modules/datasource/index.ts';
 import type { VersioningApi } from '../../modules/versioning/types.ts';
+import { coerceArray } from '../array.ts';
 import { getEnv } from '../env.ts';
 import { regEx } from '../regex.ts';
 import type { Opt, ToolConfig, ToolConstraint, ToolName } from './types.ts';
@@ -329,7 +330,7 @@ export async function resolveConstraint(
   }
 
   const pkgReleases = await getPkgReleases(toolConfig);
-  const releases = pkgReleases?.releases ?? [];
+  const releases = coerceArray(pkgReleases?.releases);
 
   if (!releases?.length) {
     logger.warn({ toolConfig }, 'No tool releases found.');

--- a/lib/util/exec/docker/index.ts
+++ b/lib/util/exec/docker/index.ts
@@ -3,6 +3,7 @@ import { join, quote } from 'shlex';
 import { GlobalConfig } from '../../../config/global.ts';
 import { SYSTEM_INSUFFICIENT_MEMORY } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../array.ts';
 import { newlineRegex, regEx } from '../../regex.ts';
 import { uniq } from '../../uniq.ts';
 import { rawExec } from '../common.ts';
@@ -149,7 +150,7 @@ export async function generateDockerCommand(
   sideCarImage: string,
 ): Promise<string> {
   const { envVars, cwd } = options;
-  const volumes = options.volumes ?? [];
+  const volumes = coerceArray(options.volumes);
   const {
     localDir,
     cacheDir,

--- a/lib/util/exec/index.ts
+++ b/lib/util/exec/index.ts
@@ -81,7 +81,7 @@ async function prepareRawExec(
   sideCarImage: string,
 ): Promise<RawExecArguments> {
   const { docker } = opts;
-  const preCommands = opts.preCommands ?? [];
+  const preCommands = coerceArray(opts.preCommands);
   const customEnvVariables = getCustomEnv();
   const userConfiguredEnv = getUserEnv();
   const { containerbaseDir, binarySource } = GlobalConfig.get();

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -37,6 +37,7 @@ import { logger } from '../../logger/index.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
 import type { GitProtocol } from '../../types/git.ts';
 import { incCountValue, incLimitedValue } from '../../workers/global/limits.ts';
+import { coerceArray } from '../array.ts';
 import { getCache } from '../cache/repository/index.ts';
 import { getEnv } from '../env.ts';
 import type { ExtraEnv } from '../exec/types.ts';
@@ -406,7 +407,7 @@ export function setUserRepoConfig({
   gitIgnoredAuthors,
   gitAuthor,
 }: RenovateConfig): void {
-  config.ignoredAuthors = gitIgnoredAuthors ?? [];
+  config.ignoredAuthors = coerceArray(gitIgnoredAuthors);
   setGitAuthor(gitAuthor);
 }
 

--- a/lib/util/package-rules/index.ts
+++ b/lib/util/package-rules/index.ts
@@ -7,6 +7,7 @@ import type {
 import { mergeChildConfig } from '../../config/utils.ts';
 import { logger } from '../../logger/index.ts';
 import type { StageName } from '../../types/skip-reason.ts';
+import { coerceArray } from '../array.ts';
 import { compile } from '../template/index.ts';
 import matchers from './matchers.ts';
 
@@ -37,7 +38,7 @@ export async function applyPackageRules<T extends PackageRuleInputConfig>(
   stageName?: StageName,
 ): Promise<T> {
   let config = { ...inputConfig };
-  const packageRules = config.packageRules ?? [];
+  const packageRules = coerceArray(config.packageRules);
   logger.trace(
     { dependency: config.depName, packageRules },
     `Checking against ${packageRules.length} packageRules`,

--- a/lib/util/stats.ts
+++ b/lib/util/stats.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logger/index.ts';
+import { coerceArray } from './array.ts';
 import * as memCache from './cache/memory/index.ts';
 import type { GitOperationType } from './git/types.ts';
 import { parseUrl } from './url.ts';
@@ -109,8 +110,9 @@ export class GetDatasourceReleasesStats {
     packageName: string,
     duration: number,
   ): void {
-    const data =
-      memCache.get<GetReleasesDataPoint[]>('get-releases-stats') ?? [];
+    const data = coerceArray(
+      memCache.get<GetReleasesDataPoint[]>('get-releases-stats'),
+    );
     data.push({ datasource, registryUrl, packageName, duration });
     memCache.set('get-releases-stats', data);
   }
@@ -129,8 +131,9 @@ export class GetDatasourceReleasesStats {
   }
 
   static getReport(): GetReleaseStatsReport {
-    const data =
-      memCache.get<GetReleasesDataPoint[]>('get-releases-stats') ?? [];
+    const data = coerceArray(
+      memCache.get<GetReleasesDataPoint[]>('get-releases-stats'),
+    );
 
     // Process all datapoints into a hierarchical structure of datasource, registry url, and package name.
     const durationData: getReleaseStatsInternal<number[]> = {
@@ -226,7 +229,9 @@ type PackageCacheData = number[];
 
 export class PackageCacheStats {
   static writeSet(duration: number): void {
-    const data = memCache.get<PackageCacheData>('package-cache-sets') ?? [];
+    const data = coerceArray(
+      memCache.get<PackageCacheData>('package-cache-sets'),
+    );
     data.push(duration);
     memCache.set('package-cache-sets', data);
   }
@@ -240,7 +245,9 @@ export class PackageCacheStats {
   }
 
   static writeGet(duration: number): void {
-    const data = memCache.get<PackageCacheData>('package-cache-gets') ?? [];
+    const data = coerceArray(
+      memCache.get<PackageCacheData>('package-cache-gets'),
+    );
     data.push(duration);
     memCache.set('package-cache-gets', data);
   }
@@ -254,12 +261,14 @@ export class PackageCacheStats {
   }
 
   static getReport(): { get: TimingStatsReport; set: TimingStatsReport } {
-    const packageCacheGets =
-      memCache.get<PackageCacheData>('package-cache-gets') ?? [];
+    const packageCacheGets = coerceArray(
+      memCache.get<PackageCacheData>('package-cache-gets'),
+    );
     const get = makeTimingReport(packageCacheGets);
 
-    const packageCacheSets =
-      memCache.get<PackageCacheData>('package-cache-sets') ?? [];
+    const packageCacheSets = coerceArray(
+      memCache.get<PackageCacheData>('package-cache-sets'),
+    );
     const set = makeTimingReport(packageCacheSets);
 
     return { get, set };
@@ -307,8 +316,8 @@ export interface DatasourceCacheReport {
 
 export class DatasourceCacheStats {
   private static getData(): DatasourceCacheDataPoint[] {
-    return (
-      memCache.get<DatasourceCacheDataPoint[]>('datasource-cache-stats') ?? []
+    return coerceArray(
+      memCache.get<DatasourceCacheDataPoint[]>('datasource-cache-stats'),
     );
   }
 
@@ -449,15 +458,17 @@ interface HttpStatsCollection {
 
 export class HttpStats {
   static write(data: HttpRequestStatsDataPoint): void {
-    const httpRequests =
-      memCache.get<HttpRequestStatsDataPoint[]>('http-requests') ?? [];
+    const httpRequests = coerceArray(
+      memCache.get<HttpRequestStatsDataPoint[]>('http-requests'),
+    );
     httpRequests.push(data);
     memCache.set('http-requests', httpRequests);
   }
 
   static getDataPoints(): HttpRequestStatsDataPoint[] {
-    const httpRequests =
-      memCache.get<HttpRequestStatsDataPoint[]>('http-requests') ?? [];
+    const httpRequests = coerceArray(
+      memCache.get<HttpRequestStatsDataPoint[]>('http-requests'),
+    );
 
     // istanbul ignore next: sorting is hard and not worth testing
     httpRequests.sort((a, b) => {
@@ -705,7 +716,7 @@ type AbandonedPackageReport = Record<string, Record<string, string>>;
 
 export class AbandonedPackageStats {
   static getData(): AbandonedPackage[] {
-    return memCache.get<AbandonedPackage[]>('abandonment-stats') ?? [];
+    return coerceArray(memCache.get<AbandonedPackage[]>('abandonment-stats'));
   }
 
   private static setData(data: AbandonedPackage[]): void {

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -2,6 +2,7 @@ import type { MockInstance } from 'vitest';
 import { getEnvName } from '../../../../config/options/env.ts';
 import { getOptions } from '../../../../config/options/index.ts';
 import { logger } from '../../../../logger/index.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import * as env from './env.ts';
 import type { ParseConfigOptions } from './types.ts';
 
@@ -401,7 +402,7 @@ describe('workers/global/config/parse/env', () => {
       if (envName === '') {
         continue;
       }
-      const existing = envNameToOptions.get(envName) ?? [];
+      const existing = coerceArray(envNameToOptions.get(envName));
       existing.push(option.name);
       envNameToOptions.set(envName, existing);
     }

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -53,7 +53,7 @@ export async function parseConfigs(
     isNonEmptyArray(fileConfig.extends) &&
     isNonEmptyArray(additionalFileConfig.extends)
   ) {
-    config.extends = [...fileConfig.extends, ...(config.extends ?? [])];
+    config.extends = [...fileConfig.extends, ...coerceArray(config.extends)];
   }
   config = mergeChildConfig(config, envConfig);
   config = mergeChildConfig(config, cliConfig);
@@ -123,9 +123,9 @@ export async function parseConfigs(
   // TODO #41551
   if (isNonEmptyArray(cliConfig.repositories)) {
     const existingRepos = [
-      ...(fileConfig.repositories ?? []),
-      ...(additionalFileConfig.repositories ?? []),
-      ...(envConfig.repositories ?? []),
+      ...coerceArray(fileConfig.repositories),
+      ...coerceArray(additionalFileConfig.repositories),
+      ...coerceArray(envConfig.repositories),
     ];
 
     if (isNonEmptyArray(existingRepos)) {

--- a/lib/workers/repository/errors-warnings.ts
+++ b/lib/workers/repository/errors-warnings.ts
@@ -39,7 +39,7 @@ function getDepWarnings(
   const warnings: string[] = [];
   const warningFiles: string[] = [];
   for (const files of Object.values(packageFiles ?? {})) {
-    for (const file of files ?? []) {
+    for (const file of coerceArray(files)) {
       // TODO: remove condition when type is fixed (#22198)
       if (file.packageFile) {
         for (const dep of coerceArray(file.deps)) {

--- a/lib/workers/repository/extract/extract-fingerprint-config.ts
+++ b/lib/workers/repository/extract/extract-fingerprint-config.ts
@@ -5,6 +5,7 @@ import type { RegexManagerTemplates } from '../../../modules/manager/custom/rege
 import type { CustomExtractConfig } from '../../../modules/manager/custom/types.ts';
 import { validMatchFields } from '../../../modules/manager/custom/utils.ts';
 import { getEnabledManagersList } from '../../../modules/manager/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import type { WorkerExtractConfig } from '../../types.ts';
 
 export interface FingerprintExtractConfig {
@@ -43,8 +44,8 @@ function getFilteredManagerConfig(
     npmrc: config.npmrc,
     npmrcMerge: config.npmrcMerge,
     enabled: config.enabled,
-    ignorePaths: config.ignorePaths ?? [],
-    includePaths: config.includePaths ?? [],
+    ignorePaths: coerceArray(config.ignorePaths),
+    includePaths: coerceArray(config.includePaths),
     skipInstalls: config.skipInstalls,
     registryAliases: config.registryAliases,
     fileList: [],
@@ -60,7 +61,7 @@ export function generateFingerprintConfig(
   for (const manager of managerList) {
     const managerConfig = getManagerConfig(config, manager);
     if (isCustomManager(manager)) {
-      const filteredCustomManagers = (config.customManagers ?? []).filter(
+      const filteredCustomManagers = coerceArray(config.customManagers).filter(
         (mgr) => mgr.customType === manager,
       );
       for (const customManager of filteredCustomManagers) {

--- a/lib/workers/repository/extract/index.ts
+++ b/lib/workers/repository/extract/index.ts
@@ -9,6 +9,7 @@ import {
   hashMap,
 } from '../../../modules/manager/index.ts';
 import { scm } from '../../../modules/platform/scm.ts';
+import { coerceArray } from '../../../util/array.ts';
 import type { ExtractResult, WorkerExtractConfig } from '../../types.ts';
 import { getMatchingFiles } from './file-match.ts';
 import { getManagerPackageFiles } from './manager-files.ts';
@@ -33,9 +34,9 @@ export async function extractAllDependencies(
       const managerConfig = getManagerConfig(config, manager);
       managerConfig.manager = manager;
       if (isCustomManager(manager)) {
-        const filteredCustomManagers = (config.customManagers ?? []).filter(
-          (mgr) => mgr.customType === manager,
-        );
+        const filteredCustomManagers = coerceArray(
+          config.customManagers,
+        ).filter((mgr) => mgr.customType === manager);
         for (const customManager of filteredCustomManagers) {
           tryConfig(mergeChildConfig(managerConfig, customManager));
         }

--- a/lib/workers/repository/finalize/repository-statistics.ts
+++ b/lib/workers/repository/finalize/repository-statistics.ts
@@ -2,6 +2,7 @@ import type { RenovateConfig } from '../../../config/types.ts';
 import { addBranchStats } from '../../../instrumentation/reporting.ts';
 import { logger } from '../../../logger/index.ts';
 import type { Pr } from '../../../modules/platform/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import {
   getCache,
   isCacheModified,
@@ -79,7 +80,7 @@ function filterDependencyDashboardData(
     const upgradesFiltered: Partial<BranchUpgradeCache>[] = [];
     const { branchName, prNo, prTitle, result, upgrades, prBlockedBy } = branch;
 
-    for (const upgrade of upgrades ?? []) {
+    for (const upgrade of coerceArray(upgrades)) {
       const {
         datasource,
         depName,
@@ -140,7 +141,7 @@ export function runBranchSummary(config: RenovateConfig): void {
   const branchMetadata: BranchMetadata[] = [];
   const inactiveBranches: string[] = [];
 
-  for (const branch of branches ?? []) {
+  for (const branch of coerceArray(branches)) {
     if (branch.sha) {
       branchMetadata.push(branchCacheToMetadata(branch));
     } else {
@@ -184,7 +185,7 @@ export function getUpdateSummary(branches: BranchCache[]): UpdateSummary {
       };
       summaryByBase.set(baseBranch, entry);
     }
-    for (const upgrade of branch.upgrades ?? []) {
+    for (const upgrade of coerceArray(branch.upgrades)) {
       const { updateType } = upgrade;
       if (updateType) {
         entry.total += 1;

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../../modules/platform/github/schema.ts';
 import { platform } from '../../../modules/platform/index.ts';
 import * as allVersioning from '../../../modules/versioning/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { sanitizeMarkdown } from '../../../util/markdown.ts';
 import { regEx } from '../../../util/regex.ts';
 import { titleCase } from '../../../util/string.ts';
@@ -166,7 +167,9 @@ export async function detectVulnerabilityAlerts(
     }
   }
   logger.debug({ alertPackageRules }, 'alert package rules');
-  config.packageRules = (config.packageRules ?? []).concat(alertPackageRules);
+  config.packageRules = coerceArray(config.packageRules).concat(
+    alertPackageRules,
+  );
   return config;
 }
 

--- a/lib/workers/repository/package-files.ts
+++ b/lib/workers/repository/package-files.ts
@@ -158,6 +158,7 @@ export class PackageFiles {
     data: Map<string, Record<string, PackageFile[]> | null>,
   ): boolean {
     // get detected managers list of the last listed base branch
+    // oxlint-disable-next-line renovate/prefer-coerce-array -- tuple destructuring default; coerceArray() widens the tuple to a union array
     const [branch, managers] = Array.from(data).pop() ?? [];
     if (!branch) {
       return false;

--- a/lib/workers/repository/process/limits.ts
+++ b/lib/workers/repository/process/limits.ts
@@ -5,6 +5,7 @@ import { logger } from '../../../logger/index.ts';
 import { platform } from '../../../modules/platform/index.ts';
 import { scm } from '../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { getCache } from '../../../util/cache/repository/index.ts';
 import { getInheritedOrGlobal } from '../../../util/common.ts';
 import type { BranchConfig } from '../../types.ts';
@@ -82,7 +83,7 @@ export async function getCommitsHourlyCount(
       );
 
       const cache = getCache();
-      const cachedBranches = cache.branches ?? [];
+      const cachedBranches = coerceArray(cache.branches);
 
       // if we don't have all of our branches in our cache (for instance, if we're not using the Repository Cache, or this is the first run against a repo), we need to fall back to the SCM
       const needsScmFallback = branches.some(

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -21,6 +21,7 @@ import type {
 } from '../../../modules/manager/types.ts';
 import type { VersioningApi } from '../../../modules/versioning/index.ts';
 import { get as getVersioning } from '../../../modules/versioning/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { sanitizeMarkdown } from '../../../util/markdown.ts';
 import * as p from '../../../util/promises.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -239,7 +240,7 @@ export class Vulnerabilities {
           osvVulnerability,
         );
 
-        for (const affected of osvVulnerability.affected ?? []) {
+        for (const affected of coerceArray(osvVulnerability.affected)) {
           const isVulnerable = this.isPackageVulnerable(
             ecosystem,
             osvPackageName,
@@ -298,7 +299,7 @@ export class Vulnerabilities {
     // the OpenSSF's Malicious Packages (https://github.com/ossf/malicious-packages) is a source of advisories through osv.dev, which takes various sources of advisories, and will re-publish them with more specific information about their malicious usage
     if (osvVulnerability.id.startsWith('MAL-')) {
       // is the current dependency vulnerable?
-      for (const affected of osvVulnerability.affected ?? []) {
+      for (const affected of coerceArray(osvVulnerability.affected)) {
         // is the current dependency vulnerable?
         const isVulnerable = this.isPackageVulnerable(
           ecosystem,
@@ -325,7 +326,7 @@ export class Vulnerabilities {
         }
 
         // or are any of the updates vulnerable?
-        for (const update of dep.updates ?? []) {
+        for (const update of coerceArray(dep.updates)) {
           const newVersion = update.newVersion ?? update.newValue!;
 
           const isUpdateVulnerable = this.isPackageVulnerable(
@@ -432,7 +433,7 @@ export class Vulnerabilities {
     affected: Osv.Affected,
     versioningApi: VersioningApi,
   ): boolean {
-    for (const range of affected.ranges ?? []) {
+    for (const range of coerceArray(affected.ranges)) {
       if (range.type === 'GIT') {
         continue;
       }
@@ -490,7 +491,7 @@ export class Vulnerabilities {
     const fixedVersions: string[] = [];
     const lastAffectedVersions: string[] = [];
 
-    for (const range of affected.ranges ?? []) {
+    for (const range of coerceArray(affected.ranges)) {
       if (range.type === 'GIT') {
         continue;
       }
@@ -641,7 +642,9 @@ export class Vulnerabilities {
     vulnerability: Osv.Vulnerability,
     affected: Osv.Affected,
   ): string[] {
-    let aliases = [vulnerability.id].concat(vulnerability.aliases ?? []).sort();
+    let aliases = [vulnerability.id]
+      .concat(coerceArray(vulnerability.aliases))
+      .sort();
     aliases = aliases.map((id) => {
       if (id.startsWith('CVE-')) {
         return `[${id}](https://nvd.nist.gov/vuln/detail/${id})`;

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -67,8 +67,8 @@ export async function postUpgradeCommandsExecutor(
   filteredUpgradeCommands: BranchUpgradeConfig[],
   config: BranchConfig,
 ): Promise<PostUpgradeCommandsExecutionResult> {
-  let updatedArtifacts = [...(config.updatedArtifacts ?? [])];
-  const artifactErrors = [...(config.artifactErrors ?? [])];
+  let updatedArtifacts = [...coerceArray(config.updatedArtifacts)];
+  const artifactErrors = [...coerceArray(config.artifactErrors)];
   const allowedCommands = GlobalConfig.get('allowedCommands');
 
   for (const upgrade of filteredUpgradeCommands) {

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -30,6 +30,7 @@ import type { Pr } from '../../../../modules/platform/index.ts';
 import { platform } from '../../../../modules/platform/index.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import { getElapsedMs } from '../../../../util/date.ts';
 import { emojify } from '../../../../util/emoji.ts';
 import { filterValidCommitTrailers } from '../../../../util/git/commit-trailers.ts';
@@ -627,13 +628,13 @@ export async function processBranch(
         config,
         branchConfig.packageFiles!,
       );
-      config.artifactErrors = (config.artifactErrors ?? []).concat(
+      config.artifactErrors = coerceArray(config.artifactErrors).concat(
         additionalFiles.artifactErrors,
       );
-      config.artifactNotices = (config.artifactNotices ?? []).concat(
-        additionalFiles.artifactNotices ?? [],
+      config.artifactNotices = coerceArray(config.artifactNotices).concat(
+        coerceArray(additionalFiles.artifactNotices),
       );
-      config.updatedArtifacts = (config.updatedArtifacts ?? []).concat(
+      config.updatedArtifacts = coerceArray(config.updatedArtifacts).concat(
         additionalFiles.updatedArtifacts,
       );
       // `gh actions-lock` rewrites the whole lockfile from the workflows on disk, so like the lock files above it runs once here, after every updated package file has been written, rather than per package file.

--- a/lib/workers/repository/update/pr/labels.ts
+++ b/lib/workers/repository/update/pr/labels.ts
@@ -3,6 +3,7 @@ import { dequal } from 'dequal';
 import type { RenovateConfig } from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import { platform } from '../../../../modules/platform/index.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import * as template from '../../../../util/template/index.ts';
 
 /**
@@ -19,8 +20,8 @@ function trimLabel(label: string, limit: number): string {
 
 export function prepareLabels(config: RenovateConfig): string[] {
   const labelCharLimit = platform.labelCharLimit?.() ?? 50;
-  const labels = config.labels ?? [];
-  const addLabels = config.addLabels ?? [];
+  const labels = coerceArray(config.labels);
+  const addLabels = coerceArray(config.addLabels);
   return [...new Set([...labels, ...addLabels])]
     .filter(isNonEmptyStringAndNotWhitespace)
     .map((label) => template.compile(label, config))
@@ -83,12 +84,12 @@ export function shouldUpdateLabels(
   }
 
   // If the labels are unchanged, they should not be updated
-  if (dequal((configuredLabels ?? []).sort(), prInitialLabels.sort())) {
+  if (dequal(coerceArray(configuredLabels).sort(), prInitialLabels.sort())) {
     return false;
   }
 
   // If the labels in the PR have been modified by the user, they should not be updated
-  if (areLabelsModified(prInitialLabels, prCurrentLabels ?? [])) {
+  if (areLabelsModified(prInitialLabels, coerceArray(prCurrentLabels))) {
     logger.debug('Labels have been modified by user - skipping labels update.');
     return false;
   }

--- a/lib/workers/repository/update/pr/participants.ts
+++ b/lib/workers/repository/update/pr/participants.ts
@@ -4,6 +4,7 @@ import type { RenovateConfig } from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import type { Pr } from '../../../../modules/platform/index.ts';
 import { platform } from '../../../../modules/platform/index.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import { noLeadingAtSymbol } from '../../../../util/common.ts';
 import { sampleSize } from '../../../../util/sample.ts';
 import { codeOwnersForPr } from './code-owners.ts';
@@ -46,7 +47,7 @@ export async function addParticipants(
   config: RenovateConfig,
   pr: Pr,
 ): Promise<void> {
-  let assignees = config.assignees ?? [];
+  let assignees = coerceArray(config.assignees);
   logger.debug(`addParticipants(pr=${pr?.number})`);
   if (config.assigneesFromCodeOwners) {
     assignees = await addCodeOwners(config, assignees, pr);
@@ -73,7 +74,7 @@ export async function addParticipants(
     }
   }
 
-  let reviewers = config.reviewers ?? [];
+  let reviewers = coerceArray(config.reviewers);
   if (config.reviewersFromCodeOwners) {
     reviewers = await addCodeOwners(config, reviewers, pr);
     logger.debug(

--- a/lib/workers/repository/updates/flatten.ts
+++ b/lib/workers/repository/updates/flatten.ts
@@ -9,6 +9,7 @@ import { logger } from '../../../logger/index.ts';
 import { getDefaultConfig } from '../../../modules/datasource/index.ts';
 import { get } from '../../../modules/manager/index.ts';
 import type { PackageFile } from '../../../modules/manager/types.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { detectSemanticCommits } from '../../../util/git/semantic.ts';
 import { applyPackageRules } from '../../../util/package-rules/index.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -209,7 +210,7 @@ export async function flattenUpdates(
         updates.push(lockFileConfig);
       }
       if (get(manager, 'updateLockedDependency')) {
-        for (const lockFile of packageFileConfig.lockFiles ?? []) {
+        for (const lockFile of coerceArray(packageFileConfig.lockFiles)) {
           const lockfileRemediations = config.remediations as Record<
             string,
             Record<string, any>[]

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -3,6 +3,7 @@ import { logger } from '~test/util.ts';
 import { getConfig } from '../../../config/defaults.ts';
 import type { UpdateType } from '../../../config/types.ts';
 import { NpmDatasource } from '../../../modules/datasource/npm/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import type { BranchUpgradeConfig } from '../../types.ts';
 import { generateBranchConfig } from './generate.ts';
@@ -1528,7 +1529,7 @@ describe('workers/repository/updates/generate', () => {
         },
       ] satisfies BranchUpgradeConfig[];
       const res = generateBranchConfig(branch);
-      const excludeCommitPaths = res.excludeCommitPaths ?? [];
+      const excludeCommitPaths = coerceArray(res.excludeCommitPaths);
       expect(excludeCommitPaths.sort()).toStrictEqual(
         ['some/path', 'some/other/path', 'some/other-manager/path'].sort(),
       );
@@ -1647,9 +1648,11 @@ describe('workers/repository/updates/generate', () => {
         | docker     | some-dep    | 5.1.0 | 5.1.2 |
       `);
       expect([
+        // oxlint-disable-next-line renovate/prefer-coerce-array -- matchAll() yields an iterator, which coerceArray() does not accept
         ...(res.commitMessage?.matchAll(/another-dep/g) ?? []),
       ]).toBeArrayOfSize(1);
       expect([
+        // oxlint-disable-next-line renovate/prefer-coerce-array -- matchAll() yields an iterator, which coerceArray() does not accept
         ...(res.commitMessage?.matchAll(/some-dep/g) ?? []),
       ]).toBeArrayOfSize(2);
     });

--- a/lib/workers/repository/updates/generate.ts
+++ b/lib/workers/repository/updates/generate.ts
@@ -5,6 +5,7 @@ import semver from 'semver';
 import { mergeChildConfig } from '../../../config/index.ts';
 import { CONFIG_SECRETS_EXPOSED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
+import { coerceArray } from '../../../util/array.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { sanitize } from '../../../util/sanitize.ts';
 import { safeStringify } from '../../../util/stringify.ts';
@@ -468,14 +469,14 @@ export function generateBranchConfig(
   config.labels = [
     ...new Set(
       config.upgrades
-        .map((upgrade) => upgrade.labels ?? [])
+        .map((upgrade) => coerceArray(upgrade.labels))
         .reduce((a, b) => a.concat(b), []),
     ),
   ];
   config.addLabels = [
     ...new Set(
       config.upgrades
-        .map((upgrade) => upgrade.addLabels ?? [])
+        .map((upgrade) => coerceArray(upgrade.addLabels))
         .reduce((a, b) => a.concat(b), []),
     ),
   ];

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -11,6 +11,7 @@ import noStatefulGlobalRegex from './rules/no-stateful-global-regex.ts';
 import noToolsImport from './rules/no-tools-import.ts';
 import noUnquotedExecInterpolation from './rules/no-unquoted-exec-interpolation.ts';
 import noUnvalidatedPaginationUrl from './rules/no-unvalidated-pagination-url.ts';
+import preferCoerceArray from './rules/prefer-coerce-array.ts';
 import preferFakeShaInSpecs from './rules/prefer-fake-sha-in-specs.ts';
 import preferFsUtil from './rules/prefer-fs-util.ts';
 import preferIsHelpers from './rules/prefer-is-helpers.ts';
@@ -44,6 +45,7 @@ export default definePlugin({
     'no-tools-import': noToolsImport,
     'no-unquoted-exec-interpolation': noUnquotedExecInterpolation,
     'no-unvalidated-pagination-url': noUnvalidatedPaginationUrl,
+    'prefer-coerce-array': preferCoerceArray,
     'prefer-fake-sha-in-specs': preferFakeShaInSpecs,
     'prefer-fs-util': preferFsUtil,
     'prefer-json-pipe': preferJsonPipe,

--- a/tools/lint/rules/prefer-coerce-array.spec.ts
+++ b/tools/lint/rules/prefer-coerce-array.spec.ts
@@ -1,0 +1,53 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './prefer-coerce-array.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+});
+
+ruleTester.run('prefer-coerce-array', rule, {
+  valid: [
+    // already using the helper
+    `const a = coerceArray(x);`,
+    // non-empty default
+    `const a = x ?? [1];`,
+    // asserted default is not a bare array literal
+    `const a = x ?? ([] as string[]);`,
+    // object default belongs to `prefer-coerce-object`
+    `const a = x ?? {};`,
+    // other logical operators
+    `const a = x || [];`,
+    `const a = x && [];`,
+    // assignment rather than a logical expression
+    `x ??= [];`,
+    // destructuring and parameter defaults have no helper form
+    `const { a = [] } = obj;`,
+    `function f(a = []) {}`,
+    // empty array unrelated to a nullish default
+    `const a = [];`,
+  ],
+  invalid: [
+    {
+      code: `const a = x ?? [];`,
+      errors: [{ messageId: 'preferCoerceArray' }],
+    },
+    // optional chaining operand
+    {
+      code: `const a = x?.y ?? [];`,
+      errors: [{ messageId: 'preferCoerceArray' }],
+    },
+    // call expression operand
+    {
+      code: `for (const f of getFiles() ?? []) {}`,
+      errors: [{ messageId: 'preferCoerceArray' }],
+    },
+    // chained nullish defaults report once, on the outer expression
+    {
+      code: `const a = x ?? y ?? [];`,
+      errors: [{ messageId: 'preferCoerceArray' }],
+    },
+  ],
+});

--- a/tools/lint/rules/prefer-coerce-array.ts
+++ b/tools/lint/rules/prefer-coerce-array.ts
@@ -1,0 +1,32 @@
+import { defineRule } from '@oxlint/plugins';
+
+/**
+ * Flags `x ?? []` in favour of `coerceArray(x)` from `lib/util/array.ts`.
+ *
+ * Only a bare `[]` literal counts: `x ?? [1]` keeps a meaningful default, and
+ * `x ?? ([] as Foo[])` carries an assertion the helper cannot express.
+ */
+export default defineRule({
+  meta: {
+    type: 'suggestion',
+    messages: {
+      preferCoerceArray:
+        'Use `coerceArray()` from `lib/util/array.ts` instead of `?? []`.',
+    },
+  },
+  createOnce(context) {
+    return {
+      LogicalExpression(node) {
+        if (node.operator !== '??') {
+          return;
+        }
+        if (
+          node.right.type === 'ArrayExpression' &&
+          node.right.elements.length === 0
+        ) {
+          context.report({ node, messageId: 'preferCoerceArray' });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Changes

Adds a `renovate/prefer-coerce-array` oxlint rule and applies it across `lib/`.

`x ?? []` and `coerceArray(x)` say the same thing, but only the second one is searchable and consistent, so the rule flags a `??` whose default is a bare `[]` literal. A meaningful default (`x ?? [1]`) and an asserted one (`x ?? ([] as Foo[])`) still pass, as does a destructuring or parameter default, where the helper has no equivalent form.

The rule is enabled for `lib/**` (including specs). `tools/**` is left out because it may not import from `lib/`.

Applying it rewrote 153 sites in 84 files. Three of those the helper cannot cover, and they are handled individually rather than silenced wholesale:

- `lib/workers/repository/package-files.ts` — tuple destructuring default; `coerceArray()` widens the tuple to a union array, so the `?? []` stays with a disable comment
- `lib/workers/repository/updates/generate.spec.ts` — defaults `matchAll()`, which yields an iterator rather than an array; same, with a disable comment
- `lib/modules/manager/mise/upgradeable-tooling.ts` — declares a `Record<string, string>` return, so the `?? []` fallback was the wrong shape to begin with and becomes `coerceObject()`

A fourth, `lib/modules/platform/github/index.ts`, defaulted an `Object.entries(...).find()` tuple only to destructure one element out of it; that one is hoisted into a named variable in a separate commit, which drops the `?? []` altogether.

The rewrite is mechanical and behaviour-preserving otherwise: for a `T[] | null | undefined` input, `coerceArray(x)` and `x ?? []` are equivalent.

`#45216` (`coerceObject`) builds on this branch — the two touch overlapping lines in several files, so they are best reviewed and merged in order.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45217
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5 via Claude Code wrote the lint rule and its tests, and ran the codemod that applied the rule across `lib/`.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`tools/lint/rules/prefer-coerce-array.spec.ts` covers the rule itself. The existing suite covers the rewritten call sites; `tsc --noEmit`, `oxlint`, `biome` and `prettier` are clean, and `vitest run --changed` passes apart from two failures that also reproduce on `main` in this environment (`lib/logger/pretty-stdout.spec.ts` colour detection and a `git clone` submodule test blocked by `protocol.file.allow`).
