### PR TITLE
fix(manager/copier): set `isExecutable` on added and modified files

### DIFF
--- a/lib/modules/manager/copier/artifacts.spec.ts
+++ b/lib/modules/manager/copier/artifacts.spec.ts
@@ -1,3 +1,4 @@
+import type { Stats } from 'node:fs';
 import upath from 'upath';
 import { mockDeep } from 'vitest-mock-extended';
 import { mockExecAll } from '~test/exec-util.ts';
@@ -437,6 +438,152 @@ describe('modules/manager/copier/artifacts', () => {
           },
         },
       ]);
+    });
+
+    it('marks files executable when the owner execute bit is set', async () => {
+      mockExecAll();
+
+      git.isFileModeEnabled.mockResolvedValue(true);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          conflicted: [],
+          modified: ['.copier-answers.yml'],
+          not_added: ['bin/deploy.sh'],
+          deleted: [],
+          renamed: [{ from: 'renamed_old.sh', to: 'renamed_new.sh' }],
+        }),
+      );
+
+      fs.readLocalFile.mockResolvedValueOnce(
+        '_src: https://github.com/foo/bar\n_commit: 1.1.0',
+      );
+      fs.readLocalFile.mockResolvedValueOnce('new script contents');
+      fs.readLocalFile.mockResolvedValueOnce('renamed script contents');
+      fs.statLocalFile.mockImplementation((path) =>
+        Promise.resolve(
+          partial<Stats>({
+            isFile: () => true,
+            mode: path === '.copier-answers.yml' ? 0o644 : 0o744,
+          }),
+        ),
+      );
+
+      const result = await updateArtifacts({
+        packageFileName: '.copier-answers.yml',
+        updatedDeps: upgrades,
+        newPackageFileContent: '',
+        config,
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: '.copier-answers.yml',
+            contents: '_src: https://github.com/foo/bar\n_commit: 1.1.0',
+          },
+        },
+        {
+          file: {
+            type: 'addition',
+            path: 'bin/deploy.sh',
+            contents: 'new script contents',
+            isExecutable: true,
+          },
+        },
+        {
+          file: {
+            type: 'deletion',
+            path: 'renamed_old.sh',
+          },
+        },
+        {
+          file: {
+            type: 'addition',
+            path: 'renamed_new.sh',
+            contents: 'renamed script contents',
+            isExecutable: true,
+          },
+        },
+      ]);
+    });
+
+    it('does not mark files executable if they cannot be inspected', async () => {
+      mockExecAll();
+
+      git.isFileModeEnabled.mockResolvedValue(true);
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          conflicted: [],
+          modified: ['.copier-answers.yml'],
+          not_added: ['submodule'],
+          deleted: [],
+          renamed: [],
+        }),
+      );
+
+      fs.readLocalFile.mockResolvedValueOnce(
+        '_src: https://github.com/foo/bar\n_commit: 1.1.0',
+      );
+      fs.readLocalFile.mockResolvedValueOnce(null);
+      fs.statLocalFile.mockImplementation((path) =>
+        Promise.resolve(
+          path === 'submodule'
+            ? partial<Stats>({ isFile: () => false, mode: 0o744 })
+            : null,
+        ),
+      );
+
+      const result = await updateArtifacts({
+        packageFileName: '.copier-answers.yml',
+        updatedDeps: upgrades,
+        newPackageFileContent: '',
+        config,
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: '.copier-answers.yml',
+            contents: '_src: https://github.com/foo/bar\n_commit: 1.1.0',
+          },
+        },
+        {
+          file: {
+            type: 'addition',
+            path: 'submodule',
+            contents: null,
+          },
+        },
+      ]);
+    });
+
+    it('does not inspect file modes when file mode tracking is disabled', async () => {
+      mockExecAll();
+
+      git.isFileModeEnabled.mockResolvedValue(false);
+      fs.readLocalFile.mockResolvedValueOnce(
+        '_src: https://github.com/foo/bar\n_commit: 1.1.0',
+      );
+
+      const result = await updateArtifacts({
+        packageFileName: '.copier-answers.yml',
+        updatedDeps: upgrades,
+        newPackageFileContent: '',
+        config,
+      });
+
+      expect(result).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: '.copier-answers.yml',
+            contents: '_src: https://github.com/foo/bar\n_commit: 1.1.0',
+          },
+        },
+      ]);
+      expect(fs.statLocalFile).not.toHaveBeenCalled();
     });
 
     it('reports an error, but adds conflicts', async () => {

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -3,9 +3,9 @@ import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
-import { readLocalFile } from '../../../util/fs/index.ts';
+import { readLocalFile, statLocalFile } from '../../../util/fs/index.ts';
 import { withGitEnvironment } from '../../../util/git/exec.ts';
-import { getRepoStatus } from '../../../util/git/index.ts';
+import { getRepoStatus, isFileModeEnabled } from '../../../util/git/index.ts';
 import type {
   UpdateArtifact,
   UpdateArtifactsConfig,
@@ -17,7 +17,29 @@ import {
 } from './utils.ts';
 
 const DEFAULT_COMMAND_OPTIONS = ['--skip-answered', '--defaults'];
+const ownerExecutePermission = 0o100;
 const gitExec = withGitEnvironment(['git-tags']);
+
+async function detectExecutable(
+  path: string,
+  canReadFileMode: boolean,
+): Promise<true | undefined> {
+  if (!canReadFileMode) {
+    return undefined;
+  }
+
+  const fileStats = await statLocalFile(path);
+  if (!fileStats?.isFile()) {
+    return undefined;
+  }
+
+  if ((fileStats.mode & ownerExecutePermission) === 0) {
+    return undefined;
+  }
+
+  // Git derives its executable flag from the owner's execute permission.
+  return true;
+}
 
 function buildCommand(
   config: UpdateArtifactsConfig,
@@ -109,6 +131,8 @@ export async function updateArtifacts({
     res.push(...artifactError(packageFileName, msg));
   }
 
+  const canReadFileMode = await isFileModeEnabled();
+
   for (const f of [
     ...status.modified,
     ...status.not_added,
@@ -119,6 +143,7 @@ export async function updateArtifacts({
         type: 'addition',
         path: f,
         contents: await readLocalFile(f),
+        isExecutable: await detectExecutable(f, canReadFileMode),
       },
     };
     if (status.conflicted.includes(f)) {
@@ -154,6 +179,7 @@ export async function updateArtifacts({
         type: 'addition',
         path: f.to,
         contents: await readLocalFile(f.to),
+        isExecutable: await detectExecutable(f.to, canReadFileMode),
       },
     });
   }


### PR DESCRIPTION
## Changes

The copier manager now detects whether files added or modified by `copier update` carry the owner execute bit and propagates that as `isExecutable` on the returned file additions (including renamed files). Previously the flag was never set, so executable files copied from a template (e.g. `bin/deploy.sh`) were committed without the executable bit — `commitFiles` rewrites additions from `contents` and only chmods `+x` when `isExecutable` is set.

Detection mirrors the existing post-upgrade-commands logic: file modes are only inspected when `core.fileMode` is enabled, only regular files are considered, and executability is derived from the owner execute bit, matching how git derives its executable flag.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42239
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @Sanjay-doppalapudi will read and reply directly.

## Documentation (please check one with an [x])

- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests
