### PR TITLE
docs: point to `logLevelRemap` for `minimumReleaseAgeBehaviour=timestamp-optional` warnings

### DIFF
--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -29,6 +29,25 @@ The following configuration options can be used to enable and tune the functiona
 - [`minimumReleaseAgeBehaviour`](../configuration-options.md#minimumreleaseagebehaviour)
 - [`internalChecksFilter`](../configuration-options.md#internalchecksfilter)
 
+### timestamp-optional warning
+
+When `minimumReleaseAgeBehaviour` is set to `timestamp-optional`, renovate will log a warning, which is then also shown on the Dependency Dashboard.
+
+This warning serves to inform users about at least one dependency not being able to adhere to the minimum release age due to the configuration.
+
+In cases where this is not desired, you can remap the warning to a lower log level with `logLevelRemap`:
+
+```json
+{
+  "logLevelRemap": [
+    {
+      "matchMessage": "/Some .+ did not have a releaseTimestamp, but as we're running with minimumReleaseAgeBehaviour=timestamp-optional, proceeding/",
+      "newLogLevel": "info"
+    }
+  ]
+}
+```
+
 ## FAQs
 
 ### Where does the release timestamp need to be set?

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -31,7 +31,7 @@ The following configuration options can be used to enable and tune the functiona
 
 ### `minimumReleaseAgeBehaviour=timestamp-optional` warning
 
-When `minimumReleaseAgeBehaviour` is set to `timestamp-optional`, renovate will log a warning, which is then also shown on the Dependency Dashboard.
+When Renovate runs in `minimumReleaseAgeBehaviour=timestamp-optional`, Renovate will log a warning, which is then also shown on the Dependency Dashboard.
 
 This warning serves to inform users about at least one dependency not being able to adhere to the minimum release age due to the configuration.
 

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -35,7 +35,7 @@ When Renovate runs in `minimumReleaseAgeBehaviour=timestamp-optional`, Renovate 
 
 This warning serves to inform users about at least one dependency not being able to adhere to the minimum release age due to the configuration.
 
-In cases where this is not desired, you can remap the warning to a lower log level with `logLevelRemap`:
+In cases where this is not desired, you can remap the warning to a lower log level with [`logLevelRemap`](../configuration-options.md#loglevelremap):
 
 ```json
 {

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -29,7 +29,7 @@ The following configuration options can be used to enable and tune the functiona
 - [`minimumReleaseAgeBehaviour`](../configuration-options.md#minimumreleaseagebehaviour)
 - [`internalChecksFilter`](../configuration-options.md#internalchecksfilter)
 
-### timestamp-optional warning
+### `minimumReleaseAgeBehaviour=timestamp-optional` warning
 
 When `minimumReleaseAgeBehaviour` is set to `timestamp-optional`, renovate will log a warning, which is then also shown on the Dependency Dashboard.
 

--- a/docs/usage/key-concepts/minimum-release-age.md
+++ b/docs/usage/key-concepts/minimum-release-age.md
@@ -31,7 +31,7 @@ The following configuration options can be used to enable and tune the functiona
 
 ### `minimumReleaseAgeBehaviour=timestamp-optional` warning
 
-When Renovate runs in `minimumReleaseAgeBehaviour=timestamp-optional`, Renovate will log a warning, which is then also shown on the Dependency Dashboard.
+When Renovate runs with `minimumReleaseAgeBehaviour=timestamp-optional`, Renovate will log a warning, which is then also shown on the Dependency Dashboard.
 
 This warning serves to inform users about at least one dependency not being able to adhere to the minimum release age due to the configuration.
 


### PR DESCRIPTION
## Changes

This adds documentation for minimumReleaseAgeBehaviour, explaining how to prevent a warning on all dependency dashboards when using timestamp-optional. 

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This adds the documentation discussed in https://github.com/renovatebot/renovate/discussions/45367#discussioncomment-18145194.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The added configuration example is part of the internal renovate-config `default.json` for a GitHub organization in my workplace.
