### PR TITLE
fix(datasource/docker): update traefik source URL to traefik/traefik

### DIFF
--- a/lib/data/source-urls.json
+++ b/lib/data/source-urls.json
@@ -3,7 +3,7 @@
   "docker": {
     "adminer": "https://github.com/vrana/adminer",
     "amd64/registry": "https://github.com/distribution/distribution",
-    "amd64/traefik": "https://github.com/containous/traefik",
+    "amd64/traefik": "https://github.com/traefik/traefik",
     "confluentinc/ksqldb-cli": "https://github.com/confluentinc/ksql",
     "confluentinc/ksqldb-server": "https://github.com/confluentinc/ksql",
     "coredns/coredns": "https://github.com/coredns/coredns",
@@ -29,7 +29,7 @@
     "prom/blackbox-exporter": "https://github.com/prometheus/blackbox_exporter",
     "registry": "https://github.com/distribution/distribution",
     "timberio/vector": "https://github.com/vectordotdev/vector",
-    "traefik": "https://github.com/containous/traefik",
+    "traefik": "https://github.com/traefik/traefik",
     "xpkg.upbound.io/upbound/provider-gcp": "https://github.com/upbound/provider-gcp"
   },
   "helm": {


### PR DESCRIPTION
## Changes

`traefik` and `amd64/traefik` still map to `containous/traefik`, an org renamed to `traefik` in 2020,
so Traefik update PRs title their release notes with the old org 

Example here: traefik/traefik-helm-chart#1981.

## Context



- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Claude Code (Opus 5) investigated the root cause and drafted this PR body. The change itself is two
data lines. The registry labels and the `addMetaData()` / `_getLabels()` behaviour were verified
against the live `library/traefik` image.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @mloiseleur will read and reply directly.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only

The public repository: https://github.com/traefik/traefik-helm-chart
