### PR TITLE
feat(config): add `minimumReleaseAgeBuffer` option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2975,6 +2975,30 @@ When set to `timestamp-optional`, Renovate will treat a release without a releas
 
 This only applies when used with [`minimumReleaseAge`](#minimumreleaseage).
 
+## `minimumReleaseAgeBuffer`
+
+Use this option to extend the time Renovate waits before suggesting an update, by a percentage of [`minimumReleaseAge`](#minimumreleaseage).
+
+Some projects publish a set of related packages, where companion packages (like platform-specific binaries) are published _after_ the main package.
+For example, `@biomejs/biome@2.5.10` may be published some minutes before `@biomejs/cli-linux-x64@2.5.10`.
+If your package manager enforces its own release age cooldown, like pnpm's `minimumReleaseAge` setting or npm's `--before` flag, Renovate may suggest the main package as soon as it passes `minimumReleaseAge`, while a companion package published later is still within the package manager's cooldown.
+The package manager then refuses to update the lock file, and the update fails with an artifact error.
+
+`minimumReleaseAgeBuffer` avoids this by letting Renovate wait longer than the package manager's cooldown.
+Renovate defers the update until `minimumReleaseAge` _plus_ the buffer percentage has passed, while the package manager keeps using the plain `minimumReleaseAge` cutoff.
+This way, packages published up to the buffer time after the suggested release have also passed the package manager's cooldown.
+
+For example, with the following configuration Renovate waits about 3.3 days (3 days plus 10%) before suggesting an update, while the package manager's cooldown stays at 3 days:
+
+```json
+{
+  "minimumReleaseAge": "3 days",
+  "minimumReleaseAgeBuffer": 10
+}
+```
+
+This only applies when used with [`minimumReleaseAge`](#minimumreleaseage).
+
 ## `minor`
 
 Add to this object if you wish to define rules that apply only to minor updates.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2977,7 +2977,7 @@ This only applies when used with [`minimumReleaseAge`](#minimumreleaseage).
 
 ## `minimumReleaseAgeBuffer`
 
-Use this option to extend the time Renovate waits before suggesting an update, by a percentage of [`minimumReleaseAge`](#minimumreleaseage).
+Use this option to extend the time Renovate waits before suggesting an update, on top of [`minimumReleaseAge`](#minimumreleaseage).
 
 Some projects publish a set of related packages, where companion packages (like platform-specific binaries) are published _after_ the main package.
 For example, `@biomejs/biome@2.5.10` may be published some minutes before `@biomejs/cli-linux-x64@2.5.10`.
@@ -2985,15 +2985,18 @@ If your package manager enforces its own release age cooldown, like pnpm's `mini
 The package manager then refuses to update the lock file, and the update fails with an artifact error.
 
 `minimumReleaseAgeBuffer` avoids this by letting Renovate wait longer than the package manager's cooldown.
-Renovate defers the update until `minimumReleaseAge` _plus_ the buffer percentage has passed, while the package manager keeps using the plain `minimumReleaseAge` cutoff.
+Renovate defers the update until `minimumReleaseAge` _plus_ the buffer duration has passed, while the package manager keeps using the plain `minimumReleaseAge` cutoff.
 This way, packages published up to the buffer time after the suggested release have also passed the package manager's cooldown.
 
-For example, with the following configuration Renovate waits about 3.3 days (3 days plus 10%) before suggesting an update, while the package manager's cooldown stays at 3 days:
+By default, Renovate uses a buffer of 10 minutes.
+Set `minimumReleaseAgeBuffer` to `null` to disable the buffer.
+
+For example, with the following configuration Renovate waits 3 days plus 1 hour before suggesting an update, while the package manager's cooldown stays at 3 days:
 
 ```json
 {
   "minimumReleaseAge": "3 days",
-  "minimumReleaseAgeBuffer": 10
+  "minimumReleaseAgeBuffer": "1 hour"
 }
 ```
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2165,6 +2165,13 @@ const options: Readonly<RenovateOptions>[] = [
     allowedValues: ['timestamp-required', 'timestamp-optional'],
   },
   {
+    name: 'minimumReleaseAgeBuffer',
+    description:
+      'Percentage of extra time added to `minimumReleaseAge` before an update is considered stable.',
+    type: 'integer',
+    default: 0,
+  },
+  {
     name: 'abandonmentThreshold',
     description:
       'Flags packages that have not been updated within this period as abandoned.',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2167,9 +2167,9 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'minimumReleaseAgeBuffer',
     description:
-      'Percentage of extra time added to `minimumReleaseAge` before an update is considered stable.',
-    type: 'integer',
-    default: 0,
+      'Extra time added to `minimumReleaseAge` before an update is considered stable.',
+    type: 'string',
+    default: '10 minutes',
   },
   {
     name: 'abandonmentThreshold',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -125,6 +125,7 @@ export interface RenovateSharedConfig {
   manager?: string;
   milestone?: number;
   minimumReleaseAge?: Nullish<string>;
+  minimumReleaseAgeBuffer?: Nullish<number>;
   npmrc?: string;
   npmrcMerge?: boolean;
   npmToken?: string;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -125,7 +125,7 @@ export interface RenovateSharedConfig {
   manager?: string;
   milestone?: number;
   minimumReleaseAge?: Nullish<string>;
-  minimumReleaseAgeBuffer?: Nullish<number>;
+  minimumReleaseAgeBuffer?: Nullish<string>;
   npmrc?: string;
   npmrcMerge?: boolean;
   npmToken?: string;

--- a/lib/util/minimum-release-age.spec.ts
+++ b/lib/util/minimum-release-age.spec.ts
@@ -1,5 +1,8 @@
 import * as _dateUtil from './date.ts';
-import { checkMinimumReleaseAge } from './minimum-release-age.ts';
+import {
+  calculateMinimumReleaseAgeMs,
+  checkMinimumReleaseAge,
+} from './minimum-release-age.ts';
 import { toMs } from './pretty-time.ts';
 import type { Timestamp } from './timestamp.ts';
 
@@ -7,6 +10,38 @@ vi.mock('./date.ts');
 const dateUtil = vi.mocked(_dateUtil);
 
 describe('util/minimum-release-age', () => {
+  describe('.calculateMinimumReleaseAgeMs()', () => {
+    it('returns 0 if minimumReleaseAge is not set', () => {
+      expect(
+        calculateMinimumReleaseAgeMs({ minimumReleaseAgeBuffer: 10 }),
+      ).toBe(0);
+    });
+
+    it('returns minimumReleaseAge if minimumReleaseAgeBuffer is not set', () => {
+      expect(
+        calculateMinimumReleaseAgeMs({ minimumReleaseAge: '3 days' }),
+      ).toBe(toMs('3 days'));
+    });
+
+    it('ignores a negative minimumReleaseAgeBuffer', () => {
+      expect(
+        calculateMinimumReleaseAgeMs({
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBuffer: -10,
+        }),
+      ).toBe(toMs('3 days'));
+    });
+
+    it('extends minimumReleaseAge by the minimumReleaseAgeBuffer percentage', () => {
+      expect(
+        calculateMinimumReleaseAgeMs({
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBuffer: 10,
+        }),
+      ).toBe((toMs('3 days') ?? 0) * 1.1);
+    });
+  });
+
   describe('.checkMinimumReleaseAge()', () => {
     it('is not pending if minimumReleaseAge is not set', () => {
       const res = checkMinimumReleaseAge(
@@ -42,6 +77,32 @@ describe('util/minimum-release-age', () => {
       expect(res).toEqual({
         isPending: false,
         minimumReleaseAgeMs: toMs('3 days'),
+        hasTimestamp: true,
+      });
+    });
+
+    it('is pending if the release is older than minimumReleaseAge but within the minimumReleaseAgeBuffer', () => {
+      dateUtil.getElapsedMs.mockReturnValueOnce((toMs('3 days') ?? 0) + 1);
+      const res = checkMinimumReleaseAge(
+        { minimumReleaseAge: '3 days', minimumReleaseAgeBuffer: 10 },
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: true,
+        minimumReleaseAgeMs: (toMs('3 days') ?? 0) * 1.1,
+        hasTimestamp: true,
+      });
+    });
+
+    it('is not pending if the release is older than minimumReleaseAge plus the minimumReleaseAgeBuffer', () => {
+      dateUtil.getElapsedMs.mockReturnValueOnce(toMs('4 days') ?? 0);
+      const res = checkMinimumReleaseAge(
+        { minimumReleaseAge: '3 days', minimumReleaseAgeBuffer: 10 },
+        '2021-01-01T00:00:00.000Z' as Timestamp,
+      );
+      expect(res).toEqual({
+        isPending: false,
+        minimumReleaseAgeMs: (toMs('3 days') ?? 0) * 1.1,
         hasTimestamp: true,
       });
     });

--- a/lib/util/minimum-release-age.spec.ts
+++ b/lib/util/minimum-release-age.spec.ts
@@ -13,7 +13,7 @@ describe('util/minimum-release-age', () => {
   describe('.calculateMinimumReleaseAgeMs()', () => {
     it('returns 0 if minimumReleaseAge is not set', () => {
       expect(
-        calculateMinimumReleaseAgeMs({ minimumReleaseAgeBuffer: 10 }),
+        calculateMinimumReleaseAgeMs({ minimumReleaseAgeBuffer: '10 minutes' }),
       ).toBe(0);
     });
 
@@ -23,22 +23,31 @@ describe('util/minimum-release-age', () => {
       ).toBe(toMs('3 days'));
     });
 
-    it('ignores a negative minimumReleaseAgeBuffer', () => {
+    it('ignores an invalid minimumReleaseAgeBuffer', () => {
       expect(
         calculateMinimumReleaseAgeMs({
           minimumReleaseAge: '3 days',
-          minimumReleaseAgeBuffer: -10,
+          minimumReleaseAgeBuffer: 'bananas',
         }),
       ).toBe(toMs('3 days'));
     });
 
-    it('extends minimumReleaseAge by the minimumReleaseAgeBuffer percentage', () => {
+    it('ignores a negative minimumReleaseAgeBuffer', () => {
       expect(
         calculateMinimumReleaseAgeMs({
           minimumReleaseAge: '3 days',
-          minimumReleaseAgeBuffer: 10,
+          minimumReleaseAgeBuffer: '-10 minutes',
         }),
-      ).toBe((toMs('3 days') ?? 0) * 1.1);
+      ).toBe(toMs('3 days'));
+    });
+
+    it('extends minimumReleaseAge by the minimumReleaseAgeBuffer duration', () => {
+      expect(
+        calculateMinimumReleaseAgeMs({
+          minimumReleaseAge: '3 days',
+          minimumReleaseAgeBuffer: '10 minutes',
+        }),
+      ).toBe((toMs('3 days') ?? 0) + (toMs('10 minutes') ?? 0));
     });
   });
 
@@ -84,12 +93,12 @@ describe('util/minimum-release-age', () => {
     it('is pending if the release is older than minimumReleaseAge but within the minimumReleaseAgeBuffer', () => {
       dateUtil.getElapsedMs.mockReturnValueOnce((toMs('3 days') ?? 0) + 1);
       const res = checkMinimumReleaseAge(
-        { minimumReleaseAge: '3 days', minimumReleaseAgeBuffer: 10 },
+        { minimumReleaseAge: '3 days', minimumReleaseAgeBuffer: '10 minutes' },
         '2021-01-01T00:00:00.000Z' as Timestamp,
       );
       expect(res).toEqual({
         isPending: true,
-        minimumReleaseAgeMs: (toMs('3 days') ?? 0) * 1.1,
+        minimumReleaseAgeMs: (toMs('3 days') ?? 0) + (toMs('10 minutes') ?? 0),
         hasTimestamp: true,
       });
     });
@@ -97,12 +106,12 @@ describe('util/minimum-release-age', () => {
     it('is not pending if the release is older than minimumReleaseAge plus the minimumReleaseAgeBuffer', () => {
       dateUtil.getElapsedMs.mockReturnValueOnce(toMs('4 days') ?? 0);
       const res = checkMinimumReleaseAge(
-        { minimumReleaseAge: '3 days', minimumReleaseAgeBuffer: 10 },
+        { minimumReleaseAge: '3 days', minimumReleaseAgeBuffer: '10 minutes' },
         '2021-01-01T00:00:00.000Z' as Timestamp,
       );
       expect(res).toEqual({
         isPending: false,
-        minimumReleaseAgeMs: (toMs('3 days') ?? 0) * 1.1,
+        minimumReleaseAgeMs: (toMs('3 days') ?? 0) + (toMs('10 minutes') ?? 0),
         hasTimestamp: true,
       });
     });

--- a/lib/util/minimum-release-age.ts
+++ b/lib/util/minimum-release-age.ts
@@ -14,22 +14,25 @@ export interface MinimumReleaseAgeCheckResult {
 
 /**
  * Calculates the effective minimum release age in milliseconds, extended by
- * the `minimumReleaseAgeBuffer` percentage if configured.
+ * the `minimumReleaseAgeBuffer` duration if configured.
  */
 export function calculateMinimumReleaseAgeMs(config: {
   minimumReleaseAge?: string | null;
-  minimumReleaseAgeBuffer?: number | null;
+  minimumReleaseAgeBuffer?: string | null;
 }): number {
   const minimumReleaseAgeMs = isNonEmptyString(config.minimumReleaseAge)
     ? coerceNumber(toMs(config.minimumReleaseAge), 0)
     : 0;
 
-  const bufferPercent = coerceNumber(config.minimumReleaseAgeBuffer, 0);
-  if (!minimumReleaseAgeMs || bufferPercent <= 0) {
-    return minimumReleaseAgeMs;
+  if (!minimumReleaseAgeMs) {
+    return 0;
   }
 
-  return Math.round(minimumReleaseAgeMs * (1 + bufferPercent / 100));
+  const bufferMs = isNonEmptyString(config.minimumReleaseAgeBuffer)
+    ? coerceNumber(toMs(config.minimumReleaseAgeBuffer), 0)
+    : 0;
+
+  return minimumReleaseAgeMs + Math.max(bufferMs, 0);
 }
 
 /**
@@ -42,7 +45,7 @@ export function calculateMinimumReleaseAgeMs(config: {
 export function checkMinimumReleaseAge(
   config: {
     minimumReleaseAge?: string | null;
-    minimumReleaseAgeBuffer?: number | null;
+    minimumReleaseAgeBuffer?: string | null;
     minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour | null;
   },
   releaseTimestamp: Timestamp | null | undefined,

--- a/lib/util/minimum-release-age.ts
+++ b/lib/util/minimum-release-age.ts
@@ -7,12 +7,34 @@ import type { Timestamp } from './timestamp.ts';
 
 export interface MinimumReleaseAgeCheckResult {
   isPending: boolean;
+  /** Effective minimum release age, including `minimumReleaseAgeBuffer`. */
   minimumReleaseAgeMs: number;
   hasTimestamp: boolean;
 }
 
 /**
- * Checks whether a release satisfies `minimumReleaseAge`.
+ * Calculates the effective minimum release age in milliseconds, extended by
+ * the `minimumReleaseAgeBuffer` percentage if configured.
+ */
+export function calculateMinimumReleaseAgeMs(config: {
+  minimumReleaseAge?: string | null;
+  minimumReleaseAgeBuffer?: number | null;
+}): number {
+  const minimumReleaseAgeMs = isNonEmptyString(config.minimumReleaseAge)
+    ? coerceNumber(toMs(config.minimumReleaseAge), 0)
+    : 0;
+
+  const bufferPercent = coerceNumber(config.minimumReleaseAgeBuffer, 0);
+  if (!minimumReleaseAgeMs || bufferPercent <= 0) {
+    return minimumReleaseAgeMs;
+  }
+
+  return Math.round(minimumReleaseAgeMs * (1 + bufferPercent / 100));
+}
+
+/**
+ * Checks whether a release satisfies `minimumReleaseAge`, extended by
+ * `minimumReleaseAgeBuffer` if configured.
  *
  * Separate from `internalChecksFilter` to allow reuse, and lives here so that
  * managers can import it without an import cycle.
@@ -20,13 +42,12 @@ export interface MinimumReleaseAgeCheckResult {
 export function checkMinimumReleaseAge(
   config: {
     minimumReleaseAge?: string | null;
+    minimumReleaseAgeBuffer?: number | null;
     minimumReleaseAgeBehaviour?: MinimumReleaseAgeBehaviour | null;
   },
   releaseTimestamp: Timestamp | null | undefined,
 ): MinimumReleaseAgeCheckResult {
-  const minimumReleaseAgeMs = isNonEmptyString(config.minimumReleaseAge)
-    ? coerceNumber(toMs(config.minimumReleaseAge), 0)
-    : 0;
+  const minimumReleaseAgeMs = calculateMinimumReleaseAgeMs(config);
 
   if (!minimumReleaseAgeMs) {
     return {

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -38,8 +38,7 @@ import {
   isActiveConfidenceLevel,
   satisfiesConfidenceLevel,
 } from '../../../../util/merge-confidence/index.ts';
-import { coerceNumber } from '../../../../util/number.ts';
-import { toMs } from '../../../../util/pretty-time.ts';
+import { calculateMinimumReleaseAgeMs } from '../../../../util/minimum-release-age.ts';
 import * as template from '../../../../util/template/index.ts';
 import { getCount, isLimitReached } from '../../../global/limits.ts';
 import type {
@@ -432,9 +431,7 @@ export async function processBranch(
       config.stabilityStatus = 'green';
       // Default to 'success' but set 'pending' if any update is pending
       for (const upgrade of config.upgrades) {
-        const minimumReleaseAgeMs = isNonEmptyString(upgrade.minimumReleaseAge)
-          ? coerceNumber(toMs(upgrade.minimumReleaseAge), 0)
-          : 0;
+        const minimumReleaseAgeMs = calculateMinimumReleaseAgeMs(upgrade);
 
         if (minimumReleaseAgeMs) {
           const minimumReleaseAgeBehaviour: MinimumReleaseAgeBehaviour =


### PR DESCRIPTION
## Changes

Adds a new configuration option `minimumReleaseAgeBuffer`, a duration string (default `"30 minutes"`) which extends the time Renovate waits before suggesting an update, on top of `minimumReleaseAge`.

Motivation: some projects publish a set of related packages where companion packages (e.g. platform-specific binaries) are published *after* the main package. In https://github.com/renovatebot/renovate/pull/45540#issuecomment-5455810176, `@biomejs/biome@2.5.10` passed `minimumReleaseAge` while `@biomejs/cli-linux-x64@2.5.10` (published later) was still inside pnpm's own `minimumReleaseAge` cooldown, so the lock file update failed with an artifact error.

With this option, Renovate defers the update until `minimumReleaseAge` _plus_ the buffer duration has passed, while package managers keep enforcing the plain `minimumReleaseAge` cutoff — giving later-published companion packages time to clear the package manager's cooldown.

Implementation details:

- New helper `calculateMinimumReleaseAgeMs()` in `lib/util/minimum-release-age.ts`, used by both `checkMinimumReleaseAge()` (lookup filtering) and the branch worker's stability status check, so both defer consistently.
- Managers (npm `--before`, pnpm, poetry, etc.) are unchanged and continue to use the un-buffered `minimumReleaseAge`.
- The buffer only applies when `minimumReleaseAge` is set; invalid or negative durations are treated as no buffer; users can opt out with `"minimumReleaseAgeBuffer": null`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

### Why 30 minutes

Renovate's own repo uses a 7 day `minimumReleaseAge` for the npm datasource and a matching 7 day pnpm `minimumReleaseAge`, so the only slack between "Renovate proposes the main package" and "pnpm accepts all companions" is the publish gap between the main package and its last companion. Gaps for the last 15 releases, from registry timestamps (2026-09-14):

| Release | Main package published | Last companion gap | Covered by 10 min? |
|---|---|---|---|
| `@biomejs/biome@2.5.10` (#45540) | 2026-08-21 17:40:42Z | 3 min 51 s | yes |
| `oxlint@1.82.0` (#46026) | 2026-09-07 14:59:19Z | 9 min 12 s | yes, 48 s margin |
| `oxlint@1.78.0` | 2026-08-10 10:47:19Z | 11 min 0 s | no |
| `oxlint@1.83.0` | 2026-09-14 12:12:38Z | 11 min 52 s | no |

Biome's companions land within 5 minutes on every recent release. Oxlint's gap has exceeded 10 minutes twice and is trending upward, so a 10 minute buffer only narrows the race window instead of closing it. 30 minutes covers every observed gap with margin, at the cost of a delay that is negligible against a multi-day cooldown.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, tests and documentation were generated with Claude Code (model: Fable 5), directed and reviewed by @secustor.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
