### PR TITLE
feat(helm-values): support name as repository alias

### DIFF
--- a/lib/modules/manager/helm-values/extract.spec.ts
+++ b/lib/modules/manager/helm-values/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import { partial } from '~test/util.ts';
 import type { ExtractConfig } from '../types.ts';
@@ -57,6 +58,40 @@ describe('modules/manager/helm-values/extract', () => {
       );
       expect(result).toMatchSnapshot();
       expect(result?.deps).toHaveLength(5);
+    });
+
+    it('uses name as an alias for repository', () => {
+      const result = extractPackageFile(
+        codeBlock`image:
+  name: traefik
+  tag: 2.2.8`,
+        packageFile,
+        config,
+      );
+
+      expect(result).toMatchObject({
+        deps: [
+          {
+            currentValue: '2.2.8',
+            depName: 'traefik',
+            datasource: 'docker',
+            versioning: 'docker',
+          },
+        ],
+      });
+    });
+
+    it('prefers repository when name is also present', () => {
+      const result = extractPackageFile(
+        codeBlock`image:
+  name: ignored
+  repository: traefik
+  tag: 2.2.8`,
+        packageFile,
+        config,
+      );
+
+      expect(result?.deps[0].depName).toBe('traefik');
     });
 
     it('extract data from file with multiple documents', () => {

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -54,7 +54,7 @@ export function findDependenciesInternal(
 
       let registry = currentItem.registry;
       registry = registry ? `${registry}/` : '';
-      const repository = String(currentItem.repository ?? currentItem.name);
+      const repository = `${currentItem.repository ?? currentItem.name}`;
       const tag = `${currentItem.tag ?? currentItem.version}`;
       packageDependencies.push(
         getHelmDep(registry, repository, tag, registryAliases),

--- a/lib/modules/manager/helm-values/extract.ts
+++ b/lib/modules/manager/helm-values/extract.ts
@@ -54,7 +54,7 @@ export function findDependenciesInternal(
 
       let registry = currentItem.registry;
       registry = registry ? `${registry}/` : '';
-      const repository = String(currentItem.repository);
+      const repository = String(currentItem.repository ?? currentItem.name);
       const tag = `${currentItem.tag ?? currentItem.version}`;
       packageDependencies.push(
         getHelmDep(registry, repository, tag, registryAliases),

--- a/lib/modules/manager/helm-values/readme.md
+++ b/lib/modules/manager/helm-values/readme.md
@@ -11,6 +11,10 @@ image:
   repository: 'some-docker/dependency'
   version: v1.0.0
 
+image:
+  name: 'some-docker/dependency' # alias for repository
+  tag: v1.0.0
+
 coreImage:
   registry: docker.io
   repository: bitnami/harbor-core

--- a/lib/modules/manager/helm-values/types.ts
+++ b/lib/modules/manager/helm-values/types.ts
@@ -1,6 +1,7 @@
 export interface HelmDockerImageDependencyBasic {
   registry?: string;
-  repository: string;
+  name?: string;
+  repository?: string;
 }
 
 export interface HelmDockerImageDependencyTag extends HelmDockerImageDependencyBasic {

--- a/lib/modules/manager/helm-values/util.ts
+++ b/lib/modules/manager/helm-values/util.ts
@@ -30,7 +30,7 @@ export function matchesHelmValuesDockerHeuristic(
   return !!(
     parentKeyRe.test(parentKey) &&
     isObject(data) &&
-    hasKey('repository', data) &&
+    (hasKey('repository', data) || hasKey('name', data)) &&
     (hasKey('tag', data) || hasKey('version', data))
   );
 }


### PR DESCRIPTION
## Changes

Supports `name` as an alias for `repository` when extracting Docker dependencies from Helm values files.

- Recognizes `image.name` alongside the existing `image.repository` convention.
- Continues preferring `repository` when both fields are present, preserving existing behavior.
- Adds regression coverage and documents the supported alias.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #7010
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI Codex using GPT-5 assisted with issue validation, implementation, regression tests, documentation, validation, self-review, and PR preparation. The resulting change was reviewed against Renovate's existing Helm values extraction behavior and contribution policies.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable; the behavior is covered by focused Helm values manager unit tests.
