### PR TITLE
test: replace env operation with `vi.stubEnv()` 

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -302,6 +302,7 @@
         "renovate/prefer-fake-sha-in-specs": "error",
         "renovate/prefer-nullish-util": "off",
         "renovate/prefer-partial-in-specs": "error",
+        "renovate/prefer-stub-env": "error",
         "renovate/test-root-describe": "error",
         "typescript/explicit-function-return-type": "off"
       }

--- a/lib/config/decrypt.spec.ts
+++ b/lib/config/decrypt.spec.ts
@@ -16,8 +16,8 @@ describe('config/decrypt', () => {
     beforeEach(() => {
       config = {};
       GlobalConfig.reset();
-      delete process.env.MEND_HOSTED;
-      delete process.env.RENOVATE_X_ENCRYPTED_STRICT;
+      vi.stubEnv('MEND_HOSTED', undefined);
+      vi.stubEnv('RENOVATE_X_ENCRYPTED_STRICT', undefined);
     });
 
     it('returns empty with no privateKey', async () => {
@@ -41,7 +41,7 @@ describe('config/decrypt', () => {
     it('throws exception if encrypted found but no privateKey', async () => {
       config.encrypted = { a: '1' };
 
-      process.env.RENOVATE_X_ENCRYPTED_STRICT = 'true';
+      vi.stubEnv('RENOVATE_X_ENCRYPTED_STRICT', 'true');
       await expect(decryptConfig(config, repository)).rejects.toThrow(
         'config-validation',
       );
@@ -51,8 +51,8 @@ describe('config/decrypt', () => {
     it('throws exception if encrypted found but no privateKey- Mend Hosted', async () => {
       config.encrypted = { a: '1' };
 
-      process.env.MEND_HOSTED = 'true';
-      process.env.RENOVATE_X_ENCRYPTED_STRICT = 'true';
+      vi.stubEnv('MEND_HOSTED', 'true');
+      vi.stubEnv('RENOVATE_X_ENCRYPTED_STRICT', 'true');
 
       await expect(decryptConfig(config, repository)).rejects.toMatchObject({
         message: 'config-validation',
@@ -67,8 +67,8 @@ describe('config/decrypt', () => {
       GlobalConfig.set({
         productLinks: { documentation: 'https://custom.example.com/' },
       });
-      process.env.MEND_HOSTED = 'true';
-      process.env.RENOVATE_X_ENCRYPTED_STRICT = 'true';
+      vi.stubEnv('MEND_HOSTED', 'true');
+      vi.stubEnv('RENOVATE_X_ENCRYPTED_STRICT', 'true');
 
       await expect(decryptConfig(config, repository)).rejects.toMatchObject({
         validationMessage: expect.stringContaining(

--- a/lib/config/decrypt/bcpgp.spec.ts
+++ b/lib/config/decrypt/bcpgp.spec.ts
@@ -34,11 +34,11 @@ describe('config/decrypt/bcpgp', () => {
       config = {};
       GlobalConfig.reset();
       setPrivateKeys(undefined, undefined);
-      delete process.env.RENOVATE_X_PGP_RUNTIME;
+      vi.stubEnv('RENOVATE_X_PGP_RUNTIME', undefined);
     });
 
     it('returns null for invalid key', async () => {
-      process.env.RENOVATE_X_PGP_RUNTIME = 'invalid-runtime';
+      vi.stubEnv('RENOVATE_X_PGP_RUNTIME', 'invalid-runtime');
       expect(
         await tryDecryptBcPgp(
           'invalid-key',
@@ -52,7 +52,7 @@ describe('config/decrypt/bcpgp', () => {
     });
 
     it('works broken PGP message', async () => {
-      process.env.RENOVATE_X_PGP_RUNTIME = 'wasm-dotnet';
+      vi.stubEnv('RENOVATE_X_PGP_RUNTIME', 'wasm-dotnet');
       expect(
         await tryDecryptBcPgp(
           privateKey,
@@ -72,7 +72,7 @@ describe('config/decrypt/bcpgp', () => {
     it('fails with ECC and AEAD (wasm-dotnet', async () => {
       // not supported by bouncycastle C# implementation
       // https://github.com/bcgit/bc-csharp/issues/497
-      process.env.RENOVATE_X_PGP_RUNTIME = 'wasm-dotnet';
+      vi.stubEnv('RENOVATE_X_PGP_RUNTIME', 'wasm-dotnet');
       expect(
         await tryDecryptBcPgp(
           privateKeyEcc,

--- a/lib/instrumentation/index.spec.ts
+++ b/lib/instrumentation/index.spec.ts
@@ -22,29 +22,25 @@ afterAll(disableInstrumentations);
 
 describe('instrumentation/index', () => {
   let tmpDir: DirectoryResult;
-  const oldEnv = process.env;
 
   beforeEach(async () => {
     tmpDir = await dir({ unsafeCleanup: true });
 
     api.trace.disable(); // clear global components
-    process.env = { ...oldEnv };
 
     // remove any otel env
     for (const key in process.env) {
       if (key.startsWith('OTEL_')) {
-        delete process.env[key];
+        vi.stubEnv(key, undefined);
       }
     }
-    delete process.env.RENOVATE_TRACING_CONSOLE_EXPORTER;
-    delete process.env.RENOVATE_TRACING_FILE_EXPORTER_PATH;
+    vi.stubEnv('RENOVATE_TRACING_CONSOLE_EXPORTER', undefined);
+    vi.stubEnv('RENOVATE_TRACING_FILE_EXPORTER_PATH', undefined);
     // prevent real network calls to cloud metadata endpoints (AWS/GCP/Azure) during tests
-    process.env.RENOVATE_USE_CLOUD_METADATA_SERVICES = 'false';
+    vi.stubEnv('RENOVATE_USE_CLOUD_METADATA_SERVICES', 'false');
   });
 
   afterAll(async () => {
-    process.env = oldEnv; // Restore old environment
-
     await tmpDir.cleanup();
   });
 
@@ -57,7 +53,7 @@ describe('instrumentation/index', () => {
   });
 
   it('activate console logger', () => {
-    process.env.RENOVATE_TRACING_CONSOLE_EXPORTER = 'true';
+    vi.stubEnv('RENOVATE_TRACING_CONSOLE_EXPORTER', 'true');
 
     init();
     const traceProvider = getTracerProvider();
@@ -78,9 +74,9 @@ describe('instrumentation/index', () => {
   });
 
   it('registers OpenTelemetry file exporter if enabled', () => {
-    process.env.RENOVATE_TRACING_FILE_EXPORTER_PATH = upath.join(
-      tmpDir.path,
-      'test-traces.jsonl',
+    vi.stubEnv(
+      'RENOVATE_TRACING_FILE_EXPORTER_PATH',
+      upath.join(tmpDir.path, 'test-traces.jsonl'),
     );
 
     init();
@@ -108,8 +104,8 @@ describe('instrumentation/index', () => {
 
   it('registers GitOperationSpanProcessor, GetDatasourceReleasesSpanProcessor regardless of tracing being enabled', () => {
     // intentionally don't set it
-    delete process.env.RENOVATE_TRACING_CONSOLE_EXPORTER;
-    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    vi.stubEnv('RENOVATE_TRACING_CONSOLE_EXPORTER', undefined);
+    vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', undefined);
 
     init();
     const traceProvider = getTracerProvider();
@@ -127,7 +123,7 @@ describe('instrumentation/index', () => {
   });
 
   it('activate remote logger', () => {
-    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'https://collector.example.com';
+    vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'https://collector.example.com');
 
     init();
     const traceProvider = getTracerProvider();
@@ -160,8 +156,8 @@ describe('instrumentation/index', () => {
   });
 
   it('activate console logger and remote logger', () => {
-    process.env.RENOVATE_TRACING_CONSOLE_EXPORTER = 'true';
-    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = 'https://collector.example.com';
+    vi.stubEnv('RENOVATE_TRACING_CONSOLE_EXPORTER', 'true');
+    vi.stubEnv('OTEL_EXPORTER_OTLP_ENDPOINT', 'https://collector.example.com');
 
     init();
     const traceProvider = getTracerProvider();
@@ -199,7 +195,7 @@ describe('instrumentation/index', () => {
     //
     // Claude Sonnet 4.6 suggests that we instead create an (admittedly brittle) test to validate that this is marked as `__wrapped`.
     it('patches bunyan Logger._emit when tracing is enabled', () => {
-      process.env.RENOVATE_TRACING_CONSOLE_EXPORTER = 'true';
+      vi.stubEnv('RENOVATE_TRACING_CONSOLE_EXPORTER', 'true');
       init();
 
       const mod = bunyan();

--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -38,7 +38,7 @@ await init();
 
 describe('logger/index', () => {
   beforeEach(() => {
-    delete process.env.LOG_FILE_LEVEL;
+    vi.stubEnv('LOG_FILE_LEVEL', undefined);
   });
 
   it('inits', () => {
@@ -204,7 +204,7 @@ describe('logger/index', () => {
 
   describe('createDefaultStreams', () => {
     beforeEach(() => {
-      delete process.env.LOG_FILE_FORMAT;
+      vi.stubEnv('LOG_FILE_FORMAT', undefined);
     });
 
     it('creates log file stream', () => {
@@ -230,7 +230,7 @@ describe('logger/index', () => {
       'handles log file stream $logFileLevel level',
       ({ logFileLevel, expectedLogLevel }) => {
         if (logFileLevel !== null) {
-          process.env.LOG_FILE_LEVEL = logFileLevel?.toString();
+          vi.stubEnv('LOG_FILE_LEVEL', logFileLevel?.toString());
         }
 
         const streams = createDefaultStreams(
@@ -257,7 +257,7 @@ describe('logger/index', () => {
     ])(
       'handles log file stream $logFileFormat format',
       ({ logFileFormat, expectedType }) => {
-        process.env.LOG_FILE_FORMAT = logFileFormat;
+        vi.stubEnv('LOG_FILE_FORMAT', logFileFormat);
 
         const streams = createDefaultStreams(
           'info',
@@ -272,7 +272,7 @@ describe('logger/index', () => {
     );
 
     it('writes pretty formatted data synchronously to log file', async () => {
-      process.env.LOG_FILE_FORMAT = 'pretty';
+      vi.stubEnv('LOG_FILE_FORMAT', 'pretty');
 
       const streams = createDefaultStreams(
         'info',

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -126,11 +126,7 @@ describe('logger/pretty-stdout', () => {
 
   describe('formatRecord(rec)', () => {
     beforeEach(() => {
-      process.env.FORCE_COLOR = '1';
-    });
-
-    afterEach(() => {
-      delete process.env.FORCE_COLOR;
+      vi.stubEnv('FORCE_COLOR', '1');
     });
 
     it('formats record', () => {

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -125,10 +125,6 @@ describe('logger/pretty-stdout', () => {
   });
 
   describe('formatRecord(rec)', () => {
-    beforeEach(() => {
-      vi.stubEnv('FORCE_COLOR', '1');
-    });
-
     it('formats record', () => {
       const rec: BunyanRecord = {
         level: 10,
@@ -139,9 +135,13 @@ describe('logger/pretty-stdout', () => {
           d: ['e', 'f'],
         },
       };
+      // The colorized level strings are built once, when the module is
+      // imported, so whether they carry ANSI codes depends on the colour
+      // support of the surrounding environment. Derive the expectation the
+      // same way instead of assuming an uncoloured terminal.
       expect(prettyStdout.formatRecord(rec)).toEqual(
         [
-          `TRACE: test message`,
+          `${util.styleText('gray', 'TRACE')}: test message`,
           `       "config": {"a": "b", "d": ["e", "f"]}`,
           ``,
         ].join('\n'),

--- a/lib/modules/datasource/docker/index.spec.ts
+++ b/lib/modules/datasource/docker/index.spec.ts
@@ -169,10 +169,10 @@ describe('modules/datasource/docker/index', () => {
       username: 'some-username',
       password: 'some-password',
     });
-    delete process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE;
-    delete process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP;
-    delete process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN;
-    delete process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN;
+    vi.stubEnv('RENOVATE_X_DOCKER_HUB_TAGS_DISABLE', undefined);
+    vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', undefined);
+    vi.stubEnv('RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN', undefined);
+    vi.stubEnv('RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN', undefined);
   });
 
   describe('getDigest', () => {
@@ -1736,7 +1736,7 @@ describe('modules/datasource/docker/index', () => {
 
   describe('getReleases', () => {
     it('returns null if no token', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_TAGS_DISABLE', 'true');
       httpMock
         .scope(baseUrl)
         .get('/library/node/tags/list?n=10000')
@@ -1808,7 +1808,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('follows cross-origin tags pagination when the datasource is opted in', async () => {
-      process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN', 'true');
       httpMock
         .scope('https://registry.company.com/v2')
         .get('/node/tags/list?n=10000')
@@ -1842,7 +1842,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('does not opt docker in when only another datasource is opted in', async () => {
-      process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      vi.stubEnv('RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN', 'true');
       httpMock
         .scope('https://registry.company.com/v2')
         .get('/node/tags/list?n=10000')
@@ -1868,9 +1868,9 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('uses custom max pages', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       GlobalConfig.set({ dockerMaxPages: 2 });
-      process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_TAGS_DISABLE', 'true');
       httpMock
         .scope(baseUrl)
         .get('/library/node/tags/list?n=10000')
@@ -2494,7 +2494,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('Uses Docker Hub tags for registry-1.docker.io', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       httpMock
         .scope(dockerHubUrl)
         .get('/library/node/tags?page_size=1000&ordering=last_updated')
@@ -2541,7 +2541,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('Uses custom page limit for Docker hub repository tags', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       GlobalConfig.set({ dockerMaxPages: 2 });
       httpMock
         .scope(dockerHubUrl)
@@ -2593,7 +2593,7 @@ describe('modules/datasource/docker/index', () => {
 
     // as this could lead to a Server-Side Request Forgery (SSRF), but could also be misconfiguration
     it('does not follow Docker Hub tags pagination to a different origin', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       httpMock
         .scope(dockerHubUrl)
         .get('/library/node/tags?page_size=1000&ordering=last_updated')
@@ -2633,8 +2633,8 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('follows cross-origin Docker Hub pagination when the datasource is opted in', async () => {
-      process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN', 'true');
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       httpMock
         .scope(dockerHubUrl)
         .get('/library/node/tags?page_size=1000&ordering=last_updated')
@@ -2679,7 +2679,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('adds library/ prefix for Docker Hub (implicit)', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       const tags = ['1.0.0'];
       httpMock
         .scope(dockerHubUrl)
@@ -2708,7 +2708,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('adds library/ prefix for Docker Hub (explicit)', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       httpMock
         .scope(dockerHubUrl)
         .get('/library/node/tags?page_size=1000&ordering=last_updated')
@@ -2755,7 +2755,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('sets releaseTimestamp on digests from Docker Hub', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
       httpMock
         .scope(dockerHubUrl)
         .get('/library/node/tags?page_size=1000&ordering=last_updated')
@@ -2833,7 +2833,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('returns null on error', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_TAGS_DISABLE', 'true');
       httpMock
         .scope(baseUrl)
         .get('/my/node/tags/list?n=10000')
@@ -2848,7 +2848,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('strips trailing slash from registry', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_TAGS_DISABLE', 'true');
       httpMock
         .scope(baseUrl)
         .get('/my/node/tags/list?n=10000')
@@ -2875,7 +2875,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('returns null if no auth', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_TAGS_DISABLE = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_TAGS_DISABLE', 'true');
       hostRules.clear();
       httpMock
         .scope(baseUrl)
@@ -3579,7 +3579,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('skips docker hub labels', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
 
       httpMock.scope('https://index.docker.io/v2');
 
@@ -3593,7 +3593,7 @@ describe('modules/datasource/docker/index', () => {
     });
 
     it('does not skip non docker hub registry labels', async () => {
-      process.env.RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_HUB_DISABLE_LABEL_LOOKUP', 'true');
 
       httpMock
         .scope('https://ghcr.io/v2')

--- a/lib/modules/datasource/git-refs/index.spec.ts
+++ b/lib/modules/datasource/git-refs/index.spec.ts
@@ -2,6 +2,7 @@ import type { SimpleGit } from 'simple-git';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
+import { clearEnv } from '~test/util.ts';
 import * as git from '../../../util/git/index.ts';
 import { getPkgReleases } from '../index.ts';
 import { GitRefsDatasource } from './index.ts';
@@ -18,8 +19,7 @@ describe('modules/datasource/git-refs/index', () => {
   let gitMock: MockProxy<SimpleGit>;
 
   beforeEach(() => {
-    // clear environment variables
-    process.env = {};
+    clearEnv();
 
     // reset git mock
     gitMock = mock<SimpleGit>({

--- a/lib/modules/datasource/git-tags/index.spec.ts
+++ b/lib/modules/datasource/git-tags/index.spec.ts
@@ -2,6 +2,7 @@ import type { SimpleGit } from 'simple-git';
 import type { MockProxy } from 'vitest-mock-extended';
 import { mock } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
+import { clearEnv } from '~test/util.ts';
 import * as git from '../../../util/git/index.ts';
 import { getPkgReleases } from '../index.ts';
 import { GitTagsDatasource } from './index.ts';
@@ -19,8 +20,7 @@ describe('modules/datasource/git-tags/index', () => {
   let gitMock: MockProxy<SimpleGit>;
 
   beforeEach(() => {
-    // clear environment variables
-    process.env = {};
+    clearEnv();
 
     // reset git mock
     gitMock = mock<SimpleGit>({

--- a/lib/modules/datasource/go/index.spec.ts
+++ b/lib/modules/datasource/go/index.spec.ts
@@ -51,10 +51,6 @@ const datasource = new GoDatasource();
 
 describe('modules/datasource/go/index', () => {
   describe('getReleases', () => {
-    afterEach(() => {
-      delete process.env.GOPROXY;
-    });
-
     it('fetches releases', async () => {
       const expected = { releases: [{ version: '0.0.1' }] };
       getReleasesProxyMock.mockResolvedValue(expected);
@@ -211,12 +207,8 @@ describe('modules/datasource/go/index', () => {
     });
 
     describe('GOPROXY', () => {
-      afterEach(() => {
-        delete process.env.GOPROXY;
-      });
-
       it('returns null when GOPROXY contains off', async () => {
-        process.env.GOPROXY = 'https://proxy.golang.org,off';
+        vi.stubEnv('GOPROXY', 'https://proxy.golang.org,off');
         const res = await datasource.getDigest(
           { packageName: 'golang.org/x/text' },
           'v1.2.3',
@@ -227,10 +219,6 @@ describe('modules/datasource/go/index', () => {
   });
 
   describe('using getPkgReleases', () => {
-    afterEach(() => {
-      delete process.env.GOPROXY;
-    });
-
     describe('constraints', () => {
       // TODO deprecated #42600
       it('are respected based on an exact match on the `go` constraint', async () => {

--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -100,15 +100,8 @@ describe('modules/datasource/go/releases-goproxy', () => {
       githubQueryReleases.mockResolvedValue([]);
     });
 
-    afterEach(() => {
-      delete process.env.GOPROXY;
-      delete process.env.GONOPROXY;
-      delete process.env.GOPRIVATE;
-      delete process.env.GOINSECURE;
-    });
-
     it('handles direct', async () => {
-      process.env.GOPROXY = 'direct';
+      vi.stubEnv('GOPROXY', 'direct');
 
       githubGetTags.mockResolvedValueOnce({
         releases: [
@@ -132,8 +125,8 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('skips GONOPROXY and GOPRIVATE packages', async () => {
-      process.env.GOPROXY = baseUrl;
-      process.env.GOPRIVATE = 'github.com/google/*';
+      vi.stubEnv('GOPROXY', baseUrl);
+      vi.stubEnv('GOPRIVATE', 'github.com/google/*');
 
       githubGetTags.mockResolvedValueOnce({
         releases: [
@@ -201,7 +194,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('resolves sourceUrl from goproxy Origin without calling the vanity domain', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/k8s.io/api`)
@@ -246,7 +239,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('prefers the GitHub Release timestamp over the commit timestamp', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/stretchr/testify`)
@@ -296,7 +289,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('keeps the commit timestamp when the GitHub Release is older', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/google/btree`)
@@ -337,7 +330,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('matches GitHub Releases of modules in a subdirectory', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/aws/aws-sdk-go-v2/service/s3`)
@@ -375,7 +368,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('matches GitHub Releases of `+incompatible` versions', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/docker/docker`)
@@ -411,7 +404,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('skips GitHub Releases lookup for non-GitHub source URLs', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/bitbucket.org/library/go-lib`)
@@ -440,7 +433,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles GitHub Releases fetch errors', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/google/btree`)
@@ -470,7 +463,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles timestamp fetch errors', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/google/btree`)
@@ -509,7 +502,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     `(
       'handles pipe fallback when abortOnError is $abortOnError',
       async ({ abortOnError }: { abortOnError: boolean }) => {
-        process.env.GOPROXY = `https://example.com|${baseUrl}`;
+        vi.stubEnv('GOPROXY', `https://example.com|${baseUrl}`);
         hostRules.add({ abortOnError });
 
         httpMock
@@ -552,7 +545,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     );
 
     it('handles pipe fallback across an empty segment', async () => {
-      process.env.GOPROXY = `https://example.com|,${baseUrl}`;
+      vi.stubEnv('GOPROXY', `https://example.com|,${baseUrl}`);
 
       httpMock
         .scope('https://example.com/github.com/google/btree')
@@ -584,11 +577,12 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles comma fallback', async () => {
-      process.env.GOPROXY = [
-        'https://foo.example.com',
-        'https://bar.example.com',
-        baseUrl,
-      ].join(',');
+      vi.stubEnv(
+        'GOPROXY',
+        ['https://foo.example.com', 'https://bar.example.com', baseUrl].join(
+          ',',
+        ),
+      );
 
       httpMock
         .scope('https://foo.example.com/github.com/google/btree')
@@ -634,12 +628,15 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('short-circuits for errors other than 404 or 410', async () => {
-      process.env.GOPROXY = [
-        'https://foo.com',
-        'https://bar.com',
-        'https://baz.com',
-        'direct',
-      ].join(',');
+      vi.stubEnv(
+        'GOPROXY',
+        [
+          'https://foo.com',
+          'https://bar.com',
+          'https://baz.com',
+          'direct',
+        ].join(','),
+      );
 
       httpMock
         .scope('https://foo.com/github.com/foo/bar')
@@ -663,11 +660,10 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('supports "direct" keyword', async () => {
-      process.env.GOPROXY = [
-        'https://foo.com',
-        'https://bar.com',
-        'direct',
-      ].join(',');
+      vi.stubEnv(
+        'GOPROXY',
+        ['https://foo.com', 'https://bar.com', 'direct'].join(','),
+      );
 
       httpMock
         .scope('https://foo.com/github.com/foo/bar')
@@ -701,8 +697,9 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('supports "off" keyword', async () => {
-      process.env.GOPROXY = ['https://foo.com', 'https://bar.com', 'off'].join(
-        ',',
+      vi.stubEnv(
+        'GOPROXY',
+        ['https://foo.com', 'https://bar.com', 'off'].join(','),
       );
 
       httpMock
@@ -723,7 +720,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles soureUrl fetch errors', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/custom.com/lib/btree`)
@@ -760,7 +757,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     `(
       'handles major releases with abortOnError is $abortOnError',
       async ({ abortOnError }: { abortOnError: boolean }) => {
-        process.env.GOPROXY = baseUrl;
+        vi.stubEnv('GOPROXY', baseUrl);
         hostRules.add({ abortOnError });
 
         httpMock
@@ -810,7 +807,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     );
 
     it('handles major releases with 403 status (Artifactory)', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/google/btree`)
@@ -858,7 +855,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles gopkg.in major releases', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/gopkg.in/yaml`)
@@ -901,7 +898,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles gopkg.in major releases from v0', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/gopkg.in/foo`)
@@ -938,7 +935,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('handles baseURL with slash at the end', async () => {
-      process.env.GOPROXY = `${baseUrl}/`;
+      vi.stubEnv('GOPROXY', `${baseUrl}/`);
 
       httpMock
         .scope(`${baseUrl}/gopkg.in/foo`)
@@ -975,7 +972,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('continues if package returns no releases', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/google/btree`)
@@ -992,7 +989,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
     });
 
     it('uses latest if package has no releases', async () => {
-      process.env.GOPROXY = baseUrl;
+      vi.stubEnv('GOPROXY', baseUrl);
 
       httpMock
         .scope(`${baseUrl}/github.com/google/btree`)

--- a/lib/modules/datasource/npm/index.spec.ts
+++ b/lib/modules/datasource/npm/index.spec.ts
@@ -365,7 +365,7 @@ describe('modules/datasource/npm/index', () => {
       .scope('https://registry.from-env.com')
       .get('/foobar')
       .reply(200, npmResponse);
-    process.env.REGISTRY = 'https://registry.from-env.com';
+    vi.stubEnv('REGISTRY', 'https://registry.from-env.com');
     GlobalConfig.set({ exposeAllEnv: true });
 
     const npmrc = 'registry=${REGISTRY}';

--- a/lib/modules/datasource/npm/npmrc.spec.ts
+++ b/lib/modules/datasource/npm/npmrc.spec.ts
@@ -202,7 +202,7 @@ describe('modules/datasource/npm/npmrc', () => {
 
   it('sanitize _authtoken with high trust', () => {
     GlobalConfig.set({ exposeAllEnv: true });
-    process.env.TEST_TOKEN = 'test';
+    vi.stubEnv('TEST_TOKEN', 'test');
     setNpmrc(
       '//registry.test.com:_authToken=${TEST_TOKEN}\n_authToken=\nregistry=http://localhost',
     );

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -1,6 +1,7 @@
 import { Readable } from 'node:stream';
 import { codeBlock } from 'common-tags';
-import upath from 'upath';
+import type { DirectoryResult } from 'tmp-promise';
+import tmp from 'tmp-promise';
 import { mockDeep } from 'vitest-mock-extended';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
@@ -346,11 +347,18 @@ describe('modules/datasource/nuget/index', () => {
     });
 
     describe('determine source URL from nupkg', () => {
-      beforeEach(() => {
-        GlobalConfig.set({
-          cacheDir: upath.join('/tmp/cache'),
-        });
+      // These tests really download the .nupkg to disk, so give them a
+      // throwaway directory instead of a fixed path under the system tmpdir.
+      let cacheDirResult: DirectoryResult;
+
+      beforeEach(async () => {
+        cacheDirResult = await tmp.dir({ unsafeCleanup: true });
+        GlobalConfig.set({ cacheDir: cacheDirResult.path });
         vi.stubEnv('RENOVATE_X_NUGET_DOWNLOAD_NUPKGS', 'true');
+      });
+
+      afterEach(async () => {
+        await cacheDirResult?.cleanup();
       });
 
       it('can determine source URL from nupkg when PackageBaseAddress is missing', async () => {

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -121,7 +121,7 @@ const configV3Deprecated = {
 describe('modules/datasource/nuget/index', () => {
   beforeEach(() => {
     GlobalConfig.reset();
-    delete process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN;
+    vi.stubEnv('RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN', undefined);
   });
 
   describe('parseRegistryUrl', () => {
@@ -350,11 +350,7 @@ describe('modules/datasource/nuget/index', () => {
         GlobalConfig.set({
           cacheDir: upath.join('/tmp/cache'),
         });
-        process.env.RENOVATE_X_NUGET_DOWNLOAD_NUPKGS = 'true';
-      });
-
-      afterEach(() => {
-        delete process.env.RENOVATE_X_NUGET_DOWNLOAD_NUPKGS;
+        vi.stubEnv('RENOVATE_X_NUGET_DOWNLOAD_NUPKGS', 'true');
       });
 
       it('can determine source URL from nupkg when PackageBaseAddress is missing', async () => {
@@ -979,7 +975,7 @@ describe('modules/datasource/nuget/index', () => {
     });
 
     it('follows cross-origin pagination when the datasource is opted in (v2)', async () => {
-      process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      vi.stubEnv('RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN', 'true');
       httpMock
         .scope('https://www.nuget.org')
         .get(

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -80,15 +80,8 @@ const datasource = PypiDatasource.id;
 
 describe('modules/datasource/pypi/index', () => {
   describe('getReleases', () => {
-    const OLD_ENV = process.env;
-
     beforeEach(() => {
-      process.env = { ...OLD_ENV };
-      delete process.env.PIP_INDEX_URL;
-    });
-
-    afterEach(() => {
-      process.env = OLD_ENV;
+      vi.stubEnv('PIP_INDEX_URL', undefined);
     });
 
     it('returns null for 404', async () => {

--- a/lib/modules/datasource/util.spec.ts
+++ b/lib/modules/datasource/util.spec.ts
@@ -6,25 +6,20 @@ import {
 
 describe('modules/datasource/util', () => {
   describe('isCrossOriginPaginationAllowed', () => {
-    afterEach(() => {
-      delete process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN;
-      delete process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN;
-    });
-
     it('returns false when the flag is unset', () => {
       expect(isCrossOriginPaginationAllowed('docker')).toBe(false);
       expect(isCrossOriginPaginationAllowed('nuget')).toBe(false);
     });
 
     it('returns true only for the opted-in datasource', () => {
-      process.env.RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      vi.stubEnv('RENOVATE_X_DOCKER_PAGINATION_ALLOW_CROSS_ORIGIN', 'true');
       expect(isCrossOriginPaginationAllowed('docker')).toBe(true);
       // per-datasource: docker's flag must not opt nuget in
       expect(isCrossOriginPaginationAllowed('nuget')).toBe(false);
     });
 
     it('reads a separate flag for nuget', () => {
-      process.env.RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN = 'true';
+      vi.stubEnv('RENOVATE_X_NUGET_PAGINATION_ALLOW_CROSS_ORIGIN', 'true');
       expect(isCrossOriginPaginationAllowed('nuget')).toBe(true);
       expect(isCrossOriginPaginationAllowed('docker')).toBe(false);
     });

--- a/lib/modules/manager/bundler/artifacts.spec.ts
+++ b/lib/modules/manager/bundler/artifacts.spec.ts
@@ -49,7 +49,7 @@ const updatedGemfileLock = {
 describe('modules/manager/bundler/artifacts', () => {
   describe('updateArtifacts', () => {
     beforeEach(() => {
-      delete process.env.GEM_HOME;
+      vi.stubEnv('GEM_HOME', undefined);
 
       env.getChildProcessEnv.mockReturnValue(envMock.basic);
       docker.resetPrefetchedImages();

--- a/lib/modules/manager/cargo/extract.spec.ts
+++ b/lib/modules/manager/cargo/extract.spec.ts
@@ -33,8 +33,8 @@ describe('modules/manager/cargo/extract', () => {
     const config: ExtractConfig = {};
 
     beforeEach(() => {
-      delete process.env.CARGO_REGISTRIES_PRIVATE_CRATES_INDEX;
-      delete process.env.CARGO_REGISTRIES_MCORBIN_INDEX;
+      vi.stubEnv('CARGO_REGISTRIES_PRIVATE_CRATES_INDEX', undefined);
+      vi.stubEnv('CARGO_REGISTRIES_MCORBIN_INDEX', undefined);
 
       hostRules.clear();
       hostRules.add({
@@ -297,10 +297,14 @@ replace-with = "mcorbin"`,
     });
 
     it('extracts registry urls from environment', async () => {
-      process.env.CARGO_REGISTRIES_PRIVATE_CRATES_INDEX =
-        'https://dl.cloudsmith.io/basic/my-org/my-repo/cargo/index.git';
-      process.env.CARGO_REGISTRIES_MCORBIN_INDEX =
-        'https://github.com/mcorbin/testregistry';
+      vi.stubEnv(
+        'CARGO_REGISTRIES_PRIVATE_CRATES_INDEX',
+        'https://dl.cloudsmith.io/basic/my-org/my-repo/cargo/index.git',
+      );
+      vi.stubEnv(
+        'CARGO_REGISTRIES_MCORBIN_INDEX',
+        'https://github.com/mcorbin/testregistry',
+      );
       const res = await extractPackageFile(cargo6toml, 'Cargo.toml', {
         ...config,
       });

--- a/lib/modules/manager/git-submodules/extract.spec.ts
+++ b/lib/modules/manager/git-submodules/extract.spec.ts
@@ -1,6 +1,7 @@
 import { isArray, isString } from '@sindresorhus/is';
 import type { Response, SimpleGit } from 'simple-git';
 import { mock } from 'vitest-mock-extended';
+import { clearEnv } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import * as git from '../../../util/git/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
@@ -17,8 +18,7 @@ describe('modules/manager/git-submodules/extract', () => {
     GlobalConfig.set({ localDir: `${import.meta.dirname}/__fixtures__` });
     // clear host rules
     hostRules.clear();
-    // clear environment variables
-    process.env = {};
+    clearEnv();
 
     createSimpleGit.mockImplementation((...args: any[]) => {
       const git = simpleGit(...args);

--- a/lib/modules/manager/git-submodules/update.spec.ts
+++ b/lib/modules/manager/git-submodules/update.spec.ts
@@ -4,7 +4,7 @@ import type { DirectoryResult } from 'tmp-promise';
 import { dir } from 'tmp-promise';
 import upath from 'upath';
 import { mock } from 'vitest-mock-extended';
-import { fs } from '~test/util.ts';
+import { clearEnv, fs } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import type {
   InternalGlobalConfigOptions,
@@ -23,8 +23,7 @@ const baseDir = `${import.meta.dirname}/__fixtures__`;
 describe('modules/manager/git-submodules/update', () => {
   beforeEach(() => {
     GlobalConfig.set({ localDir: baseDir });
-    // clear environment variables
-    process.env = {};
+    clearEnv();
 
     createSimpleGit.mockReturnValue(gitMock);
   });

--- a/lib/modules/manager/gomod/artifacts-gomodtidyall.spec.ts
+++ b/lib/modules/manager/gomod/artifacts-gomodtidyall.spec.ts
@@ -71,7 +71,7 @@ function baseConfig(
 
 describe('modules/manager/gomod/artifacts-gomodtidyall', () => {
   beforeEach(() => {
-    delete process.env.GOPATH;
+    vi.stubEnv('GOPATH', undefined);
     env.getChildProcessEnv.mockReturnValue({ ...envMock.basic, ...goEnv });
     GlobalConfig.set(adminConfig);
     docker.resetPrefetchedImages();

--- a/lib/modules/manager/gomod/artifacts.spec.ts
+++ b/lib/modules/manager/gomod/artifacts.spec.ts
@@ -83,7 +83,7 @@ const goEnv = {
 
 describe('modules/manager/gomod/artifacts', () => {
   beforeEach(() => {
-    delete process.env.GOPATH;
+    vi.stubEnv('GOPATH', undefined);
     env.getChildProcessEnv.mockReturnValue({ ...envMock.basic, ...goEnv });
     GlobalConfig.set(adminConfig);
     docker.resetPrefetchedImages();

--- a/lib/modules/manager/npm/post-update/yarn.spec.ts
+++ b/lib/modules/manager/npm/post-update/yarn.spec.ts
@@ -42,10 +42,10 @@ describe('modules/manager/npm/post-update/yarn', () => {
 
   beforeEach(() => {
     util.env.getChildProcessEnv.mockReturnValue(envMock.basic);
-    delete process.env.BUILDPACK;
-    delete process.env.HTTP_PROXY;
-    delete process.env.HTTPS_PROXY;
-    delete process.env.RENOVATE_X_YARN_PROXY;
+    vi.stubEnv('BUILDPACK', undefined);
+    vi.stubEnv('HTTP_PROXY', undefined);
+    vi.stubEnv('HTTPS_PROXY', undefined);
+    vi.stubEnv('RENOVATE_X_YARN_PROXY', undefined);
     Fixtures.reset();
     GlobalConfig.set({
       localDir: '.',
@@ -251,9 +251,9 @@ describe('modules/manager/npm/post-update/yarn', () => {
   });
 
   it('sets http proxy', async () => {
-    process.env.HTTP_PROXY = 'http://proxy';
-    process.env.HTTPS_PROXY = 'http://proxy';
-    process.env.RENOVATE_X_YARN_PROXY = 'true';
+    vi.stubEnv('HTTP_PROXY', 'http://proxy');
+    vi.stubEnv('HTTPS_PROXY', 'http://proxy');
+    vi.stubEnv('RENOVATE_X_YARN_PROXY', 'true');
     GlobalConfig.set({
       localDir: '.',
       allowScripts: true,
@@ -503,7 +503,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   });
 
   it('supports corepack', async () => {
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
     GlobalConfig.set({
       localDir: '.',
       binarySource: 'install',
@@ -549,7 +549,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   });
 
   it('supports packageManager url corepack', async () => {
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
     GlobalConfig.set({
       localDir: '.',
       binarySource: 'install',
@@ -598,7 +598,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   });
 
   it('supports corepack on grouping', async () => {
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
     GlobalConfig.set({
       localDir: '.',
       binarySource: 'install',
@@ -647,7 +647,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   });
 
   it('supports customizing corepack version via config constraints', async () => {
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
 
     GlobalConfig.set({
       localDir: '.',
@@ -708,7 +708,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   it('uses slim yarn instead of corepack', async () => {
     // sanity check for later refactorings
     expect(plocktest1YarnLockV1).toBeTruthy();
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
     GlobalConfig.set({
       localDir: '.',
       binarySource: 'install',
@@ -747,7 +747,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   it('uses devEngine.packageManager(object) instead of corepack', async () => {
     // sanity check for later refactorings
     expect(plocktest1YarnLockV1).toBeTruthy();
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
     GlobalConfig.set({
       localDir: '.',
       binarySource: 'install',
@@ -786,7 +786,7 @@ describe('modules/manager/npm/post-update/yarn', () => {
   it('uses devEngine.packageManager(array) instead of corepack', async () => {
     // sanity check for later refactorings
     expect(plocktest1YarnLockV1).toBeTruthy();
-    process.env.CONTAINERBASE = 'true';
+    vi.stubEnv('CONTAINERBASE', 'true');
     GlobalConfig.set({
       localDir: '.',
       binarySource: 'install',

--- a/lib/modules/manager/pip-compile/artifacts.spec.ts
+++ b/lib/modules/manager/pip-compile/artifacts.spec.ts
@@ -562,11 +562,6 @@ describe('modules/manager/pip-compile/artifacts', () => {
   });
 
   describe('constructPipCompileCmd()', () => {
-    afterEach(() => {
-      delete process.env.PIP_INDEX_URL;
-      delete process.env.PIP_EXTRA_INDEX_URL;
-    });
-
     it('throws for garbage', () => {
       expect(() =>
         constructPipCompileCmd(
@@ -602,7 +597,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('does not add --no-emit-index-url when PIP_INDEX_URL has no credentials', () => {
-      process.env.PIP_INDEX_URL = 'https://example.com/pypi/simple';
+      vi.stubEnv('PIP_INDEX_URL', 'https://example.com/pypi/simple');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -611,7 +606,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when credentials are found in PIP_INDEX_URL', () => {
-      process.env.PIP_INDEX_URL = 'https://user:pass@example.com/pypi/simple';
+      vi.stubEnv('PIP_INDEX_URL', 'https://user:pass@example.com/pypi/simple');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -620,8 +615,10 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when credentials are found in PIP_EXTRA_INDEX_URL', () => {
-      process.env.PIP_EXTRA_INDEX_URL =
-        'https://user:pass@example.com/pypi/simple';
+      vi.stubEnv(
+        'PIP_EXTRA_INDEX_URL',
+        'https://user:pass@example.com/pypi/simple',
+      );
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -630,7 +627,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when only a username is found in PIP_INDEX_URL', () => {
-      process.env.PIP_INDEX_URL = 'https://user@example.com/pypi/simple';
+      vi.stubEnv('PIP_INDEX_URL', 'https://user@example.com/pypi/simple');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -639,7 +636,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when only a username is found in PIP_EXTRA_INDEX_URL', () => {
-      process.env.PIP_EXTRA_INDEX_URL = 'https://user@example.com/pypi/simple';
+      vi.stubEnv('PIP_EXTRA_INDEX_URL', 'https://user@example.com/pypi/simple');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -648,7 +645,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when only a password is found in PIP_INDEX_URL', () => {
-      process.env.PIP_INDEX_URL = 'https://:pass@example.com/pypi/simple';
+      vi.stubEnv('PIP_INDEX_URL', 'https://:pass@example.com/pypi/simple');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -657,7 +654,10 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when only a password is found in PIP_EXTRA_INDEX_URL', () => {
-      process.env.PIP_EXTRA_INDEX_URL = 'https://:pass@example.com/pypi/simple';
+      vi.stubEnv(
+        'PIP_EXTRA_INDEX_URL',
+        'https://:pass@example.com/pypi/simple',
+      );
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -666,7 +666,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url when PIP_INDEX_URL is invalid', () => {
-      process.env.PIP_INDEX_URL = 'invalid-url';
+      vi.stubEnv('PIP_INDEX_URL', 'invalid-url');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -675,7 +675,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url PIP_EXTRA_INDEX_URL is invalid', () => {
-      process.env.PIP_EXTRA_INDEX_URL = 'invalid-url';
+      vi.stubEnv('PIP_EXTRA_INDEX_URL', 'invalid-url');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(simpleHeader, 'subdir/requirements.txt'),
@@ -684,8 +684,10 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('returns --no-emit-index-url only once when its in the header and credentials are present in the environment', () => {
-      process.env.PIP_EXTRA_INDEX_URL =
-        'https://user:pass@example.com/pypi/simple';
+      vi.stubEnv(
+        'PIP_EXTRA_INDEX_URL',
+        'https://user:pass@example.com/pypi/simple',
+      );
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(
@@ -699,7 +701,7 @@ describe('modules/manager/pip-compile/artifacts', () => {
     });
 
     it('allow explicit --emit-index-url', () => {
-      process.env.PIP_INDEX_URL = 'https://user:pass@example.com/pypi/simple';
+      vi.stubEnv('PIP_INDEX_URL', 'https://user:pass@example.com/pypi/simple');
       expect(
         constructPipCompileCmd(
           extractHeaderCommand(

--- a/lib/modules/manager/pip_requirements/extract.spec.ts
+++ b/lib/modules/manager/pip_requirements/extract.spec.ts
@@ -16,25 +16,18 @@ const requirementsGitPackages = Fixtures.get('requirements-git-packages.txt');
 
 describe('modules/manager/pip_requirements/extract', () => {
   beforeEach(() => {
-    delete process.env.PIP_TEST_TOKEN;
+    vi.stubEnv('PIP_TEST_TOKEN', undefined);
     GlobalConfig.reset();
   });
 
   afterEach(() => {
-    delete process.env.PIP_TEST_TOKEN;
+    vi.stubEnv('PIP_TEST_TOKEN', undefined);
     GlobalConfig.reset();
   });
 
   describe('extractPackageFile()', () => {
-    const OLD_ENV = process.env;
-
     beforeEach(() => {
-      process.env = { ...OLD_ENV };
-      delete process.env.PIP_INDEX_URL;
-    });
-
-    afterEach(() => {
-      process.env = OLD_ENV;
+      vi.stubEnv('PIP_INDEX_URL', undefined);
     });
 
     it('returns null for empty', () => {
@@ -160,7 +153,7 @@ describe('modules/manager/pip_requirements/extract', () => {
     });
 
     it('should not replace env vars in low trust mode', () => {
-      process.env.PIP_TEST_TOKEN = 'its-a-secret';
+      vi.stubEnv('PIP_TEST_TOKEN', 'its-a-secret');
       const res = extractPackageFile(requirements7);
       expect(res?.additionalRegistryUrls).toEqual([
         'http://$PIP_TEST_TOKEN:example.com/private-pypi/',
@@ -171,7 +164,7 @@ describe('modules/manager/pip_requirements/extract', () => {
     });
 
     it('should replace env vars in high trust mode', () => {
-      process.env.PIP_TEST_TOKEN = 'its-a-secret';
+      vi.stubEnv('PIP_TEST_TOKEN', 'its-a-secret');
       GlobalConfig.set({ exposeAllEnv: true });
       const res = extractPackageFile(requirements7);
       expect(res?.additionalRegistryUrls).toEqual([

--- a/lib/modules/manager/poetry/extract.spec.ts
+++ b/lib/modules/manager/poetry/extract.spec.ts
@@ -28,16 +28,10 @@ const pyproject12toml = Fixtures.get('pyproject.12.toml');
 describe('modules/manager/poetry/extract', () => {
   describe('extractPackageFile()', () => {
     let filename: string;
-    const OLD_ENV = process.env;
 
     beforeEach(() => {
       filename = '';
-      process.env = { ...OLD_ENV };
-      delete process.env.PIP_INDEX_URL;
-    });
-
-    afterEach(() => {
-      process.env = OLD_ENV;
+      vi.stubEnv('PIP_INDEX_URL', undefined);
     });
 
     it('returns null for empty', async () => {

--- a/lib/modules/platform/codecommit/index.spec.ts
+++ b/lib/modules/platform/codecommit/index.spec.ts
@@ -38,8 +38,8 @@ async function reInitRepo(codeCommit: Platform): Promise<void> {
       repositoryId: 'id',
     },
   });
-  process.env.AWS_ACCESS_KEY_ID = 'something';
-  process.env.AWS_SECRET_ACCESS_KEY = 'something';
+  vi.stubEnv('AWS_ACCESS_KEY_ID', 'something');
+  vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'something');
 
   await codeCommit.initRepo({ repository: 'repositoryName' });
 }
@@ -55,9 +55,9 @@ describe('modules/platform/codecommit/index', () => {
   });
 
   beforeEach(() => {
-    delete process.env.AWS_REGION;
-    delete process.env.AWS_ACCESS_KEY_ID;
-    delete process.env.AWS_SECRET_ACCESS_KEY;
+    vi.stubEnv('AWS_REGION', undefined);
+    vi.stubEnv('AWS_ACCESS_KEY_ID', undefined);
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', undefined);
     codeCommitClient.reset();
     vi.useRealTimers();
   });
@@ -109,7 +109,7 @@ describe('modules/platform/codecommit/index', () => {
     });
 
     it('should init with env vars', async () => {
-      process.env.AWS_REGION = 'REGION';
+      vi.stubEnv('AWS_REGION', 'REGION');
       await expect(
         codeCommit.initPlatform({
           username: 'abc',
@@ -187,8 +187,8 @@ describe('modules/platform/codecommit/index', () => {
           repositoryId: 'id',
         },
       });
-      process.env.AWS_ACCESS_KEY_ID = 'something';
-      process.env.AWS_SECRET_ACCESS_KEY = 'something';
+      vi.stubEnv('AWS_ACCESS_KEY_ID', 'something');
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'something');
       await expect(
         codeCommit.initRepo({ repository: 'repositoryName' }),
       ).resolves.toEqual({
@@ -200,8 +200,8 @@ describe('modules/platform/codecommit/index', () => {
     });
 
     it('gets the right url', () => {
-      process.env.AWS_ACCESS_KEY_ID = '';
-      process.env.AWS_SECRET_ACCESS_KEY = '';
+      vi.stubEnv('AWS_ACCESS_KEY_ID', '');
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', '');
       expect(
         getCodeCommitUrl(
           {
@@ -216,9 +216,9 @@ describe('modules/platform/codecommit/index', () => {
     });
 
     it('gets the eu-central-1 url', () => {
-      process.env.AWS_ACCESS_KEY_ID = '';
-      process.env.AWS_SECRET_ACCESS_KEY = '';
-      process.env.AWS_REGION = 'eu-central-1';
+      vi.stubEnv('AWS_ACCESS_KEY_ID', '');
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', '');
+      vi.stubEnv('AWS_REGION', 'eu-central-1');
       expect(
         getCodeCommitUrl(
           {
@@ -232,10 +232,10 @@ describe('modules/platform/codecommit/index', () => {
 
     it('gets url with username and token', () => {
       vi.useFakeTimers().setSystemTime(new Date('2020-01-01'));
-      process.env.AWS_ACCESS_KEY_ID = 'access-key-id';
-      process.env.AWS_SECRET_ACCESS_KEY = 'secret-access-key';
-      process.env.AWS_REGION = 'eu-central-1';
-      process.env.AWS_SESSION_TOKEN = '';
+      vi.stubEnv('AWS_ACCESS_KEY_ID', 'access-key-id');
+      vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'secret-access-key');
+      vi.stubEnv('AWS_REGION', 'eu-central-1');
+      vi.stubEnv('AWS_SESSION_TOKEN', '');
       const signer = new aws4.RequestSigner({
         service: 'codecommit',
         host: 'git-codecommit.eu-central-1.amazonaws.com',

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -56,7 +56,7 @@ describe('modules/platform/github/index', () => {
 
     const repoCache = repository.getCache();
     delete repoCache.platform;
-    delete process.env.RENOVATE_X_GITHUB_HOST_RULES;
+    vi.stubEnv('RENOVATE_X_GITHUB_HOST_RULES', undefined);
   });
 
   describe('initPlatform()', () => {
@@ -421,7 +421,7 @@ describe('modules/platform/github/index', () => {
     });
 
     it('should autodetect email/user on default endpoint with GitHub App', async () => {
-      process.env.RENOVATE_X_GITHUB_HOST_RULES = 'true';
+      vi.stubEnv('RENOVATE_X_GITHUB_HOST_RULES', 'true');
       httpMock
         .scope(githubApiHost, {
           reqheaders: {

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -40,14 +40,14 @@ describe('modules/platform/gitlab/index', () => {
     hostRules.add({
       token: '123test',
     });
-    delete process.env.GITLAB_IGNORE_REPO_URL;
-    delete process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_CHECK_ATTEMPTS;
-    delete process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY;
-    delete process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS;
-    delete process.env.RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN;
-    delete process.env.RENOVATE_X_GITLAB_MERGE_REQUEST_DELAY;
-    delete process.env.RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE;
-    delete process.env.RENOVATE_X_PLATFORM_VERSION;
+    vi.stubEnv('GITLAB_IGNORE_REPO_URL', undefined);
+    vi.stubEnv('RENOVATE_X_GITLAB_BRANCH_STATUS_CHECK_ATTEMPTS', undefined);
+    vi.stubEnv('RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY', undefined);
+    vi.stubEnv('RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS', undefined);
+    vi.stubEnv('RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN', undefined);
+    vi.stubEnv('RENOVATE_X_GITLAB_MERGE_REQUEST_DELAY', undefined);
+    vi.stubEnv('RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE', undefined);
+    vi.stubEnv('RENOVATE_X_PLATFORM_VERSION', undefined);
 
     gitlab.resetPlatform();
     memCache.init();
@@ -488,7 +488,7 @@ describe('modules/platform/gitlab/index', () => {
     });
 
     it('should fall back respecting when GITLAB_IGNORE_REPO_URL is set', async () => {
-      process.env.GITLAB_IGNORE_REPO_URL = 'true';
+      vi.stubEnv('GITLAB_IGNORE_REPO_URL', 'true');
       const selfHostedUrl = 'http://mycompany.com/gitlab';
       httpMock
         .scope(selfHostedUrl)
@@ -1205,7 +1205,7 @@ describe('modules/platform/gitlab/index', () => {
     it.each(states)(
       'skips setting branch status %s when RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE is set and no pipeline is found',
       async (state) => {
-        process.env.RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE = 'true';
+        vi.stubEnv('RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE', 'true');
         const scope = await initRepo();
         scope
           .get(`/api/v4/projects/some%2Frepo/repository/commits/${branchSha}`)
@@ -1229,7 +1229,7 @@ describe('modules/platform/gitlab/index', () => {
     );
 
     it('does not skip setting branch status when RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE is not true', async () => {
-      process.env.RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE = 'false';
+      vi.stubEnv('RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE', 'false');
       const scope = await initRepo();
       scope
         .post(`/api/v4/projects/some%2Frepo/statuses/${branchSha}`)
@@ -1258,7 +1258,7 @@ describe('modules/platform/gitlab/index', () => {
     });
 
     it('sets branch status when RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE is true and pipeline is found', async () => {
-      process.env.RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE = 'true';
+      vi.stubEnv('RENOVATE_X_GITLAB_SKIP_STATUS_WITHOUT_PIPELINE', 'true');
       const scope = await initRepo();
       scope
         .post(
@@ -1350,7 +1350,7 @@ describe('modules/platform/gitlab/index', () => {
     it('waits for RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY ms when set', async () => {
       const delay = 5000;
       const retry = 2;
-      process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY = String(delay);
+      vi.stubEnv('RENOVATE_X_GITLAB_BRANCH_STATUS_DELAY', String(delay));
 
       const scope = await initRepo();
       scope
@@ -1391,7 +1391,7 @@ describe('modules/platform/gitlab/index', () => {
     it('do RENOVATE_X_GITLAB_BRANCH_STATUS_CHECK_ATTEMPTS attemps when set', async () => {
       const delay = 1000;
       const retry = 5;
-      process.env.RENOVATE_X_GITLAB_BRANCH_STATUS_CHECK_ATTEMPTS = `${retry}`;
+      vi.stubEnv('RENOVATE_X_GITLAB_BRANCH_STATUS_CHECK_ATTEMPTS', `${retry}`);
 
       const scope = await initRepo();
       scope
@@ -2270,8 +2270,8 @@ describe('modules/platform/gitlab/index', () => {
 
   describe('createPr(branchName, title, body)', () => {
     beforeEach(() => {
-      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '2';
-      process.env.RENOVATE_X_GITLAB_MERGE_REQUEST_DELAY = '100';
+      vi.stubEnv('RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS', '2');
+      vi.stubEnv('RENOVATE_X_GITLAB_MERGE_REQUEST_DELAY', '100');
     });
 
     it('returns the PR', async () => {
@@ -2631,7 +2631,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(405, {})
         .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200, {});
-      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
+      vi.stubEnv('RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS', '3');
       const pr = await gitlab.createPr({
         sourceBranch: 'some-branch',
         targetBranch: 'master',
@@ -2694,7 +2694,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(200, reply_body)
         .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200, {});
-      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
+      vi.stubEnv('RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS', '3');
       const pr = await gitlab.createPr({
         sourceBranch: 'some-branch',
         targetBranch: 'master',
@@ -2756,7 +2756,7 @@ describe('modules/platform/gitlab/index', () => {
         .reply(405, {})
         .put('/api/v4/projects/undefined/merge_requests/12345/merge')
         .reply(200, {});
-      process.env.RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS = '3';
+      vi.stubEnv('RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS', '3');
       const pr = await gitlab.createPr({
         sourceBranch: 'some-branch',
         targetBranch: 'master',
@@ -3400,7 +3400,7 @@ describe('modules/platform/gitlab/index', () => {
 
     it('auto-approve with different user', async () => {
       await initPlatform('13.3.6-ee');
-      process.env.RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN = 'some-token';
+      vi.stubEnv('RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN', 'some-token');
       httpMock
         .scope(gitlabApiHost)
         .get(

--- a/lib/modules/platform/gitlab/pr-cache.spec.ts
+++ b/lib/modules/platform/gitlab/pr-cache.spec.ts
@@ -76,7 +76,7 @@ describe('modules/platform/gitlab/pr-cache', () => {
     memCacheReset();
     repoCacheReset();
     cache = getCache();
-    delete process.env.GITLAB_IGNORE_REPO_URL;
+    vi.stubEnv('GITLAB_IGNORE_REPO_URL', undefined);
     setBaseUrl('https://gitlab.com/api/v4');
   });
 

--- a/lib/modules/platform/index.spec.ts
+++ b/lib/modules/platform/index.spec.ts
@@ -11,7 +11,7 @@ vi.unmock('./scm.ts');
 
 describe('modules/platform/index', () => {
   beforeEach(() => {
-    process.env.RENOVATE_X_GITHUB_HOST_RULES = 'true';
+    vi.stubEnv('RENOVATE_X_GITHUB_HOST_RULES', 'true');
   });
 
   it('validates', async () => {

--- a/lib/proxy.spec.ts
+++ b/lib/proxy.spec.ts
@@ -9,22 +9,22 @@ describe('proxy', () => {
   const noProxy = 'http://example.org/no-proxy';
 
   beforeEach(() => {
-    delete process.env.HTTP_PROXY;
-    delete process.env.http_proxy;
-    delete process.env.HTTPS_PROXY;
-    delete process.env.https_proxy;
-    delete process.env.NO_PROXY;
-    delete process.env.no_proxy;
+    vi.stubEnv('HTTP_PROXY', undefined);
+    vi.stubEnv('http_proxy', undefined);
+    vi.stubEnv('HTTPS_PROXY', undefined);
+    vi.stubEnv('https_proxy', undefined);
+    vi.stubEnv('NO_PROXY', undefined);
+    vi.stubEnv('no_proxy', undefined);
   });
 
   it('respects HTTP_PROXY', () => {
-    process.env.HTTP_PROXY = httpProxy;
+    vi.stubEnv('HTTP_PROXY', httpProxy);
     bootstrap();
     expect(hasProxy()).toBeTrue();
   });
 
   it('copies upper case HTTP_PROXY to http_proxy', () => {
-    process.env.HTTP_PROXY = httpProxy;
+    vi.stubEnv('HTTP_PROXY', httpProxy);
     bootstrap();
     expect(hasProxy()).toBeTrue();
     expect(process.env.HTTP_PROXY).toBeDefined();
@@ -37,13 +37,13 @@ describe('proxy', () => {
   });
 
   it('respects HTTPS_PROXY', () => {
-    process.env.HTTPS_PROXY = httpsProxy;
+    vi.stubEnv('HTTPS_PROXY', httpsProxy);
     bootstrap();
     expect(hasProxy()).toBeTrue();
   });
 
   it('copies upper case HTTPS_PROXY to https_proxy', () => {
-    process.env.HTTPS_PROXY = httpsProxy;
+    vi.stubEnv('HTTPS_PROXY', httpsProxy);
     bootstrap();
     expect(hasProxy()).toBeTrue();
     expect(process.env.HTTPS_PROXY).toBeDefined();
@@ -56,37 +56,37 @@ describe('proxy', () => {
   });
 
   it('does nothing', () => {
-    process.env.no_proxy = noProxy;
+    vi.stubEnv('no_proxy', noProxy);
     bootstrap();
     expect(hasProxy()).toBeFalse();
   });
 
   it('sanitizes password from HTTP_PROXY credentials', () => {
-    process.env.HTTP_PROXY = 'http://user:s3cr3t@example.org';
+    vi.stubEnv('HTTP_PROXY', 'http://user:s3cr3t@example.org');
     bootstrap();
     expect(addSecretForSanitizing).toHaveBeenCalledWith('s3cr3t', 'global');
   });
 
   it('sanitizes password from HTTPS_PROXY credentials', () => {
-    process.env.HTTPS_PROXY = 'http://user:s3cr3t@example.org';
+    vi.stubEnv('HTTPS_PROXY', 'http://user:s3cr3t@example.org');
     bootstrap();
     expect(addSecretForSanitizing).toHaveBeenCalledWith('s3cr3t', 'global');
   });
 
   it('does not sanitize username-only proxy credentials', () => {
-    process.env.HTTP_PROXY = 'http://user@example.org';
+    vi.stubEnv('HTTP_PROXY', 'http://user@example.org');
     bootstrap();
     expect(addSecretForSanitizing).not.toHaveBeenCalled();
   });
 
   it('sanitizes password-only proxy credentials', () => {
-    process.env.HTTP_PROXY = 'http://:s3cr3t@example.org';
+    vi.stubEnv('HTTP_PROXY', 'http://:s3cr3t@example.org');
     bootstrap();
     expect(addSecretForSanitizing).toHaveBeenCalledWith('s3cr3t', 'global');
   });
 
   it('does not sanitize when proxy has no credentials', () => {
-    process.env.HTTP_PROXY = httpProxy;
+    vi.stubEnv('HTTP_PROXY', httpProxy);
     bootstrap();
     expect(addSecretForSanitizing).not.toHaveBeenCalled();
   });

--- a/lib/util/cache/package/backend.spec.ts
+++ b/lib/util/cache/package/backend.spec.ts
@@ -25,7 +25,7 @@ describe('util/cache/package/backend', () => {
   let sqliteBackend: ReturnType<typeof mockBackend>;
 
   beforeEach(() => {
-    delete process.env.RENOVATE_X_SQLITE_PACKAGE_CACHE;
+    vi.stubEnv('RENOVATE_X_SQLITE_PACKAGE_CACHE', undefined);
     fileBackend = mockBackend();
     redisBackend = mockBackend();
     sqliteBackend = mockBackend();
@@ -77,7 +77,7 @@ describe('util/cache/package/backend', () => {
   });
 
   it('initializes sqlite backend', async () => {
-    process.env.RENOVATE_X_SQLITE_PACKAGE_CACHE = 'true';
+    vi.stubEnv('RENOVATE_X_SQLITE_PACKAGE_CACHE', 'true');
 
     await backend.init({ cacheDir: 'some-dir' });
 

--- a/lib/util/env.spec.ts
+++ b/lib/util/env.spec.ts
@@ -1,15 +1,16 @@
+import { clearEnv } from '~test/util.ts';
 import * as memCache from './cache/memory/index.ts';
 import { getEnv, setCustomEnv, setUserEnv } from './env.ts';
 
 describe('util/env', () => {
   beforeEach(() => {
-    process.env = {};
+    clearEnv();
     memCache.init();
   });
 
   describe('getEnv', () => {
     it('return combined env', () => {
-      process.env.RENOVATE_MEND_HOSTED = 'true';
+      vi.stubEnv('RENOVATE_MEND_HOSTED', 'true');
       setUserEnv({
         SOME_KEY: 'SOME_VALUE',
       });
@@ -24,7 +25,7 @@ describe('util/env', () => {
     });
 
     it('maintains precendence', () => {
-      process.env.SOME_KEY = 'processEnvValue';
+      vi.stubEnv('SOME_KEY', 'processEnvValue');
       setUserEnv({
         SOME_KEY: 'userEnvValue',
       });

--- a/lib/util/exec/common.spec.ts
+++ b/lib/util/exec/common.spec.ts
@@ -868,12 +868,12 @@ describe('util/exec/common', () => {
     const killSpy = vi.spyOn(process, 'kill');
 
     afterEach(() => {
-      delete process.env.RENOVATE_X_EXEC_GPID_HANDLE;
+      vi.stubEnv('RENOVATE_X_EXEC_GPID_HANDLE', undefined);
       vi.restoreAllMocks();
     });
 
     it('calls process.kill on the gpid', async () => {
-      process.env.RENOVATE_X_EXEC_GPID_HANDLE = 'true';
+      vi.stubEnv('RENOVATE_X_EXEC_GPID_HANDLE', 'true');
       const cmd = 'ls -l';
       const exitSignal = 'SIGTERM';
       const stub = getSpawnStub({ cmd, exitCode: null, exitSignal });
@@ -893,7 +893,7 @@ describe('util/exec/common', () => {
     });
 
     it('handles process.kill call on non existent gpid', async () => {
-      process.env.RENOVATE_X_EXEC_GPID_HANDLE = 'true';
+      vi.stubEnv('RENOVATE_X_EXEC_GPID_HANDLE', 'true');
       const cmd = 'ls -l';
       const exitSignal = 'SIGTERM';
       const stub = getSpawnStub({ cmd, exitCode: null, exitSignal });

--- a/lib/util/exec/containerbase.spec.ts
+++ b/lib/util/exec/containerbase.spec.ts
@@ -16,7 +16,7 @@ describe('util/exec/containerbase', () => {
   describe('isDynamicInstall()', () => {
     beforeEach(() => {
       GlobalConfig.reset();
-      delete process.env.CONTAINERBASE;
+      vi.stubEnv('CONTAINERBASE', undefined);
     });
 
     it('returns false if binarySource is not install', () => {
@@ -30,7 +30,7 @@ describe('util/exec/containerbase', () => {
 
     it('returns false if any unsupported tools', () => {
       GlobalConfig.set({ binarySource: 'install' });
-      process.env.CONTAINERBASE = 'true';
+      vi.stubEnv('CONTAINERBASE', 'true');
       const toolConstraints: ToolConstraint[] = [
         { toolName: 'node' },
         // @ts-expect-error -- intentionally using invalid constraint names
@@ -41,7 +41,7 @@ describe('util/exec/containerbase', () => {
 
     it('returns true if supported tools', () => {
       GlobalConfig.set({ binarySource: 'install' });
-      process.env.CONTAINERBASE = 'true';
+      vi.stubEnv('CONTAINERBASE', 'true');
       const toolConstraints: ToolConstraint[] = [{ toolName: 'npm' }];
       expect(isDynamicInstall(toolConstraints)).toBeTrue();
     });

--- a/lib/util/exec/env.spec.ts
+++ b/lib/util/exec/env.spec.ts
@@ -28,6 +28,11 @@ describe('util/exec/env', () => {
   ];
 
   beforeEach(() => {
+    // Clear any ambient value first, so that a forwarded variable which is set
+    // in the surrounding environment cannot leak into the assertions below.
+    basicEnvVars.forEach((env) => {
+      vi.stubEnv(env, undefined);
+    });
     envVars.forEach((env) => {
       vi.stubEnv(env, env);
     });

--- a/lib/util/exec/env.spec.ts
+++ b/lib/util/exec/env.spec.ts
@@ -29,12 +29,8 @@ describe('util/exec/env', () => {
 
   beforeEach(() => {
     envVars.forEach((env) => {
-      process.env[env] = env;
+      vi.stubEnv(env, env);
     });
-  });
-
-  afterEach(() => {
-    envVars.forEach((env) => delete process.env[env]);
   });
 
   it('returns default environment variables', () => {
@@ -68,22 +64,22 @@ describe('util/exec/env', () => {
   });
 
   it('static environment variables override the process environment variables', () => {
-    process.env.CI = 'false';
+    vi.stubEnv('CI', 'false');
 
     expect(getChildProcessEnv()).toMatchObject({
       CI: 'true',
     });
 
-    delete process.env.CI;
+    vi.stubEnv('CI', undefined);
   });
 
   it('returns environment variable only if defined', () => {
-    delete process.env.PATH;
+    vi.stubEnv('PATH', undefined);
     expect(getChildProcessEnv()).not.toHaveProperty('PATH');
   });
 
   it('returns custom environment variables if passed and defined', () => {
-    process.env.FOOBAR = 'FOOBAR';
+    vi.stubEnv('FOOBAR', 'FOOBAR');
     expect(getChildProcessEnv(['FOOBAR'])).toMatchObject({
       DOCKER_HOST: 'DOCKER_HOST',
       FOOBAR: 'FOOBAR',
@@ -95,7 +91,7 @@ describe('util/exec/env', () => {
       NO_PROXY: 'NO_PROXY',
       PATH: 'PATH',
     });
-    delete process.env.LANG;
+    vi.stubEnv('LANG', undefined);
   });
 
   describe('getChildProcessEnv when exposeAllEnv=true', () => {
@@ -109,7 +105,7 @@ describe('util/exec/env', () => {
 
     it('static environment variables override the process environment variables', () => {
       GlobalConfig.set({ exposeAllEnv: true });
-      process.env.CI = 'false';
+      vi.stubEnv('CI', 'false');
 
       expect(getChildProcessEnv()).toMatchObject({
         CI: 'true',

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -1,3 +1,9 @@
+// oxlint-disable renovate/prefer-stub-env -- these tests assert on the *whole*
+// env handed to the child process, so they need `process.env` to hold exactly
+// the fixture and nothing else. `vi.stubEnv()` cannot express that: it refuses
+// to delete `PROD`, `DEV` and `SSR`, setting them to '' instead, and those
+// would then show up in the `exposeAllEnv` expectations. Nothing here stubs,
+// so the two styles are not mixed.
 import { mockDeep } from 'vitest-mock-extended';
 import { exec as cpExec, envMock } from '~test/exec-util.ts';
 import { logger } from '~test/util.ts';

--- a/lib/util/git/auth.spec.ts
+++ b/lib/util/git/auth.spec.ts
@@ -5,10 +5,6 @@ import {
 } from './auth.ts';
 
 describe('util/git/auth', () => {
-  afterEach(() => {
-    delete process.env.GIT_CONFIG_COUNT;
-  });
-
   describe('getGitAuthenticatedEnvironmentVariables()', () => {
     it('returns url with token', () => {
       expect(
@@ -132,7 +128,7 @@ describe('util/git/auth', () => {
     });
 
     it('returns url with token and already existing GIT_CONFIG_COUNT from parameter over environment', () => {
-      process.env.GIT_CONFIG_COUNT = '54';
+      vi.stubEnv('GIT_CONFIG_COUNT', '54');
       expect(
         getGitAuthenticatedEnvironmentVariables(
           { GIT_CONFIG_COUNT: '1' },
@@ -155,7 +151,7 @@ describe('util/git/auth', () => {
     });
 
     it('does not inherit GIT_CONFIG_COUNT from the process environment', () => {
-      process.env.GIT_CONFIG_COUNT = '1';
+      vi.stubEnv('GIT_CONFIG_COUNT', '1');
       expect(
         getGitAuthenticatedEnvironmentVariables({}, 'https://github.com/', {
           token: 'token1234',

--- a/lib/util/git/exec.spec.ts
+++ b/lib/util/git/exec.spec.ts
@@ -16,12 +16,6 @@ describe('util/git/exec', () => {
     clear();
   });
 
-  afterEach(() => {
-    delete process.env.GIT_CONFIG_COUNT;
-    delete process.env.GIT_CONFIG_KEY_0;
-    delete process.env.GIT_CONFIG_VALUE_0;
-  });
-
   it('appends authentication to approved runtime Git configuration', async () => {
     exec.mockResolvedValue({ stdout: '', stderr: '' });
     const gitExec = withGitEnvironment();
@@ -78,9 +72,9 @@ describe('util/git/exec', () => {
   it('does not import unapproved runtime Git configuration', async () => {
     exec.mockResolvedValue({ stdout: '', stderr: '' });
     const gitExec = withGitEnvironment();
-    process.env.GIT_CONFIG_COUNT = '1';
-    process.env.GIT_CONFIG_KEY_0 = 'process-key';
-    process.env.GIT_CONFIG_VALUE_0 = 'process-value';
+    vi.stubEnv('GIT_CONFIG_COUNT', '1');
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'process-key');
+    vi.stubEnv('GIT_CONFIG_VALUE_0', 'process-value');
     add({
       hostType: 'github',
       matchHost: 'api.github.com',

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -84,9 +84,9 @@ describe('util/git/index', { timeout: 30000 }, () => {
     await fs.writeFile(`${base.path}/master_file`, defaultBranch);
     await fs.writeFile(`${base.path}/file_to_delete`, 'bye');
     await repo.add(['master_file', 'file_to_delete']);
-    process.env.GIT_COMMITTER_DATE = masterCommitDate.toISOString();
+    vi.stubEnv('GIT_COMMITTER_DATE', masterCommitDate.toISOString());
     await repo.commit('master message');
-    delete process.env.GIT_COMMITTER_DATE;
+    vi.stubEnv('GIT_COMMITTER_DATE', undefined);
 
     await repo.checkout(['-b', 'renovate/future_branch', defaultBranch]);
     await fs.writeFile(`${base.path}/future_file`, 'future');
@@ -173,10 +173,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
 
   let tmpDir: tmp.DirectoryResult;
 
-  const OLD_ENV = process.env;
-
   beforeEach(async () => {
-    process.env = { ...OLD_ENV };
     setCustomEnv({});
     origin = await tmp.dir({ unsafeCleanup: true });
     const repo = simpleGit(origin.path);
@@ -211,7 +208,6 @@ describe('util/git/index', { timeout: 30000 }, () => {
 
   afterAll(async () => {
     setCustomEnv({});
-    process.env = OLD_ENV;
     await base?.cleanup();
   });
 
@@ -260,7 +256,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     });
 
     it('retries the func call if ExternalHostError thrown', async () => {
-      process.env.NODE_ENV = '';
+      vi.stubEnv('NODE_ENV', '');
       const gitFunc = vi
         .fn()
         .mockImplementationOnce(() => {
@@ -275,7 +271,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     });
 
     it('retries the func call up to retry count if ExternalHostError thrown', async () => {
-      process.env.NODE_ENV = '';
+      vi.stubEnv('NODE_ENV', '');
       const gitFunc = vi.fn().mockImplementation(() => {
         throw new Error('The remote end hung up unexpectedly');
       });
@@ -2013,7 +2009,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       // set up our repo again, so we can initialise it with `RENOVATE_X_CLEAR_HOOKS`
       tmpDir = await tmp.dir({ unsafeCleanup: true });
       GlobalConfig.set({ localDir: tmpDir.path });
-      process.env.RENOVATE_X_CLEAR_HOOKS = 'true';
+      vi.stubEnv('RENOVATE_X_CLEAR_HOOKS', 'true');
       await git.initRepo({
         url: origin.path,
       });
@@ -2026,17 +2022,17 @@ describe('util/git/index', { timeout: 30000 }, () => {
       const tmpGit = simpleGit(tmpDir.path);
       const hooksPath = (await tmpGit.raw(['config', 'core.hooksPath'])).trim();
       expect(hooksPath).toBe('/dev/null');
-      delete process.env.RENOVATE_X_CLEAR_HOOKS;
+      vi.stubEnv('RENOVATE_X_CLEAR_HOOKS', undefined);
     });
 
     it('should not inherit unsafe git environment variables from process.env', async () => {
-      process.env.GIT_CONFIG_COUNT = '1';
-      process.env.GIT_CONFIG_KEY_0 = 'core.hooksPath';
-      process.env.GIT_CONFIG_VALUE_0 = '/tmp/hooks';
-      process.env.GIT_CONFIG_GLOBAL = '/tmp/global-gitconfig';
-      process.env.GIT_CONFIG_SYSTEM = '/tmp/system-gitconfig';
-      process.env.PAGER = 'less';
-      process.env.GIT_ASKPASS = '/tmp/.git-askpass';
+      vi.stubEnv('GIT_CONFIG_COUNT', '1');
+      vi.stubEnv('GIT_CONFIG_KEY_0', 'core.hooksPath');
+      vi.stubEnv('GIT_CONFIG_VALUE_0', '/tmp/hooks');
+      vi.stubEnv('GIT_CONFIG_GLOBAL', '/tmp/global-gitconfig');
+      vi.stubEnv('GIT_CONFIG_SYSTEM', '/tmp/system-gitconfig');
+      vi.stubEnv('PAGER', 'less');
+      vi.stubEnv('GIT_ASKPASS', '/tmp/.git-askpass');
 
       const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
       await git.initRepo({ url: origin.path });
@@ -2138,7 +2134,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
     it('should allow process.env GIT_SSH_COMMAND to override the default', async () => {
       // GIT_SSH_COMMAND is declared in extraEnv, so the key is inherited
       // from process.env via parentEnv (higher priority than extraEnv).
-      process.env.GIT_SSH_COMMAND = 'ssh -o SomeHostOption=yes';
+      vi.stubEnv('GIT_SSH_COMMAND', 'ssh -o SomeHostOption=yes');
 
       const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
       await git.initRepo({ url: origin.path });

--- a/lib/util/git/index.spec.ts
+++ b/lib/util/git/index.spec.ts
@@ -2033,6 +2033,9 @@ describe('util/git/index', { timeout: 30000 }, () => {
       vi.stubEnv('GIT_CONFIG_SYSTEM', '/tmp/system-gitconfig');
       vi.stubEnv('PAGER', 'less');
       vi.stubEnv('GIT_ASKPASS', '/tmp/.git-askpass');
+      // process.env deliberately overrides the default GIT_SSH_COMMAND, so an
+      // ambient value would be forwarded instead of the one asserted below.
+      vi.stubEnv('GIT_SSH_COMMAND', undefined);
 
       const envSpy = vi.spyOn(SimpleGit.prototype, 'env');
       await git.initRepo({ url: origin.path });
@@ -2060,6 +2063,7 @@ describe('util/git/index', { timeout: 30000 }, () => {
       // + GIT_CONFIG_VALUE_n via customEnvVariables.
       // simple-git >=3.36.0 blocks git operations when these vars are present unless
       // allowUnsafeConfigEnvCount is enabled in the simple-git config.
+      vi.stubEnv('GIT_SSH_COMMAND', undefined);
       setCustomEnv({
         GIT_CONFIG_COUNT: '3',
         GIT_CONFIG_KEY_0: 'url.https://ssh:token@example.com/.insteadOf',

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -54,7 +54,7 @@ describe('util/http/github', () => {
   let repoCache: RepoCacheData = {};
 
   beforeEach(() => {
-    delete process.env.RENOVATE_X_REBASE_PAGINATION_LINKS;
+    vi.stubEnv('RENOVATE_X_REBASE_PAGINATION_LINKS', undefined);
     githubApi = new GithubHttp();
     setBaseUrl(githubApiHost);
     repoCache = {};
@@ -333,7 +333,7 @@ describe('util/http/github', () => {
     });
 
     it('rebases GHE Server pagination links', async () => {
-      process.env.RENOVATE_X_REBASE_PAGINATION_LINKS = '1';
+      vi.stubEnv('RENOVATE_X_REBASE_PAGINATION_LINKS', '1');
       // The origin and base URL which Renovate uses (from its config) to reach GHE:
       const baseUrl = 'http://ghe.alternative.domain.com/api/v3';
       setBaseUrl(baseUrl);
@@ -384,7 +384,7 @@ describe('util/http/github', () => {
     });
 
     it('preserves pagination links for github.com', async () => {
-      process.env.RENOVATE_X_REBASE_PAGINATION_LINKS = '1';
+      vi.stubEnv('RENOVATE_X_REBASE_PAGINATION_LINKS', '1');
       const baseUrl = 'https://api.github.com/';
 
       setBaseUrl(baseUrl);

--- a/lib/util/http/gitlab.spec.ts
+++ b/lib/util/http/gitlab.spec.ts
@@ -20,7 +20,7 @@ describe('util/http/gitlab', () => {
   beforeEach(() => {
     gitlabApi = new GitlabHttp();
     setBaseUrl(`${gitlabApiHost}/api/v4/`);
-    delete process.env.GITLAB_IGNORE_REPO_URL;
+    vi.stubEnv('GITLAB_IGNORE_REPO_URL', undefined);
 
     hostRules.add({
       hostType: 'gitlab',
@@ -61,7 +61,7 @@ describe('util/http/gitlab', () => {
   });
 
   it('paginates with GITLAB_IGNORE_REPO_URL set', async () => {
-    process.env.GITLAB_IGNORE_REPO_URL = 'true';
+    vi.stubEnv('GITLAB_IGNORE_REPO_URL', 'true');
     setBaseUrl(`${selfHostedUrl}/api/v4/`);
 
     httpMock
@@ -182,16 +182,10 @@ describe('util/http/gitlab', () => {
   });
 
   describe('handles 409 errors', () => {
-    let NODE_ENV: string | undefined;
-
-    beforeAll(() => {
+    beforeEach(() => {
       // Unset NODE_ENV so that we can test the retry logic
-      NODE_ENV = process.env.NODE_ENV;
-      delete process.env.NODE_ENV;
-    });
-
-    afterAll(() => {
-      process.env.NODE_ENV = NODE_ENV;
+      vi.stubEnv('NODE_ENV', undefined);
+      gitlabApi = new GitlabHttp();
     });
 
     it('retries the request on resource lock', async () => {
@@ -222,16 +216,10 @@ describe('util/http/gitlab', () => {
   });
 
   describe('handles 400 source_branch errors', () => {
-    let NODE_ENV: string | undefined;
-
-    beforeAll(() => {
+    beforeEach(() => {
       // Unset NODE_ENV so that we can test the retry logic
-      NODE_ENV = process.env.NODE_ENV;
-      delete process.env.NODE_ENV;
-    });
-
-    afterAll(() => {
-      process.env.NODE_ENV = NODE_ENV;
+      vi.stubEnv('NODE_ENV', undefined);
+      gitlabApi = new GitlabHttp();
     });
 
     it('retries the request when source branch does not yet exist', async () => {

--- a/lib/util/http/got.spec.ts
+++ b/lib/util/http/got.spec.ts
@@ -9,11 +9,11 @@ describe('util/http/got', () => {
   const rejectUnauth = 'NODE_TLS_REJECT_UNAUTHORIZED';
 
   beforeEach(() => {
-    delete process.env[rejectUnauth];
+    vi.stubEnv(rejectUnauth, undefined);
   });
 
   it('configures rejectUnauthorized when forced', () => {
-    process.env[rejectUnauth] = '0';
+    vi.stubEnv(rejectUnauth, '0');
     const opts = {};
     configureRejectUnauth(opts);
     expect(opts).toEqual({ https: { rejectUnauthorized: false } });

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -15,7 +15,7 @@ describe('util/http/host-rules', () => {
   };
 
   beforeEach(() => {
-    delete process.env.HTTP_PROXY;
+    vi.stubEnv('HTTP_PROXY', undefined);
 
     // clean up hostRules
     hostRules.clear();
@@ -54,10 +54,6 @@ describe('util/http/host-rules', () => {
       hostType: 'bitbucket-server',
       token: 'cdef',
     });
-  });
-
-  afterEach(() => {
-    delete process.env.HTTP_PROXY;
   });
 
   it('adds token', () => {
@@ -164,7 +160,7 @@ describe('util/http/host-rules', () => {
   });
 
   it('disables http2', () => {
-    process.env.HTTP_PROXY = 'http://proxy';
+    vi.stubEnv('HTTP_PROXY', 'http://proxy');
     bootstrap();
     hostRules.add({ enableHttp2: true });
 

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -436,16 +436,9 @@ describe('util/http/index', () => {
   });
 
   describe('retry', () => {
-    let NODE_ENV: string | undefined;
-
-    beforeAll(() => {
-      NODE_ENV = process.env.NODE_ENV;
-      delete process.env.NODE_ENV;
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', undefined);
       http = new Http('dummy');
-    });
-
-    afterAll(() => {
-      process.env.NODE_ENV = NODE_ENV;
     });
 
     it('works', async () => {

--- a/lib/workers/global/config/parse/additional-config-file.spec.ts
+++ b/lib/workers/global/config/parse/additional-config-file.spec.ts
@@ -195,7 +195,7 @@ describe('workers/global/config/parse/additional-config-file', () => {
       expect(fileConfig.processEnv).toBeUndefined();
       expect(process.env.SOME_KEY).toBe('SOME_VALUE');
       await fs.promises.unlink(configFile);
-      delete process.env.SOME_KEY;
+      vi.stubEnv('SOME_KEY', undefined);
     });
 
     it('does not export env variables to environment from processEnv object if key/value is invalid', async () => {
@@ -224,8 +224,8 @@ describe('workers/global/config/parse/additional-config-file', () => {
       expect(process.env.valid_Key).toBe('true');
       expect(process.env.SOME_OTHER_KEY).toBeUndefined();
       await fs.promises.unlink(configFile);
-      delete process.env.SOME_KEY;
-      delete process.env.valid_Key;
+      vi.stubEnv('SOME_KEY', undefined);
+      vi.stubEnv('valid_Key', undefined);
     });
   });
 

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -34,7 +34,7 @@ describe('workers/global/config/parse/env', () => {
       );
     });
 
-    delete process.env.RENOVATE_CONFIG_MIGRATION;
+    vi.stubEnv('RENOVATE_CONFIG_MIGRATION', undefined);
 
     it('supports list single', async () => {
       const envParam: NodeJS.ProcessEnv = { RENOVATE_LABELS: 'a' };

--- a/lib/workers/global/config/parse/file.spec.ts
+++ b/lib/workers/global/config/parse/file.spec.ts
@@ -202,7 +202,7 @@ describe('workers/global/config/parse/file', () => {
       expect(fileConfig.processEnv).toBeUndefined();
       expect(process.env.SOME_KEY).toBe('SOME_VALUE');
       await fs.promises.unlink(configFile);
-      delete process.env.SOME_KEY;
+      vi.stubEnv('SOME_KEY', undefined);
     });
 
     it('does not export env variables to environment from processEnv object if key/value is invalid', async () => {
@@ -231,8 +231,8 @@ describe('workers/global/config/parse/file', () => {
       expect(process.env.valid_Key).toBe('true');
       expect(process.env.SOME_OTHER_KEY).toBeUndefined();
       await fs.promises.unlink(configFile);
-      delete process.env.SOME_KEY;
-      delete process.env.valid_Key;
+      vi.stubEnv('SOME_KEY', undefined);
+      vi.stubEnv('valid_Key', undefined);
     });
   });
 

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -44,10 +44,10 @@ describe('workers/global/index', () => {
     logger.getProblems.mockImplementation(() => []);
     logger.logLevel.mockImplementation(() => 'info');
     initPlatform.mockImplementation((input) => Promise.resolve(input));
-    delete process.env.AWS_SECRET_ACCESS_KEY;
-    delete process.env.AWS_SESSION_TOKEN;
-    delete process.env.COREPACK_NPM_TOKEN;
-    delete process.env.COREPACK_NPM_PASSWORD;
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', undefined);
+    vi.stubEnv('AWS_SESSION_TOKEN', undefined);
+    vi.stubEnv('COREPACK_NPM_TOKEN', undefined);
+    vi.stubEnv('COREPACK_NPM_PASSWORD', undefined);
   });
 
   describe('getRepositoryConfig', () => {
@@ -153,10 +153,10 @@ describe('workers/global/index', () => {
       maintainYarnLock: true,
       foo: 1,
     });
-    process.env.AWS_SECRET_ACCESS_KEY = 'key';
-    process.env.AWS_SESSION_TOKEN = 'token';
-    process.env.COREPACK_NPM_TOKEN = 'corepack-token';
-    process.env.COREPACK_NPM_PASSWORD = 'corepack-password';
+    vi.stubEnv('AWS_SECRET_ACCESS_KEY', 'key');
+    vi.stubEnv('AWS_SESSION_TOKEN', 'token');
+    vi.stubEnv('COREPACK_NPM_TOKEN', 'corepack-token');
+    vi.stubEnv('COREPACK_NPM_PASSWORD', 'corepack-password');
     await expect(globalWorker.start()).resolves.toBe(0);
     expect(addSecretForSanitizing).toHaveBeenCalledTimes(4);
   });
@@ -237,7 +237,7 @@ describe('workers/global/index', () => {
   });
 
   it('exits with zero when warnings are logged', async () => {
-    delete process.env.LOG_LEVEL;
+    vi.stubEnv('LOG_LEVEL', undefined);
     parseConfigs.mockResolvedValueOnce({
       baseDir: '/tmp/base',
       cacheDir: '/tmp/cache',

--- a/lib/workers/global/initialize.spec.ts
+++ b/lib/workers/global/initialize.spec.ts
@@ -83,8 +83,8 @@ describe('workers/global/initialize', () => {
 
   describe('configureThirdPartyLibraries()', () => {
     beforeEach(() => {
-      delete process.env.AWS_EC2_METADATA_DISABLED;
-      delete process.env.METADATA_SERVER_DETECTION;
+      vi.stubEnv('AWS_EC2_METADATA_DISABLED', undefined);
+      vi.stubEnv('METADATA_SERVER_DETECTION', undefined);
     });
 
     it('sets env vars when cloud metadata services disabled', async () => {

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -1025,7 +1025,7 @@ describe('workers/repository/init/merge', () => {
           fs.readLocalFile.mockResolvedValueOnce(
             JSON.stringify(repoFileConfig),
           );
-          process.env[repoStaticConfigFileKey] = 'static_config.json';
+          vi.stubEnv(repoStaticConfigFileKey, 'static_config.json');
           fs.readSystemFile.mockResolvedValueOnce(JSON.stringify(staticConfig));
 
           const got = await mergeRenovateConfig(currentConfig);

--- a/lib/workers/repository/update/pr/changelog/forgejo/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/forgejo/index.spec.ts
@@ -40,7 +40,7 @@ const changelogSource = new ForgejoChangeLogSource();
 describe('workers/repository/update/pr/changelog/forgejo/index', () => {
   beforeAll(() => {
     // TODO: why?
-    delete process.env.GITHUB_ENDPOINT;
+    vi.stubEnv('GITHUB_ENDPOINT', undefined);
   });
 
   describe('getChangeLogJSON', () => {

--- a/lib/workers/repository/update/pr/changelog/gitea/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitea/index.spec.ts
@@ -40,7 +40,7 @@ const changelogSource = new GiteaChangeLogSource();
 describe('workers/repository/update/pr/changelog/gitea/index', () => {
   beforeAll(() => {
     // TODO: why?
-    delete process.env.GITHUB_ENDPOINT;
+    vi.stubEnv('GITHUB_ENDPOINT', undefined);
   });
 
   describe('getChangeLogJSON', () => {

--- a/lib/workers/repository/update/pr/changelog/github/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.spec.ts
@@ -288,7 +288,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
         matchHost: 'https://github-enterprise.example.com/',
         token: 'abc',
       });
-      process.env.GITHUB_ENDPOINT = '';
+      vi.stubEnv('GITHUB_ENDPOINT', '');
       expect(
         await getChangeLogJSON({
           ...upgrade,

--- a/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/gitlab/index.spec.ts
@@ -262,7 +262,7 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         matchHost: 'https://gitlab-enterprise.example.com/',
         token: 'abc',
       });
-      process.env.GITHUB_ENDPOINT = '';
+      vi.stubEnv('GITHUB_ENDPOINT', '');
       expect(
         await getChangeLogJSON({
           ...upgrade,
@@ -295,7 +295,7 @@ describe('workers/repository/update/pr/changelog/gitlab/index', () => {
         matchHost: 'https://git.test.com/',
         token: 'abc',
       });
-      process.env.GITHUB_ENDPOINT = '';
+      vi.stubEnv('GITHUB_ENDPOINT', '');
       expect(
         await getChangeLogJSON({
           ...upgrade,

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -335,7 +335,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
         matchHost: 'https://github-enterprise.example.com/',
         token: 'abc',
       });
-      process.env.GITHUB_ENDPOINT = '';
+      vi.stubEnv('GITHUB_ENDPOINT', '');
       expect(
         await getChangeLogJSON({
           ...upgrade,

--- a/test/util.ts
+++ b/test/util.ts
@@ -95,3 +95,26 @@ export function fakeSha(
 ): LongCommitSha {
   return toLongCommitSha(hash(seed, algorithm));
 }
+
+/**
+ * Variables that `vi.stubEnv()` treats as booleans: it maps them onto '1' / ''
+ * rather than deleting them, so they cannot be cleared through a stub.
+ * Vitest sets them itself, and nothing under test reads them.
+ */
+const unstubbableEnvVars = new Set(['PROD', 'DEV', 'SSR']);
+
+/**
+ * Clear every environment variable for the duration of the current test.
+ *
+ * Replacing `process.env` wholesale would break `vi.stubEnv()`, which captures
+ * the original object when the worker starts and would keep deleting from it.
+ * Stubbing each key instead keeps that intact, and `unstubEnvs` restores them
+ * all before the next test.
+ */
+export function clearEnv(): void {
+  for (const key of Object.keys(process.env)) {
+    if (!unstubbableEnvVars.has(key)) {
+      vi.stubEnv(key, undefined);
+    }
+  }
+}

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -19,6 +19,7 @@ import preferJsonPipe from './rules/prefer-json-pipe.ts';
 import preferLuxon from './rules/prefer-luxon.ts';
 import preferNullishUtil from './rules/prefer-nullish-util.ts';
 import preferPartialInSpecs from './rules/prefer-partial-in-specs.ts';
+import preferStubEnv from './rules/prefer-stub-env.ts';
 import requireRegexUtil from './rules/require-regex-util.ts';
 import testRootDescribe from './rules/test-root-describe.ts';
 import v8IgnoreNoCount from './rules/v8-ignore-no-count.ts';
@@ -52,6 +53,7 @@ export default definePlugin({
     'prefer-is-object': preferIsObject,
     'prefer-nullish-util': preferNullishUtil,
     'prefer-partial-in-specs': preferPartialInSpecs,
+    'prefer-stub-env': preferStubEnv,
     'require-regex-util': requireRegexUtil,
     'test-root-describe': testRootDescribe,
     'v8-ignore-no-count': v8IgnoreNoCount,

--- a/tools/lint/rules/prefer-stub-env.spec.ts
+++ b/tools/lint/rules/prefer-stub-env.spec.ts
@@ -1,0 +1,110 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './prefer-stub-env.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+});
+
+ruleTester.run('prefer-stub-env', rule, {
+  valid: [
+    // module scope: a stub here is reverted before the first test runs
+    `process.env.CONTAINERBASE = 'true';`,
+    `delete process.env.NPM_CONFIG_CACHE;`,
+    // `beforeAll` / `afterAll` / `describe` bodies run once, same problem
+    `beforeAll(() => { process.env.FOO = 'bar'; });`,
+    `afterAll(() => { delete process.env.FOO; });`,
+    `describe('suite', () => { process.env.FOO = 'bar'; });`,
+    // reading is always fine
+    `it('works', () => { expect(process.env.FOO).toBe('bar'); });`,
+    `beforeEach(() => { const old = process.env.FOO; });`,
+    // already migrated
+    `beforeEach(() => { vi.stubEnv('FOO', 'bar'); });`,
+    // a different object that merely looks similar
+    `beforeEach(() => { other.env.FOO = 'bar'; });`,
+    `beforeEach(() => { process.other.FOO = 'bar'; });`,
+    // deleting something that is not a `process.env` member
+    `beforeEach(() => { delete foo.bar; });`,
+  ],
+  invalid: [
+    {
+      code: `beforeEach(() => { process.env.FOO = 'bar'; });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+      output: `beforeEach(() => { vi.stubEnv('FOO', 'bar'); });`,
+    },
+    {
+      code: `afterEach(() => { delete process.env.FOO; });`,
+      errors: [{ messageId: 'preferStubEnvDelete' }],
+      output: `afterEach(() => { vi.stubEnv('FOO', undefined); });`,
+    },
+    {
+      code: `it('works', () => { process.env.FOO = 'bar'; });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+      output: `it('works', () => { vi.stubEnv('FOO', 'bar'); });`,
+    },
+    {
+      code: `test('works', () => { delete process.env.FOO; });`,
+      errors: [{ messageId: 'preferStubEnvDelete' }],
+      output: `test('works', () => { vi.stubEnv('FOO', undefined); });`,
+    },
+    // the innermost suite function decides
+    {
+      code: `describe('suite', () => { beforeEach(() => { process.env.FOO = 'bar'; }); });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+      output: `describe('suite', () => { beforeEach(() => { vi.stubEnv('FOO', 'bar'); }); });`,
+    },
+    // `it.only` / `it.each(...)` are recognised as test contexts
+    {
+      code: `it.only('works', () => { process.env.FOO = 'bar'; });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+      output: `it.only('works', () => { vi.stubEnv('FOO', 'bar'); });`,
+    },
+    {
+      code: `it.each([1])('works', () => { delete process.env.FOO; });`,
+      errors: [{ messageId: 'preferStubEnvDelete' }],
+      output: `it.each([1])('works', () => { vi.stubEnv('FOO', undefined); });`,
+    },
+    // computed access keeps the key expression verbatim
+    {
+      code: `beforeEach(() => { process.env['FOO'] = 'bar'; });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+      output: `beforeEach(() => { vi.stubEnv('FOO', 'bar'); });`,
+    },
+    {
+      code: `beforeEach(() => { envVars.forEach((key) => { delete process.env[key]; }); });`,
+      errors: [{ messageId: 'preferStubEnvDelete' }],
+      output: `beforeEach(() => { envVars.forEach((key) => { vi.stubEnv(key, undefined); }); });`,
+    },
+    // the assigned value is carried over verbatim
+    {
+      code: `beforeEach(() => { process.env.FOO = upath.join(dir, 'x'); });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+      output: `beforeEach(() => { vi.stubEnv('FOO', upath.join(dir, 'x')); });`,
+    },
+    // compound assignment has no direct stub equivalent, so it is not fixed
+    {
+      code: `beforeEach(() => { process.env.PATH += ':/x'; });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+    },
+    // used as an expression rather than a statement, so it is not fixed
+    {
+      code: `it('works', () => { const v = (process.env.FOO = 'bar'); });`,
+      errors: [{ messageId: 'preferStubEnv' }],
+    },
+    // replacing the whole object is reported anywhere, and never fixed
+    {
+      code: `const OLD_ENV = process.env; beforeEach(() => { process.env = { ...OLD_ENV }; });`,
+      errors: [{ messageId: 'noProcessEnvReassign' }],
+    },
+    {
+      code: `beforeAll(() => { process.env = {}; });`,
+      errors: [{ messageId: 'noProcessEnvReassign' }],
+    },
+    {
+      code: `process.env = {};`,
+      errors: [{ messageId: 'noProcessEnvReassign' }],
+    },
+  ],
+});

--- a/tools/lint/rules/prefer-stub-env.ts
+++ b/tools/lint/rules/prefer-stub-env.ts
@@ -1,0 +1,174 @@
+import type { ESTree } from '@oxlint/plugins';
+import { defineRule } from '@oxlint/plugins';
+
+/**
+ * Names of the vitest suite functions that establish the innermost calling
+ * context. Walking up from a `process.env` mutation, the first of these found
+ * decides whether the mutation happens per-test (where `vi.stubEnv` works) or
+ * once per file (where it does not).
+ */
+const CONTEXT_NAMES = new Set([
+  'beforeEach',
+  'afterEach',
+  'beforeAll',
+  'afterAll',
+  'it',
+  'test',
+  'describe',
+]);
+
+/**
+ * Contexts that run per test. `unstubEnvs` reverts stubs *before* each test,
+ * so only stubs created from here survive into the test that needs them.
+ *
+ * Module scope, `describe` bodies and `beforeAll` / `afterAll` are absent on
+ * purpose: a `vi.stubEnv()` call there is undone before the first test runs,
+ * so those have to keep assigning to `process.env` directly.
+ */
+const PER_TEST_CONTEXTS = new Set(['beforeEach', 'afterEach', 'it', 'test']);
+
+/**
+ * Resolve the name a suite function is called by, so that `it.each(...)(...)`
+ * and `it.only(...)` are recognised the same way as a plain `it(...)`.
+ */
+function getCalleeName(callee: ESTree.Node): string | null {
+  switch (callee.type) {
+    case 'Identifier':
+      return callee.name;
+    // `it.only`, `test.each`, ...
+    case 'MemberExpression':
+      return callee.object.type === 'Identifier' ? callee.object.name : null;
+    // `it.each([...])(...)` calls the result of `it.each([...])`
+    case 'CallExpression':
+      return getCalleeName(callee.callee);
+    default:
+      return null;
+  }
+}
+
+/** Find the name of the innermost enclosing suite function call. */
+function getEnclosingContextName(node: ESTree.Node): string | null {
+  for (
+    let current: ESTree.Node | null = node.parent;
+    current;
+    current = current.parent
+  ) {
+    if (current.type === 'CallExpression') {
+      const name = getCalleeName(current.callee);
+      if (name !== null && CONTEXT_NAMES.has(name)) {
+        return name;
+      }
+    }
+  }
+  return null;
+}
+
+/** Whether `node` is the `process.env` member expression. */
+function isProcessEnv(node: ESTree.Node): boolean {
+  return (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.object.type === 'Identifier' &&
+    node.object.name === 'process' &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'env'
+  );
+}
+
+/** Whether `node` reads a single variable off `process.env`. */
+function isProcessEnvMember(
+  node: ESTree.Node,
+): node is ESTree.MemberExpression {
+  return node.type === 'MemberExpression' && isProcessEnv(node.object);
+}
+
+export default defineRule({
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    messages: {
+      preferStubEnv:
+        'Use `vi.stubEnv({{key}}, ...)` instead of assigning to `process.env` inside `{{context}}`. `unstubEnvs` is enabled in vitest.config.mts, so stubs are reverted before every test and need no manual cleanup.',
+      preferStubEnvDelete:
+        'Use `vi.stubEnv({{key}}, undefined)` instead of `delete process.env` inside `{{context}}`. `unstubEnvs` is enabled in vitest.config.mts, so stubs are reverted before every test and need no manual cleanup.',
+      noProcessEnvReassign:
+        'Do not replace the `process.env` object. `vi.stubEnv()` captures the original object when the worker starts, so after a reassignment its deletes silently target the old object and leave the variable set. Stub the individual variables instead.',
+    },
+  },
+  createOnce(context) {
+    /**
+     * Source text of the key to pass to `vi.stubEnv`: the literal property
+     * name quoted, or the computed expression verbatim.
+     */
+    function keyText(member: ESTree.MemberExpression): string {
+      if (member.computed) {
+        return context.sourceCode.getText(member.property);
+      }
+      return member.property.type === 'Identifier'
+        ? `'${member.property.name}'`
+        : context.sourceCode.getText(member.property);
+    }
+
+    return {
+      AssignmentExpression(node) {
+        // `process.env = { ...OLD_ENV }` breaks `vi.stubEnv` outright, so it is
+        // reported wherever it appears, not just inside a per-test context.
+        if (isProcessEnv(node.left)) {
+          context.report({ node, messageId: 'noProcessEnvReassign' });
+          return;
+        }
+
+        if (!isProcessEnvMember(node.left)) {
+          return;
+        }
+
+        const contextName = getEnclosingContextName(node);
+        if (contextName === null || !PER_TEST_CONTEXTS.has(contextName)) {
+          return;
+        }
+
+        const key = keyText(node.left);
+        context.report({
+          node,
+          messageId: 'preferStubEnv',
+          data: { key, context: contextName },
+          // Only a plain `=` maps onto a stub, and only as a statement: as an
+          // expression the assignment yields the assigned value whereas
+          // `vi.stubEnv()` yields the `vi` utils object.
+          fix:
+            node.operator === '=' && node.parent.type === 'ExpressionStatement'
+              ? (fixer) =>
+                  fixer.replaceText(
+                    node,
+                    `vi.stubEnv(${key}, ${context.sourceCode.getText(node.right)})`,
+                  )
+              : undefined,
+        });
+      },
+
+      UnaryExpression(node) {
+        if (node.operator !== 'delete' || !isProcessEnvMember(node.argument)) {
+          return;
+        }
+
+        const contextName = getEnclosingContextName(node);
+        if (contextName === null || !PER_TEST_CONTEXTS.has(contextName)) {
+          return;
+        }
+
+        const key = keyText(node.argument);
+        context.report({
+          node,
+          messageId: 'preferStubEnvDelete',
+          data: { key, context: contextName },
+          // `delete` yields a boolean, so only replace it as a statement.
+          fix:
+            node.parent.type === 'ExpressionStatement'
+              ? (fixer) =>
+                  fixer.replaceText(node, `vi.stubEnv(${key}, undefined)`)
+              : undefined,
+        });
+      },
+    };
+  },
+});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -94,6 +94,7 @@ export default defineConfig(() =>
         ],
         reporters,
         mockReset: true,
+        unstubEnvs: true,
         coverage: {
           provider: 'v8',
           skipFull: !ci,


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Replaces `process.env` operations in tests with `vi.stubEnv()` which allows us to set globally the resetting of these variables

## Context

For now I have not added an additional oxlint rule though probably makes sense to add one. 

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
