### PR TITLE
feat(datasource/aws-eks-addon): add host rule authentication

### DIFF
--- a/lib/modules/datasource/aws-eks-addon/index.spec.ts
+++ b/lib/modules/datasource/aws-eks-addon/index.spec.ts
@@ -6,6 +6,7 @@ import {
 } from '@aws-sdk/client-eks';
 import { mockClient } from 'aws-sdk-client-mock';
 import { logger } from '../../../../test/util.ts';
+import * as hostRules from '../../../util/host-rules.ts';
 import { getPkgReleases } from '../index.ts';
 
 import { AwsEKSAddonDataSource } from './index.ts';
@@ -88,6 +89,10 @@ const addonInfo: AddonInfo = {
 };
 
 describe('modules/datasource/aws-eks-addon/index', () => {
+  beforeEach(() => {
+    hostRules.clear();
+  });
+
   describe('getPkgReleases()', () => {
     it.each`
       des               | req
@@ -164,6 +169,32 @@ describe('modules/datasource/aws-eks-addon/index', () => {
         packageName: '{"addonName":"vpc-cni-not-exist", "profile":"paradox"}',
       });
       expect(eksMock.calls()).toHaveLength(1);
+    });
+
+    it('prefers host rule credentials over the configured profile', async () => {
+      hostRules.add({
+        hostType: datasource,
+        username: 'access-key-id',
+        password: 'secret-access-key',
+        token: 'session-token',
+      });
+      mockDescribeAddonVersionsCommand({ addons: [] });
+
+      const awsEksAddonDatasource = new AwsEKSAddonDataSource();
+      await awsEksAddonDatasource.getReleases({
+        packageName:
+          '{"addonName":"host-rule-credentials","profile":"ignored-profile"}',
+      });
+
+      const eks = eksMock.call(0).thisValue as EKSClient;
+      expect(await eks.config.credentials()).toEqual({
+        accessKeyId: 'access-key-id',
+        secretAccessKey: 'secret-access-key',
+        sessionToken: 'session-token',
+        $source: {
+          CREDENTIALS_CODE: 'e',
+        },
+      });
     });
 
     it('with addon and region', async () => {

--- a/lib/modules/datasource/aws-eks-addon/index.ts
+++ b/lib/modules/datasource/aws-eks-addon/index.ts
@@ -4,6 +4,7 @@ import { isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { coerceArray } from '../../../util/array.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import * as hostRules from '../../../util/host-rules.ts';
 import * as awsEksAddonVersioning from '../../versioning/aws-eks-addon/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
@@ -80,9 +81,19 @@ export class AwsEKSAddonDataSource extends Datasource {
   private getClient({ region, profile }: EksAddonsFilter): EKSClient {
     const cacheKey = `${region ?? 'default'}#${profile ?? 'default'}`;
     if (!(cacheKey in this.clients)) {
+      const { password, token, username } = hostRules.find({
+        hostType: AwsEKSAddonDataSource.id,
+      });
       this.clients[cacheKey] = new EKSClient({
         ...(region && { region }),
-        credentials: fromNodeProviderChain(profile ? { profile } : undefined),
+        credentials:
+          username && password
+            ? {
+                accessKeyId: username,
+                secretAccessKey: password,
+                sessionToken: token,
+              }
+            : fromNodeProviderChain(profile ? { profile } : undefined),
       });
     }
     return this.clients[cacheKey];

--- a/lib/modules/datasource/aws-eks-addon/readme.md
+++ b/lib/modules/datasource/aws-eks-addon/readme.md
@@ -12,6 +12,25 @@ You can use common AWS configuration options, for example:
 - Provide credentials via the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or your `~/.aws/credentials` file
 - Select the profile to use via `AWS_PROFILE` environment variable
 
+You can also provide credentials specifically for this datasource with a `hostRules` entry.
+Set `hostType` to `aws-eks-addon`, `username` to the access key ID, `password` to the secret access key, and optionally `token` to the session token:
+
+```json
+{
+  "hostRules": [
+    {
+      "hostType": "aws-eks-addon",
+      "username": "access-key-id",
+      "password": "secret-access-key",
+      "token": "session-token"
+    }
+  ]
+}
+```
+
+These credentials only apply to AWS EKS Addon lookups.
+When this host rule is absent or incomplete, Renovate uses the default AWS credential provider chain.
+
 Alternatively, you can specify different `region` and `profile` for each addon.
 
 Read the [AWS Developer Guide - Configuring the SDK for JavaScript](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/configuring-the-jssdk.html) for more information on these configuration options.


### PR DESCRIPTION
## Changes

Adds datasource-specific AWS credentials for `aws-eks-addon` through Renovate `hostRules`.

- Maps `username`, `password`, and optional `token` to the AWS SDK access key ID, secret access key, and session token.
- Prefers complete host-rule credentials over a profile configured in the package name.
- Preserves the default AWS credential provider chain when the host rule is absent or incomplete.
- Documents the configuration and adds a regression test based on the existing AWS Machine Image datasource convention.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #42989
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). OpenAI Codex using GPT-5 assisted with issue research, implementation, tests, documentation, validation, and PR preparation. The resulting change was reviewed against the repository's existing AWS Machine Image implementation and contribution policies.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable; this datasource credential-selection change is covered by unit tests.
