### PR TITLE
ci: ensure scripts in `.github/` are linted

### DIFF
--- a/.github/workflows/close-answered-discussions.yml
+++ b/.github/workflows/close-answered-discussions.yml
@@ -26,5 +26,5 @@ jobs:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const script = require('.github/workflows/close-answered-discussions/script.cjs')
+            const script = require('./tools/close-answered-discussions.cjs')
             console.log(await script({github, context, discussionAnsweredDays: 30}))

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -398,7 +398,6 @@
     "**/.venv/",
     "tools/mkdocs/docs",
     "tools/mkdocs/site",
-    ".github/workflows/**/*.js",
     ".worktrees/**/*",
     ".markdownlint-cli2.mjs",
     "tools/mkdocs/.cache",

--- a/tools/close-answered-discussions.cjs
+++ b/tools/close-answered-discussions.cjs
@@ -1,5 +1,9 @@
 // Parses the ISO date string and checks it's past the age window
 // Co-authored-by: GPT-4.1 (GitHub Copilot)
+/**
+ * @param {string} dateString
+ * @param {number} daysAgo
+ */
 function isOlderThanDaysAgo(dateString, daysAgo) {
   const parsedDate = new Date(dateString);
   const now = new Date();
@@ -7,6 +11,9 @@ function isOlderThanDaysAgo(dateString, daysAgo) {
   return parsedDate < thresholdDate;
 }
 
+/**
+ * @param {{ github: any, context: any, discussionAnsweredDays: number }} params
+ */
 module.exports = async ({ github, context, discussionAnsweredDays }) => {
   const owner = context.repo.owner;
   const repo = context.repo.repo;
@@ -34,6 +41,7 @@ module.exports = async ({ github, context, discussionAnsweredDays }) => {
   while (true) {
     // oxlint-disable-next-line no-console
     console.debug({ cursor }, 'Starting query');
+    /** @type {{ repository: any }} */
     const { repository } = await github.graphql(query, { cursor });
 
     // oxlint-disable-next-line no-console


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As per request in #45462, we can perform a prefactor to ensure that our
scripts for CI-related functionality are part of `tools`, so they're
linted appropriately.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
