### PR TITLE
fix(datasource/docker): add netbox source URL

### DIFF
--- a/lib/data/source-urls.json
+++ b/lib/data/source-urls.json
@@ -15,6 +15,7 @@
     "drone/drone-runner-kube": "https://github.com/drone-runners/drone-runner-kube",
     "drone/drone-runner-ssh": "https://github.com/drone-runners/drone-runner-ssh",
     "gcr.io/kaniko-project/executor": "https://github.com/GoogleContainerTools/kaniko",
+    "ghcr.io/netbox-community/netbox": "https://github.com/netbox-community/netbox",
     "gitea/gitea": "https://github.com/go-gitea/gitea",
     "gitlab/gitlab-ce": "https://gitlab.com/gitlab-org/gitlab-foss",
     "gitlab/gitlab-runner": "https://gitlab.com/gitlab-org/gitlab-runner",


### PR DESCRIPTION
### Changes

Adds one `docker` entry mapping `ghcr.io/netbox-community/netbox` to
`https://github.com/netbox-community/netbox`.

### Context

The NetBox application image labels its source as the repository that *builds* it, not the one
that releases it:

```
$ (config labels for ghcr.io/netbox-community/netbox:v4.6.9)
org.opencontainers.image.source   https://github.com/netbox-community/netbox-docker.git
```

`netbox-docker` and NetBox itself use different version schemes, so a changelog lookup for an
application version finds nothing in the labelled repository:

| Repository | Release tags | `v4.6.9` present |
|---|---|---|
| `netbox-community/netbox-docker` (labelled) | `5.0.2`, `5.0.1`, `5.0.0`, `4.0.2` | ✗ 404 |
| `netbox-community/netbox` (this PR) | `v4.6.9`, … | ✓ 3,660-char body |

So users tracking the image get an update PR with no release notes attached, for a Django
application whose releases are where schema migrations are announced.

This is the case `source-urls.json` documents itself as being for — *"Only necessary when the
changelog data cannot be found in the package's source repository"*. The labelled repository is
arguably correct as provenance; it just isn't where the changelog is.

### Why not `packageRules.sourceUrl`

Configuring it locally does not work for this: a datasource-supplied `sourceUrl` wins over the
`packageRules` value. The rule is accepted and echoed in config, but the resolved dependency still
carries the label value. Tested against `renovate/renovate:43`:

```
"sourceUrl": "https://github.com/netbox-community/netbox-docker",
"lookupName": "netbox-community/netbox",
"currentVersion": "v4.6.8",  →  "newValue": "v4.6.9"
```

Same behaviour reported in discussion #41505.

### Verification

- Key is `packageName.toLowerCase()` per `addMetaData` in `lib/modules/datasource/metadata.ts`;
  the observed `packageName` for this image is registry-qualified (`ghcr.io/netbox-community/netbox`),
  which is how the key is written.
- Matches the inner key pattern in `tools/schemas/source-urls-schema.json`.
- Inserted in alphabetical position (between `gcr.io/kaniko-project/executor` and `gitea/gitea`) to
  satisfy the sorted-keys test added in #41722.
- File parses; `docker` keys verified still sorted.
