### PR TITLE
refactor(lint): add `types-location` rule and enable it for `lib/modules`

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -242,6 +242,13 @@
       }
     },
     {
+      "files": ["lib/modules/**"],
+      "excludeFiles": ["**/*.spec.ts", "**/schema.ts", "**/schema/**"],
+      "rules": {
+        "renovate/types-location": "error"
+      }
+    },
+    {
       "files": ["lib/util/url.ts"],
       "rules": {
         "renovate/no-new-url": "off"

--- a/lib/modules/datasource/docker/dockerhub-cache.spec.ts
+++ b/lib/modules/datasource/docker/dockerhub-cache.spec.ts
@@ -1,7 +1,7 @@
 import * as _packageCache from '../../../util/cache/package/index.ts';
-import type { DockerHubCacheData } from './dockerhub-cache.ts';
 import { DockerHubCache } from './dockerhub-cache.ts';
 import type { DockerHubTag } from './schema.ts';
+import type { DockerHubCacheData } from './types.ts';
 
 vi.mock('../../../util/cache/package/index.ts');
 const packageCache = vi.mocked(_packageCache);

--- a/lib/modules/datasource/docker/dockerhub-cache.ts
+++ b/lib/modules/datasource/docker/dockerhub-cache.ts
@@ -2,11 +2,7 @@ import { dequal } from 'dequal';
 import { DateTime } from 'luxon';
 import * as packageCache from '../../../util/cache/package/index.ts';
 import type { DockerHubTag } from './schema.ts';
-
-export interface DockerHubCacheData {
-  items: Record<number, DockerHubTag>;
-  updatedAt: string | null;
-}
+import type { DockerHubCacheData } from './types.ts';
 
 const cacheNamespace = 'datasource-docker-hub-cache';
 

--- a/lib/modules/datasource/docker/types.ts
+++ b/lib/modules/datasource/docker/types.ts
@@ -1,3 +1,10 @@
+import type { DockerHubTag } from './schema.ts';
+
+export interface DockerHubCacheData {
+  items: Record<number, DockerHubTag>;
+  updatedAt: string | null;
+}
+
 export interface RegistryRepository {
   registryHost: string;
   dockerRepository: string;

--- a/lib/modules/datasource/go/common.ts
+++ b/lib/modules/datasource/go/common.ts
@@ -8,10 +8,6 @@ import { getSourceUrl as gitlabSourceUrl } from '../gitlab-tags/util.ts';
 
 import type { DataSource } from './types.ts';
 
-export type GoproxyFallback =
-  | ',' // WhenNotFoundOrGone
-  | '|'; // Always
-
 export function getSourceUrl(
   dataSource?: DataSource | null,
 ): string | undefined {

--- a/lib/modules/datasource/go/types.ts
+++ b/lib/modules/datasource/go/types.ts
@@ -1,4 +1,6 @@
-import type { GoproxyFallback } from './common.ts';
+export type GoproxyFallback =
+  | ',' // WhenNotFoundOrGone
+  | '|'; // Always
 
 export interface DataSource {
   datasource: string;

--- a/lib/modules/datasource/rubygems/types.ts
+++ b/lib/modules/datasource/rubygems/types.ts
@@ -1,0 +1,6 @@
+import type { Result } from '../../../util/result.ts';
+
+export type VersionsResult = Result<
+  string[],
+  'unsupported-api' | 'package-not-found'
+>;

--- a/lib/modules/datasource/rubygems/versions-endpoint-cache.ts
+++ b/lib/modules/datasource/rubygems/versions-endpoint-cache.ts
@@ -10,6 +10,7 @@ import { Result } from '../../../util/result.ts';
 import { LooseArray } from '../../../util/schema-utils/index.ts';
 import { copystr } from '../../../util/string.ts';
 import { parseUrl } from '../../../util/url.ts';
+import type { VersionsResult } from './types.ts';
 
 type PackageVersions = Map<string, string[]>;
 
@@ -129,11 +130,6 @@ type VersionLines = z.infer<typeof VersionLines>;
 function isStale(regCache: VersionsEndpointData): boolean {
   return getElapsedMinutes(regCache.syncedAt) >= 15;
 }
-
-export type VersionsResult = Result<
-  string[],
-  'unsupported-api' | 'package-not-found'
->;
 
 export class VersionsEndpointCache {
   private readonly http: Http;

--- a/lib/modules/datasource/rust-version/index.ts
+++ b/lib/modules/datasource/rust-version/index.ts
@@ -4,7 +4,8 @@ import { asTimestamp } from '../../../util/timestamp.ts';
 import * as rustVersioning from '../../versioning/rust-release-channel/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
-import { type ParsedManifestUrl, parseManifestUrl } from './parse.ts';
+import { parseManifestUrl } from './parse.ts';
+import type { ParsedManifestUrl } from './types.ts';
 
 export class RustVersionDatasource extends Datasource {
   static readonly id = 'rust-version';

--- a/lib/modules/datasource/rust-version/parse.ts
+++ b/lib/modules/datasource/rust-version/parse.ts
@@ -1,9 +1,5 @@
 import { regEx } from '../../../util/regex.ts';
-
-export interface ParsedManifestUrl {
-  date: string;
-  version: string;
-}
+import type { ParsedManifestUrl } from './types.ts';
 
 /**
  * Parse a Rust manifest URL to extract the release date and version identifier.

--- a/lib/modules/datasource/rust-version/types.ts
+++ b/lib/modules/datasource/rust-version/types.ts
@@ -1,0 +1,4 @@
+export interface ParsedManifestUrl {
+  date: string;
+  version: string;
+}

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -3,7 +3,7 @@ import { logger } from '../../../logger/index.ts';
 import { isSkipComment } from '../../../util/ignore.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
-import type { StaticTooling } from './upgradeable-tooling.ts';
+import type { StaticTooling } from './types.ts';
 import { upgradeableTooling } from './upgradeable-tooling.ts';
 
 export function extractPackageFile(content: string): PackageFileContent | null {

--- a/lib/modules/manager/asdf/index.spec.ts
+++ b/lib/modules/manager/asdf/index.spec.ts
@@ -1,6 +1,6 @@
 import { codeBlock } from 'common-tags';
 import { extractPackageFile, supportedDatasources } from './index.ts';
-import type { StaticTooling } from './upgradeable-tooling.ts';
+import type { StaticTooling } from './types.ts';
 import { upgradeableTooling } from './upgradeable-tooling.ts';
 
 describe('modules/manager/asdf/index', () => {

--- a/lib/modules/manager/asdf/types.ts
+++ b/lib/modules/manager/asdf/types.ts
@@ -1,0 +1,13 @@
+import type { PackageDependency } from '../types.ts';
+
+export type StaticTooling = Partial<PackageDependency> &
+  Required<Pick<PackageDependency, 'datasource'>>;
+
+export type DynamicTooling = (version: string) => StaticTooling | undefined;
+
+export type ToolingConfig = StaticTooling | DynamicTooling;
+
+export interface ToolingDefinition {
+  config: ToolingConfig;
+  asdfPluginUrl: string;
+}

--- a/lib/modules/manager/asdf/upgradeable-tooling.ts
+++ b/lib/modules/manager/asdf/upgradeable-tooling.ts
@@ -14,18 +14,7 @@ import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as regexVersioning from '../../versioning/regex/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
-import type { PackageDependency } from '../types.ts';
-
-export type StaticTooling = Partial<PackageDependency> &
-  Required<Pick<PackageDependency, 'datasource'>>;
-
-export type DynamicTooling = (version: string) => StaticTooling | undefined;
-
-export type ToolingConfig = StaticTooling | DynamicTooling;
-export interface ToolingDefinition {
-  config: ToolingConfig;
-  asdfPluginUrl: string;
-}
+import type { ToolingDefinition } from './types.ts';
 
 const hugoDefinition: ToolingDefinition = {
   // This plugin supports the names `hugo` & `gohugo`

--- a/lib/modules/manager/bazel-module/extract.ts
+++ b/lib/modules/manager/bazel-module/extract.ts
@@ -11,10 +11,10 @@ import type {
 } from '../types.ts';
 import * as bazelrc from './bazelrc.ts';
 import { RuleToCratePackageDep } from './parser/crate.ts';
-import type { ResultFragment } from './parser/fragments.ts';
 import { parse } from './parser/index.ts';
 import { RuleToMavenPackageDep, fillRegistryUrls } from './parser/maven.ts';
 import { RuleToDockerPackageDep } from './parser/oci.ts';
+import type { ResultFragment } from './parser/types.ts';
 import * as rules from './rules.ts';
 import {
   GitRepositoryToPackageDep,

--- a/lib/modules/manager/bazel-module/parser/context.ts
+++ b/lib/modules/manager/bazel-module/parser/context.ts
@@ -1,20 +1,15 @@
+import * as fragments from './fragments.ts';
 import type {
   AllFragments,
   ArrayFragment,
+  CtxCompatible,
   ExtensionTagFragment,
   PreparedExtensionTagFragment,
   RepoRuleCallFragment,
   ResultFragment,
   RuleFragment,
   UseRepoRuleFragment,
-} from './fragments.ts';
-import * as fragments from './fragments.ts';
-
-// Represents the fields that the context must have.
-export interface CtxCompatible {
-  results: ResultFragment[];
-  stack: AllFragments[];
-}
+} from './types.ts';
 
 export class CtxProcessingError extends Error {
   readonly current: AllFragments;

--- a/lib/modules/manager/bazel-module/parser/fragments.ts
+++ b/lib/modules/manager/bazel-module/parser/fragments.ts
@@ -5,6 +5,7 @@ import {
   LooseRecord,
 } from '../../../../util/schema-utils/index.ts';
 import * as starlark from './starlark.ts';
+import type { ChildFragments } from './types.ts';
 
 export const StringFragment = z.object({
   type: z.literal('string'),
@@ -16,7 +17,7 @@ export const BooleanFragment = z.object({
   value: z.boolean(),
   isComplete: z.literal(true),
 });
-const PrimitiveFragments = z.discriminatedUnion('type', [
+export const PrimitiveFragments = z.discriminatedUnion('type', [
   StringFragment,
   BooleanFragment,
 ]);
@@ -30,7 +31,7 @@ export const StringArrayFragment = z.object({
   items: LooseArray(StringFragment),
   isComplete: z.boolean(),
 });
-const ValueFragments = z.discriminatedUnion('type', [
+export const ValueFragments = z.discriminatedUnion('type', [
   StringFragment,
   BooleanFragment,
   ArrayFragment,
@@ -94,28 +95,7 @@ export const AllFragments = z.discriminatedUnion('type', [
   StringFragment,
 ]);
 
-export type AllFragments = z.infer<typeof AllFragments>;
-export type ArrayFragment = z.infer<typeof ArrayFragment>;
-export type AttributeFragment = z.infer<typeof AttributeFragment>;
-export type BooleanFragment = z.infer<typeof BooleanFragment>;
-export type ChildFragments = Record<string, ValueFragments>;
-export type PrimitiveFragments = z.infer<typeof PrimitiveFragments>;
-export type RuleFragment = z.infer<typeof RuleFragment>;
-export type PreparedExtensionTagFragment = z.infer<
-  typeof PreparedExtensionTagFragment
->;
-export type ExtensionTagFragment = z.infer<typeof ExtensionTagFragment>;
-export type UseRepoRuleFragment = z.infer<typeof UseRepoRuleFragment>;
-export type RepoRuleCallFragment = z.infer<typeof RepoRuleCallFragment>;
-export type StringFragment = z.infer<typeof StringFragment>;
-export type ValueFragments = z.infer<typeof ValueFragments>;
-export type ResultFragment =
-  | RuleFragment
-  | ExtensionTagFragment
-  | UseRepoRuleFragment
-  | RepoRuleCallFragment;
-
-export function string(value: string): StringFragment {
+export function string(value: string): z.infer<typeof StringFragment> {
   return {
     type: 'string',
     isComplete: true,
@@ -123,7 +103,9 @@ export function string(value: string): StringFragment {
   };
 }
 
-export function boolean(value: string | boolean): BooleanFragment {
+export function boolean(
+  value: string | boolean,
+): z.infer<typeof BooleanFragment> {
   return {
     type: 'boolean',
     isComplete: true,
@@ -135,7 +117,7 @@ export function rule(
   rule: string,
   children: ChildFragments = {},
   isComplete = false,
-): RuleFragment {
+): z.infer<typeof RuleFragment> {
   return {
     type: 'rule',
     rule,
@@ -148,7 +130,7 @@ export function preparedExtensionTag(
   extension: string,
   rawExtension: string,
   offset: number,
-): PreparedExtensionTagFragment {
+): z.infer<typeof PreparedExtensionTagFragment> {
   return {
     type: 'preparedExtensionTag',
     extension,
@@ -166,7 +148,7 @@ export function extensionTag(
   children: ChildFragments = {},
   rawString?: string,
   isComplete = false,
-): ExtensionTagFragment {
+): z.infer<typeof ExtensionTagFragment> {
   return {
     type: 'extensionTag',
     extension,
@@ -184,7 +166,7 @@ export function useRepoRule(
   bzlFile: string,
   ruleName: string,
   isComplete = false,
-): UseRepoRuleFragment {
+): z.infer<typeof UseRepoRuleFragment> {
   return {
     type: 'useRepoRule',
     variableName,
@@ -200,7 +182,7 @@ export function repoRuleCall(
   children: ChildFragments = {},
   rawString?: string,
   isComplete = false,
-): RepoRuleCallFragment {
+): z.infer<typeof RepoRuleCallFragment> {
   return {
     type: 'repoRuleCall',
     functionName,
@@ -213,9 +195,9 @@ export function repoRuleCall(
 
 export function attribute(
   name: string,
-  value?: ValueFragments,
+  value?: z.infer<typeof ValueFragments>,
   isComplete = false,
-): AttributeFragment {
+): z.infer<typeof AttributeFragment> {
   return {
     type: 'attribute',
     name,
@@ -225,9 +207,9 @@ export function attribute(
 }
 
 export function array(
-  items: PrimitiveFragments[] = [],
+  items: z.infer<typeof PrimitiveFragments>[] = [],
   isComplete = false,
-): ArrayFragment {
+): z.infer<typeof ArrayFragment> {
   return {
     type: 'array',
     items,
@@ -235,12 +217,14 @@ export function array(
   };
 }
 
-export function isValue(data: unknown): data is ValueFragments {
+export function isValue(data: unknown): data is z.infer<typeof ValueFragments> {
   const result = ValueFragments.safeParse(data);
   return result.success;
 }
 
-export function isPrimitive(data: unknown): data is PrimitiveFragments {
+export function isPrimitive(
+  data: unknown,
+): data is z.infer<typeof PrimitiveFragments> {
   const result = PrimitiveFragments.safeParse(data);
   return result.success;
 }

--- a/lib/modules/manager/bazel-module/parser/index.ts
+++ b/lib/modules/manager/bazel-module/parser/index.ts
@@ -1,13 +1,13 @@
 import { lang, query as q } from '@renovatebot/good-enough-parser';
 import { Ctx } from './context.ts';
 import { extensionTags } from './extension-tags.ts';
-import type { ResultFragment } from './fragments.ts';
 import {
   clearRepoRuleVariables,
   repoRuleCall,
   useRepoRuleAssignment,
 } from './repo-rules.ts';
 import { rules } from './rules.ts';
+import type { ResultFragment } from './types.ts';
 
 const rule = q.alt<Ctx>(
   rules,

--- a/lib/modules/manager/bazel-module/parser/types.ts
+++ b/lib/modules/manager/bazel-module/parser/types.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod/v4';
+import type * as fragments from './fragments.ts';
+
+export type AllFragments = z.infer<typeof fragments.AllFragments>;
+export type ArrayFragment = z.infer<typeof fragments.ArrayFragment>;
+export type AttributeFragment = z.infer<typeof fragments.AttributeFragment>;
+export type BooleanFragment = z.infer<typeof fragments.BooleanFragment>;
+export type ChildFragments = Record<string, ValueFragments>;
+export type PrimitiveFragments = z.infer<typeof fragments.PrimitiveFragments>;
+export type RuleFragment = z.infer<typeof fragments.RuleFragment>;
+export type PreparedExtensionTagFragment = z.infer<
+  typeof fragments.PreparedExtensionTagFragment
+>;
+export type ExtensionTagFragment = z.infer<
+  typeof fragments.ExtensionTagFragment
+>;
+export type UseRepoRuleFragment = z.infer<typeof fragments.UseRepoRuleFragment>;
+export type RepoRuleCallFragment = z.infer<
+  typeof fragments.RepoRuleCallFragment
+>;
+export type StringFragment = z.infer<typeof fragments.StringFragment>;
+export type ValueFragments = z.infer<typeof fragments.ValueFragments>;
+export type ResultFragment =
+  | RuleFragment
+  | ExtensionTagFragment
+  | UseRepoRuleFragment
+  | RepoRuleCallFragment;
+
+// Represents the fields that the context must have.
+export interface CtxCompatible {
+  results: ResultFragment[];
+  stack: AllFragments[];
+}

--- a/lib/modules/manager/bazel-module/rules.spec.ts
+++ b/lib/modules/manager/bazel-module/rules.spec.ts
@@ -4,12 +4,6 @@ import { BazelDatasource } from '../../datasource/bazel/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import type { PackageDependency } from '../types.ts';
 import { parse } from './parser/index.ts';
-import type {
-  BasePackageDep,
-  BazelModulePackageDep,
-  MergePackageDep,
-  OverridePackageDep,
-} from './rules.ts';
 import {
   GitRepositoryToPackageDep,
   RuleToBazelModulePackageDep,
@@ -17,6 +11,12 @@ import {
   processModulePkgDeps,
   toPackageDependencies,
 } from './rules.ts';
+import type {
+  BasePackageDep,
+  BazelModulePackageDep,
+  MergePackageDep,
+  OverridePackageDep,
+} from './types.ts';
 
 const customRegistryUrl = 'https://example.com/custom_registry';
 

--- a/lib/modules/manager/bazel-module/rules.ts
+++ b/lib/modules/manager/bazel-module/rules.ts
@@ -9,31 +9,14 @@ import { BazelDatasource } from '../../datasource/bazel/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import type { PackageDependency } from '../types.ts';
 import { RuleFragment, StringFragment } from './parser/fragments.ts';
+import type {
+  BasePackageDep,
+  BazelModulePackageDep,
+  MergePackageDep,
+  OverridePackageDep,
+} from './types.ts';
 
 // Rule Schemas
-
-export interface BasePackageDep extends PackageDependency {
-  depType: string;
-  depName: string;
-}
-
-type BasePackageDepMergeKeys = Extract<keyof BasePackageDep, 'registryUrls'>;
-
-export interface MergePackageDep extends BasePackageDep {
-  // The fields that should be copied from this struct to the bazel_dep
-  // PackageDependency.
-  bazelDepMergeFields: BasePackageDepMergeKeys[];
-}
-
-export interface OverridePackageDep extends BasePackageDep {
-  // This value is set as the skipReason on the bazel_dep PackageDependency.
-  bazelDepSkipReason: SkipReason;
-}
-
-export type BazelModulePackageDep =
-  | BasePackageDep
-  | OverridePackageDep
-  | MergePackageDep;
 
 function isOverride(value: BazelModulePackageDep): value is OverridePackageDep {
   return 'bazelDepSkipReason' in value;

--- a/lib/modules/manager/bazel-module/types.ts
+++ b/lib/modules/manager/bazel-module/types.ts
@@ -1,0 +1,25 @@
+import type { SkipReason } from '../../../types/index.ts';
+import type { PackageDependency } from '../types.ts';
+
+export interface BasePackageDep extends PackageDependency {
+  depType: string;
+  depName: string;
+}
+
+type BasePackageDepMergeKeys = Extract<keyof BasePackageDep, 'registryUrls'>;
+
+export interface MergePackageDep extends BasePackageDep {
+  // The fields that should be copied from this struct to the bazel_dep
+  // PackageDependency.
+  bazelDepMergeFields: BasePackageDepMergeKeys[];
+}
+
+export interface OverridePackageDep extends BasePackageDep {
+  // This value is set as the skipReason on the bazel_dep PackageDependency.
+  bazelDepSkipReason: SkipReason;
+}
+
+export type BazelModulePackageDep =
+  | BasePackageDep
+  | OverridePackageDep
+  | MergePackageDep;

--- a/lib/modules/manager/custom/jsonata/utils.ts
+++ b/lib/modules/manager/custom/jsonata/utils.ts
@@ -5,7 +5,7 @@ import { logger } from '../../../../logger/index.ts';
 import * as template from '../../../../util/template/index.ts';
 import { parseUrl } from '../../../../util/url.ts';
 import type { PackageDependency } from '../../types.ts';
-import type { ValidMatchFields } from '../utils.ts';
+import type { ValidMatchFields } from '../types.ts';
 import { checkIsValidDependency, validMatchFields } from '../utils.ts';
 import { QueryResultZod } from './schema.ts';
 import type { JSONataManagerTemplates, JsonataExtractConfig } from './types.ts';

--- a/lib/modules/manager/custom/regex/utils.ts
+++ b/lib/modules/manager/custom/regex/utils.ts
@@ -4,7 +4,7 @@ import { logger } from '../../../../logger/index.ts';
 import * as template from '../../../../util/template/index.ts';
 import { parseUrl } from '../../../../util/url.ts';
 import type { PackageDependency } from '../../types.ts';
-import type { ValidMatchFields } from '../utils.ts';
+import type { ValidMatchFields } from '../types.ts';
 import { validMatchFields } from '../utils.ts';
 import type {
   ExtractionTemplate,

--- a/lib/modules/manager/custom/types.ts
+++ b/lib/modules/manager/custom/types.ts
@@ -1,5 +1,6 @@
 import type { JSONataManagerConfig } from './jsonata/types.ts';
 import type { RegexManagerConfig } from './regex/types.ts';
+import type { validMatchFields } from './utils.ts';
 
 export interface CustomExtractConfig
   extends Partial<RegexManagerConfig>, Partial<JSONataManagerConfig> {}
@@ -14,3 +15,5 @@ export interface CustomManager
 
 // NOTE:
 // the two interfaces might seem similar but they have different usage similar to ManagerConfig and ExtractConfig
+
+export type ValidMatchFields = (typeof validMatchFields)[number];

--- a/lib/modules/manager/custom/utils.ts
+++ b/lib/modules/manager/custom/utils.ts
@@ -15,8 +15,6 @@ export const validMatchFields = [
   'indentation',
 ] as const;
 
-export type ValidMatchFields = (typeof validMatchFields)[number];
-
 export function isValidDependency({
   depName,
   currentValue,

--- a/lib/modules/manager/devbox/tool-versioning.ts
+++ b/lib/modules/manager/devbox/tool-versioning.ts
@@ -3,9 +3,7 @@ import * as nodeVersioning from '../../versioning/node/index.ts';
 import * as pythonVersioning from '../../versioning/python/index.ts';
 import * as rubyVersioning from '../../versioning/ruby/index.ts';
 import * as semver from '../../versioning/semver/index.ts';
-import type { VersioningApi } from '../../versioning/types.ts';
-
-export type ToolVersioning = Record<string, { api: VersioningApi; id: string }>;
+import type { ToolVersioning } from './types.ts';
 
 export const devboxToolVersioning: ToolVersioning = {
   nodejs: {

--- a/lib/modules/manager/devbox/types.ts
+++ b/lib/modules/manager/devbox/types.ts
@@ -1,0 +1,3 @@
+import type { VersioningApi } from '../../versioning/types.ts';
+
+export type ToolVersioning = Record<string, { api: VersioningApi; id: string }>;

--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -12,28 +12,7 @@ import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as condaVersioning from '../../versioning/conda/index.ts';
 import * as npmVersioning from '../../versioning/npm/index.ts';
 import type { PackageDependency } from '../types.ts';
-
-/**
- * Parses a step - or just its `with:` block - into the dependencies it
- * declares. Most actions declare a single one, but a step may yield several.
- */
-export type ActionSchema = z.ZodType<PackageDependency[]>;
-
-export interface CommunityActionConfig {
-  datasource: string;
-  depName?: string;
-  packageName: string;
-  versioning?: string;
-  extractVersion?: string;
-
-  /**
-   * Parses the `with:` block, defaulting to the `version:` input.
-   *
-   * The fields above are applied to every dependency it yields, so a schema
-   * which yields dependencies of more than one kind must set them itself.
-   */
-  withSchema?: ActionSchema;
-}
+import type { ActionSchema, CommunityActionConfig } from './types.ts';
 
 export function actionSchema(
   name: string,

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -24,11 +24,14 @@ import type {
   PackageFileContent,
 } from '../types.ts';
 import { actionsLockFile, isLockfileManaged } from './common.ts';
-import type { DockerReference, RepositoryReference } from './parse.ts';
 import { isSha, isShortSha, parseUsesLine, versionLikeRe } from './parse.ts';
 import type { UsesStep } from './schema.ts';
 import { ActionsLockfile, CommunityActions, Workflow } from './schema.ts';
-import type { LockfileState } from './types.ts';
+import type {
+  DockerReference,
+  LockfileState,
+  RepositoryReference,
+} from './types.ts';
 
 // detects if we run against a Github Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
 // This reflects the behavior of how GitHub looks up Actions

--- a/lib/modules/manager/github-actions/parse.ts
+++ b/lib/modules/manager/github-actions/parse.ts
@@ -1,5 +1,12 @@
 import is from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
+import type {
+  ActionReference,
+  CommentData,
+  DockerReference,
+  ParsedUsesLine,
+  RepositoryReference,
+} from './types.ts';
 
 function splitFirstFrom(
   str: string,
@@ -36,76 +43,6 @@ export function parseQuote(input: string): QuotedValue {
   }
 
   return { value: trimmed, quote: '' };
-}
-
-/**
- * Docker container:
- * - `docker://image:tag`
- * - `docker://image@digest`
- * - `docker://image:tag@digest`
- */
-export interface DockerReference {
-  kind: 'docker';
-  image: string;
-  tag?: string;
-  digest?: string;
-  originalRef: string;
-}
-
-/**
- * Local file or directory:
- * - `./path/to/action`
- * - `./.github/workflows/main.yml`
- */
-export interface LocalReference {
-  kind: 'local';
-  path: string;
-}
-
-/**
- * Repository:
- * - `owner/repo[/path]@ref`
- * - `https://host/owner/repo[/path]@ref`
- */
-export interface RepositoryReference {
-  kind: 'repository';
-
-  hostname: string;
-  isExplicitHostname: boolean;
-
-  owner: string;
-  repo: string;
-  path?: string;
-
-  ref: string;
-}
-
-export type ActionReference =
-  | DockerReference
-  | LocalReference
-  | RepositoryReference;
-
-export interface ParsedUsesLine {
-  /** The whitespace before "uses:" */
-  indentation: string;
-
-  /** The `uses:` (and optional `-`) part */
-  usesPrefix: string;
-
-  /** The raw value part, potentially quoted (e.g. `actions/checkout@v2`) */
-  replaceString: string;
-
-  /** Whitespace between value and `#` */
-  commentPrecedingWhitespace: string;
-
-  /** The full comment including `#` */
-  commentString: string;
-
-  actionRef: ActionReference | null;
-  commentData: CommentData;
-
-  /** The quote char used (' or " or empty) */
-  quote: string;
 }
 
 const shaRe = regEx(/^(?:[a-f0-9]{40}|[a-f0-9]{64})$/);
@@ -190,14 +127,6 @@ export function parseActionReference(uses: string): ActionReference | null {
   }
 
   return parseRepositoryReference(uses);
-}
-
-export interface CommentData {
-  pinnedVersion?: string;
-  ref?: string;
-  ratchetExclude?: boolean;
-  matchedString?: string;
-  index?: number;
 }
 
 const pinTokenRe = regEx(

--- a/lib/modules/manager/github-actions/schema.ts
+++ b/lib/modules/manager/github-actions/schema.ts
@@ -5,8 +5,8 @@ import {
   Yaml,
   withDebugMessage,
 } from '../../../util/schema-utils/index.ts';
-import type { ActionSchema } from './community.ts';
 import { actionSchema, communityActions } from './community.ts';
+import type { ActionSchema } from './types.ts';
 
 const UsesStep = z.object({
   uses: z.string(),

--- a/lib/modules/manager/github-actions/types.ts
+++ b/lib/modules/manager/github-actions/types.ts
@@ -1,5 +1,6 @@
+import type { z } from 'zod/v4';
 import type { FileChange } from '../../../util/git/types.ts';
-import type { ArtifactError } from '../types.ts';
+import type { ArtifactError, PackageDependency } from '../types.ts';
 import type { ActionsLockfile } from './schema.ts';
 
 /** Mirrors the shape `processBranch` already concatenates onto its config for lock file updates. */
@@ -16,3 +17,103 @@ export type LockfileState =
   | { type: 'missing' }
   | { type: 'unparseable' }
   | { type: 'parsed'; onboardedWorkflows: OnboardedWorkflows };
+
+/**
+ * Docker container:
+ * - `docker://image:tag`
+ * - `docker://image@digest`
+ * - `docker://image:tag@digest`
+ */
+export interface DockerReference {
+  kind: 'docker';
+  image: string;
+  tag?: string;
+  digest?: string;
+  originalRef: string;
+}
+
+/**
+ * Local file or directory:
+ * - `./path/to/action`
+ * - `./.github/workflows/main.yml`
+ */
+export interface LocalReference {
+  kind: 'local';
+  path: string;
+}
+
+/**
+ * Repository:
+ * - `owner/repo[/path]@ref`
+ * - `https://host/owner/repo[/path]@ref`
+ */
+export interface RepositoryReference {
+  kind: 'repository';
+
+  hostname: string;
+  isExplicitHostname: boolean;
+
+  owner: string;
+  repo: string;
+  path?: string;
+
+  ref: string;
+}
+
+export type ActionReference =
+  | DockerReference
+  | LocalReference
+  | RepositoryReference;
+
+export interface CommentData {
+  pinnedVersion?: string;
+  ref?: string;
+  ratchetExclude?: boolean;
+  matchedString?: string;
+  index?: number;
+}
+
+export interface ParsedUsesLine {
+  /** The whitespace before "uses:" */
+  indentation: string;
+
+  /** The `uses:` (and optional `-`) part */
+  usesPrefix: string;
+
+  /** The raw value part, potentially quoted (e.g. `actions/checkout@v2`) */
+  replaceString: string;
+
+  /** Whitespace between value and `#` */
+  commentPrecedingWhitespace: string;
+
+  /** The full comment including `#` */
+  commentString: string;
+
+  actionRef: ActionReference | null;
+  commentData: CommentData;
+
+  /** The quote char used (' or " or empty) */
+  quote: string;
+}
+
+/**
+ * Parses a step - or just its `with:` block - into the dependencies it
+ * declares. Most actions declare a single one, but a step may yield several.
+ */
+export type ActionSchema = z.ZodType<PackageDependency[]>;
+
+export interface CommunityActionConfig {
+  datasource: string;
+  depName?: string;
+  packageName: string;
+  versioning?: string;
+  extractVersion?: string;
+
+  /**
+   * Parses the `with:` block, defaulting to the `version:` input.
+   *
+   * The fields above are applied to every dependency it yields, so a schema
+   * which yields dependencies of more than one kind must set them itself.
+   */
+  withSchema?: ActionSchema;
+}

--- a/lib/modules/manager/haskell-cabal/extract.ts
+++ b/lib/modules/manager/haskell-cabal/extract.ts
@@ -1,4 +1,5 @@
 import { regEx } from '../../../util/regex.ts';
+import type { CabalDependency } from './types.ts';
 
 const buildDependsRegex = regEx(
   /(?<buildDependsFieldName>build-depends[ \t]*:)/i,
@@ -38,12 +39,6 @@ export function countPackageNameLength(input: string): number | null {
     return null;
   }
   return idx;
-}
-
-export interface CabalDependency {
-  packageName: string;
-  currentValue: string;
-  replaceString: string;
 }
 
 /**

--- a/lib/modules/manager/haskell-cabal/index.ts
+++ b/lib/modules/manager/haskell-cabal/index.ts
@@ -7,8 +7,8 @@ import type {
   PackageFileContent,
   RangeConfig,
 } from '../types.ts';
-import type { CabalDependency } from './extract.ts';
 import { extractNamesAndRanges, findDepends } from './extract.ts';
+import type { CabalDependency } from './types.ts';
 
 export const defaultConfig = {
   managerFilePatterns: ['/\\.cabal$/'],

--- a/lib/modules/manager/haskell-cabal/types.ts
+++ b/lib/modules/manager/haskell-cabal/types.ts
@@ -1,0 +1,5 @@
+export interface CabalDependency {
+  packageName: string;
+  currentValue: string;
+  replaceString: string;
+}

--- a/lib/modules/manager/homebrew/handlers/github.ts
+++ b/lib/modules/manager/homebrew/handlers/github.ts
@@ -4,27 +4,12 @@ import { parseUrl } from '../../../../util/url.ts';
 import { GithubReleasesDatasource } from '../../../datasource/github-releases/index.ts';
 import { GithubTagsDatasource } from '../../../datasource/github-tags/index.ts';
 import type { PackageDependency } from '../../types.ts';
+import type {
+  GitHubManagerData,
+  GitHubUrlParsedResult,
+  GitHubUrlType,
+} from '../types.ts';
 import { HomebrewUrlHandler } from './base.ts';
-
-export type GitHubUrlType = 'archive' | 'releases';
-
-// URL parsing result with urlType for datasource selection
-export interface GitHubUrlParsedResult {
-  type: 'github';
-  currentValue: string;
-  ownerName: string;
-  repoName: string;
-  urlType: GitHubUrlType;
-}
-
-// Manager data with type discriminator
-export interface GitHubManagerData {
-  type: 'github';
-  ownerName: string;
-  repoName: string;
-  sha256: string | null;
-  url: string | null;
-}
 
 export class GitHubUrlHandler extends HomebrewUrlHandler {
   readonly type = 'github';

--- a/lib/modules/manager/homebrew/handlers/npm.ts
+++ b/lib/modules/manager/homebrew/handlers/npm.ts
@@ -4,22 +4,8 @@ import { regEx } from '../../../../util/regex.ts';
 import { parseUrl } from '../../../../util/url.ts';
 import { NpmDatasource } from '../../../datasource/npm/index.ts';
 import type { PackageDependency } from '../../types.ts';
+import type { NpmManagerData, NpmUrlParsedResult } from '../types.ts';
 import { HomebrewUrlHandler } from './base.ts';
-
-// URL parsing result
-export interface NpmUrlParsedResult {
-  type: 'npm';
-  currentValue: string;
-  packageName: string;
-}
-
-// Manager data with type discriminator
-export interface NpmManagerData {
-  type: 'npm';
-  packageName: string;
-  sha256: string | null;
-  url: string | null;
-}
 
 export class NpmUrlHandler extends HomebrewUrlHandler {
   readonly type = 'npm';

--- a/lib/modules/manager/homebrew/types.ts
+++ b/lib/modules/manager/homebrew/types.ts
@@ -1,8 +1,37 @@
-import type {
-  GitHubManagerData,
-  GitHubUrlParsedResult,
-} from './handlers/github.ts';
-import type { NpmManagerData, NpmUrlParsedResult } from './handlers/npm.ts';
+export type GitHubUrlType = 'archive' | 'releases';
+
+// URL parsing result with urlType for datasource selection
+export interface GitHubUrlParsedResult {
+  type: 'github';
+  currentValue: string;
+  ownerName: string;
+  repoName: string;
+  urlType: GitHubUrlType;
+}
+
+// Manager data with type discriminator
+export interface GitHubManagerData {
+  type: 'github';
+  ownerName: string;
+  repoName: string;
+  sha256: string | null;
+  url: string | null;
+}
+
+// URL parsing result
+export interface NpmUrlParsedResult {
+  type: 'npm';
+  currentValue: string;
+  packageName: string;
+}
+
+// Manager data with type discriminator
+export interface NpmManagerData {
+  type: 'npm';
+  packageName: string;
+  sha256: string | null;
+  url: string | null;
+}
 
 // Future extensibility for additional datasources
 export type UrlParsedResult = GitHubUrlParsedResult | NpmUrlParsedResult;

--- a/lib/modules/manager/mise/backends.ts
+++ b/lib/modules/manager/mise/backends.ts
@@ -17,14 +17,8 @@ import { normalizePythonDepName } from '../../datasource/pypi/common.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
 import { RubygemsDatasource } from '../../datasource/rubygems/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
-import type { PackageDependency } from '../types.ts';
 import type { MiseToolOptions } from './schema.ts';
-
-export type BackendToolingConfig = Omit<PackageDependency, 'depName'> &
-  Required<
-    | Pick<PackageDependency, 'packageName' | 'datasource'>
-    | Pick<PackageDependency, 'packageName' | 'skipReason'>
-  >;
+import type { BackendToolingConfig } from './types.ts';
 
 /**
  * Create a tooling config for aqua backend

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -9,9 +9,8 @@ import {
 import { logger } from '../../../logger/index.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import { regEx } from '../../../util/regex.ts';
-import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
+import type { StaticTooling } from '../asdf/types.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
-import type { BackendToolingConfig } from './backends.ts';
 import {
   createAquaToolConfig,
   createCargoToolConfig,
@@ -27,7 +26,7 @@ import {
 import { getLockFileName, getLockedVersion } from './lockfile.ts';
 import type { MiseTool, MiseToolOptions } from './schema.ts';
 import { MiseLockFile } from './schema.ts';
-import type { ToolingDefinition } from './upgradeable-tooling.ts';
+import type { BackendToolingConfig, ToolingDefinition } from './types.ts';
 import {
   asdfTooling,
   getOrderedMiseRegistryBackends,

--- a/lib/modules/manager/mise/lockfile.ts
+++ b/lib/modules/manager/mise/lockfile.ts
@@ -1,13 +1,7 @@
 import upath from 'upath';
 import { regEx } from '../../../util/regex.ts';
 import type { MiseLockFile } from './schema.ts';
-
-export interface MiseConfigType {
-  /** True when config filename contains `.local.` (e.g. mise.local.toml) */
-  isLocal: boolean;
-  /** Environment name extracted from filename, e.g. 'test' for mise.test.toml */
-  env?: string;
-}
+import type { MiseConfigType } from './types.ts';
 
 /**
  * Parses the config file name to determine its type (local, env-specific, or default).

--- a/lib/modules/manager/mise/types.ts
+++ b/lib/modules/manager/mise/types.ts
@@ -1,6 +1,27 @@
+import type { ToolingConfig } from '../asdf/types.ts';
+import type { PackageDependency } from '../types.ts';
+
 export interface MiseRegistryData {
   meta: {
     version: string;
   };
   tools: Record<string, Record<string, string>>;
+}
+
+export interface MiseConfigType {
+  /** True when config filename contains `.local.` (e.g. mise.local.toml) */
+  isLocal: boolean;
+  /** Environment name extracted from filename, e.g. 'test' for mise.test.toml */
+  env?: string;
+}
+
+export type BackendToolingConfig = Omit<PackageDependency, 'depName'> &
+  Required<
+    | Pick<PackageDependency, 'packageName' | 'datasource'>
+    | Pick<PackageDependency, 'packageName' | 'skipReason'>
+  >;
+
+export interface ToolingDefinition {
+  config: ToolingConfig;
+  misePluginUrl?: string;
 }

--- a/lib/modules/manager/mise/upgradeable-tooling.ts
+++ b/lib/modules/manager/mise/upgradeable-tooling.ts
@@ -11,15 +11,9 @@ import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as regexVersioning from '../../versioning/regex/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
 import * as semverPartialVersioning from '../../versioning/semver-partial/index.ts';
-import type { ToolingConfig } from '../asdf/upgradeable-tooling.ts';
 import { upgradeableTooling } from '../asdf/upgradeable-tooling.ts';
 import { MiseRegistryJson } from './schema.ts';
-import type { MiseRegistryData } from './types.ts';
-
-export interface ToolingDefinition {
-  config: ToolingConfig;
-  misePluginUrl?: string;
-}
+import type { MiseRegistryData, ToolingDefinition } from './types.ts';
 
 export const asdfTooling = upgradeableTooling;
 

--- a/lib/modules/manager/npm/npmrc.ts
+++ b/lib/modules/manager/npm/npmrc.ts
@@ -6,11 +6,7 @@ import {
   readLocalFile,
 } from '../../../util/fs/index.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
-
-export interface NpmrcResult {
-  npmrc: string | undefined;
-  npmrcFileName: string | null;
-}
+import type { NpmrcResult } from './types.ts';
 
 export async function resolveNpmrc(
   packageFile: string,

--- a/lib/modules/manager/npm/post-update/node-version.ts
+++ b/lib/modules/manager/npm/post-update/node-version.ts
@@ -5,7 +5,7 @@ import type { ToolConstraint } from '../../../../util/exec/types.ts';
 import { readLocalFile } from '../../../../util/fs/index.ts';
 import { newlineRegex, regEx } from '../../../../util/regex.ts';
 import type { PostUpdateConfig, Upgrade } from '../../types.ts';
-import type { LazyPackageJson } from './utils.ts';
+import type { LazyPackageJson } from './types.ts';
 
 async function getNodeFile(filename: string): Promise<string | null> {
   try {

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -32,17 +32,12 @@ import type { PostUpdateConfig, Upgrade } from '../../types.ts';
 import { PackageLock } from '../schema.ts';
 import { composeLockFile, parseLockFile } from '../utils.ts';
 import { getNodeToolConstraint } from './node-version.ts';
-import type { GenerateLockFileResult } from './types.ts';
+import type { GenerateLockFileResult, NpmrcCooldownResult } from './types.ts';
 import {
   getNodeOptions,
   getPackageManagerVersion,
   lazyLoadPackageJson,
 } from './utils.ts';
-
-export interface NpmrcCooldownResult {
-  date: DateTime<true>;
-  source: 'before' | 'min-release-age';
-}
 
 export function parseNpmrcCooldownDate(
   npmrcContent: string | null,

--- a/lib/modules/manager/npm/post-update/rules.ts
+++ b/lib/modules/manager/npm/post-update/rules.ts
@@ -4,13 +4,7 @@ import * as hostRules from '../../../../util/host-rules.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { toBase64 } from '../../../../util/string.ts';
 import { isHttpUrl } from '../../../../util/url.ts';
-import type { YarnRcYmlFile } from './types.ts';
-
-export interface HostRulesResult {
-  additionalNpmrcContent: string[];
-  additionalYarnRcYml?: any;
-}
-
+import type { HostRulesResult, YarnRcYmlFile } from './types.ts';
 export function processHostRules(): HostRulesResult {
   const additionalYarnRcYml: YarnRcYmlFile = { npmRegistries: {} };
 

--- a/lib/modules/manager/npm/post-update/types.ts
+++ b/lib/modules/manager/npm/post-update/types.ts
@@ -1,3 +1,4 @@
+import type { DateTime } from 'luxon';
 import type { FileChange } from '../../../../util/git/types.ts';
 import type {
   ArtifactError,
@@ -5,6 +6,7 @@ import type {
   PackageFile,
 } from '../../types.ts';
 import type { NpmManagerData } from '../types.ts';
+import type { lazyLoadPackageJson } from './utils.ts';
 
 export interface DetermineLockFileDirsResult {
   yarnLockDirs: string[];
@@ -53,3 +55,15 @@ export interface YarnRcYmlFile {
   yarnPath?: string | null;
   npmRegistries: Record<string, YarnRcNpmRegistry>;
 }
+
+export interface HostRulesResult {
+  additionalNpmrcContent: string[];
+  additionalYarnRcYml?: any;
+}
+
+export interface NpmrcCooldownResult {
+  date: DateTime<true>;
+  source: 'before' | 'min-release-age';
+}
+
+export type LazyPackageJson = ReturnType<typeof lazyLoadPackageJson>;

--- a/lib/modules/manager/npm/post-update/utils.ts
+++ b/lib/modules/manager/npm/post-update/utils.ts
@@ -10,7 +10,6 @@ export function lazyLoadPackageJson(
 ): Lazy<Promise<PackageJson>> {
   return new Lazy(() => loadPackageJson(lockFileDir));
 }
-export type LazyPackageJson = ReturnType<typeof lazyLoadPackageJson>;
 
 export function getPackageManagerVersion(
   name: string,

--- a/lib/modules/manager/npm/types.ts
+++ b/lib/modules/manager/npm/types.ts
@@ -86,3 +86,8 @@ export interface NpmManagerData extends NpmLockFiles, Record<string, any> {
   yarnZeroInstall?: boolean;
   workspacesPackages?: string[] | string;
 }
+
+export interface NpmrcResult {
+  npmrc: string | undefined;
+  npmrcFileName: string | null;
+}

--- a/lib/modules/manager/pixi/lockfile.ts
+++ b/lib/modules/manager/pixi/lockfile.ts
@@ -11,23 +11,10 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
-import type { PackageDependency, UpdateArtifactsResult } from '../types.ts';
+import type { UpdateArtifactsResult } from '../types.ts';
+import type { UpdatePixiLockfile } from './types.ts';
 
 export const commandLock = 'pixi lock --no-progress --color=never --quiet';
-
-export interface UpdatePixiLockfile {
-  packageFileName: string;
-  updatedDeps: PackageDependency[] | undefined;
-  isLockFileMaintenance: boolean | undefined;
-  /** `pixi` version constraint passed to the tool installer. */
-  constraint: string | undefined;
-  /**
-   * When set, the content is written to `packageFileName` before running
-   * `pixi lock`. Callers that have already written the package file to disk
-   * (e.g. the `pep621` manager) should leave this `undefined`.
-   */
-  newPackageFileContent?: string;
-}
 
 /**
  * Regenerate the sibling `pixi.lock` of a package file by running `pixi lock`.

--- a/lib/modules/manager/pixi/types.ts
+++ b/lib/modules/manager/pixi/types.ts
@@ -1,0 +1,15 @@
+import type { PackageDependency } from '../types.ts';
+
+export interface UpdatePixiLockfile {
+  packageFileName: string;
+  updatedDeps: PackageDependency[] | undefined;
+  isLockFileMaintenance: boolean | undefined;
+  /** `pixi` version constraint passed to the tool installer. */
+  constraint: string | undefined;
+  /**
+   * When set, the content is written to `packageFileName` before running
+   * `pixi lock`. Callers that have already written the package file to disk
+   * (e.g. the `pep621` manager) should leave this `undefined`.
+   */
+  newPackageFileContent?: string;
+}

--- a/lib/modules/manager/proto/extract.ts
+++ b/lib/modules/manager/proto/extract.ts
@@ -1,5 +1,5 @@
 import { logger } from '../../../logger/index.ts';
-import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
+import type { StaticTooling } from '../asdf/types.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
 import { ProtoToolsFile } from './schema.ts';
 import { protoTooling } from './upgradeable-tooling.ts';

--- a/lib/modules/manager/proto/types.ts
+++ b/lib/modules/manager/proto/types.ts
@@ -1,0 +1,5 @@
+import type { StaticTooling } from '../asdf/types.ts';
+
+export interface ToolingDefinition {
+  config: StaticTooling;
+}

--- a/lib/modules/manager/proto/upgradeable-tooling.ts
+++ b/lib/modules/manager/proto/upgradeable-tooling.ts
@@ -5,11 +5,7 @@ import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { RubyVersionDatasource } from '../../datasource/ruby-version/index.ts';
 import { RustVersionDatasource } from '../../datasource/rust-version/index.ts';
 import * as semverVersioning from '../../versioning/semver/index.ts';
-import type { StaticTooling } from '../asdf/upgradeable-tooling.ts';
-
-export interface ToolingDefinition {
-  config: StaticTooling;
-}
+import type { ToolingDefinition } from './types.ts';
 
 /**
  * Maps proto built-in tool names to Renovate datasource configurations.

--- a/lib/modules/manager/terragrunt/common.ts
+++ b/lib/modules/manager/terragrunt/common.ts
@@ -1,2 +1,0 @@
-export type TerragruntResourceTypes = 'unknown';
-export type TerragruntDependencyTypes = 'unknown' | 'terraform';

--- a/lib/modules/manager/terragrunt/types.ts
+++ b/lib/modules/manager/terragrunt/types.ts
@@ -1,8 +1,7 @@
 import type { PackageDependency } from '../types.ts';
-import type {
-  TerragruntDependencyTypes,
-  TerragruntResourceTypes,
-} from './common.ts';
+
+export type TerragruntResourceTypes = 'unknown';
+export type TerragruntDependencyTypes = 'unknown' | 'terraform';
 
 export interface ExtractionResult {
   lineNumber: number;

--- a/lib/modules/manager/terragrunt/util.ts
+++ b/lib/modules/manager/terragrunt/util.ts
@@ -1,5 +1,5 @@
 import { regEx } from '../../../util/regex.ts';
-import type { TerragruntDependencyTypes } from './common.ts';
+import type { TerragruntDependencyTypes } from './types.ts';
 
 export const keyValueExtractionRegex = regEx(
   /^\s*source\s+=\s+"(?<value>[^"]+)"/,

--- a/lib/modules/platform/azure/azure-helper.ts
+++ b/lib/modules/platform/azure/azure-helper.ts
@@ -13,6 +13,7 @@ import { streamToString } from '../../../util/streams.ts';
 import { getNewBranchName } from '../util.ts';
 import * as azureApi from './azure-got-wrapper.ts';
 import { WrappedException } from './schema.ts';
+import type { AzureBranchObj } from './types.ts';
 import {
   getBranchNameWithoutRefsPrefix,
   getBranchNameWithoutRefsheadsPrefix,
@@ -32,11 +33,6 @@ export async function getRefs(
     getBranchNameWithoutRefsPrefix(branchName),
   );
   return refs;
-}
-
-export interface AzureBranchObj {
-  name: string;
-  oldObjectId: string;
 }
 
 export async function getAzureBranchObj(

--- a/lib/modules/platform/azure/types.ts
+++ b/lib/modules/platform/azure/types.ts
@@ -27,3 +27,8 @@ export interface Config {
   /** Work item type for issues; from `azureWorkItemType`, defaults to `Issue`. */
   workItemType: string;
 }
+
+export interface AzureBranchObj {
+  name: string;
+  oldObjectId: string;
+}

--- a/lib/modules/platform/bitbucket-server/index.ts
+++ b/lib/modules/platform/bitbucket-server/index.ts
@@ -66,6 +66,8 @@ import type {
   BbsRestPr,
   BbsRestRepo,
   BbsRestUserRef,
+  BitbucketCommitStatus,
+  BitbucketStatus,
 } from './types.ts';
 import * as utils from './utils.ts';
 import {
@@ -483,7 +485,7 @@ export async function refreshPr(number: number): Promise<void> {
 async function getStatus(
   branchName: string,
   memCache = true,
-): Promise<utils.BitbucketCommitStatus> {
+): Promise<BitbucketCommitStatus> {
   const branchCommit = git.getBranchCommit(branchName);
 
   /* v8 ignore next: temporary code */
@@ -492,7 +494,7 @@ async function getStatus(
     : { memCache: false };
 
   return (
-    await bitbucketServerHttp.getJsonUnchecked<utils.BitbucketCommitStatus>(
+    await bitbucketServerHttp.getJsonUnchecked<BitbucketCommitStatus>(
       // TODO: types (#22198)
       `./rest/build-status/1.0/commits/stats/${branchCommit!}`,
       opts,
@@ -534,7 +536,7 @@ export async function getBranchStatus(
 async function getStatusCheck(
   branchName: string,
   memCache = true,
-): Promise<utils.BitbucketStatus[]> {
+): Promise<BitbucketStatus[]> {
   const branchCommit = git.getBranchCommit(branchName);
 
   const opts: BitbucketServerHttpOptions = { paginate: true };
@@ -546,7 +548,7 @@ async function getStatusCheck(
   }
 
   return (
-    await bitbucketServerHttp.getJsonUnchecked<utils.BitbucketStatus[]>(
+    await bitbucketServerHttp.getJsonUnchecked<BitbucketStatus[]>(
       `./rest/build-status/1.0/commits/${branchCommit!}`,
       opts,
     )

--- a/lib/modules/platform/bitbucket-server/types.ts
+++ b/lib/modules/platform/bitbucket-server/types.ts
@@ -78,3 +78,20 @@ export interface BbsPrCacheData {
   updatedDate: number | null;
   author: string | null;
 }
+
+export interface BitbucketCommitStatus {
+  failed: number;
+  inProgress: number;
+  successful: number;
+}
+
+export type BitbucketBranchState =
+  | 'SUCCESSFUL'
+  | 'FAILED'
+  | 'INPROGRESS'
+  | 'STOPPED';
+
+export interface BitbucketStatus {
+  key: string;
+  state: BitbucketBranchState;
+}

--- a/lib/modules/platform/bitbucket-server/utils.ts
+++ b/lib/modules/platform/bitbucket-server/utils.ts
@@ -34,23 +34,6 @@ export function prInfo(pr: BbsRestPr): BbsPr {
   };
 }
 
-export interface BitbucketCommitStatus {
-  failed: number;
-  inProgress: number;
-  successful: number;
-}
-
-export type BitbucketBranchState =
-  | 'SUCCESSFUL'
-  | 'FAILED'
-  | 'INPROGRESS'
-  | 'STOPPED';
-
-export interface BitbucketStatus {
-  key: string;
-  state: BitbucketBranchState;
-}
-
 export function isInvalidReviewersResponse(err: BitbucketError): boolean {
   const errors = err?.response?.body?.errors ?? [];
   return (

--- a/lib/modules/platform/bitbucket/comments.spec.ts
+++ b/lib/modules/platform/bitbucket/comments.spec.ts
@@ -1,11 +1,12 @@
 import * as httpMock from '~test/http-mock.ts';
 import { setBaseUrl } from '../../../util/http/bitbucket.ts';
 import * as comments from './comments.ts';
+import type { CommentsConfig } from './types.ts';
 
 const baseUrl = 'https://api.bitbucket.org';
 
 describe('modules/platform/bitbucket/comments', () => {
-  const config: comments.CommentsConfig = { repository: 'some/repo' };
+  const config: CommentsConfig = { repository: 'some/repo' };
 
   beforeEach(() => {
     setBaseUrl(baseUrl);

--- a/lib/modules/platform/bitbucket/comments.ts
+++ b/lib/modules/platform/bitbucket/comments.ts
@@ -4,7 +4,7 @@ import type {
   EnsureCommentConfig,
   EnsureCommentRemovalConfig,
 } from '../types.ts';
-import type { Account, Config, PagedResult } from './types.ts';
+import type { Account, CommentsConfig, PagedResult } from './types.ts';
 
 export const REOPEN_PR_COMMENT_KEYWORD = 'reopen!';
 
@@ -15,8 +15,6 @@ interface Comment {
   id: number;
   user: Account;
 }
-
-export type CommentsConfig = Pick<Config, 'repository'>;
 
 interface EnsureBitbucketCommentConfig extends EnsureCommentConfig {
   config: CommentsConfig;

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -90,3 +90,5 @@ export interface BitbucketPrCacheData {
   updated_on: string | null;
   author: string | null;
 }
+
+export type CommentsConfig = Pick<Config, 'repository'>;

--- a/lib/modules/platform/codecommit/index.ts
+++ b/lib/modules/platform/codecommit/index.ts
@@ -28,7 +28,6 @@ import type {
   MergePRConfig,
   PlatformParams,
   PlatformResult,
-  Pr,
   RepoParams,
   RepoResult,
   UpdatePrConfig,
@@ -36,12 +35,7 @@ import type {
 import { getNewBranchName, repoFingerprint } from '../util.ts';
 import { smartTruncate } from '../utils/pr-body.ts';
 import * as client from './codecommit-client.ts';
-
-export interface CodeCommitPr extends Pr {
-  body: string;
-  destinationCommit: string;
-  sourceCommit: string;
-}
+import type { CodeCommitPr } from './types.ts';
 
 interface Config {
   repository?: string;

--- a/lib/modules/platform/codecommit/types.ts
+++ b/lib/modules/platform/codecommit/types.ts
@@ -1,0 +1,7 @@
+import type { Pr } from '../types.ts';
+
+export interface CodeCommitPr extends Pr {
+  body: string;
+  destinationCommit: string;
+  sourceCommit: string;
+}

--- a/lib/modules/versioning/apk/index.ts
+++ b/lib/modules/versioning/apk/index.ts
@@ -1,8 +1,8 @@
 import { isTruthy } from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
 import type { VersioningApi } from '../types.ts';
+import type { ApkVersion } from './types.ts';
 
 export const id = 'apk';
 export const displayName = 'Alpine Package Keeper (APK)';
@@ -19,19 +19,6 @@ const versionRegex = regEx(
 
 // Regex for splitting version strings into alphanumeric parts
 const alphaNumRegex = regEx(/([a-zA-Z]+)|(\d+)/g);
-
-export interface ApkVersion extends GenericVersion {
-  /**
-   * version is the main version part: it defines the version of origin software
-   * that was packaged.
-   */
-  version: string;
-  /**
-   * releaseString is used to distinguish between different versions of packaging for the
-   * same upstream version.
-   */
-  releaseString: string;
-}
 
 class ApkVersioningApi extends GenericVersioningApi {
   /**

--- a/lib/modules/versioning/apk/types.ts
+++ b/lib/modules/versioning/apk/types.ts
@@ -1,0 +1,14 @@
+import type { GenericVersion } from '../types.ts';
+
+export interface ApkVersion extends GenericVersion {
+  /**
+   * version is the main version part: it defines the version of origin software
+   * that was packaged.
+   */
+  version: string;
+  /**
+   * releaseString is used to distinguish between different versions of packaging for the
+   * same upstream version.
+   */
+  releaseString: string;
+}

--- a/lib/modules/versioning/aws-machine-image/index.ts
+++ b/lib/modules/versioning/aws-machine-image/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'aws-machine-image';
 export const displayName = 'aws-machine-image';

--- a/lib/modules/versioning/azure-rest-api/index.ts
+++ b/lib/modules/versioning/azure-rest-api/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'azure-rest-api';
 export const displayName = 'azure-rest-api';

--- a/lib/modules/versioning/deb/index.ts
+++ b/lib/modules/versioning/deb/index.ts
@@ -1,7 +1,7 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
 import type { VersioningApi } from '../types.ts';
+import type { DebVersion } from './types.ts';
 
 export const id = 'deb';
 export const displayName = 'Deb version';
@@ -18,24 +18,6 @@ const numericPattern = regEx(/\d+/g);
 const characterOrder =
   '~ ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+-.:';
 const numericChars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
-
-export interface DebVersion extends GenericVersion {
-  /**
-   * epoch, defaults to 0 if not present, are used to leave version mistakes and previous
-   * versioning schemes behind.
-   */
-  epoch: number;
-  /**
-   * upstreamVersion is the main version part: it defines the version of origin software
-   * that was packaged.
-   */
-  upstreamVersion: string;
-  /**
-   * debianRevision is used to distinguish between different versions of packaging for the
-   * same upstream version.
-   */
-  debianRevision: string;
-}
 
 class DebVersioningApi extends GenericVersioningApi {
   protected _parse(version: string): DebVersion | null {

--- a/lib/modules/versioning/deb/types.ts
+++ b/lib/modules/versioning/deb/types.ts
@@ -1,0 +1,19 @@
+import type { GenericVersion } from '../types.ts';
+
+export interface DebVersion extends GenericVersion {
+  /**
+   * epoch, defaults to 0 if not present, are used to leave version mistakes and previous
+   * versioning schemes behind.
+   */
+  epoch: number;
+  /**
+   * upstreamVersion is the main version part: it defines the version of origin software
+   * that was packaged.
+   */
+  upstreamVersion: string;
+  /**
+   * debianRevision is used to distinguish between different versions of packaging for the
+   * same upstream version.
+   */
+  debianRevision: string;
+}

--- a/lib/modules/versioning/debian/common.ts
+++ b/lib/modules/versioning/debian/common.ts
@@ -1,7 +1,8 @@
 import { DateTime } from 'luxon';
 import { logger } from '../../../logger/index.ts';
 import { regEx } from '../../../util/regex.ts';
-import type { DistroInfo, DistroInfoRecordWithVersion } from '../distro.ts';
+import type { DistroInfo } from '../distro.ts';
+import type { DistroInfoRecordWithVersion } from '../types.ts';
 
 const refreshInterval = { days: 1 };
 

--- a/lib/modules/versioning/debian/index.ts
+++ b/lib/modules/versioning/debian/index.ts
@@ -1,8 +1,11 @@
 import type { RangeStrategy } from '../../../types/index.ts';
 import { DistroInfo } from '../distro.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { NewValueConfig, VersioningApi } from '../types.ts';
+import type {
+  GenericVersion,
+  NewValueConfig,
+  VersioningApi,
+} from '../types.ts';
 import {
   RollingReleasesData,
   getDatedContainerImageCodename,

--- a/lib/modules/versioning/devbox/index.ts
+++ b/lib/modules/versioning/devbox/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'devbox';
 export const displayName = 'devbox';

--- a/lib/modules/versioning/distro.ts
+++ b/lib/modules/versioning/distro.ts
@@ -1,26 +1,12 @@
 import { DateTime } from 'luxon';
 import dataFiles from '../../data-files.generated.ts';
 import { regEx } from '../../util/regex.ts';
-
-export interface DistroSchedule {
-  codename: string;
-  series: string;
-  created: string;
-  release?: string;
-  eol?: string;
-  eol_server?: string;
-  eol_esm?: string;
-  eol_lts?: string;
-  eol_elts?: string;
-}
-
-export type DistroDataFile =
-  | 'data/ubuntu-distro-info.json'
-  | 'data/debian-distro-info.json';
-
-export type DistroInfoRecord = Record<string, DistroSchedule>;
-
-export type DistroInfoRecordWithVersion = { version: string } & DistroSchedule;
+import type {
+  DistroDataFile,
+  DistroInfoRecord,
+  DistroInfoRecordWithVersion,
+  DistroSchedule,
+} from './types.ts';
 
 // Days to delay new releases
 const delay = 1;

--- a/lib/modules/versioning/docker/index.ts
+++ b/lib/modules/versioning/docker/index.ts
@@ -1,8 +1,7 @@
 import { regEx } from '../../../util/regex.ts';
 import { coerceString } from '../../../util/string.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'docker';
 export const displayName = 'Docker';

--- a/lib/modules/versioning/generic.spec.ts
+++ b/lib/modules/versioning/generic.spec.ts
@@ -1,8 +1,7 @@
 import { partial } from '~test/util.ts';
 import { regEx } from '../../util/regex.ts';
-import type { GenericVersion } from './generic.ts';
 import { GenericVersioningApi } from './generic.ts';
-import type { NewValueConfig } from './types.ts';
+import type { GenericVersion, NewValueConfig } from './types.ts';
 
 describe('modules/versioning/generic', () => {
   const optionalFunctions = [

--- a/lib/modules/versioning/generic.ts
+++ b/lib/modules/versioning/generic.ts
@@ -1,16 +1,6 @@
 import { isNonEmptyString } from '@sindresorhus/is';
 import { regEx } from '../../util/regex.ts';
-import type { NewValueConfig, VersioningApi } from './types.ts';
-
-export interface GenericVersion {
-  release: number[];
-  /** prereleases are treated in the standard semver manner, if present */
-  prerelease?: string;
-  suffix?: string;
-}
-export type VersionParser = (version: string) => GenericVersion;
-
-export type VersionComparator = (version: string, other: string) => number;
+import type { GenericVersion, NewValueConfig, VersioningApi } from './types.ts';
 
 export abstract class GenericVersioningApi<
   T extends GenericVersion = GenericVersion,

--- a/lib/modules/versioning/git/index.ts
+++ b/lib/modules/versioning/git/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'git';
 export const displayName = 'git';

--- a/lib/modules/versioning/glasskube/index.ts
+++ b/lib/modules/versioning/glasskube/index.ts
@@ -1,7 +1,6 @@
 import { SemVer } from 'semver';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'glasskube';
 export const displayName = 'glasskube';

--- a/lib/modules/versioning/gradle/compare.ts
+++ b/lib/modules/versioning/gradle/compare.ts
@@ -222,7 +222,7 @@ interface PrefixRange {
   tokens: Token[];
 }
 
-export type RangeBound = 'inclusive' | 'exclusive';
+type RangeBound = 'inclusive' | 'exclusive';
 
 interface MavenBasedRange {
   leftBound: RangeBound;

--- a/lib/modules/versioning/hermit/index.ts
+++ b/lib/modules/versioning/hermit/index.ts
@@ -1,6 +1,6 @@
 import { satisfies } from 'semver';
-import type { RegExpVersion } from '../regex/index.ts';
 import { RegExpVersioningApi } from '../regex/index.ts';
+import type { RegExpVersion } from '../regex/types.ts';
 import type { VersioningApiConstructor } from '../types.ts';
 
 export const id = 'hermit';

--- a/lib/modules/versioning/ivy/parse.ts
+++ b/lib/modules/versioning/ivy/parse.ts
@@ -1,15 +1,10 @@
 import { regEx } from '../../../util/regex.ts';
 import { isSingleVersion, parseRange, rangeToStr } from '../maven/compare.ts';
+import type { Revision } from './types.ts';
 
 const REV_TYPE_LATEST = 'REV_TYPE_LATEST';
 const REV_TYPE_SUBREV = 'REV_TYPE_SUBREVISION';
 const REV_TYPE_RANGE = 'REV_TYPE_RANGE';
-
-export interface Revision {
-  type: typeof REV_TYPE_LATEST | typeof REV_TYPE_RANGE | typeof REV_TYPE_SUBREV;
-
-  value: string;
-}
 
 export const LATEST_REGEX = regEx(/^latest\.|^latest$/i);
 

--- a/lib/modules/versioning/ivy/types.ts
+++ b/lib/modules/versioning/ivy/types.ts
@@ -1,0 +1,5 @@
+export interface Revision {
+  type: 'REV_TYPE_LATEST' | 'REV_TYPE_RANGE' | 'REV_TYPE_SUBREVISION';
+
+  value: string;
+}

--- a/lib/modules/versioning/lambda-node/index.spec.ts
+++ b/lib/modules/versioning/lambda-node/index.spec.ts
@@ -1,6 +1,6 @@
 import { DateTime } from 'luxon';
 import { api as lambdaVer } from './index.ts';
-import type { LambdaData } from './schedule.ts';
+import type { LambdaData } from './types.ts';
 
 vi.mock('../../../data-files.generated.ts', async (importOriginal) => {
   const dataFiles = (

--- a/lib/modules/versioning/lambda-node/schedule.ts
+++ b/lib/modules/versioning/lambda-node/schedule.ts
@@ -1,17 +1,7 @@
 import dataFiles from '../../../data-files.generated.ts';
 import { regEx } from '../../../util/regex.ts';
 import { isStable } from '../node/index.ts';
-
-interface LambdaSchedule {
-  cycle: string;
-
-  /**
-   * Either `true` if currently in support or a string indicating the date at which support will end
-   */
-  support: true | string;
-}
-
-export type LambdaData = Record<string, LambdaSchedule>;
+import type { LambdaData, LambdaSchedule } from './types.ts';
 
 const lambdaSchedule: LambdaData = JSON.parse(
   dataFiles.get('data/lambda-node-js-schedule.json')!,

--- a/lib/modules/versioning/lambda-node/types.ts
+++ b/lib/modules/versioning/lambda-node/types.ts
@@ -1,0 +1,10 @@
+export interface LambdaSchedule {
+  cycle: string;
+
+  /**
+   * Either `true` if currently in support or a string indicating the date at which support will end
+   */
+  support: true | string;
+}
+
+export type LambdaData = Record<string, LambdaSchedule>;

--- a/lib/modules/versioning/loose/index.ts
+++ b/lib/modules/versioning/loose/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'loose';
 export const displayName = 'Loose';

--- a/lib/modules/versioning/maven/compare.ts
+++ b/lib/modules/versioning/maven/compare.ts
@@ -1,5 +1,6 @@
 import { isString } from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
+import type { Range, Token } from './types.ts';
 
 const PREFIX_DOT = 'PREFIX_DOT';
 const PREFIX_HYPHEN = 'PREFIX_HYPHEN';
@@ -7,25 +8,6 @@ const ALPHA_SUFFIX = '-alpha';
 
 const TYPE_NUMBER = 'TYPE_NUMBER';
 const TYPE_QUALIFIER = 'TYPE_QUALIFIER';
-
-export interface BaseToken {
-  prefix: string;
-  type: typeof TYPE_NUMBER | typeof TYPE_QUALIFIER;
-  val: number | string;
-  isTransition?: boolean;
-}
-
-export interface NumberToken extends BaseToken {
-  type: typeof TYPE_NUMBER;
-  val: number;
-}
-
-export interface QualifierToken extends BaseToken {
-  type: typeof TYPE_QUALIFIER;
-  val: string;
-}
-
-export type Token = NumberToken | QualifierToken;
 
 function iterateChars(
   str: string,
@@ -420,15 +402,6 @@ function isValid(str: string): boolean {
     return false;
   }
   return isVersion(str) || !!parseRange(str);
-}
-
-export interface Range {
-  leftType: typeof INCLUDING_POINT | typeof EXCLUDING_POINT | null;
-  leftValue: string | null;
-  leftBracket: string | null;
-  rightType: typeof INCLUDING_POINT | typeof EXCLUDING_POINT | null;
-  rightValue: string | null;
-  rightBracket: string | null;
 }
 
 function rangeToStr(fullRange: Range[] | null): string | null {

--- a/lib/modules/versioning/maven/types.ts
+++ b/lib/modules/versioning/maven/types.ts
@@ -1,0 +1,27 @@
+export interface BaseToken {
+  prefix: string;
+  type: 'TYPE_NUMBER' | 'TYPE_QUALIFIER';
+  val: number | string;
+  isTransition?: boolean;
+}
+
+export interface NumberToken extends BaseToken {
+  type: 'TYPE_NUMBER';
+  val: number;
+}
+
+export interface QualifierToken extends BaseToken {
+  type: 'TYPE_QUALIFIER';
+  val: string;
+}
+
+export type Token = NumberToken | QualifierToken;
+
+export interface Range {
+  leftType: 'INCLUDING_POINT' | 'EXCLUDING_POINT' | null;
+  leftValue: string | null;
+  leftBracket: string | null;
+  rightType: 'INCLUDING_POINT' | 'EXCLUDING_POINT' | null;
+  rightValue: string | null;
+  rightBracket: string | null;
+}

--- a/lib/modules/versioning/nixpkgs/index.ts
+++ b/lib/modules/versioning/nixpkgs/index.ts
@@ -3,8 +3,8 @@ import {
   isNonEmptyArray,
   isNonEmptyStringAndNotWhitespace,
 } from '@sindresorhus/is';
-import type { RegExpVersion } from '../regex/index.ts';
 import { RegExpVersioningApi } from '../regex/index.ts';
+import type { RegExpVersion } from '../regex/types.ts';
 import type { VersioningApiConstructor } from '../types.ts';
 
 export const id = 'nixpkgs';

--- a/lib/modules/versioning/node/schedule.ts
+++ b/lib/modules/versioning/node/schedule.ts
@@ -1,19 +1,13 @@
 import _nodeSchedule from '../../../data/node-js-schedule.json' with { type: 'json' };
 import type { Nullish } from '../../../types/index.ts';
 import semver from '../semver/index.ts';
+import type {
+  NodeJsData,
+  NodeJsSchedule,
+  NodeJsScheduleWithVersion,
+} from './types.ts';
 
-interface NodeJsSchedule {
-  alpha?: string;
-  lts?: string;
-  maintenance?: string;
-  end: string;
-  start: string;
-  codename?: string;
-}
-
-export type NodeJsData = Record<string, NodeJsSchedule>;
 const nodeSchedule: NodeJsData = _nodeSchedule;
-export type NodeJsScheduleWithVersion = { version: string } & NodeJsSchedule;
 
 const nodeCodenames = new Map<string, NodeJsScheduleWithVersion>();
 for (const version of Object.keys(nodeSchedule)) {

--- a/lib/modules/versioning/node/types.ts
+++ b/lib/modules/versioning/node/types.ts
@@ -1,0 +1,12 @@
+export interface NodeJsSchedule {
+  alpha?: string;
+  lts?: string;
+  maintenance?: string;
+  end: string;
+  start: string;
+  codename?: string;
+}
+
+export type NodeJsData = Record<string, NodeJsSchedule>;
+
+export type NodeJsScheduleWithVersion = { version: string } & NodeJsSchedule;

--- a/lib/modules/versioning/paket/index.ts
+++ b/lib/modules/versioning/paket/index.ts
@@ -2,7 +2,6 @@ import type { RangeStrategy } from '../../../types/versioning.ts';
 import { parseVersion } from '../nuget/parser.ts';
 import type { NugetVersion } from '../nuget/types.ts';
 import type { NewValueConfig, VersioningApi } from '../types.ts';
-import type { PaketConstraint, PaketRange } from './range.ts';
 import {
   adaptToPrecision,
   bumpAtPrecision,
@@ -15,6 +14,7 @@ import {
   releaseParts,
   twiddle,
 } from './range.ts';
+import type { PaketConstraint, PaketRange } from './types.ts';
 import { compare, sameReleaseParts } from './version.ts';
 
 export const id = 'paket';

--- a/lib/modules/versioning/paket/range.ts
+++ b/lib/modules/versioning/paket/range.ts
@@ -3,20 +3,13 @@ import { regEx } from '../../../util/regex.ts';
 import { parseVersion } from '../nuget/parser.ts';
 import type { NugetVersion } from '../nuget/types.ts';
 import { versionToString } from '../nuget/version.ts';
+import type {
+  PaketConstraint,
+  PaketInterval,
+  PaketOperator,
+  PaketRange,
+} from './types.ts';
 import { compare, sameReleaseParts } from './version.ts';
-
-export type PaketOperator = '' | '=' | '==' | '>' | '>=' | '<' | '<=' | '~>';
-
-export interface PaketConstraint {
-  operator: PaketOperator;
-  version: NugetVersion;
-}
-
-export interface PaketRange {
-  strategy: '!' | '@' | null;
-  constraints: PaketConstraint[];
-  prereleaseTags: string[];
-}
 
 const constraintOperators: readonly string[] = [
   '=',
@@ -166,25 +159,6 @@ export function twiddle(version: NugetVersion): NugetVersion {
   const precision = Math.max(releaseParts(version).length - 1, 1);
   return bumpAtPrecision(version, precision);
 }
-
-export type PaketInterval =
-  | {
-      kind:
-        | 'specific'
-        | 'override'
-        | 'minimum'
-        | 'greater-than'
-        | 'maximum'
-        | 'less-than';
-      version: NugetVersion;
-    }
-  | {
-      kind: 'range';
-      from: NugetVersion;
-      fromInclusive: boolean;
-      to: NugetVersion;
-      toInclusive: boolean;
-    };
 
 function intervalOfPair(
   first: PaketConstraint,

--- a/lib/modules/versioning/paket/types.ts
+++ b/lib/modules/versioning/paket/types.ts
@@ -1,0 +1,33 @@
+import type { NugetVersion } from '../nuget/types.ts';
+
+export type PaketOperator = '' | '=' | '==' | '>' | '>=' | '<' | '<=' | '~>';
+
+export interface PaketConstraint {
+  operator: PaketOperator;
+  version: NugetVersion;
+}
+
+export interface PaketRange {
+  strategy: '!' | '@' | null;
+  constraints: PaketConstraint[];
+  prereleaseTags: string[];
+}
+
+export type PaketInterval =
+  | {
+      kind:
+        | 'specific'
+        | 'override'
+        | 'minimum'
+        | 'greater-than'
+        | 'maximum'
+        | 'less-than';
+      version: NugetVersion;
+    }
+  | {
+      kind: 'range';
+      from: NugetVersion;
+      fromInclusive: boolean;
+      to: NugetVersion;
+      toInclusive: boolean;
+    };

--- a/lib/modules/versioning/perl/index.ts
+++ b/lib/modules/versioning/perl/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'perl';
 export const displayName = 'Perl';

--- a/lib/modules/versioning/redhat/index.ts
+++ b/lib/modules/versioning/redhat/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'redhat';
 export const displayName = 'Red Hat';

--- a/lib/modules/versioning/regex/index.ts
+++ b/lib/modules/versioning/regex/index.ts
@@ -1,21 +1,13 @@
 import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
 import type { VersioningApiConstructor } from '../types.ts';
+import type { RegExpVersion } from './types.ts';
 
 export const id = 'regex';
 export const displayName = 'Regular Expression';
 export const urls = [];
 export const supportsRanges = false;
-
-export interface RegExpVersion extends GenericVersion {
-  /**
-   * compatibility, if present, are treated as a compatibility layer: we will
-   * never try to update to a version with a different compatibility.
-   */
-  compatibility: string;
-}
 
 export class RegExpVersioningApi extends GenericVersioningApi<RegExpVersion> {
   // config is expected to be overridden by a user-specified RegExp value

--- a/lib/modules/versioning/regex/types.ts
+++ b/lib/modules/versioning/regex/types.ts
@@ -1,0 +1,9 @@
+import type { GenericVersion } from '../types.ts';
+
+export interface RegExpVersion extends GenericVersion {
+  /**
+   * compatibility, if present, are treated as a compatibility layer: we will
+   * never try to update to a version with a different compatibility.
+   */
+  compatibility: string;
+}

--- a/lib/modules/versioning/rpm/index.ts
+++ b/lib/modules/versioning/rpm/index.ts
@@ -1,8 +1,8 @@
 import { isNumericString } from '@sindresorhus/is';
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
 import type { VersioningApi } from '../types.ts';
+import type { RpmVersion } from './types.ts';
 
 export const id = 'rpm';
 export const displayName = 'RPM version';
@@ -15,39 +15,6 @@ export const supportsRanges = false;
 
 const alphaNumPattern = regEx(/([a-zA-Z]+)|(\d+)|(~)/g);
 const epochPattern = regEx(/^\d+$/);
-
-export interface RpmVersion extends GenericVersion {
-  /**
-   * epoch, defaults to 0 if not present, are used to leave version mistakes and previous
-   * versioning schemes behind.
-   */
-  epoch: number;
-  /**
-   * upstreamVersion is the main version part: it defines the version of origin software
-   * that was packaged.
-   */
-  upstreamVersion: string;
-  /**
-   * rpmRelease is used to distinguish between different versions of packaging for the
-   * same upstream version.
-   */
-  rpmRelease: string;
-
-  /**
-   * rpmPreRelease is used to distinguish versions of prerelease of the same upstream and release version
-   * Example: Python 3.12.0-1 > Python 3.12.0-1~a1
-   */
-  rpmPreRelease: string;
-
-  /**
-   * snapshot is an archive taken from upstream's source code control system which is not equivalent to any release version.
-   * This field must at minimum consist of the date in eight-digit "YYYYMMDD" format. The packager MAY
-   * include up to 17 characters of additional information after the date. The following formats are suggested:
-   * YYYYMMDD.<revision>
-   * YYYYMMDD<scm><revision>
-   */
-  snapshot: string;
-}
 
 class RpmVersioningApi extends GenericVersioningApi {
   /**

--- a/lib/modules/versioning/rpm/types.ts
+++ b/lib/modules/versioning/rpm/types.ts
@@ -1,0 +1,34 @@
+import type { GenericVersion } from '../types.ts';
+
+export interface RpmVersion extends GenericVersion {
+  /**
+   * epoch, defaults to 0 if not present, are used to leave version mistakes and previous
+   * versioning schemes behind.
+   */
+  epoch: number;
+  /**
+   * upstreamVersion is the main version part: it defines the version of origin software
+   * that was packaged.
+   */
+  upstreamVersion: string;
+  /**
+   * rpmRelease is used to distinguish between different versions of packaging for the
+   * same upstream version.
+   */
+  rpmRelease: string;
+
+  /**
+   * rpmPreRelease is used to distinguish versions of prerelease of the same upstream and release version
+   * Example: Python 3.12.0-1 > Python 3.12.0-1~a1
+   */
+  rpmPreRelease: string;
+
+  /**
+   * snapshot is an archive taken from upstream's source code control system which is not equivalent to any release version.
+   * This field must at minimum consist of the date in eight-digit "YYYYMMDD" format. The packager MAY
+   * include up to 17 characters of additional information after the date. The following formats are suggested:
+   * YYYYMMDD.<revision>
+   * YYYYMMDD<scm><revision>
+   */
+  snapshot: string;
+}

--- a/lib/modules/versioning/ruby/range.ts
+++ b/lib/modules/versioning/ruby/range.ts
@@ -5,20 +5,7 @@ import { create } from '@renovatebot/ruby-semver/dist/ruby/version.js';
 import { logger } from '../../../logger/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { EQUAL, GT, GTE, LT, LTE, NOT_EQUAL, PGTE } from './operator.ts';
-
-export interface Range {
-  version: string;
-  operator: string;
-  delimiter: string;
-  /**
-   * If the range is `~>` and immediately followed by `>=`,
-   * the latter range is considered the former's companion
-   * and assigned here instead of being an independent range.
-   *
-   * Example: `'~> 6.2', '>= 6.2.1'`
-   */
-  companion?: Range;
-}
+import type { Range } from './types.ts';
 
 function parse(range: string): Range {
   const regExp = regEx(

--- a/lib/modules/versioning/ruby/strategies/bump.ts
+++ b/lib/modules/versioning/ruby/strategies/bump.ts
@@ -1,7 +1,7 @@
 import { gt, gte, lt } from '@renovatebot/ruby-semver';
 import { GTE, LT, LTE, NOT_EQUAL, PGTE } from '../operator.ts';
-import type { Range } from '../range.ts';
 import { parseRanges, stringifyRanges } from '../range.ts';
+import type { Range } from '../types.ts';
 import { adapt, trimZeroes } from '../version.ts';
 import { replacePart } from './replace.ts';
 

--- a/lib/modules/versioning/ruby/strategies/replace.ts
+++ b/lib/modules/versioning/ruby/strategies/replace.ts
@@ -1,7 +1,7 @@
 import { logger } from '../../../../logger/index.ts';
 import { EQUAL, GT, GTE, LT, LTE, NOT_EQUAL, PGTE } from '../operator.ts';
-import type { Range } from '../range.ts';
 import { parseRanges, satisfiesRange, stringifyRanges } from '../range.ts';
+import type { Range } from '../types.ts';
 import { adapt, decrement, floor, increment } from '../version.ts';
 
 // Common logic for replace, widen, and bump strategies

--- a/lib/modules/versioning/ruby/strategies/widen.ts
+++ b/lib/modules/versioning/ruby/strategies/widen.ts
@@ -1,6 +1,6 @@
 import { GTE, LT, PGTE } from '../operator.ts';
-import type { Range } from '../range.ts';
 import { parseRanges, satisfiesRange, stringifyRanges } from '../range.ts';
+import type { Range } from '../types.ts';
 import { increment, pgteUpperBound } from '../version.ts';
 import { replacePart } from './replace.ts';
 

--- a/lib/modules/versioning/ruby/types.ts
+++ b/lib/modules/versioning/ruby/types.ts
@@ -1,0 +1,13 @@
+export interface Range {
+  version: string;
+  operator: string;
+  delimiter: string;
+  /**
+   * If the range is `~>` and immediately followed by `>=`,
+   * the latter range is considered the former's companion
+   * and assigned here instead of being an independent range.
+   *
+   * Example: `'~> 6.2', '>= 6.2.1'`
+   */
+  companion?: Range;
+}

--- a/lib/modules/versioning/semver/common.ts
+++ b/lib/modules/versioning/semver/common.ts
@@ -1,8 +1,7 @@
 import { regEx } from '../../../util/regex.ts';
+import type { SemVerXRange } from './types.ts';
 
-const SEMVER_X_RANGE = ['*', 'x', 'X', ''] as const;
-type SemVerXRangeArray = typeof SEMVER_X_RANGE;
-export type SemVerXRange = SemVerXRangeArray[number];
+const SEMVER_X_RANGE: readonly SemVerXRange[] = ['*', 'x', 'X', ''];
 
 const RANGE_SEPARATOR = regEx(/(\s+|,|\|\||[()])/);
 const NUMERIC_RELEASE_PART = '(?:0|[1-9]\\d*)';

--- a/lib/modules/versioning/semver/types.ts
+++ b/lib/modules/versioning/semver/types.ts
@@ -1,0 +1,1 @@
+export type SemVerXRange = '*' | 'x' | 'X' | '';

--- a/lib/modules/versioning/types.ts
+++ b/lib/modules/versioning/types.ts
@@ -1,6 +1,36 @@
 import type { SemVer } from 'semver';
 import type { RangeStrategy } from '../../types/index.ts';
 
+export interface GenericVersion {
+  release: number[];
+  /** prereleases are treated in the standard semver manner, if present */
+  prerelease?: string;
+  suffix?: string;
+}
+export type VersionParser = (version: string) => GenericVersion;
+
+export type VersionComparator = (version: string, other: string) => number;
+
+export interface DistroSchedule {
+  codename: string;
+  series: string;
+  created: string;
+  release?: string;
+  eol?: string;
+  eol_server?: string;
+  eol_esm?: string;
+  eol_lts?: string;
+  eol_elts?: string;
+}
+
+export type DistroDataFile =
+  | 'data/ubuntu-distro-info.json'
+  | 'data/debian-distro-info.json';
+
+export type DistroInfoRecord = Record<string, DistroSchedule>;
+
+export type DistroInfoRecordWithVersion = { version: string } & DistroSchedule;
+
 export interface NewValueConfig {
   currentValue: string;
   rangeStrategy: RangeStrategy;

--- a/lib/modules/versioning/unity3d-packages/index.ts
+++ b/lib/modules/versioning/unity3d-packages/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'unity3d-packages';
 export const displayName = 'Unity3D Packages';

--- a/lib/modules/versioning/unity3d/index.ts
+++ b/lib/modules/versioning/unity3d/index.ts
@@ -1,7 +1,6 @@
 import { regEx } from '../../../util/regex.ts';
-import type { GenericVersion } from '../generic.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { GenericVersion, VersioningApi } from '../types.ts';
 
 export const id = 'unity3d';
 export const displayName = 'Unity3D';

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -1,7 +1,7 @@
 import { codeBlock } from 'common-tags';
 import { z } from 'zod/v4';
-import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/community.ts';
 import { communityActions } from '../../../../lib/modules/manager/github-actions/community.ts';
+import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/types.ts';
 import { readFile, updateFile } from '../../../utils/index.ts';
 import { replaceContent } from '../../utils.ts';
 

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -21,6 +21,7 @@ import preferNullishUtil from './rules/prefer-nullish-util.ts';
 import preferPartialInSpecs from './rules/prefer-partial-in-specs.ts';
 import requireRegexUtil from './rules/require-regex-util.ts';
 import testRootDescribe from './rules/test-root-describe.ts';
+import typesLocation from './rules/types-location.ts';
 import v8IgnoreNoCount from './rules/v8-ignore-no-count.ts';
 import v8IgnoreReason from './rules/v8-ignore-reason.ts';
 import validateConfigWarningsAndErrors from './rules/validate-config-warnings-and-errors.ts';
@@ -54,6 +55,7 @@ export default definePlugin({
     'prefer-partial-in-specs': preferPartialInSpecs,
     'require-regex-util': requireRegexUtil,
     'test-root-describe': testRootDescribe,
+    'types-location': typesLocation,
     'v8-ignore-no-count': v8IgnoreNoCount,
     'v8-ignore-reason': v8IgnoreReason,
     'validate-config-warnings-and-errors': validateConfigWarningsAndErrors,

--- a/tools/lint/rules/types-location.spec.ts
+++ b/tools/lint/rules/types-location.spec.ts
@@ -1,0 +1,107 @@
+import path from 'node:path';
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './types-location.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+
+/** A logic file, where exported types are reported. */
+const logicFile = path.join(repoRoot, 'lib/modules/manager/npm/npmrc.ts');
+
+/** The file types are expected to live in. */
+const typesFile = path.join(repoRoot, 'lib/modules/manager/npm/types.ts');
+
+/** A file below a `types` directory, which is the same convention split up. */
+const nestedTypesFile = path.join(repoRoot, 'lib/modules/foo/types/bar.ts');
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+  cwd: repoRoot,
+});
+
+ruleTester.run('types-location', rule, {
+  valid: [
+    // the types file itself collects them
+    {
+      code: `export interface Foo {\n  bar: string;\n}`,
+      filename: typesFile,
+    },
+    {
+      code: `export type Foo = string;`,
+      filename: typesFile,
+    },
+    // and so does anything below a `types` directory
+    {
+      code: `export interface Foo {\n  bar: string;\n}`,
+      filename: nestedTypesFile,
+    },
+    // file-local types are intentionally local
+    {
+      code: `interface Foo {\n  bar: string;\n}`,
+      filename: logicFile,
+    },
+    {
+      code: `type Foo = string;`,
+      filename: logicFile,
+    },
+    // re-exports carry no declaration of their own
+    {
+      code: `export type { Foo } from './types.ts';`,
+      filename: logicFile,
+    },
+    {
+      code: `export type * from './types.ts';`,
+      filename: logicFile,
+    },
+    {
+      code: `import type { Foo } from './types.ts';\nexport type { Foo };`,
+      filename: logicFile,
+    },
+    // values are not types
+    {
+      code: `export const foo = 42;`,
+      filename: logicFile,
+    },
+    {
+      code: `export function foo(): void {}`,
+      filename: logicFile,
+    },
+    {
+      code: `export enum Foo {\n  Bar,\n}`,
+      filename: logicFile,
+    },
+    {
+      code: `export class Foo {}`,
+      filename: logicFile,
+    },
+  ],
+  invalid: [
+    {
+      code: `export interface Foo {\n  bar: string;\n}`,
+      filename: logicFile,
+      errors: [{ messageId: 'moveToTypesFile' }],
+    },
+    {
+      code: `export type Foo = string;`,
+      filename: logicFile,
+      errors: [{ messageId: 'moveToTypesFile' }],
+    },
+    // a file named `types.ts` outside `lib` is still gated on its own basename
+    {
+      code: `export type Foo = string;`,
+      filename: path.join(repoRoot, 'lib/modules/manager/npm/mytypes.ts'),
+      errors: [{ messageId: 'moveToTypesFile' }],
+    },
+    // several declarations in one file
+    {
+      code: `export type Foo = string;\nexport interface Bar {\n  baz: number;\n}`,
+      filename: logicFile,
+      errors: [
+        { messageId: 'moveToTypesFile' },
+        { messageId: 'moveToTypesFile' },
+      ],
+    },
+  ],
+});

--- a/tools/lint/rules/types-location.ts
+++ b/tools/lint/rules/types-location.ts
@@ -1,0 +1,52 @@
+import path from 'node:path';
+import { defineRule } from '@oxlint/plugins';
+
+/**
+ * Type-only declarations belong in a colocated `types.ts`. The file that
+ * collects them is itself exempt, and so is anything nested below a `types`
+ * directory, which is the same convention split across several files.
+ */
+function isTypesFile(filename: string): boolean {
+  const segments = filename.split(path.sep);
+  const basename = segments.pop();
+  return basename === 'types.ts' || segments.includes('types');
+}
+
+export default defineRule({
+  meta: {
+    type: 'suggestion',
+    messages: {
+      moveToTypesFile:
+        'Exported type `{{name}}` is declared outside a `types.ts` file. Reviewers consistently ask for types to live in a colocated `types.ts` — move it there.',
+    },
+  },
+  createOnce(context) {
+    return {
+      before() {
+        if (isTypesFile(context.physicalFilename ?? context.filename)) {
+          return false;
+        }
+      },
+
+      // Only `export interface X` / `export type X = …` are both module scope
+      // *and* consumed elsewhere, which is the syntactic signal that the type
+      // belongs in types.ts. File-local types are intentionally local and are
+      // exempt, and so are re-exports (`export type { X }`, `export type *`),
+      // which carry no declaration of their own.
+      ExportNamedDeclaration(node) {
+        const { declaration } = node;
+        if (
+          declaration?.type !== 'TSInterfaceDeclaration' &&
+          declaration?.type !== 'TSTypeAliasDeclaration'
+        ) {
+          return;
+        }
+        context.report({
+          node: declaration.id,
+          messageId: 'moveToTypesFile',
+          data: { name: declaration.id.name },
+        });
+      },
+    };
+  },
+});


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Reviewers consistently ask for exported types to be moved into a colocated `types.ts`. Add a `renovate/types-location` oxlint rule that reports `export interface` / `export type` declarations outside such a file, and turn it on across `lib/modules`.

Re-exports (`export type { X }`, `export type *`), file-local types, and values (enums, classes, functions) are left alone. `schema.ts` files and `schema/` directories are excluded via config.


## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45214
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @secustor  will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
