### PR TITLE
fix(manager/npm): run npm install twice during lock file maintenance

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4183,6 +4183,8 @@ Run `npm install` with `--prefer-dedupe` for npm >= 7 or `npm dedupe` after `pac
 
 Run `npm install` commands _twice_ to work around bugs where `npm` generates invalid lock files if run only once.
 
+During lock file maintenance, Renovate always runs `npm install` twice, even without this option, because regenerating a lock file from scratch is known to need a second pass.
+
 ### `pnpmDedupe`
 
 Run `pnpm dedupe` after `pnpm-lock.yaml` updates.

--- a/lib/modules/manager/npm/post-update/__snapshots__/npm.spec.ts.snap
+++ b/lib/modules/manager/npm/post-update/__snapshots__/npm.spec.ts.snap
@@ -26,32 +26,6 @@ exports[`modules/manager/npm/post-update/npm > generates lock files 1`] = `
 ]
 `;
 
-exports[`modules/manager/npm/post-update/npm > performs lock file maintenance 1`] = `
-[
-  {
-    "cmd": "npm install --package-lock-only --no-audit --ignore-scripts",
-    "options": {
-      "cwd": "some-dir",
-      "env": {
-        "CI": "true",
-        "HOME": "/home/user",
-        "HTTPS_PROXY": "https://example.com",
-        "HTTP_PROXY": "http://example.com",
-        "LANG": "en_US.UTF-8",
-        "LC_ALL": "en_US",
-        "NO_PROXY": "localhost",
-        "PATH": "/tmp/path",
-      },
-      "maxBuffer": 10485760,
-      "stderr": "pipe",
-      "stdin": "pipe",
-      "stdout": "pipe",
-      "timeout": 900000,
-    },
-  },
-]
-`;
-
 exports[`modules/manager/npm/post-update/npm > performs lock file updates 1`] = `
 [
   {

--- a/lib/modules/manager/npm/post-update/npm.spec.ts
+++ b/lib/modules/manager/npm/post-update/npm.spec.ts
@@ -396,7 +396,38 @@ describe('modules/manager/npm/post-update/npm', () => {
     expect(fs.readLocalFile).toHaveBeenCalledTimes(3);
     expect(fs.deleteLocalFile).toHaveBeenCalledTimes(1);
     expect(res.lockFile).toBe('package-lock-contents');
-    expect(execSnapshots).toMatchSnapshot();
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+      },
+      {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+      },
+    ]);
+  });
+
+  it('does not run npm install four times for lock file maintenance with npmInstallTwice', async () => {
+    const execSnapshots = mockExecAll();
+    // package.json
+    fs.readLocalFile.mockResolvedValue('{}');
+    fs.readLocalFile.mockResolvedValue('package-lock-contents');
+    const res = await npmHelper.generateLockFile(
+      'some-dir',
+      {},
+      'package-lock.json',
+      { postUpdateOptions: ['npmInstallTwice'] },
+      [{ isLockFileMaintenance: true }],
+    );
+    expect(fs.deleteLocalFile).toHaveBeenCalledTimes(1);
+    expect(res.lockFile).toBe('package-lock-contents');
+    expect(execSnapshots).toMatchObject([
+      {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+      },
+      {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+      },
+    ]);
   });
 
   it('works for docker mode', async () => {
@@ -434,6 +465,8 @@ describe('modules/manager/npm/post-update/npm', () => {
           '&& ' +
           'install-tool npm 6.0.0 ' +
           '&& ' +
+          'npm install --package-lock-only --no-audit ' +
+          '&& ' +
           'npm install --package-lock-only --no-audit' +
           "'",
       },
@@ -463,6 +496,9 @@ describe('modules/manager/npm/post-update/npm', () => {
       {
         cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
       },
+      {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+      },
     ]);
   });
 
@@ -485,6 +521,9 @@ describe('modules/manager/npm/post-update/npm', () => {
     expect(res.lockFile).toBe('package-lock-contents');
     expect(execSnapshots).toMatchObject([
       { cmd: 'install-tool node 16.16.0' },
+      {
+        cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
+      },
       {
         cmd: 'npm install --package-lock-only --no-audit --ignore-scripts',
       },

--- a/lib/modules/manager/npm/post-update/npm.ts
+++ b/lib/modules/manager/npm/post-update/npm.ts
@@ -273,6 +273,18 @@ export async function generateLockFile(
       commands.push(`npm install ${cmdOptions}${beforeFlag}`.trim());
     }
 
+    // Lock file maintenance recreates the lock file from scratch, and a single
+    // `npm install` can generate a lock file which is out of sync with
+    // package.json, so we need to run the install a second time (#37531).
+    // Skipped if `npmInstallTwice` is configured, as that doubles all install
+    // commands already.
+    if (
+      upgrades.some((upgrade) => upgrade.isLockFileMaintenance) &&
+      !postUpdateOptions?.includes('npmInstallTwice')
+    ) {
+      commands.push(`npm install ${cmdOptions}${beforeFlag}`.trim());
+    }
+
     // postUpdateOptions
     if (
       config.postUpdateOptions?.includes('npmDedupe') &&

--- a/lib/modules/manager/npm/readme.md
+++ b/lib/modules/manager/npm/readme.md
@@ -5,6 +5,7 @@
 Unfortunately, `npm` itself sometimes generates invalid lock files which fail `npm ci`.
 Try adding `"postUpdateOptions": ["npmInstallTwice"]` to tell Renovate run any `npm install` command (which is used to update lock files) twice.
 This is less efficient than running npm once, but has been known to fix most problems of this type.
+Renovate already runs `npm install` twice during lock file maintenance, because regenerating a lock file from scratch is known to need a second pass.
 
 If this npm bug remains unfixed, and it becomes too frequent for Renovate users, then we may need to modify Renovate to do this by default.
 Please post feedback to the Renovate repository "Discussions" if you're needing to use this feature frequently or widely.


### PR DESCRIPTION
## Changes

Lock file maintenance deletes `package-lock.json` and regenerates it from scratch, and a single `npm install --package-lock-only` pass can produce a lock file that is out of sync with `package.json` (see the maintainer repro in #36118), so `npm ci` rejects the maintenance branch. The `npmInstallTwice` workaround from #37532 helps only when users opt in, and per the issue feedback branches still end up broken after rebasing.

This change always runs the composed `npm install` command a second time when the upgrade set contains a lock file maintenance upgrade, mirroring the existing unconditional double run for remediations in `generateLockFile`. Branch creation and rebase share the same lock file generation path, so both are covered. The extra pass is skipped when `npmInstallTwice` is configured, since that option already doubles every install command (kept at exactly two runs, never four).

Question for maintainers: the npm manager readme already anticipates possibly doing this by default for all updates. This PR deliberately scopes the default second pass to lock file maintenance only (where the lock file is regenerated from scratch and the failure is deterministic); happy to widen it if you prefer.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #37531
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The root-cause analysis, code, tests and docs were produced with substantive assistance from Claude Code (Anthropic), directed and reviewed by the contributor.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @Sanjay-doppalapudi will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
