### PR TITLE
fix(datasource/jsr): accept scopes shorter than the JSR registration minimum

### DIFF
--- a/lib/modules/datasource/jsr/util.spec.ts
+++ b/lib/modules/datasource/jsr/util.spec.ts
@@ -14,8 +14,16 @@ describe('modules/datasource/jsr/util', () => {
     expect(res).toBeNull();
   });
 
-  it('should return null for below scope min length', () => {
-    const res = extractJsrPackageName('@sc/packagename');
+  it('should extract a scope shorter than the JSR registration minimum', () => {
+    const res = extractJsrPackageName('@db/sqlite');
+    expect(res).toStrictEqual({
+      scope: 'db',
+      name: 'sqlite',
+    });
+  });
+
+  it('should return null for an empty scope', () => {
+    const res = extractJsrPackageName('@/packagename');
     expect(res).toBeNull();
   });
 

--- a/lib/modules/datasource/jsr/util.ts
+++ b/lib/modules/datasource/jsr/util.ts
@@ -29,9 +29,11 @@ function parseJsrScopeName(name: string): string | null {
   if (name.length > 100) {
     return null;
   }
-  if (name.length < 3) {
-    return null;
-  }
+  // JSR applies a three character minimum when a scope is registered, but
+  // shorter scopes exist and publish packages: `@db` holds the Deno database
+  // drivers, `@db/sqlite` among them. Reading a dependency is not the place
+  // to re-check registration policy, and a scope that doesn't exist simply
+  // 404s at the registry.
   if (!regEx(/^[a-zA-Z0-9-_]+$/).test(name)) {
     return null;
   }

--- a/lib/modules/manager/deno/schema.spec.ts
+++ b/lib/modules/manager/deno/schema.spec.ts
@@ -365,6 +365,22 @@ describe('modules/manager/deno/schema', () => {
       });
     });
 
+    it('jsr package under a short scope', () => {
+      expect(
+        DenoDependency.parse({
+          depValue: 'jsr:@db/sqlite@^0.13.0',
+          depType: 'imports',
+        }),
+      ).toEqual({
+        currentRawValue: 'jsr:@db/sqlite@^0.13.0',
+        currentValue: '^0.13.0',
+        datasource: 'jsr',
+        depName: '@db/sqlite',
+        depType: 'imports',
+        versioning: 'deno',
+      });
+    });
+
     it('invalid jsr package versions', () => {
       expect(
         DenoDependency.parse({


### PR DESCRIPTION
## Changes

A Deno project that depends on `jsr:@db/sqlite` never gets an update for it. `extractJsrPackageName` rejects the scope because `parseJsrScopeName` requires three characters, so the deno manager sets `skipReason: 'invalid-name'` and the jsr datasource returns null before it ever asks the registry. Nothing warns; the dependency is simply never looked at.

The scope is real. `https://jsr.io/@db/sqlite/meta.json` answers with `latest: 0.13.0`, and the rest of the Deno database drivers live beside it — `@db/postgres` at 0.19.5, `@db/redis` at 0.41.2, `@db/mysql`. Those are the packages the Deno docs point at for SQLite and Postgres, so it isn't an exotic corner.

The three character minimum is real too, and the port here is faithful — upstream `frontend/utils/ids.ts` still has it. But that is the rule JSR applies when someone *registers* a scope, and `@db` exists regardless. Reading a dependency out of a manifest is not the place to re-check registration policy: the name either resolves at the registry or it 404s, and the 404 is already handled. So this drops the minimum and keeps the rest, including the 100 character maximum and the character set, which still rejects an empty scope.

I found it by running the deno manager's import extraction over the `deno.json` of 120 repos: 1180 `npm:`/`jsr:` specifiers, and the only one dropped for a reason other than being a relative path was `jsr:@db/sqlite@^0.13.0`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude (Opus) was used for the investigation, the change, the tests and this description. I have read the diff and run the tests myself.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @MLuc24 will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The test that pinned the old behaviour is replaced by one that extracts `@db/sqlite`, plus one for an empty scope so that path stays covered, and there is a deno manager test for `jsr:@db/sqlite@^0.13.0` extracting rather than being skipped. `vitest run lib/modules/datasource/jsr lib/modules/manager/deno` is 164 passing, `tsc --noEmit` is clean, and so are oxlint, biome and prettier on the changed files.
