### PR TITLE
fix(util/markdown): preserve at signs in URLs

### DIFF
--- a/lib/util/markdown.spec.ts
+++ b/lib/util/markdown.spec.ts
@@ -110,5 +110,15 @@ describe('util/markdown', () => {
         'mention @&#8203;user here',
       );
     });
+
+    it('should not add zero-width space to @ inside URLs', async () => {
+      const input =
+        'Read more at https://medium.com/@fastifyjs/fastify-v4-ga-59f2103b5f0e by @user';
+      const linkified = await linkify(input, { repository: 'some/repo' });
+
+      expect(sanitizeMarkdown(linkified)).toEqual(
+        'Read more at <https://medium.com/@fastifyjs/fastify-v4-ga-59f2103b5f0e> by [@&#8203;user](https://github.com/user)\n',
+      );
+    });
   });
 });

--- a/lib/util/markdown.ts
+++ b/lib/util/markdown.ts
@@ -10,11 +10,13 @@ export function sanitizeMarkdown(markdown: string): string {
   // Put a zero width space after every # followed by a digit
   res = res.replace(regEx(/(\W)#(\d)/gi), '$1#&#8203;$2');
   // Put a zero width space after every @ symbol to prevent unintended hyperlinking,
-  // but leave code blocks (triple backticks) and inline code spans untouched
+  // but leave URLs, code blocks (triple backticks), and inline code spans untouched
   res = res
-    .split(regEx(/(```[\s\S]*?```|`[^`\n]*?`)/g))
+    .split(regEx(/(```[\s\S]*?```|`[^`\n]*?`|https?:\/\/[^\s<]+)/gi))
     .map((part) =>
-      part.startsWith('`') ? part : part.replace(regEx(/@/g), '@&#8203;'),
+      part.startsWith('`') || regEx(/^https?:\/\//i).test(part)
+        ? part
+        : part.replace(regEx(/@/g), '@&#8203;'),
     )
     .join('');
   res = res.replace(regEx(/([a-z]@)&#8203;/gi), '$1');


### PR DESCRIPTION
## Changes

Preserves `@` characters inside HTTP(S) URLs when sanitizing release-note Markdown.

- Keeps URLs such as `https://medium.com/@fastifyjs/...` intact after linkification and sanitization.
- Continues inserting a zero-width entity into ordinary GitHub mentions so they are not unintentionally linked.
- Adds an issue-derived regression test covering the combined `linkify()` and `sanitizeMarkdown()` behavior.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #15958
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). OpenAI Codex using GPT-5 assisted with issue validation, implementation, regression tests, validation, self-review, and PR preparation. The resulting change was reviewed against Renovate's existing Markdown sanitization behavior and contribution policies.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable; this Markdown sanitization behavior is covered by an issue-derived unit test.
