### PR TITLE
fix: automerge outside of schedule when within automergeSchedule

### DIFF
--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -205,6 +205,49 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('checks PR automerge after refreshing statuses when not updating out of schedule', async () => {
+      schedule.isScheduledNow.mockImplementation(
+        (_config, scheduleKey) => scheduleKey === 'automergeSchedule',
+      );
+      config.updateNotScheduled = false;
+      config.automerge = true;
+      config.statusCheckNames = {
+        artifactError: null,
+        configValidation: null,
+        mergeConfidence: null,
+        minimumReleaseAge: 'renovate/stability-days',
+      };
+      config.upgrades = partial<BranchUpgradeConfig>([
+        {
+          minimumReleaseAge: '1 day',
+          releaseTimestamp: '2019-01-01' as Timestamp,
+        },
+      ]);
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+        }),
+      );
+      platform.getBranchStatusCheck.mockResolvedValue(null);
+      prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
+
+      const res = await branchWorker.processBranch(config);
+
+      expect(res).toEqual({
+        branchExists: true,
+        commitSha: null,
+        result: 'automerged',
+      });
+      expect(prAutomerge.checkAutoMerge).toHaveBeenCalledTimes(1);
+      expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
+      expect(platform.setBranchStatus).toHaveBeenCalledTimes(1);
+      expect(platform.setBranchStatus.mock.invocationCallOrder[0]).toBeLessThan(
+        prAutomerge.checkAutoMerge.mock.invocationCallOrder[0],
+      );
+    });
+
     it('skips branch for fresh release with minimumReleaseAge', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(true);
       config.prCreation = 'not-pending';

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -248,6 +248,45 @@ describe('workers/repository/update/branch/index', () => {
       );
     });
 
+    it('skips branch update when PR is not automerged outside schedule', async () => {
+      schedule.isScheduledNow.mockImplementation(
+        (_config, scheduleKey) => scheduleKey === 'automergeSchedule',
+      );
+      config.updateNotScheduled = false;
+      config.automerge = true;
+      config.statusCheckNames = {
+        artifactError: null,
+        configValidation: null,
+        mergeConfidence: null,
+        minimumReleaseAge: 'renovate/stability-days',
+      };
+      config.upgrades = partial<BranchUpgradeConfig>([
+        {
+          minimumReleaseAge: '1 day',
+          releaseTimestamp: '2019-01-01' as Timestamp,
+        },
+      ]);
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+        }),
+      );
+      platform.getBranchStatusCheck.mockResolvedValue(null);
+      prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: false });
+
+      const res = await branchWorker.processBranch(config);
+
+      expect(res).toEqual({
+        branchExists: true,
+        prNo: 5,
+        result: 'update-not-scheduled',
+      });
+      expect(prAutomerge.checkAutoMerge).toHaveBeenCalledTimes(1);
+      expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
+    });
+
     it('skips branch for fresh release with minimumReleaseAge', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(true);
       config.prCreation = 'not-pending';

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -205,6 +205,29 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('skips PR automerge outside automerge schedule and outside schedule', async () => {
+      schedule.isScheduledNow.mockReturnValue(false);
+      config.updateNotScheduled = false;
+      config.automerge = true;
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+        }),
+      );
+
+      const res = await branchWorker.processBranch(config);
+
+      expect(res).toEqual({
+        branchExists: true,
+        prNo: 5,
+        result: 'update-not-scheduled',
+      });
+      expect(prAutomerge.checkAutoMerge).not.toHaveBeenCalled();
+      expect(platform.setBranchStatus).not.toHaveBeenCalled();
+    });
+
     it('checks PR automerge even when not updating out of schedule and rebaseWhen=never', async () => {
       schedule.isScheduledNow.mockImplementation(
         (_config, scheduleKey) => scheduleKey === 'automergeSchedule',

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -288,6 +288,49 @@ describe('workers/repository/update/branch/index', () => {
       expect(prWorker.ensurePr).toHaveBeenCalledTimes(0);
     });
 
+    it.each([
+      ['a forced rebase', {}, true],
+      ['Dashboard Rebase All', { dependencyDashboardRebaseAllOpen: true }],
+      ['Dashboard Approve All', { dependencyDashboardAllPending: true }],
+      [
+        'Dashboard Open All Rate-Limited',
+        { dependencyDashboardAllRateLimited: true },
+      ],
+      [
+        'Dashboard Open All Awaiting Schedule',
+        { dependencyDashboardAllAwaitingSchedule: true },
+      ],
+    ])(
+      'does not use automerge-only path outside schedule when %s is active',
+      async (_description, overrides, forceRebase = false) => {
+        schedule.isScheduledNow.mockImplementation(
+          (_config, scheduleKey) => scheduleKey === 'automergeSchedule',
+        );
+        config.updateNotScheduled = false;
+        config.automerge = true;
+        Object.assign(config, overrides);
+        scm.branchExists.mockResolvedValue(true);
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            number: 5,
+            state: 'open',
+          }),
+        );
+        getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+          ...updatedPackageFiles,
+        });
+        npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+          artifactErrors: [],
+          updatedArtifacts: [],
+        });
+
+        await branchWorker.processBranch(config, forceRebase);
+
+        expect(prAutomerge.checkAutoMerge).not.toHaveBeenCalled();
+        expect(scm.checkoutBranch).toHaveBeenCalledWith(config.baseBranch);
+      },
+    );
+
     it('skips branch for fresh release with minimumReleaseAge', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(true);
       config.prCreation = 'not-pending';

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -205,12 +205,13 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
-    it('checks PR automerge after refreshing statuses when not updating out of schedule', async () => {
+    it('checks PR automerge even when not updating out of schedule and rebaseWhen=never', async () => {
       schedule.isScheduledNow.mockImplementation(
         (_config, scheduleKey) => scheduleKey === 'automergeSchedule',
       );
       config.updateNotScheduled = false;
       config.automerge = true;
+      config.rebaseWhen = 'never';
       config.statusCheckNames = {
         artifactError: null,
         configValidation: null,

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -541,31 +541,6 @@ export async function processBranch(
       }
     }
 
-    if (
-      !config.isScheduledNow &&
-      !dependencyDashboardCheck &&
-      config.updateNotScheduled === false &&
-      !config.rebaseRequested &&
-      config.automerge &&
-      branchPr
-    ) {
-      await setBranchStatusChecks(config);
-      logger.debug('checking auto-merge');
-      const prAutomergeResult = await checkAutoMerge(branchPr, config);
-      if (prAutomergeResult?.automerged) {
-        return {
-          branchExists,
-          result: 'automerged',
-          commitSha,
-        };
-      }
-      return {
-        branchExists,
-        prNo: branchPr?.number,
-        result: 'update-not-scheduled',
-      };
-    }
-
     let userRebaseRequested =
       dependencyDashboardCheck === 'rebase' ||
       !!config.dependencyDashboardRebaseAllOpen ||
@@ -597,6 +572,28 @@ export async function processBranch(
       logger.debug(
         'A user manually requested all awaiting schedule PRs via the Dependency Dashboard.',
       );
+    } else if (
+      !config.isScheduledNow &&
+      !dependencyDashboardCheck &&
+      config.updateNotScheduled === false &&
+      config.automerge &&
+      branchPr
+    ) {
+      await setBranchStatusChecks(config);
+      logger.debug('checking auto-merge');
+      const prAutomergeResult = await checkAutoMerge(branchPr, config);
+      if (prAutomergeResult?.automerged) {
+        return {
+          branchExists,
+          result: 'automerged',
+          commitSha,
+        };
+      }
+      return {
+        branchExists,
+        prNo: branchPr?.number,
+        result: 'update-not-scheduled',
+      };
     } else if (
       branchExists &&
       config.rebaseWhen === 'never' &&

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -388,12 +388,17 @@ export async function processBranch(
         };
       }
       if (config.updateNotScheduled === false && !config.rebaseRequested) {
-        logger.debug('Skipping branch update as not within schedule');
-        return {
-          branchExists,
-          prNo: branchPr?.number,
-          result: 'update-not-scheduled',
-        };
+        if (!(config.automerge && branchPr)) {
+          logger.debug('Skipping branch update as not within schedule');
+          return {
+            branchExists,
+            prNo: branchPr?.number,
+            result: 'update-not-scheduled',
+          };
+        }
+        logger.debug(
+          'Branch update is not scheduled - will check PR automerge only',
+        );
       }
       if (
         !branchPr &&
@@ -534,6 +539,31 @@ export async function processBranch(
           result: 'pending',
         };
       }
+    }
+
+    if (
+      !config.isScheduledNow &&
+      !dependencyDashboardCheck &&
+      config.updateNotScheduled === false &&
+      !config.rebaseRequested &&
+      config.automerge &&
+      branchPr
+    ) {
+      await setBranchStatusChecks(config);
+      logger.debug('checking auto-merge');
+      const prAutomergeResult = await checkAutoMerge(branchPr, config);
+      if (prAutomergeResult?.automerged) {
+        return {
+          branchExists,
+          result: 'automerged',
+          commitSha,
+        };
+      }
+      return {
+        branchExists,
+        prNo: branchPr?.number,
+        result: 'update-not-scheduled',
+      };
     }
 
     let userRebaseRequested =

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -388,7 +388,13 @@ export async function processBranch(
         };
       }
       if (config.updateNotScheduled === false && !config.rebaseRequested) {
-        if (!(config.automerge && branchPr)) {
+        if (
+          !(
+            config.automerge &&
+            branchPr &&
+            isScheduledNow(config, 'automergeSchedule')
+          )
+        ) {
           logger.debug('Skipping branch update as not within schedule');
           return {
             branchExists,


### PR DESCRIPTION
## Changes

Make sure automerge gets triggered outside of schedule even when updateNotScheduled is false.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #33770 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). I used codex iteratively for the code and test.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @samgiz will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/samgiz/renovate-reproducer-33770