### PR TITLE
fix(changelog): dedupe releases which are equal for the versioning in use

### DIFF
--- a/lib/workers/repository/update/pr/changelog/github/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.spec.ts
@@ -1,6 +1,7 @@
 import * as httpMock from '~test/http-mock.ts';
 import { partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../../../../config/global.ts';
+import * as dockerVersioning from '../../../../../../modules/versioning/docker/index.ts';
 import * as semverVersioning from '../../../../../../modules/versioning/semver/index.ts';
 import * as githubGraphql from '../../../../../../util/github/graphql/index.ts';
 import type { GithubTagItem } from '../../../../../../util/github/graphql/types.ts';
@@ -249,6 +250,26 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
           releases: [{ version: '0.9.0' }],
         }),
       ).toBeNull();
+    });
+
+    it('deduplicates releases which are equal for the versioning in use', async () => {
+      expect(
+        await getChangeLogJSON({
+          ...upgrade,
+          versioning: dockerVersioning.id,
+          currentVersion: 'v2.2.2',
+          newVersion: 'v2.5.2',
+          releases: [
+            { version: '2.2.2' },
+            { version: '2.3.0' },
+            { version: 'v2.3.0' },
+            { version: '2.5.2' },
+            { version: 'v2.5.2' },
+          ],
+        }),
+      ).toMatchObject({
+        versions: [{ version: 'v2.5.2' }, { version: 'v2.3.0' }],
+      });
     });
 
     it('supports github enterprise and github.com changelog', async () => {

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -132,7 +132,14 @@ export abstract class ChangeLogSource {
     // This extra filter/sort should not be necessary, but better safe than sorry
     const validReleases = [...releases]
       .filter((release) => versioningApi.isVersion(release.version))
-      .sort((a, b) => versioningApi.sortVersions(a.version, b.version));
+      .sort((a, b) => versioningApi.sortVersions(a.version, b.version))
+      // Drop versions equal under this versioning, e.g. the Docker tags
+      // `3.7.12` and `v3.7.12`, else their notes are rendered twice
+      .filter(
+        (release, index, sorted) =>
+          index === sorted.length - 1 ||
+          !versioningApi.equals(release.version, sorted[index + 1].version),
+      );
 
     if (validReleases.length < 2) {
       logger.debug(


### PR DESCRIPTION
## Changes

Docker Hub publishes `3.7.12` and `v3.7.12` for one release. `sortAndRemoveDuplicates()` compares raw
strings, so both reach `config.releases`, and the consecutive-pair walk in `getChangeLogJSON()` then
renders the notes twice — the second with a `v3.7.12...v3.7.12` compare link.

Example: traefik/traefik-helm-chart#1981.

Fixed here rather than in `sortAndRemoveDuplicates()`: `docker` versioning has no `getNewValue()`, so
deduping at the datasource layer could change which literal tag gets written.

## Context

Closes https://github.com/renovatebot/renovate/issues/13037

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Claude Code (Opus 5) wrote the fix, the unit test and this PR body, under my review.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @mloiseleur will read and reply directly.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests

The public repository: https://github.com/traefik/traefik-helm-chart
