### PR TITLE
refactor(linters): add prefer-coerce-object rule

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -213,6 +213,7 @@
         "renovate/no-stateful-global-regex": "error",
         "renovate/no-tools-import": "error",
         "renovate/prefer-coerce-array": "error",
+        "renovate/prefer-coerce-object": "error",
         "renovate/prefer-is-helpers": "error",
         "renovate/prefer-is-object": "error"
       }

--- a/lib/config/migration.ts
+++ b/lib/config/migration.ts
@@ -9,6 +9,7 @@ import {
 import { dequal } from 'dequal';
 import { logger } from '../logger/index.ts';
 import { clone } from '../util/clone.ts';
+import { coerceObject } from '../util/object.ts';
 import { regEx } from '../util/regex.ts';
 import { MigrationsService } from './migrations/index.ts';
 import { getOptions } from './options/index.ts';
@@ -226,7 +227,7 @@ export function migrateConfig(
     // @ts-expect-error -- TODO: fix me
     if (isNonEmptyObject(migratedConfig['gradle-lite'])) {
       migratedConfig.gradle = mergeChildConfig(
-        migratedConfig.gradle ?? {},
+        coerceObject(migratedConfig.gradle),
         // @ts-expect-error -- TODO: fix me
         migratedConfig['gradle-lite'],
       );

--- a/lib/config/migrations/custom/node-migration.ts
+++ b/lib/config/migrations/custom/node-migration.ts
@@ -1,3 +1,4 @@
+import { coerceObject } from '../../../util/object.ts';
 import type { RenovateConfig } from '../../types.ts';
 import { AbstractMigration } from '../base/abstract-migration.ts';
 
@@ -10,7 +11,7 @@ export class NodeMigration extends AbstractMigration {
     if ((value as RenovateConfig).enabled === true) {
       // validated non-null
       delete node.enabled;
-      const travis = this.get('travis') ?? {};
+      const travis = coerceObject(this.get('travis'));
       travis.enabled = true;
       if (Object.keys(node).length) {
         this.rewrite(node);

--- a/lib/config/secrets.ts
+++ b/lib/config/secrets.ts
@@ -4,6 +4,7 @@ import {
   replaceInterpolatedValuesInObject,
   validateInterpolatedValues,
 } from '../util/interpolator.ts';
+import { coerceObject } from '../util/object.ts';
 import { regEx } from '../util/regex.ts';
 import { addSecretForSanitizing } from '../util/sanitize.ts';
 import type { AllConfig, RenovateConfig } from './types.ts';
@@ -77,14 +78,14 @@ export function applySecretsAndVariablesToConfig(
 
   const configWithVars = replaceInterpolatedValuesInObject(
     config,
-    variables ?? {},
+    coerceObject(variables),
     options.variables,
     deleteVariables,
   );
 
   return replaceInterpolatedValuesInObject(
     configWithVars,
-    secrets ?? {},
+    coerceObject(secrets),
     options.secrets,
     deleteSecrets,
   );

--- a/lib/modules/datasource/deno/index.ts
+++ b/lib/modules/datasource/deno/index.ts
@@ -3,6 +3,7 @@ import pMap from 'p-map';
 import { logger } from '../../../logger/index.ts';
 import * as packageCache from '../../../util/cache/package/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { joinUrlParts } from '../../../util/url.ts';
 import * as semanticVersioning from '../../versioning/semver/index.ts';
@@ -82,11 +83,12 @@ export class DenoDatasource extends Datasource {
     moduleAPIURL: string,
   ): Promise<ReleaseResult> {
     const detailsCacheKey = `details:${moduleAPIURL}`;
-    const releasesCache: Record<string, Release> =
-      (await packageCache.get(
+    const releasesCache: Record<string, Release> = coerceObject(
+      await packageCache.get(
         `datasource-${DenoDatasource.id}`,
         detailsCacheKey,
-      )) ?? {};
+      ),
+    );
     let cacheModified = false;
 
     const {

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../util/http/types.ts';
 import type { ParamsChallenge } from '../../../util/http/www-authenticate.ts';
 import { BearerScheme, parse } from '../../../util/http/www-authenticate.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { addSecretForSanitizing } from '../../../util/sanitize.ts';
 import {
@@ -314,9 +315,9 @@ export function getRegistryRepository(
     registryHost = `https://${registryHost}`;
   }
 
-  const { path, base } =
-    regEx(/^(?<base>https:\/\/[^/]+)\/(?<path>.+)$/).exec(registryHost)
-      ?.groups ?? {};
+  const { path, base } = coerceObject(
+    regEx(/^(?<base>https:\/\/[^/]+)\/(?<path>.+)$/).exec(registryHost)?.groups,
+  );
   if (base && path) {
     registryHost = base;
     dockerRepository = `${trimTrailingSlash(path)}/${dockerRepository}`;

--- a/lib/modules/manager/cargo/extract.ts
+++ b/lib/modules/manager/cargo/extract.ts
@@ -6,6 +6,7 @@ import {
   findLocalSiblingOrParent,
   readLocalFile,
 } from '../../../util/fs/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { api as versioning } from '../../versioning/cargo/index.ts';
 import type {
   ExtractConfig,
@@ -110,8 +111,8 @@ function extractCargoRegistries(config: CargoConfig): CargoRegistries {
   );
 
   const registryNames = new Set([
-    ...Object.keys(config.registries ?? {}),
-    ...Object.keys(config.source ?? {}),
+    ...Object.keys(coerceObject(config.registries)),
+    ...Object.keys(coerceObject(config.source)),
   ]);
   for (const registryName of registryNames) {
     result[registryName] = resolveRegistryIndex(registryName, config);
@@ -170,7 +171,7 @@ export async function extractPackageFile(
 ): Promise<PackageFileContent<CargoManagerData> | null> {
   logger.trace(`cargo.extractPackageFile(${packageFile})`);
 
-  const cargoConfig = (await readCargoConfig()) ?? {};
+  const cargoConfig = coerceObject(await readCargoConfig());
   const cargoRegistries = extractCargoRegistries(cargoConfig);
 
   const parsedCargoManifest = CargoManifest.safeParse(content);

--- a/lib/modules/manager/circleci/extract.ts
+++ b/lib/modules/manager/circleci/extract.ts
@@ -1,5 +1,6 @@
 import { isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { Result } from '../../../util/result.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
 import { OrbDatasource } from '../../datasource/orb/index.ts';
@@ -61,7 +62,7 @@ export function extractPackageFile(
     return null;
   }
 
-  const registryAliases = config?.registryAliases ?? {};
+  const registryAliases = coerceObject(config?.registryAliases);
   const deps: PackageDependency[] = [];
   extractDefinition(deps, parsed, registryAliases);
 

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -28,6 +28,7 @@ import {
 } from '../../../util/fs/index.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { Json } from '../../../util/schema-utils/index.ts';
 import { coerceString } from '../../../util/string.ts';
@@ -80,7 +81,7 @@ function getAuthJson(): string | null {
 
     if (gitlabHostRule?.token) {
       const host = coerceString(gitlabHostRule.resolvedHost, 'gitlab.com');
-      authJson['gitlab-token'] = authJson['gitlab-token'] ?? {};
+      authJson['gitlab-token'] = coerceObject(authJson['gitlab-token']);
       authJson['gitlab-token'][host] = gitlabHostRule.token;
       // https://getcomposer.org/doc/articles/authentication-for-private-packages.md#gitlab-token
       authJson['gitlab-domains'] = [
@@ -99,10 +100,10 @@ function getAuthJson(): string | null {
 
     const { resolvedHost, username, password, token } = packagistHostRule;
     if (resolvedHost && username && password) {
-      authJson['http-basic'] = authJson['http-basic'] ?? {};
+      authJson['http-basic'] = coerceObject(authJson['http-basic']);
       authJson['http-basic'][resolvedHost] = { username, password };
     } else if (resolvedHost && token) {
-      authJson.bearer = authJson.bearer ?? {};
+      authJson.bearer = coerceObject(authJson.bearer);
       authJson.bearer[resolvedHost] = token;
     }
   }

--- a/lib/modules/manager/custom/regex/strategies.ts
+++ b/lib/modules/manager/custom/regex/strategies.ts
@@ -1,4 +1,5 @@
 import { isTruthy } from '@sindresorhus/is';
+import { coerceObject } from '../../../../util/object.ts';
 import { regEx } from '../../../../util/regex.ts';
 import type { PackageDependency } from '../../types.ts';
 import { checkIsValidDependency } from '../utils.ts';
@@ -25,9 +26,7 @@ export function handleAny(
     .map((matchResult) =>
       createDependency(
         {
-          groups:
-            matchResult.groups ??
-            /* istanbul ignore next: can this happen? */ {},
+          groups: coerceObject(matchResult.groups),
           replaceString: matchResult[0],
         },
         config,
@@ -55,7 +54,7 @@ export function handleCombination(
 
   const extraction = matches
     .map((match) => ({
-      groups: match.groups ?? /* istanbul ignore next: can this happen? */ {},
+      groups: coerceObject(match.groups),
       replaceString:
         (match?.groups?.currentValue ?? match?.groups?.currentDigest)
           ? match[0]
@@ -118,7 +117,7 @@ function processRecursive(parameters: RecursionParameter): PackageDependency[] {
       ...parameters,
       content: match[0],
       index: index + 1,
-      combinedGroups: mergeGroups(combinedGroups, match.groups ?? {}),
+      combinedGroups: mergeGroups(combinedGroups, coerceObject(match.groups)),
     });
   });
 }

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -1,6 +1,7 @@
 import { isEmptyStringOrWhitespace } from '@sindresorhus/is';
 import { migrateDatasource } from '../../../../config/migrations/custom/datasource-migration.ts';
 import { logger } from '../../../../logger/index.ts';
+import { coerceObject } from '../../../../util/object.ts';
 import * as template from '../../../../util/template/index.ts';
 import { parseUrl } from '../../../../util/url.ts';
 import type { PackageDependency } from '../../types.ts';
@@ -47,7 +48,7 @@ export function createDependency(
   packageFileInfo: PackageFileInfo,
   dep?: PackageDependency,
 ): PackageDependency | null {
-  const dependency = dep ?? {};
+  const dependency = coerceObject(dep);
   const { groups, replaceString } = extractionTemplate;
   const { packageFileName, packageFileDir } = packageFileInfo;
 

--- a/lib/modules/manager/docker-compose/extract.ts
+++ b/lib/modules/manager/docker-compose/extract.ts
@@ -1,5 +1,6 @@
 import { isString, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
 import { getDep } from '../dockerfile/extract.ts';
@@ -56,7 +57,7 @@ export function extractPackageFile(
     // become optional and can no longer be used to differentiate
     // between v1 and v2.
     const services = config.services ?? config;
-    const extensions = config.extensions ?? {};
+    const extensions = coerceObject(config.extensions);
 
     // Image name/tags for services are only eligible for update if they don't
     // use variables and if the image is not built locally

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyStringAndNotWhitespace, isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import * as debianVersioning from '../../versioning/debian/index.ts';
@@ -174,7 +175,7 @@ export function getDep(
   }
 
   // Resolve registry aliases first so that we don't need special casing later on:
-  for (const [name, value] of Object.entries(registryAliases ?? {})) {
+  for (const [name, value] of Object.entries(coerceObject(registryAliases))) {
     if (currentFrom.startsWith(`${name}/`)) {
       const depName = currentFrom.substring(name.length + 1);
       const dep = getDep(`${value}/${depName}`, false);

--- a/lib/modules/manager/gleam/extract.ts
+++ b/lib/modules/manager/gleam/extract.ts
@@ -1,6 +1,7 @@
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getSiblingFileName, localPathExists } from '../../../util/fs/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { HexDatasource } from '../../datasource/hex/index.ts';
 import { api as versioning } from '../../versioning/hex/index.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
@@ -44,7 +45,7 @@ function toPackageDeps({
   deps?: Record<string, string>;
   sectionKey: string;
 }): PackageDependency[] {
-  return Object.entries(deps ?? {}).map(([name, version]) =>
+  return Object.entries(coerceObject(deps)).map(([name, version]) =>
     toPackageDep({ name, sectionKey, version }),
   );
 }

--- a/lib/modules/manager/gradle/extract/catalog.ts
+++ b/lib/modules/manager/gradle/extract/catalog.ts
@@ -1,7 +1,7 @@
 import { isPlainObject, isString } from '@sindresorhus/is';
 import deepmerge from 'deepmerge';
 import type { SkipReason } from '../../../../types/index.ts';
-import { hasKey } from '../../../../util/object.ts';
+import { coerceObject, hasKey } from '../../../../util/object.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { massage, parse as parseToml } from '../../../../util/toml.ts';
 import type { PackageDependency } from '../../types.ts';
@@ -250,8 +250,8 @@ export function parseCatalog(
   content: string,
 ): { vars: PackageVariables; deps: PackageDependency<GradleManagerData>[] } {
   const tomlContent = parseToml(massage(content)) as GradleCatalog;
-  const versions = tomlContent.versions ?? {};
-  const libs = tomlContent.libraries ?? {};
+  const versions = coerceObject(tomlContent.versions);
+  const libs = coerceObject(tomlContent.libraries);
   const libStartIndex = content.indexOf('libraries');
   const libSubContent = content.slice(libStartIndex);
   const versionStartIndex = content.indexOf('versions');
@@ -290,7 +290,7 @@ export function parseCatalog(
     extractedDeps.push(dependency);
   }
 
-  const plugins = tomlContent.plugins ?? {};
+  const plugins = coerceObject(tomlContent.plugins);
   const pluginsStartIndex = content.indexOf('[plugins]');
   const pluginsSubContent = content.slice(pluginsStartIndex);
   for (const pluginName of Object.keys(plugins)) {

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -1,4 +1,5 @@
 import upath from 'upath';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { api as gradleVersioning } from '../../versioning/gradle/index.ts';
 import type { PackageDependency } from '../types.ts';
@@ -194,7 +195,7 @@ export function updateVars(
   dir: string,
   newVars: PackageVariables,
 ): void {
-  const oldVars = registry[dir] ?? {};
+  const oldVars = coerceObject(registry[dir]);
   registry[dir] = { ...oldVars, ...newVars };
 }
 
@@ -209,7 +210,7 @@ export function updateVarsFromDefaultCatalog(
   }
 
   const rootDir = upath.dirname(dir);
-  const oldVars = registry[rootDir] ?? {};
+  const oldVars = coerceObject(registry[rootDir]);
   let defaultLibsExtName = 'libs';
   if (
     oldVars.defaultLibrariesExtensionName?.packageFile &&

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -8,6 +8,7 @@ import {
 } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
@@ -62,7 +63,9 @@ export async function extractPackageFile(
   }
 
   for (const [taskName, taskData] of Object.entries(misefile.tasks)) {
-    for (const [name, toolData] of Object.entries(taskData.tools ?? {})) {
+    for (const [name, toolData] of Object.entries(
+      coerceObject(taskData.tools),
+    )) {
       deps.push(extractToolEntry(name, toolData, `task-${taskName}-tools`));
     }
   }

--- a/lib/modules/manager/npm/artifacts.ts
+++ b/lib/modules/manager/npm/artifacts.ts
@@ -12,6 +12,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { matchRegexOrGlob } from '../../../util/string-match.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
@@ -36,8 +37,10 @@ export async function updateArtifacts(
 ): Promise<UpdateArtifactsResult[] | null> {
   logger.debug(`npm.updateArtifacts(${updateArtifactsConfig.packageFileName})`);
   let res: UpdateArtifactsResult[] = [];
-  res.push((await handlePackageManagerUpdates(updateArtifactsConfig)) ?? {});
-  res.push((await updatePnpmWorkspace(updateArtifactsConfig)) ?? {});
+  res.push(
+    coerceObject(await handlePackageManagerUpdates(updateArtifactsConfig)),
+  );
+  res.push(coerceObject(await updatePnpmWorkspace(updateArtifactsConfig)));
 
   res = res.filter(isNonEmptyObject);
   if (res.length === 0) {

--- a/lib/modules/manager/npm/extract/pnpm.ts
+++ b/lib/modules/manager/npm/extract/pnpm.ts
@@ -16,6 +16,7 @@ import {
   localPathExists,
   readLocalFile,
 } from '../../../../util/fs/index.ts';
+import { coerceObject } from '../../../../util/object.ts';
 import { parseSingleYaml, parseYaml } from '../../../../util/yaml.ts';
 import { NpmDatasource } from '../../../datasource/npm/index.ts';
 import type {
@@ -251,7 +252,7 @@ function getLockedDependencyVersions(
   for (const depType of dependencyTypes) {
     res[depType] = {};
     for (const [pkgName, versionCarrier] of Object.entries(
-      obj[depType] ?? {},
+      coerceObject(obj[depType]),
     )) {
       let version: string;
       if (isObject(versionCarrier)) {

--- a/lib/modules/manager/npm/extract/post/monorepo.ts
+++ b/lib/modules/manager/npm/extract/post/monorepo.ts
@@ -4,6 +4,7 @@ import {
   getParentDir,
   getSiblingFileName,
 } from '../../../../../util/fs/index.ts';
+import { coerceObject } from '../../../../../util/object.ts';
 import type { PackageFile } from '../../../types.ts';
 import type { NpmManagerData } from '../../types.ts';
 import { detectPnpmWorkspaces } from '../pnpm.ts';
@@ -49,7 +50,7 @@ export async function detectMonorepos(
       });
 
       for (const subPackage of internalPackageFiles) {
-        subPackage.managerData = subPackage.managerData ?? {};
+        subPackage.managerData = coerceObject(subPackage.managerData);
         subPackage.managerData.yarnZeroInstall = yarnZeroInstall;
         subPackage.managerData.hasPackageManager = hasPackageManager;
         subPackage.managerData.yarnLock ??= yarnLock;

--- a/lib/modules/manager/npm/post-update/yarn.ts
+++ b/lib/modules/manager/npm/post-update/yarn.ts
@@ -22,6 +22,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../../util/fs/index.ts';
+import { coerceObject } from '../../../../util/object.ts';
 import { newlineRegex, regEx } from '../../../../util/regex.ts';
 import { uniqueStrings } from '../../../../util/string.ts';
 import { NpmDatasource } from '../../../datasource/npm/index.ts';
@@ -357,7 +358,7 @@ export function fuzzyMatchAdditionalYarnrcYml<
   T extends { npmRegistries?: Record<string, unknown> },
 >(additionalYarnRcYml: T, existingYarnrRcYml: T): T {
   const keys = new Map(
-    Object.keys(existingYarnrRcYml.npmRegistries ?? {}).map((x) => [
+    Object.keys(coerceObject(existingYarnrRcYml.npmRegistries)).map((x) => [
       x.replace(regEx(/\/$/), '').replace(regEx(/^https?:/), ''),
       x,
     ]),
@@ -365,7 +366,9 @@ export function fuzzyMatchAdditionalYarnrcYml<
 
   return {
     ...additionalYarnRcYml,
-    npmRegistries: Object.entries(additionalYarnRcYml.npmRegistries ?? {})
+    npmRegistries: Object.entries(
+      coerceObject(additionalYarnRcYml.npmRegistries),
+    )
       .map(([k, v]) => {
         const key = keys.get(k.replace(regEx(/\/$/), '')) ?? k;
         return { [key]: v };

--- a/lib/modules/manager/nuget/extract.ts
+++ b/lib/modules/manager/nuget/extract.ts
@@ -3,6 +3,7 @@ import type { XmlElement } from 'xmldoc';
 import { XmlDocument } from 'xmldoc';
 import { logger } from '../../../logger/index.ts';
 import { getSiblingFileName, localPathExists } from '../../../util/fs/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { NugetDatasource } from '../../datasource/nuget/index.ts';
 import * as semver from '../../versioning/semver/index.ts';
@@ -179,7 +180,7 @@ export async function extractPackageFile(
       return null;
     }
 
-    for (const depName of Object.keys(manifest.tools ?? {})) {
+    for (const depName of Object.keys(coerceObject(manifest.tools))) {
       const tool = manifest.tools[depName];
       const currentValue = tool.version;
       const dep: NugetPackageDependency = {

--- a/lib/modules/manager/renovate-config/extract.ts
+++ b/lib/modules/manager/renovate-config/extract.ts
@@ -5,6 +5,7 @@ import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { getToolConfig } from '../../../util/exec/containerbase.ts';
 import { isToolName } from '../../../util/exec/types.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
@@ -79,7 +80,7 @@ export function extractPackageFile(
   }
 
   for (const [constraint, value] of Object.entries(
-    config.data.constraints ?? {},
+    coerceObject(config.data.constraints),
   )) {
     if (isToolName(constraint)) {
       const toolConfig = getToolConfig(constraint);
@@ -103,7 +104,7 @@ export function extractPackageFile(
 
   for (const packageRule of coerceArray(config.data.packageRules)) {
     for (const [constraint, value] of Object.entries(
-      packageRule.constraints ?? {},
+      coerceObject(packageRule.constraints),
     )) {
       if (isToolName(constraint)) {
         const toolConfig = getToolConfig(constraint);

--- a/lib/modules/manager/terraform/lockfile/index.ts
+++ b/lib/modules/manager/terraform/lockfile/index.ts
@@ -1,6 +1,7 @@
 import { isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../../logger/index.ts';
 import { coerceArray } from '../../../../util/array.ts';
+import { coerceObject } from '../../../../util/object.ts';
 import * as p from '../../../../util/promises.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { getDefaultVersioning } from '../../../datasource/common.ts';
@@ -36,7 +37,7 @@ async function updateAllLocks(
         packageName: lock.packageName,
         registryUrls: [lock.registryUrl],
       };
-      const { releases } = (await getPkgReleases(updateConfig)) ?? {};
+      const { releases } = coerceObject(await getPkgReleases(updateConfig));
       if (!releases) {
         return null;
       }

--- a/lib/modules/manager/velaci/extract.ts
+++ b/lib/modules/manager/velaci/extract.ts
@@ -1,5 +1,6 @@
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
 import { getDep } from '../dockerfile/extract.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
@@ -36,7 +37,7 @@ export function extractPackageFile(
   }
 
   // iterate over stages
-  for (const stage of Object.values(doc.stages ?? {})) {
+  for (const stage of Object.values(coerceObject(doc.stages))) {
     for (const step of coerceArray(stage.steps)) {
       const dep = getDep(step.image);
 
@@ -45,7 +46,7 @@ export function extractPackageFile(
   }
 
   // check secrets
-  for (const secret of Object.values(doc.secrets ?? {})) {
+  for (const secret of Object.values(coerceObject(doc.secrets))) {
     if (secret.origin) {
       const dep = getDep(secret.origin.image);
 

--- a/lib/modules/manager/woodpecker/extract.ts
+++ b/lib/modules/manager/woodpecker/extract.ts
@@ -1,5 +1,6 @@
 import { isObject, isString } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
 import { getDep } from '../dockerfile/extract.ts';
 import type { ExtractConfig, PackageFileContent } from '../types.ts';
@@ -56,7 +57,7 @@ export function extractPackageFile(
   // Image name/tags for services are only eligible for update if they don't
   // use variables and if the image is not built locally
   const deps = pipelineKeys.flatMap((pipelineKey) =>
-    Object.values(config[pipelineKey] ?? {})
+    Object.values(coerceObject(config[pipelineKey]))
       .filter((step) => isString(step?.image))
       .map((step) => getDep(step.image, true, extractConfig.registryAliases)),
   );

--- a/lib/modules/platform/gerrit/index.ts
+++ b/lib/modules/platform/gerrit/index.ts
@@ -7,6 +7,7 @@ import { getEnv } from '../../../util/env.ts';
 import * as git from '../../../util/git/index.ts';
 import type { VirtualBranch } from '../../../util/git/types.ts';
 import { setBaseUrl } from '../../../util/http/gerrit.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { toLongCommitSha } from '../../../util/schema-utils/git.ts';
 import { ensureTrailingSlash } from '../../../util/url.ts';
@@ -29,7 +30,6 @@ import type {
   UpdatePrConfig,
 } from '../types.ts';
 import { repoFingerprint } from '../util.ts';
-
 import { smartTruncate } from '../utils/pr-body.ts';
 import { readOnlyIssueBody } from '../utils/read-only-issue-body.ts';
 import { client } from './client.ts';
@@ -146,7 +146,7 @@ export async function initRepo({
     repository,
     head: branchInfo.revision,
     config: projectInfo,
-    labels: projectInfo.labels ?? {},
+    labels: coerceObject(projectInfo.labels),
   };
 
   //abandon "open" and "rejected" changes at startup
@@ -382,7 +382,7 @@ export async function getBranchStatus(
     if (hasProblems) {
       return 'red';
     }
-    const hasBlockingLabels = Object.values(change.labels ?? {}).some(
+    const hasBlockingLabels = Object.values(coerceObject(change.labels)).some(
       (label) => label.blocking,
     );
     if (hasBlockingLabels) {

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -17,6 +17,7 @@ import {
 import { logger } from '../logger/index.ts';
 import type { Nullish } from '../types/index.ts';
 import * as hostRules from './host-rules.ts';
+import { coerceObject } from './object.ts';
 import { parseUrl } from './url.ts';
 
 /**
@@ -36,7 +37,7 @@ export function detectPlatform(
   | 'github'
   | 'gitlab'
   | null {
-  const { hostname } = parseUrl(url) ?? {};
+  const { hostname } = coerceObject(parseUrl(url));
   if (hostname === 'dev.azure.com' || hostname?.endsWith('.visualstudio.com')) {
     return 'azure';
   }

--- a/lib/util/env.ts
+++ b/lib/util/env.ts
@@ -1,4 +1,5 @@
 import * as memCache from './cache/memory/index.ts';
+import { coerceObject } from './object.ts';
 
 let customEnv: Record<string, string> = {};
 
@@ -15,7 +16,7 @@ export function setUserEnv(envObj: Record<string, string> | undefined): void {
 }
 
 export function getUserEnv(): Record<string, string> {
-  return memCache.get('userEnv') ?? {};
+  return coerceObject(memCache.get('userEnv'));
 }
 
 /**

--- a/lib/util/exec/index.spec.ts
+++ b/lib/util/exec/index.spec.ts
@@ -6,6 +6,7 @@ import type { RepoGlobalConfig } from '../../config/types.ts';
 import { TEMPORARY_ERROR } from '../../constants/error-messages.ts';
 import type { UpdateArtifactsConfig } from '../../modules/manager/types.ts';
 import { setCustomEnv } from '../env.ts';
+import { coerceObject } from '../object.ts';
 import * as dockerModule from './docker/index.ts';
 import { hardcodedProcessEnv } from './env.ts';
 import { getHermitEnvs } from './hermit.ts';
@@ -965,7 +966,7 @@ describe('util/exec/index', () => {
       return Promise.resolve({ stdout: '', stderr: '' });
     });
     GlobalConfig.set({ ...globalConfig, localDir: cwd, ...adminConfig });
-    setCustomEnv(adminConfig.customEnvVariables ?? {});
+    setCustomEnv(coerceObject(adminConfig.customEnvVariables));
     if (hermitEnvs !== undefined) {
       getHermitEnvsMock.mockResolvedValue(hermitEnvs);
     }

--- a/lib/util/exec/utils.ts
+++ b/lib/util/exec/utils.ts
@@ -6,6 +6,7 @@ import {
 } from '@sindresorhus/is';
 import { join } from 'shlex';
 import { getCustomEnv, getUserEnv } from '../env.ts';
+import { coerceObject } from '../object.ts';
 import { getChildProcessEnv } from './env.ts';
 import type { CommandWithOptions, ExecOptions } from './types.ts';
 
@@ -19,7 +20,7 @@ export function getChildEnv({
   const userConfiguredEnv = getUserEnv();
 
   const inheritedKeys: string[] = [];
-  for (const [key, val] of Object.entries(extraEnv ?? {})) {
+  for (const [key, val] of Object.entries(coerceObject(extraEnv))) {
     if (isString(val)) {
       inheritedKeys.push(key);
     }

--- a/lib/util/git/index.ts
+++ b/lib/util/git/index.ts
@@ -42,6 +42,7 @@ import { getCache } from '../cache/repository/index.ts';
 import { getEnv } from '../env.ts';
 import type { ExtraEnv } from '../exec/types.ts';
 import { getChildEnv } from '../exec/utils.ts';
+import { coerceObject } from '../object.ts';
 import { newlineRegex, regEx } from '../regex.ts';
 import type { LongCommitSha } from '../schema-utils/git.ts';
 import { toLongCommitSha } from '../schema-utils/git.ts';
@@ -908,7 +909,7 @@ export async function getFileList(): Promise<string[]> {
 }
 
 export function getBranchList(): string[] {
-  return Object.keys(config.branchCommits ?? {});
+  return Object.keys(coerceObject(config.branchCommits));
 }
 
 export async function isBranchBehindBase(
@@ -1718,7 +1719,7 @@ export async function getCommitTreeSha(
   commitSha: LongCommitSha,
 ): Promise<LongCommitSha> {
   const commitOutput = await git.catFile(['-p', commitSha]);
-  const { treeSha } = treeShaRegex.exec(commitOutput)?.groups ?? {};
+  const { treeSha } = coerceObject(treeShaRegex.exec(commitOutput)?.groups);
   if (!treeSha) {
     const snippet = commitOutput.split(newlineRegex)[0];
     /* v8 ignore next -- tested, but v8 reports template literal as partial */

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -20,6 +20,7 @@ import { getCache } from '../cache/repository/index.ts';
 import { getEnv } from '../env.ts';
 import * as hostRules from '../host-rules.ts';
 import { maskToken } from '../mask.ts';
+import { coerceObject } from '../object.ts';
 import * as p from '../promises.ts';
 import { range } from '../range.ts';
 import { regEx } from '../regex.ts';
@@ -422,7 +423,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
     method: HttpMethod,
     options: InternalJsonUnsafeOptions<GithubHttpOptions>,
   ): Promise<HttpResponse<T>> {
-    const httpOptions = options.httpOptions ?? {};
+    const httpOptions = coerceObject(options.httpOptions);
     const resolvedUrl = this.resolveUrl(options.url, httpOptions);
     const opts = {
       ...options,

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -12,6 +12,7 @@ import * as memCache from '../cache/memory/index.ts';
 import { getEnv } from '../env.ts';
 import { hash } from '../hash.ts';
 import { acquireLock } from '../mutex.ts';
+import { coerceObject } from '../object.ts';
 import { type AsyncResult, Result } from '../result.ts';
 import { Toml } from '../schema-utils/index.ts';
 import { ObsoleteCacheHitLogger } from '../stats.ts';
@@ -22,7 +23,6 @@ import { applyAuthorization } from './auth.ts';
 import type { HttpCacheProvider } from './cache/types.ts';
 import { fetch, normalize, stream } from './got.ts';
 import { applyHostRule, findMatchingRule } from './host-rules.ts';
-
 import { getQueue } from './queue.ts';
 import { getRetryAfter, wrapWithRetry } from './retry-after.ts';
 import { getThrottle } from './throttle.ts';
@@ -412,7 +412,7 @@ export abstract class HttpBase<
   }
 
   async getPlain(url: string, options?: Opts): Promise<HttpResponse> {
-    const opt = options ?? {};
+    const opt = coerceObject(options);
     return await this.getText(url, {
       headers: {
         Accept: 'text/plain',

--- a/lib/util/stats.ts
+++ b/lib/util/stats.ts
@@ -2,6 +2,7 @@ import { logger } from '../logger/index.ts';
 import { coerceArray } from './array.ts';
 import * as memCache from './cache/memory/index.ts';
 import type { GitOperationType } from './git/types.ts';
+import { coerceObject } from './object.ts';
 import { parseUrl } from './url.ts';
 
 type LookupStatsData = Record<string, number[]>;
@@ -29,7 +30,7 @@ export function makeTimingReport(data: number[]): TimingStatsReport {
 
 export class LookupStats {
   static write(datasource: string, duration: number): void {
-    const data = memCache.get<LookupStatsData>('lookup-stats') ?? {};
+    const data = coerceObject(memCache.get<LookupStatsData>('lookup-stats'));
     data[datasource] ??= [];
     data[datasource].push(duration);
     memCache.set('lookup-stats', data);
@@ -48,7 +49,7 @@ export class LookupStats {
 
   static getReport(): Record<string, TimingStatsReport> {
     const report: Record<string, TimingStatsReport> = {};
-    const data = memCache.get<LookupStatsData>('lookup-stats') ?? {};
+    const data = coerceObject(memCache.get<LookupStatsData>('lookup-stats'));
     for (const [datasource, durations] of Object.entries(data)) {
       report[datasource] = makeTimingReport(durations);
     }
@@ -577,7 +578,7 @@ function sortObject<T>(obj: Record<string, T>): Record<string, T> {
 
 export class HttpCacheStats {
   static getData(): HttpCacheStatsData {
-    return memCache.get<HttpCacheStatsData>('http-cache-stats') ?? {};
+    return coerceObject(memCache.get<HttpCacheStatsData>('http-cache-stats'));
   }
 
   static read(key: string): HttpCacheHostStatsData {
@@ -590,7 +591,9 @@ export class HttpCacheStats {
   }
 
   static write(key: string, data: HttpCacheHostStatsData): void {
-    const stats = memCache.get<HttpCacheStatsData>('http-cache-stats') ?? {};
+    const stats = coerceObject(
+      memCache.get<HttpCacheStatsData>('http-cache-stats'),
+    );
     stats[key] = data;
     memCache.set('http-cache-stats', stats);
   }
@@ -684,7 +687,9 @@ type ObsoleteCacheStats = Record<
 /* v8 ignore next: temporary code */
 export class ObsoleteCacheHitLogger {
   static getData(): ObsoleteCacheStats {
-    return memCache.get<ObsoleteCacheStats>('obsolete-cache-stats') ?? {};
+    return coerceObject(
+      memCache.get<ObsoleteCacheStats>('obsolete-cache-stats'),
+    );
   }
 
   static write(url: string): void {
@@ -765,8 +770,9 @@ type GitOperationStatsData = Record<GitOperationType, number[]>;
 
 export class GitOperationStats {
   static write(operationType: GitOperationType, duration: number): void {
-    const data =
-      memCache.get<GitOperationStatsData>('git-operations-stats') ?? {};
+    const data = coerceObject(
+      memCache.get<GitOperationStatsData>('git-operations-stats'),
+    );
     data[operationType] ??= [];
     data[operationType].push(duration);
     memCache.set('git-operations-stats', data);
@@ -774,7 +780,9 @@ export class GitOperationStats {
 
   static getReport(): Record<string, TimingStatsReport> {
     const report: Record<string, TimingStatsReport> = {};
-    const data = memCache.get<LookupStatsData>('git-operations-stats') ?? {};
+    const data = coerceObject(
+      memCache.get<LookupStatsData>('git-operations-stats'),
+    );
     for (const [operationType, durations] of Object.entries(data)) {
       report[operationType] = makeTimingReport(durations);
       report[operationType].totalMs = Math.ceil(report[operationType].totalMs);

--- a/lib/workers/repository/errors-warnings.ts
+++ b/lib/workers/repository/errors-warnings.ts
@@ -4,6 +4,7 @@ import { logger } from '../../logger/index.ts';
 import type { PackageFile } from '../../modules/manager/types.ts';
 import { coerceArray } from '../../util/array.ts';
 import { emojify } from '../../util/emoji.ts';
+import { coerceObject } from '../../util/object.ts';
 import { regEx } from '../../util/regex.ts';
 import type { DepWarnings } from '../types.ts';
 
@@ -38,7 +39,7 @@ function getDepWarnings(
 ): DepWarnings {
   const warnings: string[] = [];
   const warningFiles: string[] = [];
-  for (const files of Object.values(packageFiles ?? {})) {
+  for (const files of Object.values(coerceObject(packageFiles))) {
     for (const file of coerceArray(files)) {
       // TODO: remove condition when type is fixed (#22198)
       if (file.packageFile) {

--- a/lib/workers/repository/finalize/repository-statistics.ts
+++ b/lib/workers/repository/finalize/repository-statistics.ts
@@ -12,6 +12,7 @@ import type {
   BranchUpgradeCache,
 } from '../../../util/cache/repository/types.ts';
 import { getInheritedOrGlobal } from '../../../util/common.ts';
+import { coerceObject } from '../../../util/object.ts';
 import type {
   BaseBranchMetadata,
   BaseBranchUpdateSummary,
@@ -134,7 +135,7 @@ export function runBranchSummary(config: RenovateConfig): void {
   const { scan, branches } = getCache();
 
   const baseMetadata: BaseBranchMetadata[] = [];
-  for (const [branchName, cached] of Object.entries(scan ?? {})) {
+  for (const [branchName, cached] of Object.entries(coerceObject(scan))) {
     baseMetadata.push({ branchName, sha: cached.sha });
   }
 

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { platform } from '../../../modules/platform/index.ts';
+import { coerceObject } from '../../../util/object.ts';
 import * as template from '../../../util/template/index.ts';
 import { applyHostRules } from './merge.ts';
 
@@ -122,8 +123,8 @@ export async function mergeInheritedConfig(
   if (isNullOrUndefined(filteredConfig.extends)) {
     filteredConfig = applySecretsAndVariablesToConfig({
       config: filteredConfig,
-      secrets: config.secrets ?? {},
-      variables: config.variables ?? {},
+      secrets: coerceObject(config.secrets),
+      variables: coerceObject(config.variables),
     });
     applyHostRules(filteredConfig);
     filteredConfig = InheritConfig.set(filteredConfig);
@@ -167,8 +168,8 @@ export async function mergeInheritedConfig(
 
   filteredConfig = applySecretsAndVariablesToConfig({
     config: filteredConfig,
-    secrets: config.secrets ?? {},
-    variables: config.variables ?? {},
+    secrets: coerceObject(config.secrets),
+    variables: coerceObject(config.variables),
   });
   applyHostRules(filteredConfig);
   filteredConfig = InheritConfig.set(filteredConfig);

--- a/lib/workers/repository/init/vulnerability.ts
+++ b/lib/workers/repository/init/vulnerability.ts
@@ -14,6 +14,7 @@ import { platform } from '../../../modules/platform/index.ts';
 import * as allVersioning from '../../../modules/versioning/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { sanitizeMarkdown } from '../../../util/markdown.ts';
+import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
 import { titleCase } from '../../../util/string.ts';
 import { githubEcosystemToDatasource } from '../../../util/vulnerability/ecosystem.ts';
@@ -196,7 +197,7 @@ function generatePrBodyNotes(advisory: SecurityAdvisory): string[] {
   content += `#### Details\n${details}\n`;
 
   content += '#### Severity\n';
-  const { cvss_v4, cvss_v3 } = advisory.cvss_severities ?? {};
+  const { cvss_v4, cvss_v3 } = coerceObject(advisory.cvss_severities);
   const cvss = cvss_v4?.vector_string ? cvss_v4 : cvss_v3;
   if (is.number(cvss?.score) && cvss?.vector_string) {
     content += `- CVSS Score: ${cvss.score.toFixed(1)} / 10 (${titleCase(advisory.severity)})\n`;

--- a/lib/workers/repository/onboarding/branch/index.ts
+++ b/lib/workers/repository/onboarding/branch/index.ts
@@ -9,6 +9,7 @@ import { scm } from '../../../../modules/platform/scm.ts';
 import { getCache } from '../../../../util/cache/repository/index.ts';
 import { getInheritedOrGlobal } from '../../../../util/common.ts';
 import { getBranchCommit, setGitAuthor } from '../../../../util/git/index.ts';
+import { coerceObject } from '../../../../util/object.ts';
 import { checkIfConfigured } from '../../configured.ts';
 import { extractAllDependencies } from '../../extract/index.ts';
 import { mergeRenovateConfig } from '../../init/merge.ts';
@@ -142,7 +143,7 @@ export async function checkOnboardingBranch(
 
 function handleOnboardingManualRebase(onboardingPr: Pr): void {
   const pl = GlobalConfig.get('platform');
-  const { rebaseRequested } = onboardingPr.bodyStruct ?? {};
+  const { rebaseRequested } = coerceObject(onboardingPr.bodyStruct);
   if (!['github', 'gitlab', 'gitea'].includes(pl)) {
     logger.trace(`Platform '${pl}' does not support extended markdown`);
     OnboardingState.prUpdateRequested = true;

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -12,6 +12,7 @@ import noToolsImport from './rules/no-tools-import.ts';
 import noUnquotedExecInterpolation from './rules/no-unquoted-exec-interpolation.ts';
 import noUnvalidatedPaginationUrl from './rules/no-unvalidated-pagination-url.ts';
 import preferCoerceArray from './rules/prefer-coerce-array.ts';
+import preferCoerceObject from './rules/prefer-coerce-object.ts';
 import preferFakeShaInSpecs from './rules/prefer-fake-sha-in-specs.ts';
 import preferFsUtil from './rules/prefer-fs-util.ts';
 import preferIsHelpers from './rules/prefer-is-helpers.ts';
@@ -46,6 +47,7 @@ export default definePlugin({
     'no-unquoted-exec-interpolation': noUnquotedExecInterpolation,
     'no-unvalidated-pagination-url': noUnvalidatedPaginationUrl,
     'prefer-coerce-array': preferCoerceArray,
+    'prefer-coerce-object': preferCoerceObject,
     'prefer-fake-sha-in-specs': preferFakeShaInSpecs,
     'prefer-fs-util': preferFsUtil,
     'prefer-json-pipe': preferJsonPipe,

--- a/tools/lint/rules/prefer-coerce-object.spec.ts
+++ b/tools/lint/rules/prefer-coerce-object.spec.ts
@@ -1,0 +1,53 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './prefer-coerce-object.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+});
+
+ruleTester.run('prefer-coerce-object', rule, {
+  valid: [
+    // already using the helper
+    `const a = coerceObject(x);`,
+    // non-empty default
+    `const a = x ?? { a: 1 };`,
+    // asserted default is not a bare object literal
+    `const a = x ?? ({} as Foo);`,
+    // array default belongs to `prefer-coerce-array`
+    `const a = x ?? [];`,
+    // other logical operators
+    `const a = x || {};`,
+    `const a = x && {};`,
+    // assignment rather than a logical expression
+    `x ??= {};`,
+    // destructuring and parameter defaults have no helper form
+    `const { a = {} } = obj;`,
+    `function f(a = {}) {}`,
+    // empty object unrelated to a nullish default
+    `const a = {};`,
+  ],
+  invalid: [
+    {
+      code: `const a = x ?? {};`,
+      errors: [{ messageId: 'preferCoerceObject' }],
+    },
+    // optional chaining operand
+    {
+      code: `const a = x?.y ?? {};`,
+      errors: [{ messageId: 'preferCoerceObject' }],
+    },
+    // call expression operand
+    {
+      code: `hasLockedUpdate(config, parse().workflows ?? {});`,
+      errors: [{ messageId: 'preferCoerceObject' }],
+    },
+    // chained nullish defaults report once, on the outer expression
+    {
+      code: `const a = x ?? y ?? {};`,
+      errors: [{ messageId: 'preferCoerceObject' }],
+    },
+  ],
+});

--- a/tools/lint/rules/prefer-coerce-object.ts
+++ b/tools/lint/rules/prefer-coerce-object.ts
@@ -1,0 +1,33 @@
+import { defineRule } from '@oxlint/plugins';
+
+/**
+ * Flags `x ?? {}` in favour of `coerceObject(x)` from `lib/util/object.ts`.
+ * A chain like `x ?? y ?? {}` maps onto the two-argument `coerceObject(x, y)`.
+ *
+ * Only a bare `{}` literal counts: `x ?? { a: 1 }` keeps a meaningful default,
+ * and `x ?? ({} as Foo)` carries an assertion the helper cannot express.
+ */
+export default defineRule({
+  meta: {
+    type: 'suggestion',
+    messages: {
+      preferCoerceObject:
+        'Use `coerceObject()` from `lib/util/object.ts` instead of `?? {}`.',
+    },
+  },
+  createOnce(context) {
+    return {
+      LogicalExpression(node) {
+        if (node.operator !== '??') {
+          return;
+        }
+        if (
+          node.right.type === 'ObjectExpression' &&
+          node.right.properties.length === 0
+        ) {
+          context.report({ node, messageId: 'preferCoerceObject' });
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Changes

> [!IMPORTANT]
> Stacked on #45492 (`prefer-coerce-array`) and based on it. The two rewrites touch overlapping lines in several files, so they are best reviewed and merged in order.

The object counterpart to `prefer-coerce-array`: adds a `renovate/prefer-coerce-object` oxlint rule and applies it across `lib/`.

`x ?? {}` becomes `coerceObject(x)`. The rule flags a `??` whose default is a bare `{}` literal, so a populated default (`x ?? { a: 1 }`) and an asserted one (`x ?? ({} as Foo)`) still pass — the latter keeps `lib/util/object.ts`'s own definition from tripping over itself. A `x ?? y ?? {}` chain maps onto the two-argument `coerceObject(x, y)`.

The rule is enabled for `lib/**` (including specs), alongside `prefer-coerce-array`. Every one of the 65 hits converted cleanly, so unlike the array rule this one needed no disable comments.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45216
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5 via Claude Code wrote the lint rule and its tests, and ran the codemod that applied the rule across `lib/`.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`tools/lint/rules/prefer-coerce-object.spec.ts` covers the rule itself. The existing suite covers the rewritten call sites; `tsc --noEmit`, `oxlint`, `biome` and `prettier` are clean, and `vitest run --changed` passes apart from two failures that also reproduce on `main` in this environment (`lib/logger/pretty-stdout.spec.ts` colour detection and a `git clone` submodule test blocked by `protocol.file.allow`).
