### PR TITLE
feat(pr): link configuration to dependency dashboard

### DIFF
--- a/lib/modules/platform/utils/pr-body.spec.ts
+++ b/lib/modules/platform/utils/pr-body.spec.ts
@@ -40,6 +40,21 @@ describe('modules/platform/utils/pr-body', () => {
       );
     });
 
+    it('keeps a dashboard-linked Configuration heading (when "smart")', () => {
+      const linkedHeading =
+        '### [Configuration](../issues/123 "Dependency Dashboard")';
+      const body = smartTruncate(
+        prBody.replace('### Configuration', linkedHeading),
+        3000,
+      );
+      expect(body.length).toBeLessThanOrEqual(3000);
+      expect(body).toContain('PR body was truncated to here');
+      expect(body).toContain(linkedHeading);
+      expect(body.indexOf('PR body was truncated to here')).toBeLessThan(
+        body.indexOf(linkedHeading),
+      );
+    });
+
     it('truncates content without release notes structure when notice fits', () => {
       const body = smartTruncate('x'.repeat(500), 200);
       expect(body).toHaveLength(200);

--- a/lib/modules/platform/utils/pr-body.ts
+++ b/lib/modules/platform/utils/pr-body.ts
@@ -3,7 +3,7 @@ import { emojify } from '../../../util/emoji.ts';
 import { regEx } from '../../../util/regex.ts';
 
 const re = regEx(
-  `(?<preNotes>.*### Release Notes)(?<releaseNotes>.*)### Configuration(?<postNotes>.*)`,
+  `(?<preNotes>.*### Release Notes)(?<releaseNotes>.*)(?<configHeading>### \\[?Configuration[^\\n]*)(?<postNotes>.*)`,
   's',
 );
 
@@ -34,7 +34,7 @@ export function smartTruncate(input: string, len: number): string {
     );
   }
 
-  const divider = `\n\n</details>\n\n---\n\n### Configuration`;
+  const divider = `\n\n</details>\n\n---\n\n${reMatch.groups.configHeading}`;
   const preNotes = reMatch.groups.preNotes;
   const releaseNotes = reMatch.groups.releaseNotes;
   const postNotes = reMatch.groups.postNotes;

--- a/lib/workers/repository/update/pr/body/config-description.spec.ts
+++ b/lib/workers/repository/update/pr/body/config-description.spec.ts
@@ -11,6 +11,23 @@ describe('workers/repository/update/pr/body/config-description', () => {
       upgrades: [],
     };
 
+    it('links the configuration heading to the Dependency Dashboard', () => {
+      const res = getPrConfigDescription({
+        ...config,
+        dependencyDashboardIssue: 123,
+      });
+
+      expect(res).toContain(
+        '### [Configuration](../issues/123 "Dependency Dashboard")',
+      );
+    });
+
+    it('renders a plain configuration heading without a dashboard issue', () => {
+      const res = getPrConfigDescription(config);
+
+      expect(res).toContain('### Configuration');
+    });
+
     it('renders stopUpdating=true', () => {
       const res = getPrConfigDescription({
         ...config,

--- a/lib/workers/repository/update/pr/body/config-description.ts
+++ b/lib/workers/repository/update/pr/body/config-description.ts
@@ -6,7 +6,10 @@ import { capitalize } from '../../../../../util/string.ts';
 import type { BranchConfig } from '../../../../types.ts';
 
 export function getPrConfigDescription(config: BranchConfig): string {
-  let prBody = `\n\n---\n\n### Configuration\n\n`;
+  const configurationHeading = config.dependencyDashboardIssue
+    ? `[Configuration](../issues/${config.dependencyDashboardIssue} "Dependency Dashboard")`
+    : 'Configuration';
+  let prBody = `\n\n---\n\n### ${configurationHeading}\n\n`;
   prBody += emojify(`:date: **Schedule**: `);
 
   if (config.timezone) {


### PR DESCRIPTION
Small usability improvement allowing users to quickly jump to the dep. dashboard issue.

## Changes

Links the `### Configuration` heading in the PR body to the repository's Dependency Dashboard issue, when there is one.
 
## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation 

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @kvdb will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
