### PR TITLE
chore(manager/gomod): clarify how artifact updates work with `minimumReleaseAge`

### DIFF
--- a/lib/modules/manager/gomod/artifacts-extra.spec.ts
+++ b/lib/modules/manager/gomod/artifacts-extra.spec.ts
@@ -81,20 +81,20 @@ describe('modules/manager/gomod/artifacts-extra', () => {
 
   describe('getExtraDepsNotice', () => {
     it('returns null when one of files is missing', () => {
-      expect(getExtraDepsNotice(null, goModAfter, [])).toBeNull();
-      expect(getExtraDepsNotice(goModBefore, null, [])).toBeNull();
+      expect(getExtraDepsNotice(null, goModAfter, [], {})).toBeNull();
+      expect(getExtraDepsNotice(goModBefore, null, [], {})).toBeNull();
     });
 
     it('returns null when all dependencies are excluded', () => {
       const excludeDeps = ['go', 'github.com/foo/foo', 'github.com/bar/bar'];
-      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps);
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps, {});
       expect(res).toBeNull();
     });
 
     it('returns a notice when there is an extra dependency', () => {
       const excludeDeps = ['go', 'github.com/foo/foo'];
 
-      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps);
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps, {});
 
       expect(res).toEqual(
         [
@@ -117,7 +117,7 @@ describe('modules/manager/gomod/artifacts-extra', () => {
     it('returns a notice when there are extra dependencies', () => {
       const excludeDeps = ['go'];
 
-      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps);
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps, {});
 
       expect(res).toEqual(
         [
@@ -141,7 +141,7 @@ describe('modules/manager/gomod/artifacts-extra', () => {
     it('adds special notice for updated `go` version', () => {
       const excludeDeps = ['github.com/foo/foo'];
 
-      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps);
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps, {});
 
       expect(res).toEqual(
         [
@@ -190,6 +190,7 @@ describe('modules/manager/gomod/artifacts-extra', () => {
         toolChainUpdategoModBefore,
         toolChainUpdategoModAfter,
         [],
+        {},
       );
 
       expect(res).toEqual(
@@ -239,6 +240,7 @@ describe('modules/manager/gomod/artifacts-extra', () => {
         toolChainUpdategoModBefore,
         toolChainUpdategoModAfter,
         [],
+        {},
       );
 
       expect(res).toEqual(
@@ -288,6 +290,7 @@ describe('modules/manager/gomod/artifacts-extra', () => {
         toolChainUpdategoModBefore,
         toolChainUpdategoModAfter,
         [],
+        {},
       );
 
       expect(res).toEqual(
@@ -304,6 +307,61 @@ describe('modules/manager/gomod/artifacts-extra', () => {
           '| **Package**          | **Change**           |',
           '| :------------------- | :------------------- |',
           '| `github.com/foo/foo` | `v1.0.0` -> `v1.1.1` |',
+          '| `github.com/bar/bar` | `v2.0.0` -> `v2.2.2` |',
+        ].join('\n'),
+      );
+    });
+
+    it('indicates that there are no Minimum Release Age concerns, if `minimumReleaseAge` is set', () => {
+      const excludeDeps = ['github.com/foo/foo'];
+
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps, {
+        minimumReleaseAge: '2 days',
+      });
+
+      expect(res).toEqual(
+        [
+          'In order to perform the update(s) described in the table above, Renovate ran the `go get` command, which resulted in the following additional change(s):',
+          '',
+          '',
+          '- 1 additional dependency was updated',
+          '- The `go` directive was updated for compatibility reasons',
+          '',
+          '',
+          "Due to Go's usage of [Minimal Version Selection (MVS)](https://go.dev/ref/mod#minimal-version-selection), these packages have been updated to the minimum version available, so will still abide by `minimumReleaseAge=2 days`",
+          '',
+          '',
+          'Details:',
+          '',
+          '',
+          '| **Package**          | **Change**           |',
+          '| :------------------- | :------------------- |',
+          '| `go`                 | `1.22.0` -> `1.22.2` |',
+          '| `github.com/bar/bar` | `v2.0.0` -> `v2.2.2` |',
+        ].join('\n'),
+      );
+    });
+
+    it('does not indicates that there are no Minimum Release Age concerns, if `minimumReleaseAge=null`', () => {
+      const excludeDeps = ['go', 'github.com/foo/foo'];
+
+      const res = getExtraDepsNotice(goModBefore, goModAfter, excludeDeps, {
+        minimumReleaseAge: null,
+      });
+
+      expect(res).toEqual(
+        [
+          'In order to perform the update(s) described in the table above, Renovate ran the `go get` command, which resulted in the following additional change(s):',
+          '',
+          '',
+          '- 1 additional dependency was updated',
+          '',
+          '',
+          'Details:',
+          '',
+          '',
+          '| **Package**          | **Change**           |',
+          '| :------------------- | :------------------- |',
           '| `github.com/bar/bar` | `v2.0.0` -> `v2.2.2` |',
         ].join('\n'),
       );

--- a/lib/modules/manager/gomod/artifacts-extra.ts
+++ b/lib/modules/manager/gomod/artifacts-extra.ts
@@ -1,5 +1,6 @@
 import { diffLines } from 'diff';
 import { markdownTable } from 'markdown-table';
+import type { UpdateArtifactsConfig } from '../types.ts';
 import { parseLine } from './line-parser.ts';
 import type { ExtraDep } from './types.ts';
 
@@ -84,6 +85,7 @@ export function getExtraDepsNotice(
   goModBefore: string | null,
   goModAfter: string | null,
   excludeDeps: string[],
+  { minimumReleaseAge }: Pick<UpdateArtifactsConfig, 'minimumReleaseAge'>,
 ): string | null {
   if (!goModBefore || !goModAfter) {
     return null;
@@ -117,6 +119,13 @@ export function getExtraDepsNotice(
   if (goUpdated) {
     noticeLines.push(
       '- The `go` directive was updated for compatibility reasons',
+    );
+  }
+
+  if (minimumReleaseAge) {
+    noticeLines.push('\n');
+    noticeLines.push(
+      `Due to Go's usage of [Minimal Version Selection (MVS)](https://go.dev/ref/mod#minimal-version-selection), these packages have been updated to the minimum version available, so will still abide by \`minimumReleaseAge=${minimumReleaseAge}\``,
     );
   }
 

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -482,6 +482,7 @@ export async function updateArtifacts({
         newGoModContent,
         finalGoModContent,
         updatedDepNames,
+        config,
       );
 
       if (extraDepsNotice) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When Go updates dependencies using i.e. `go get` or `go mod download`,
it uses Minimal Version Selection (MVS)[0], which takes the lowest
version available from the given packages.

In the case of an updated dependency, in practice this means that Go
will chose the version of an indirect (transitive) package dependency as
the version that the updated package points to in their `go.mod`, which
must be older than the updated package, as the updated package has only
just been updated.

This protects against cases in other ecosystems where an unpinned
transitive dependency can be pulled by an updated package, potentially
bypassing `minimumReleaseAge`.

However, I can imagine there may be some questions about this, so we can
preemptively add a note into the `Artifact update notice` when
`minimumReleaseAge` is set.

[0]: https://go.dev/ref/mod#minimal-version-selection

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
