### PR TITLE
fix(automerge): respect automerge schedule for existing PRs

### DIFF
--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -205,6 +205,55 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('automerges an existing PR outside the branch update schedule', async () => {
+      schedule.isScheduledNow.mockReturnValueOnce(false);
+      config.automerge = true;
+      config.updateNotScheduled = false;
+      scm.branchExists.mockResolvedValue(true);
+      const branchPr = partial<Pr>({
+        number: 5,
+        state: 'open',
+      });
+      platform.getBranchPr.mockResolvedValueOnce(branchPr);
+      prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: true });
+
+      const res = await branchWorker.processBranch(config);
+
+      expect(prAutomerge.checkAutoMerge).toHaveBeenCalledExactlyOnceWith(
+        branchPr,
+        expect.objectContaining({ isScheduledNow: false }),
+      );
+      expect(getUpdated.getUpdatedPackageFiles).not.toHaveBeenCalled();
+      expect(commit.commitFilesToBranch).not.toHaveBeenCalled();
+      expect(res).toEqual({
+        branchExists: true,
+        commitSha: null,
+        result: 'automerged',
+      });
+    });
+
+    it('does not update an existing PR that cannot automerge outside the schedule', async () => {
+      schedule.isScheduledNow.mockReturnValueOnce(false);
+      config.automerge = true;
+      config.updateNotScheduled = false;
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({ number: 5, state: 'open' }),
+      );
+      prAutomerge.checkAutoMerge.mockResolvedValueOnce({ automerged: false });
+
+      const res = await branchWorker.processBranch(config);
+
+      expect(prAutomerge.checkAutoMerge).toHaveBeenCalledTimes(1);
+      expect(getUpdated.getUpdatedPackageFiles).not.toHaveBeenCalled();
+      expect(commit.commitFilesToBranch).not.toHaveBeenCalled();
+      expect(res).toEqual({
+        branchExists: true,
+        prNo: 5,
+        result: 'update-not-scheduled',
+      });
+    });
+
     it('skips branch for fresh release with minimumReleaseAge', async () => {
       schedule.isScheduledNow.mockReturnValueOnce(true);
       config.prCreation = 'not-pending';

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -388,6 +388,16 @@ export async function processBranch(
         };
       }
       if (config.updateNotScheduled === false && !config.rebaseRequested) {
+        if (branchPr && config.automerge) {
+          const prAutomergeResult = await checkAutoMerge(branchPr, config);
+          if (prAutomergeResult.automerged) {
+            return {
+              branchExists,
+              result: 'automerged',
+              commitSha,
+            };
+          }
+        }
         logger.debug('Skipping branch update as not within schedule');
         return {
           branchExists,


### PR DESCRIPTION
## Changes

Allows existing Renovate pull requests to follow `automergeSchedule` even when the normal branch update `schedule` is closed and `updateNotScheduled` is `false`.

- Runs the existing PR automerge eligibility check before returning `update-not-scheduled`.
- Returns `automerged` when the existing PR is merged successfully.
- Continues to skip package-file generation, branch commits, and other branch updates when automerge is not currently possible.
- Adds regression coverage for both the successful automerge and non-merge paths.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #24275
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). OpenAI Codex using GPT-5 assisted with issue research, implementation, regression tests, validation, self-review, and PR preparation. The resulting change was reviewed against Renovate's existing schedule and PR automerge control flow and contribution policies.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable; this branch-processing control-flow change is covered by unit tests.