### PR TITLE
refactor(instrumentation): instrument changelog generation

### DIFF
--- a/lib/workers/repository/update/pr/changelog/index.ts
+++ b/lib/workers/repository/update/pr/changelog/index.ts
@@ -1,4 +1,5 @@
 import { isNullOrUndefined } from '@sindresorhus/is';
+import { instrument } from '../../../../../instrumentation/index.ts';
 import { logger } from '../../../../../logger/index.ts';
 import * as allVersioning from '../../../../../modules/versioning/index.ts';
 import { detectPlatform } from '../../../../../util/common.ts';
@@ -12,44 +13,46 @@ export * from './types.ts';
 export async function getChangeLogJSON(
   config: BranchUpgradeConfig,
 ): Promise<ChangeLogResult | null> {
-  const { sourceUrl, versioning, currentVersion, newVersion } = config;
-  try {
-    if (!(sourceUrl && currentVersion && newVersion)) {
-      return null;
-    }
-    const versioningApi = allVersioning.get(versioning);
-    if (versioningApi.equals(currentVersion, newVersion)) {
-      return null;
-    }
-    logger.debug(
-      `Fetching changelog: ${sourceUrl} (${currentVersion} -> ${newVersion})`,
-    );
-
-    const platform = detectPlatform(sourceUrl);
-
-    if (isNullOrUndefined(platform)) {
-      logger.info(
-        { sourceUrl, hostType: platform },
-        'Unknown platform, skipping changelog fetching.',
+  return await instrument('getChangeLogJSON()', async () => {
+    const { sourceUrl, versioning, currentVersion, newVersion } = config;
+    try {
+      if (!(sourceUrl && currentVersion && newVersion)) {
+        return null;
+      }
+      const versioningApi = allVersioning.get(versioning);
+      if (versioningApi.equals(currentVersion, newVersion)) {
+        return null;
+      }
+      logger.debug(
+        `Fetching changelog: ${sourceUrl} (${currentVersion} -> ${newVersion})`,
       );
+
+      const platform = detectPlatform(sourceUrl);
+
+      if (isNullOrUndefined(platform)) {
+        logger.info(
+          { sourceUrl, hostType: platform },
+          'Unknown platform, skipping changelog fetching.',
+        );
+        return null;
+      }
+
+      const changeLogSource = getChangeLogSourceFor(platform);
+
+      if (isNullOrUndefined(changeLogSource)) {
+        logger.info(
+          { sourceUrl, hostType: platform },
+          'Unknown changelog source, skipping changelog fetching.',
+        );
+        return null;
+      }
+
+      return await changeLogSource.getChangeLogJSON(config);
+    } catch (err) /* istanbul ignore next */ {
+      logger.error({ config, err }, 'getChangeLogJSON error');
       return null;
     }
-
-    const changeLogSource = getChangeLogSourceFor(platform);
-
-    if (isNullOrUndefined(changeLogSource)) {
-      logger.info(
-        { sourceUrl, hostType: platform },
-        'Unknown changelog source, skipping changelog fetching.',
-      );
-      return null;
-    }
-
-    return await changeLogSource.getChangeLogJSON(config);
-  } catch (err) /* istanbul ignore next */ {
-    logger.error({ config, err }, 'getChangeLogJSON error');
-    return null;
-  }
+  });
 }
 
 export function getChangeLogSourceFor(

--- a/lib/workers/repository/update/pr/changelog/release-notes.ts
+++ b/lib/workers/repository/update/pr/changelog/release-notes.ts
@@ -1,6 +1,7 @@
 import { isDate, isTruthy, isUndefined } from '@sindresorhus/is';
 import { DateTime } from 'luxon';
 import MarkdownIt from 'markdown-it';
+import { instrument } from '../../../../../instrumentation/index.ts';
 import { logger } from '../../../../../logger/index.ts';
 import * as memCache from '../../../../../util/cache/memory/index.ts';
 import * as packageCache from '../../../../../util/cache/package/index.ts';
@@ -152,43 +153,45 @@ export async function getReleaseNotes(
   release: ChangeLogRelease,
   config: BranchUpgradeConfig,
 ): Promise<ChangeLogNotes | null> {
-  const { packageName, depName, repository } = project;
-  const { version, gitRef } = release;
-  // TODO: types (#22198)
-  logger.trace(
-    `getReleaseNotes(${repository}, ${version}, ${packageName!}, ${depName!})`,
-  );
-  const releases = await getCachedReleaseList(project, release);
-  logger.trace({ releases }, 'Release list from getReleaseList');
-  let releaseNotes: ChangeLogNotes | null = null;
-
-  let matchedRelease = getExactReleaseMatch(
-    packageName!,
-    depName!,
-    version,
-    releases,
-  );
-  if (isUndefined(matchedRelease)) {
-    // no exact match of a release then check other cases
-    matchedRelease = releases.find(
-      (r) =>
-        r.tag === version ||
-        r.tag === `v${version}` ||
-        r.tag === gitRef ||
-        r.tag === `v${gitRef}`,
+  return await instrument('getReleaseNotes', async () => {
+    const { packageName, depName, repository } = project;
+    const { version, gitRef } = release;
+    // TODO: types (#22198)
+    logger.trace(
+      `getReleaseNotes(${repository}, ${version}, ${packageName!}, ${depName!})`,
     );
-  }
-  if (isUndefined(matchedRelease) && config.extractVersion) {
-    const extractVersionRegEx = regEx(config.extractVersion);
-    matchedRelease = releases.find((r) => {
-      const extractedVersion = extractVersionRegEx.exec(r.tag!)?.groups
-        ?.version;
-      return version === extractedVersion;
-    });
-  }
-  releaseNotes = await releaseNotesResult(matchedRelease, project);
-  logger.trace({ releaseNotes });
-  return releaseNotes;
+    const releases = await getCachedReleaseList(project, release);
+    logger.trace({ releases }, 'Release list from getReleaseList');
+    let releaseNotes: ChangeLogNotes | null = null;
+
+    let matchedRelease = getExactReleaseMatch(
+      packageName!,
+      depName!,
+      version,
+      releases,
+    );
+    if (isUndefined(matchedRelease)) {
+      // no exact match of a release then check other cases
+      matchedRelease = releases.find(
+        (r) =>
+          r.tag === version ||
+          r.tag === `v${version}` ||
+          r.tag === gitRef ||
+          r.tag === `v${gitRef}`,
+      );
+    }
+    if (isUndefined(matchedRelease) && config.extractVersion) {
+      const extractVersionRegEx = regEx(config.extractVersion);
+      matchedRelease = releases.find((r) => {
+        const extractedVersion = extractVersionRegEx.exec(r.tag!)?.groups
+          ?.version;
+        return version === extractedVersion;
+      });
+    }
+    releaseNotes = await releaseNotesResult(matchedRelease, project);
+    logger.trace({ releaseNotes });
+    return releaseNotes;
+  });
 }
 
 function getExactReleaseMatch(
@@ -478,52 +481,54 @@ export async function addReleaseNotes(
   config: BranchUpgradeConfig,
   source: ChangeLogSource,
 ): Promise<ChangeLogResult | null> {
-  if (!input?.versions || !input.project?.type) {
-    logger.debug('Missing project or versions');
-    return input ?? null;
-  }
-  const output: ChangeLogResult = {
-    ...input,
-    versions: [],
-    hasReleaseNotes: false,
-  };
-
-  const { repository, sourceDirectory, type: projectType } = input.project;
-  const cacheNamespace: PackageCacheNamespace = `changelog-${projectType}-notes@v2`;
-  const cacheKeyPrefix = sourceDirectory
-    ? `${repository}:${sourceDirectory}`
-    : `${repository}`;
-
-  for (const v of input.versions) {
-    let releaseNotes: ChangeLogNotes | null | undefined;
-    const gitRefCachePart = v.gitRef ? `:${v.gitRef}` : '';
-    const cacheKey = `${cacheKeyPrefix}:${v.version}${gitRefCachePart}`;
-    releaseNotes = await packageCache.get(cacheNamespace, cacheKey);
-    releaseNotes ??= await getReleaseNotesMd(input.project, v, source);
-    releaseNotes ??= await getReleaseNotes(input.project, v, config);
-
-    // If there is no release notes, at least try to show the compare URL
-    if (!releaseNotes && v.compare.url) {
-      releaseNotes = { url: v.compare.url, notesSourceUrl: '' };
+  return await instrument(`addReleaseNotes`, async () => {
+    if (!input?.versions || !input.project?.type) {
+      logger.debug('Missing project or versions');
+      return input ?? null;
     }
+    const output: ChangeLogResult = {
+      ...input,
+      versions: [],
+      hasReleaseNotes: false,
+    };
 
-    const cacheMinutes = releaseNotesCacheMinutes(v.date);
-    await packageCache.set(
-      cacheNamespace,
-      cacheKey,
-      releaseNotes,
-      cacheMinutes,
-    );
-    output.versions!.push({
-      ...v,
-      releaseNotes: releaseNotes!,
-    });
+    const { repository, sourceDirectory, type: projectType } = input.project;
+    const cacheNamespace: PackageCacheNamespace = `changelog-${projectType}-notes@v2`;
+    const cacheKeyPrefix = sourceDirectory
+      ? `${repository}:${sourceDirectory}`
+      : `${repository}`;
 
-    if (releaseNotes) {
-      output.hasReleaseNotes = true;
+    for (const v of input.versions) {
+      let releaseNotes: ChangeLogNotes | null | undefined;
+      const gitRefCachePart = v.gitRef ? `:${v.gitRef}` : '';
+      const cacheKey = `${cacheKeyPrefix}:${v.version}${gitRefCachePart}`;
+      releaseNotes = await packageCache.get(cacheNamespace, cacheKey);
+      releaseNotes ??= await getReleaseNotesMd(input.project, v, source);
+      releaseNotes ??= await getReleaseNotes(input.project, v, config);
+
+      // If there is no release notes, at least try to show the compare URL
+      if (!releaseNotes && v.compare.url) {
+        releaseNotes = { url: v.compare.url, notesSourceUrl: '' };
+      }
+
+      const cacheMinutes = releaseNotesCacheMinutes(v.date);
+      await packageCache.set(
+        cacheNamespace,
+        cacheKey,
+        releaseNotes,
+        cacheMinutes,
+      );
+      output.versions!.push({
+        ...v,
+        releaseNotes: releaseNotes!,
+      });
+
+      if (releaseNotes) {
+        output.hasReleaseNotes = true;
+      }
     }
-  }
-  return output;
+    return output;
+  });
 }
 
 /**

--- a/lib/workers/repository/update/pr/changelog/releases.ts
+++ b/lib/workers/repository/update/pr/changelog/releases.ts
@@ -1,4 +1,5 @@
 // TODO #22198
+import { instrument } from '../../../../../instrumentation/index.ts';
 import { logger } from '../../../../../logger/index.ts';
 import type { Release } from '../../../../../modules/datasource/index.ts';
 import {
@@ -33,69 +34,73 @@ function matchesUnstable(
 export async function getInRangeReleases(
   config: BranchUpgradeConfig,
 ): Promise<Release[] | null> {
-  const versioning = config.versioning!;
-  const currentVersion = config.currentVersion!;
-  const newVersion = config.newVersion!;
-  const depName = config.depName!;
-  const datasource = config.datasource!;
-  // istanbul ignore if
-  if (!isGetPkgReleasesConfig(config)) {
-    return null;
-  }
-  try {
-    const pkgReleases = (await getPkgReleases(config))!.releases;
-    const version = get(versioning);
+  return await instrument(`getInRangeReleases`, async () => {
+    const versioning = config.versioning!;
+    const currentVersion = config.currentVersion!;
+    const newVersion = config.newVersion!;
+    const depName = config.depName!;
+    const datasource = config.datasource!;
+    // istanbul ignore if
+    if (!isGetPkgReleasesConfig(config)) {
+      return null;
+    }
+    try {
+      const pkgReleases = (await getPkgReleases(config))!.releases;
+      const version = get(versioning);
 
-    const previousReleases = pkgReleases
-      .filter((release) =>
-        version.isCompatible(release.version, currentVersion),
-      )
-      .filter((release) => !version.isGreaterThan(release.version, newVersion))
-      .filter(
+      const previousReleases = pkgReleases
+        .filter((release) =>
+          version.isCompatible(release.version, currentVersion),
+        )
+        .filter(
+          (release) => !version.isGreaterThan(release.version, newVersion),
+        )
+        .filter(
+          (release) =>
+            version.isStable(release.version) ||
+            matchesUnstable(version, currentVersion, release.version) ||
+            matchesUnstable(version, newVersion, release.version),
+        );
+
+      const releases = previousReleases.filter(
         (release) =>
-          version.isStable(release.version) ||
-          matchesUnstable(version, currentVersion, release.version) ||
-          matchesUnstable(version, newVersion, release.version),
+          version.equals(release.version, currentVersion) ||
+          version.isGreaterThan(release.version, currentVersion),
       );
 
-    const releases = previousReleases.filter(
-      (release) =>
-        version.equals(release.version, currentVersion) ||
-        version.isGreaterThan(release.version, currentVersion),
-    );
+      /**
+       * If there is only one release, it can be one of two things:
+       *
+       *   1. There really is only one release
+       *
+       *   2. Pinned version doesn't actually exist, i.e pinning `^1.2.3` to `1.2.3`
+       *      while only `1.2.2` and `1.2.4` exist.
+       */
+      if (releases.length === 1) {
+        const newRelease = releases[0];
+        const closestPreviousRelease = previousReleases
+          .filter((release) => !version.equals(release.version, newVersion))
+          .sort((b, a) => version.sortVersions(a.version, b.version))
+          .shift();
 
-    /**
-     * If there is only one release, it can be one of two things:
-     *
-     *   1. There really is only one release
-     *
-     *   2. Pinned version doesn't actually exist, i.e pinning `^1.2.3` to `1.2.3`
-     *      while only `1.2.2` and `1.2.4` exist.
-     */
-    if (releases.length === 1) {
-      const newRelease = releases[0];
-      const closestPreviousRelease = previousReleases
-        .filter((release) => !version.equals(release.version, newVersion))
-        .sort((b, a) => version.sortVersions(a.version, b.version))
-        .shift();
-
-      if (
-        closestPreviousRelease &&
-        closestPreviousRelease.version !== newRelease.version
-      ) {
-        releases.unshift(closestPreviousRelease);
+        if (
+          closestPreviousRelease &&
+          closestPreviousRelease.version !== newRelease.version
+        ) {
+          releases.unshift(closestPreviousRelease);
+        }
       }
-    }
 
-    if (version.valueToVersion) {
-      for (const release of coerceArray(releases)) {
-        release.version = version.valueToVersion(release.version);
+      if (version.valueToVersion) {
+        for (const release of coerceArray(releases)) {
+          release.version = version.valueToVersion(release.version);
+        }
       }
+      return releases;
+    } catch (err) /* istanbul ignore next */ {
+      logger.debug({ err }, 'getInRangeReleases err');
+      logger.debug(`Error getting releases for ${depName} from ${datasource}`);
+      return null;
     }
-    return releases;
-  } catch (err) /* istanbul ignore next */ {
-    logger.debug({ err }, 'getInRangeReleases err');
-    logger.debug(`Error getting releases for ${depName} from ${datasource}`);
-    return null;
-  }
+  });
 }

--- a/lib/workers/repository/update/pr/changelog/source.ts
+++ b/lib/workers/repository/update/pr/changelog/source.ts
@@ -5,6 +5,7 @@ import {
   isNullOrUndefined,
   isTruthy,
 } from '@sindresorhus/is';
+import { instrument } from '../../../../../instrumentation/index.ts';
 import { logger } from '../../../../../logger/index.ts';
 import { getPkgReleases } from '../../../../../modules/datasource/index.ts';
 import type { Release } from '../../../../../modules/datasource/types.ts';
@@ -90,145 +91,160 @@ export abstract class ChangeLogSource {
   public async getChangeLogJSON(
     config: BranchUpgradeConfig,
   ): Promise<ChangeLogResult | null> {
-    logger.trace(`getChangeLogJSON for ${this.platform}`);
+    return await instrument(
+      `source.getChangeLogJSON(${this.platform})`,
+      async () => {
+        logger.trace(`getChangeLogJSON for ${this.platform}`);
 
-    const versioning = config.versioning!;
-    const currentVersion = config.currentVersion!;
-    const newVersion = config.newVersion!;
-    const sourceUrl = config.sourceUrl!;
-    const packageName = config.packageName!;
-    const depName = config.depName!;
-    const sourceDirectory = config.sourceDirectory;
-    const versioningApi = allVersioning.get(versioning);
+        const versioning = config.versioning!;
+        const currentVersion = config.currentVersion!;
+        const newVersion = config.newVersion!;
+        const sourceUrl = config.sourceUrl!;
+        const packageName = config.packageName!;
+        const depName = config.depName!;
+        const sourceDirectory = config.sourceDirectory;
+        const versioningApi = allVersioning.get(versioning);
 
-    if (this.shouldSkipPackage(config)) {
-      return null;
-    }
+        if (this.shouldSkipPackage(config)) {
+          return null;
+        }
 
-    const baseUrl = this.getBaseUrl(config);
-    const apiBaseUrl = this.getAPIBaseUrl(config);
-    const repository = this.getRepositoryFromUrl(config);
+        const baseUrl = this.getBaseUrl(config);
+        const apiBaseUrl = this.getAPIBaseUrl(config);
+        const repository = this.getRepositoryFromUrl(config);
 
-    const tokenResponse = this.hasValidToken(config);
-    if (!tokenResponse.isValid) {
-      if (tokenResponse.error) {
-        return {
-          error: tokenResponse.error,
-        };
-      }
-      return null;
-    }
+        const tokenResponse = this.hasValidToken(config);
+        if (!tokenResponse.isValid) {
+          if (tokenResponse.error) {
+            return {
+              error: tokenResponse.error,
+            };
+          }
+          return null;
+        }
 
-    if (isFalsy(this.hasValidRepository(repository))) {
-      logger.debug(`Invalid ${this.platform} URL found: ${sourceUrl}`);
-      return null;
-    }
+        if (isFalsy(this.hasValidRepository(repository))) {
+          logger.debug(`Invalid ${this.platform} URL found: ${sourceUrl}`);
+          return null;
+        }
 
-    const releases = config.releases ?? (await getInRangeReleases(config));
-    if (!releases?.length) {
-      logger.debug('No releases');
-      return null;
-    }
-    // This extra filter/sort should not be necessary, but better safe than sorry
-    const validReleases = [...releases]
-      .filter((release) => versioningApi.isVersion(release.version))
-      .sort((a, b) => versioningApi.sortVersions(a.version, b.version))
-      // Drop versions equal under this versioning, e.g. the Docker tags
-      // `3.7.12` and `v3.7.12`, else their notes are rendered twice
-      .filter(
-        (release, index, sorted) =>
-          index === sorted.length - 1 ||
-          !versioningApi.equals(release.version, sorted[index + 1].version),
-      );
+        const releases = config.releases ?? (await getInRangeReleases(config));
+        if (!releases?.length) {
+          logger.debug('No releases');
+          return null;
+        }
+        // This extra filter/sort should not be necessary, but better safe than sorry
+        const validReleases = [...releases]
+          .filter((release) => versioningApi.isVersion(release.version))
+          .sort((a, b) => versioningApi.sortVersions(a.version, b.version))
+          // Drop versions equal under this versioning, e.g. the Docker tags
+          // `3.7.12` and `v3.7.12`, else their notes are rendered twice
+          .filter(
+            (release, index, sorted) =>
+              index === sorted.length - 1 ||
+              !versioningApi.equals(release.version, sorted[index + 1].version),
+          );
 
-    if (validReleases.length < 2) {
-      logger.debug(
-        `Not enough valid releases for dep ${depName} (${packageName})`,
-      );
-      return null;
-    }
+        if (validReleases.length < 2) {
+          logger.debug(
+            `Not enough valid releases for dep ${depName} (${packageName})`,
+          );
+          return null;
+        }
 
-    const changelogReleases: ChangeLogRelease[] = [];
+        const changelogReleases: ChangeLogRelease[] = [];
 
-    // Check if `v` belongs to the range (currentVersion, newVersion]
-    function inRange(v: string): boolean {
-      return (
-        versioningApi.isGreaterThan(v, currentVersion) &&
-        !versioningApi.isGreaterThan(v, newVersion)
-      );
-    }
-
-    const getTags = memoize(() => this.getAllTags(apiBaseUrl, repository));
-    for (let i = 1; i < validReleases.length; i += 1) {
-      const prev = validReleases[i - 1];
-      const next = validReleases[i];
-      if (!inRange(next.version)) {
-        continue;
-      }
-      let release = await packageCache.get(
-        this.cacheNamespace,
-        this.getCacheKey(sourceUrl, packageName, prev.version, next.version),
-      );
-      if (!release) {
-        release = {
-          version: next.version,
-          date: next.releaseTimestamp,
-          gitRef: next.gitRef,
-          // put empty changes so that existing templates won't break
-          changes: [],
-          compare: {},
-        };
-        const tags = await getTags();
-        const prevHead = this.getRef(
-          versioningApi,
-          packageName,
-          depName,
-          prev,
-          tags,
-        );
-        const nextHead = this.getRef(
-          versioningApi,
-          packageName,
-          depName,
-          next,
-          tags,
-        );
-        if (isNonEmptyString(prevHead) && isNonEmptyString(nextHead)) {
-          release.compare.url = this.getCompareURL(
-            baseUrl,
-            repository,
-            prevHead,
-            nextHead,
+        // Check if `v` belongs to the range (currentVersion, newVersion]
+        function inRange(v: string): boolean {
+          return (
+            versioningApi.isGreaterThan(v, currentVersion) &&
+            !versioningApi.isGreaterThan(v, newVersion)
           );
         }
-        const cacheMinutes = 55;
-        await packageCache.set(
-          this.cacheNamespace,
-          this.getCacheKey(sourceUrl, packageName, prev.version, next.version),
-          release,
-          cacheMinutes,
-        );
-      }
-      changelogReleases.unshift(release);
-    }
 
-    let res: ChangeLogResult | null = {
-      project: {
-        apiBaseUrl,
-        baseUrl,
-        type: this.platform,
-        repository,
-        sourceUrl,
-        sourceDirectory,
-        packageName,
-        depName,
+        const getTags = memoize(() => this.getAllTags(apiBaseUrl, repository));
+        for (let i = 1; i < validReleases.length; i += 1) {
+          const prev = validReleases[i - 1];
+          const next = validReleases[i];
+          if (!inRange(next.version)) {
+            continue;
+          }
+          let release = await packageCache.get(
+            this.cacheNamespace,
+            this.getCacheKey(
+              sourceUrl,
+              packageName,
+              prev.version,
+              next.version,
+            ),
+          );
+          if (!release) {
+            release = {
+              version: next.version,
+              date: next.releaseTimestamp,
+              gitRef: next.gitRef,
+              // put empty changes so that existing templates won't break
+              changes: [],
+              compare: {},
+            };
+            const tags = await getTags();
+            const prevHead = this.getRef(
+              versioningApi,
+              packageName,
+              depName,
+              prev,
+              tags,
+            );
+            const nextHead = this.getRef(
+              versioningApi,
+              packageName,
+              depName,
+              next,
+              tags,
+            );
+            if (isNonEmptyString(prevHead) && isNonEmptyString(nextHead)) {
+              release.compare.url = this.getCompareURL(
+                baseUrl,
+                repository,
+                prevHead,
+                nextHead,
+              );
+            }
+            const cacheMinutes = 55;
+            await packageCache.set(
+              this.cacheNamespace,
+              this.getCacheKey(
+                sourceUrl,
+                packageName,
+                prev.version,
+                next.version,
+              ),
+              release,
+              cacheMinutes,
+            );
+          }
+          changelogReleases.unshift(release);
+        }
+
+        let res: ChangeLogResult | null = {
+          project: {
+            apiBaseUrl,
+            baseUrl,
+            type: this.platform,
+            repository,
+            sourceUrl,
+            sourceDirectory,
+            packageName,
+            depName,
+          },
+          versions: changelogReleases,
+        };
+
+        res = await addReleaseNotes(res, config, this);
+
+        return res;
       },
-      versions: changelogReleases,
-    };
-
-    res = await addReleaseNotes(res, config, this);
-
-    return res;
+    );
   }
 
   private findTagOfRelease(


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As part of follow-up changes, we'll be making changes to the changelog functionality (see #45502 and #45503, stacked on top of this PR).

To determine more meaningful insight into whether this has succeeded, we can add instrumentation to determine how many HTTP calls are being made.

**Bottom of the stack** — #45502 and #45503 are stacked on top of this PR.

## Context

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):



### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
