### PR TITLE
fix(template): keep unknown variables as literal text

### DIFF
--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -66,12 +66,12 @@ describe('util/http/index', () => {
       });
     });
 
-    it('renders unknown template variables as empty string', () => {
+    it('keeps unknown template variables as literal text', () => {
       GlobalConfig.set({ userAgent: 'my-agent/{{unknownVar}}' });
       const options = {};
       applyDefaultHeaders(options);
       expect(options).toMatchObject({
-        headers: { 'user-agent': 'my-agent/' },
+        headers: { 'user-agent': 'my-agent/{{unknownVar}}' },
       });
     });
 

--- a/lib/util/template/index.spec.ts
+++ b/lib/util/template/index.spec.ts
@@ -41,6 +41,49 @@ describe('util/template/index', () => {
     expect(output).toBe('github token = ""');
   });
 
+  describe('unknown variables', () => {
+    it('preserves unknown variables as literal text', () => {
+      const output = template.compile(
+        'TicketID {{project_template}}: Update dependency',
+        {},
+      );
+      expect(output).toBe('TicketID {{project_template}}: Update dependency');
+    });
+
+    it('is idempotent for values containing literal curly braces', () => {
+      const input = { depName: '{{some_dir}}' };
+      const once = template.compile('Update {{depName}}', input);
+      expect(once).toBe('Update {{some_dir}}');
+      const twice = template.compile(once, input);
+      expect(twice).toBe('Update {{some_dir}}');
+    });
+
+    it('renders allowed but unset fields as empty string', () => {
+      const output = template.compile('version "{{newVersion}}"', {});
+      expect(output).toBe('version ""');
+    });
+
+    it('renders unknown fields present in unfiltered input as empty string', () => {
+      const output = template.compile(
+        'a{{foobar}}b',
+        { foobar: undefined },
+        false,
+      );
+      expect(output).toBe('ab');
+    });
+
+    it('renders nothing for unknown block variables', () => {
+      const output = template.compile('a{{#foobar}}x{{/foobar}}b', {});
+      expect(output).toBe('ab');
+    });
+
+    it('throws for unknown helpers called with arguments', () => {
+      expect(() => template.compile("{{foobar 'baz'}}", {})).toThrow(
+        'Missing helper: "foobar"',
+      );
+    });
+  });
+
   it('exposes renovateVersion to every template, without needing to pass it explicitly', () => {
     const output = template.compile('{{renovateVersion}}', {});
     expect(output).toBe(pkg.version);

--- a/lib/util/template/index.ts
+++ b/lib/util/template/index.ts
@@ -1,6 +1,7 @@
 import {
   isArray,
   isNumber,
+  isObject,
   isPlainObject,
   isPrimitive,
   isString,
@@ -271,6 +272,39 @@ const allowedTemplateFields = new Set([
   ...Object.keys(allowedFields),
   ...exposedConfigOptions,
 ]);
+
+/**
+ * Handlebars invokes the `helperMissing` hook for a mustache like `{{someVar}}`
+ * which matches neither a helper nor a field of the input, and renders an empty
+ * string by default. That destroys data values which themselves contain
+ * handlebars-like syntax, e.g. a directory literally named `{{some_dir}}`
+ * inserted into the output by an earlier pass of nested template compilation.
+ * Keep such unknown references as literal text instead, so that compiling a
+ * template repeatedly is idempotent. References to allowed fields which are
+ * unset, or to fields filtered out by the compile proxy, still render an empty
+ * string, and calling an unknown helper with arguments still throws.
+ */
+handlebars.registerHelper(
+  'helperMissing',
+  // eslint-disable-next-line prefer-arrow-callback
+  function (this: unknown, ...args: unknown[]): unknown {
+    if (args.length !== 1) {
+      // Attempt to call an unknown helper: keep the default behavior
+      throw new Error(
+        `Missing helper: "${(args.at(-1) as { name: string }).name}"`,
+      );
+    }
+    const options = args[0] as HelperOptions & { name: string };
+    if (
+      !options.fn && // block helpers keep rendering the inverse block
+      !allowedTemplateFields.has(options.name) &&
+      !(isObject(this) && Object.hasOwn(this, options.name))
+    ) {
+      return `{{${options.name}}}`;
+    }
+    return undefined;
+  },
+);
 
 class CompileInputProxyHandler implements ProxyHandler<CompileInput> {
   private warnVariables: Set<string>;

--- a/lib/workers/repository/updates/generate.spec.ts
+++ b/lib/workers/repository/updates/generate.spec.ts
@@ -921,6 +921,31 @@ describe('workers/repository/updates/generate', () => {
       );
     });
 
+    it('preserves literal curly braces from data values in commit message and PR title', () => {
+      const branch = [
+        {
+          ...requiredDefaultOptions,
+          commitBodyTable: false,
+          manager: 'some-manager',
+          depName: 'some-dep',
+          packageFile: '{{project_template}}/package.json',
+          parentDir: '{{project_template}}',
+          commitMessagePrefix: 'TicketID {{parentDir}}:',
+          newValue: '1.2.0',
+          isSingleVersion: true,
+          newVersion: '1.2.0',
+          branchName: 'some-branch',
+        },
+      ] satisfies BranchUpgradeConfig[];
+      const res = generateBranchConfig(branch);
+      expect(res.commitMessage).toBe(
+        'TicketID {{project_template}}: Update dependency some-dep to v1.2.0',
+      );
+      expect(res.prTitle).toBe(
+        'TicketID {{project_template}}: Update dependency some-dep to v1.2.0',
+      );
+    });
+
     it('scopes monorepo commits with nested package files using base directory', () => {
       const branch = [
         {


### PR DESCRIPTION
## Changes

Commit messages, PR titles and branch names are compiled multiple times to resolve nested templates. Each extra pass replaced unknown variables with an empty string, which destroyed data values that themselves contain handlebars-like syntax — e.g. a dependency in a directory literally named `{{project_template}}` produced the PR title `TicketID : Update dependency pandas to ~=1.3.4` instead of `TicketID {{project_template}}: Update dependency pandas to ~=1.3.4`.

This PR registers a `helperMissing` hook so that a mustache which matches neither a helper nor a known field is kept as literal text, making repeated compilation idempotent. Behavior is otherwise unchanged: allowed-but-unset fields and fields filtered out by the compile proxy still render an empty string, unknown block variables still render their inverse block, and calling an unknown helper with arguments still throws. Note this means a mistyped variable name now shows up literally in output instead of silently rendering as empty, which also makes such typos easier to spot.

Verified against the wider template surface: the update-generation, custom-manager (regex/jsonata), custom-datasource, PR body, dependency dashboard, onboarding, presets, config-validation and lookup suites all pass unchanged; coverage on `lib/util/template/index.ts` is 100% of branches with all changed lines covered.

One existing expectation was updated to the new semantics: `applyDefaultHeaders` previously rendered an unknown variable in a `userAgent` template as an empty string (producing e.g. `my-agent/`); it now keeps the literal `{{unknownVar}}`, consistent with the rest of this change and making the typo visible instead of silently mangling the user agent.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #12449
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The root-cause analysis, code and tests were produced with substantive assistance from Claude Code (Anthropic), directed and reviewed by me.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @Sanjay-doppalapudi will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
