### PR TITLE
fix(github): support GHEC data residency endpoints

### DIFF
--- a/docs/usage/examples/self-hosting.md
+++ b/docs/usage/examples/self-hosting.md
@@ -52,7 +52,7 @@ docker run --rm -v "/path/to/your/config.js:/usr/src/app/config.js" renovate/ren
 ### Kubernetes
 
 Renovate's official Docker image is compatible with Kubernetes.
-The following is an example manifest of running Renovate against a GitHub Enterprise server.
+The following is an example manifest of running Renovate against GitHub Enterprise Server.
 
 ```yaml title="Kubernetes manifest"
 apiVersion: batch/v1

--- a/docs/usage/getting-started/running.md
+++ b/docs/usage/getting-started/running.md
@@ -241,7 +241,7 @@ Read the platform-specific docs to learn how to setup authentication on your pla
 - [Bitbucket Server](../modules/platform/bitbucket-server/index.md)
 - [Forgejo](../modules/platform/forgejo/index.md)
 - [Gitea](../modules/platform/gitea/index.md)
-- [github.com and GitHub Enterprise Server](../modules/platform/github/index.md)
+- [GitHub.com, GitHub Enterprise Cloud, and GitHub Enterprise Server](../modules/platform/github/index.md)
 - [GitLab](../modules/platform/gitlab/index.md)
 - [SCM-Manager](../modules/platform/scm-manager/index.md)
 

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -246,7 +246,7 @@ If you have configured your project to require Pull Requests before merging, it 
 
 If you have mandatory Pull Request reviews then it means Renovate can't automerge its own PR until such a review has happened.
 
-If you're on `github.com` or GitHub Enterprise Server (`>=3.4`) you can let Renovate bypass the mandatory Pull Request reviews using the "[Allow specified actors to bypass required pull requests](https://github.blog/changelog/2021-11-19-allow-bypassing-required-pull-requests/)" option in your branch protection rules.
+If you're on GitHub.com, GitHub Enterprise Cloud, or GitHub Enterprise Server (`>=3.4`) you can let Renovate bypass the mandatory Pull Request reviews using the "[Allow specified actors to bypass required pull requests](https://github.blog/changelog/2021-11-19-allow-bypassing-required-pull-requests/)" option in your branch protection rules.
 
 Alternatively, if you use the Mend Renovate App, you can also install the helper apps [renovate-approve](https://github.com/apps/renovate-approve) and [renovate-approve-2](https://github.com/apps/renovate-approve-2) and they will mark all automerging Pull Requests by Renovate as approved.
 These approval helper apps are only available for GitHub.

--- a/docs/usage/key-concepts/changelogs.md
+++ b/docs/usage/key-concepts/changelogs.md
@@ -51,7 +51,7 @@ See the list of platforms in the [`fetchChangeLogs` config option docs](../confi
 Most Open Source packages are hosted on github.com, which means most changelogs are hosted there too.
 Fetching changelogs from github.com requires a GitHub token because GitHub blocks unauthenticated GraphQL API use.
 
-This means that if you run Renovate on self-hosted GitHub Enterprise Server, or any non-GitHub platform which Renovate supports, then you need to configure a github.com Personal Access Token in Renovate in order to fetch changelogs.
+This means that if you run Renovate on GitHub Enterprise Cloud with data residency, self-hosted GitHub Enterprise Server, or any non-GitHub platform which Renovate supports, then you need to configure a github.com Personal Access Token in Renovate in order to fetch changelogs.
 
 Read [Running Renovate, GitHub.com token for changelogs](../getting-started/running.md#githubcom-token-for-changelogs-and-tools) to learn more.
 

--- a/lib/config/presets/internal/helpers.preset.ts
+++ b/lib/config/presets/internal/helpers.preset.ts
@@ -55,7 +55,7 @@ export const presets: Record<string, Preset> = {
   },
   githubDigestChangelogs: {
     description:
-      'Ensure that every dependency pinned by digest and sourced from GitHub.com and Github enterprise contains a link to the commit-to-commit diff',
+      'Ensure that every dependency pinned by digest and sourced from GitHub.com, GitHub Enterprise Cloud, or GitHub Enterprise Server contains a link to the commit-to-commit diff',
     packageRules: [
       {
         changelogUrl: '{{sourceUrl}}/compare/{{currentDigest}}..{{newDigest}}',

--- a/lib/modules/datasource/bitrise/index.spec.ts
+++ b/lib/modules/datasource/bitrise/index.spec.ts
@@ -16,7 +16,7 @@ describe('modules/datasource/bitrise/index', () => {
       ).resolves.toBeNull();
     });
 
-    it('support GitHub Enterprise API URL', async () => {
+    it('supports a GHES API URL', async () => {
       httpMock
         .scope(
           'https://github.mycompany.com/api/v3/repos/foo/bar/contents/steps',

--- a/lib/modules/datasource/bitrise/index.spec.ts
+++ b/lib/modules/datasource/bitrise/index.spec.ts
@@ -60,6 +60,48 @@ describe('modules/datasource/bitrise/index', () => {
       });
     });
 
+    it('uses the GHEC API host for a GHEC registry URL', async () => {
+      httpMock
+        .scope('https://api.octocorp.ghe.com/repos/foo/bar/contents/steps')
+        .get('/script')
+        .reply(200, [
+          {
+            type: 'dir',
+            name: '1.0.0',
+            path: 'steps/script/1.0.0',
+          },
+        ])
+        .get('/script/1.0.0/step.yml')
+        .reply(200, {
+          type: 'file',
+          name: 'step.yml',
+          path: 'steps/script/1.0.0/step.yml',
+          encoding: 'base64',
+          content: toBase64(codeBlock`
+          published_at: 2024-03-19T13:54:48.081077+01:00
+          source_code_url: https://octocorp.ghe.com/foo/bar
+          website: https://octocorp.ghe.com/foo/bar
+        `),
+        });
+      await expect(
+        getPkgReleases({
+          datasource: BitriseDatasource.id,
+          packageName: 'script',
+          registryUrls: ['https://octocorp.ghe.com/foo/bar'],
+        }),
+      ).resolves.toEqual({
+        homepage: 'https://bitrise.io/integrations/steps/script',
+        registryUrl: 'https://octocorp.ghe.com/foo/bar',
+        releases: [
+          {
+            releaseTimestamp: '2024-03-19T12:54:48.081Z',
+            sourceUrl: 'https://octocorp.ghe.com/foo/bar',
+            version: '1.0.0',
+          },
+        ],
+      });
+    });
+
     it('returns version and filters out the asset folder', async () => {
       httpMock
         .scope(

--- a/lib/modules/datasource/bitrise/index.ts
+++ b/lib/modules/datasource/bitrise/index.ts
@@ -3,6 +3,7 @@ import { logger } from '../../../logger/index.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { detectPlatform } from '../../../util/common.ts';
 import { parseGitUrl } from '../../../util/git/url.ts';
+import { getApiBaseUrl } from '../../../util/github/url.ts';
 import { GithubHttp } from '../../../util/http/github.ts';
 import { fromBase64 } from '../../../util/string.ts';
 import { joinUrlParts } from '../../../util/url.ts';
@@ -59,10 +60,7 @@ export class BitriseDatasource extends Datasource {
     };
 
     const massagedPackageName = encodeURIComponent(packageName);
-    const baseApiURL =
-      parsedUrl.resource === 'github.com'
-        ? 'https://api.github.com'
-        : `https://${parsedUrl.resource}/api/v3`;
+    const baseApiURL = getApiBaseUrl(`https://${parsedUrl.resource}`);
     const packageUrl = joinUrlParts(
       baseApiURL,
       'repos',

--- a/lib/modules/datasource/github-releases/readme.md
+++ b/lib/modules/datasource/github-releases/readme.md
@@ -1,4 +1,4 @@
-This datasource allows lookup releases from GitHub.com and GitHub Enterprise repositories.
+This datasource allows lookup releases from GitHub.com, GitHub Enterprise Cloud, and GitHub Enterprise Server repositories.
 
 - `registryUrl`: The URL of the GitHub registry to use. Defaults to `https://github.com/`.
 - `packageName`: The name of the repository to lookup. in the format `owner/repo`. e.g. `renovatebot/renovate`.

--- a/lib/modules/datasource/github-tags/index.spec.ts
+++ b/lib/modules/datasource/github-tags/index.spec.ts
@@ -33,6 +33,41 @@ describe('modules/datasource/github-tags/index', () => {
       expect(res).toBe('abcdef');
     });
 
+    it('uses the GHEC API host for a GHEC registry', async () => {
+      httpMock
+        .scope('https://api.octocorp.ghe.com')
+        .get(`/repos/${packageName}/commits?per_page=1`)
+        .reply(200, [{ sha: 'abcdef' }]);
+
+      const res = await github.getDigest(
+        {
+          packageName,
+          registryUrl: 'https://octocorp.ghe.com',
+        },
+        undefined,
+      );
+
+      expect(res).toBe('abcdef');
+    });
+
+    it('preserves a legacy GHEC API registry', async () => {
+      const registryUrl = 'https://octocorp.ghe.com/api/v3';
+      httpMock
+        .scope(registryUrl)
+        .get(`/repos/${packageName}/commits?per_page=1`)
+        .reply(200, [{ sha: 'abcdef' }]);
+
+      const res = await github.getDigest(
+        {
+          packageName,
+          registryUrl,
+        },
+        undefined,
+      );
+
+      expect(res).toBe('abcdef');
+    });
+
     it('returns null for missing commit', async () => {
       httpMock
         .scope(githubApiHost)

--- a/lib/modules/datasource/github-tags/readme.md
+++ b/lib/modules/datasource/github-tags/readme.md
@@ -1,4 +1,4 @@
-This datasource allows lookup Git tags from GitHub.com and GitHub Enterprise repositories.
+This datasource allows lookup Git tags from GitHub.com, GitHub Enterprise Cloud, and GitHub Enterprise Server repositories.
 
 - `registryUrl`: The URL of the GitHub registry to use. Defaults to `https://github.com/`.
 - `packageName`: The name of the repository to lookup. in the format `owner/repo`. e.g. `renovatebot/renovate`.

--- a/lib/modules/datasource/go/base.ts
+++ b/lib/modules/datasource/go/base.ts
@@ -134,7 +134,7 @@ export class BaseGoDatasource {
       return goSourceHeader;
     }
 
-    // GitHub Enterprise only returns a go-import meta
+    // GHES only returns a go-import meta
     const goImport = BaseGoDatasource.goImportHeader(html, goModule);
     if (goImport) {
       return goImport;

--- a/lib/modules/datasource/go/releases-direct.spec.ts
+++ b/lib/modules/datasource/go/releases-direct.spec.ts
@@ -258,7 +258,7 @@ describe('modules/datasource/go/releases-direct', () => {
       expect(res).toBeDefined();
     });
 
-    it('support ghe', async () => {
+    it('supports GHES', async () => {
       getDatasourceSpy.mockResolvedValueOnce({
         datasource: 'github-tags',
         registryUrl: 'https://git.enterprise.com',

--- a/lib/modules/datasource/helm/__fixtures__/sample.yaml
+++ b/lib/modules/datasource/helm/__fixtures__/sample.yaml
@@ -90,7 +90,7 @@ entries:
     - pgadmin4-1.7.2.tgz
     version: 1.7.2
   private-chart-github:
-    - description: Some private chart from a self-hosted GitHub Enterprise server
+    - description: Some private chart from a self-hosted GitHub Enterprise Server
       home: https://github.example.com/some-org/charts/tree/master/private-chart
       urls:
         - https://charts.example.com/private-chart-1.2.3.tgz

--- a/lib/modules/datasource/pod/index.spec.ts
+++ b/lib/modules/datasource/pod/index.spec.ts
@@ -273,6 +273,25 @@ describe('modules/datasource/pod/index', () => {
       });
     });
 
+    it('uses the GHEC API host for a GHEC registry URL', async () => {
+      httpMock
+        .scope('https://api.octocorp.ghe.com')
+        .get('/repos/foo/bar/contents/Specs/a/c/b/foo')
+        .reply(200, [{ name: '1.2.3' }]);
+      const res = await getPkgReleases({
+        ...config,
+        registryUrls: ['https://octocorp.ghe.com/foo/bar'],
+      });
+      expect(res).toEqual({
+        registryUrl: 'https://octocorp.ghe.com/foo/bar',
+        releases: [
+          {
+            version: '1.2.3',
+          },
+        ],
+      });
+    });
+
     it('processes real data from GHES with shard without specs', async () => {
       httpMock
         .scope(githubEntApiHost)

--- a/lib/modules/datasource/pod/index.spec.ts
+++ b/lib/modules/datasource/pod/index.spec.ts
@@ -75,7 +75,7 @@ describe('modules/datasource/pod/index', () => {
       expect(res).toBeNull();
     });
 
-    it('returns null for 404 Github enterprise', async () => {
+    it('returns null for 404 from GHES', async () => {
       httpMock
         .scope(githubEntApiHost)
         .get('/api/v3/repos/foo/bar/contents/Specs/a/c/b/foo')
@@ -96,7 +96,7 @@ describe('modules/datasource/pod/index', () => {
       expect(res).toBeNull();
     });
 
-    it('returns null for 404 Github enterprise with different url style', async () => {
+    it('returns null for 404 from GHES with different URL style', async () => {
       httpMock
         .scope(githubEntApiHost2)
         .get('/api/v3/repos/foo/bar/contents/Specs/a/c/b/foo')
@@ -254,7 +254,7 @@ describe('modules/datasource/pod/index', () => {
       });
     });
 
-    it('processes real data from Github Enterprise with shard with specs', async () => {
+    it('processes real data from GHES with shard with specs', async () => {
       httpMock
         .scope(githubEntApiHost)
         .get('/api/v3/repos/foo/bar/contents/Specs/a/c/b/foo')
@@ -273,7 +273,7 @@ describe('modules/datasource/pod/index', () => {
       });
     });
 
-    it('processes real data from Github Enterprise with shard without specs', async () => {
+    it('processes real data from GHES with shard without specs', async () => {
       httpMock
         .scope(githubEntApiHost)
         .get('/api/v3/repos/foo/bar/contents/Specs/a/c/b/foo')
@@ -294,7 +294,7 @@ describe('modules/datasource/pod/index', () => {
       });
     });
 
-    it('processes real data from Github Enterprise with specs without shard', async () => {
+    it('processes real data from GHES with specs without shard', async () => {
       httpMock
         .scope(githubEntApiHost)
         .get('/api/v3/repos/foo/bar/contents/Specs/a/c/b/foo')
@@ -317,7 +317,7 @@ describe('modules/datasource/pod/index', () => {
       });
     });
 
-    it('processes real data from Github Enterprise without specs without shard', async () => {
+    it('processes real data from GHES without specs without shard', async () => {
       httpMock
         .scope(githubEntApiHost)
         .get('/api/v3/repos/foo/bar/contents/Specs/a/c/b/foo')

--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -3,6 +3,7 @@ import { HOST_DISABLED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { getApiBaseUrl } from '../../../util/github/url.ts';
 import { GithubHttp } from '../../../util/http/github.ts';
 import type { HttpError } from '../../../util/http/index.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
@@ -40,10 +41,7 @@ function releasesGithubUrl(
   },
 ): string {
   const { hostURL, account, repo, useShard, useSpecs } = opts;
-  const prefix =
-    hostURL && hostURL !== 'https://github.com'
-      ? `${hostURL}/api/v3/repos`
-      : 'https://api.github.com/repos';
+  const prefix = `${getApiBaseUrl(hostURL)}repos`;
   const shard = shardParts(packageName).join('/');
   // `Specs` in the pods repo URL is a new requirement for legacy support also allow pod repo URL without `Specs`
   const packageNamePath = useSpecs ? `Specs/${packageName}` : packageName;

--- a/lib/modules/manager/github-actions/artifacts.ts
+++ b/lib/modules/manager/github-actions/artifacts.ts
@@ -29,7 +29,7 @@ function findToken(url: string): string | undefined {
 }
 
 /**
- * `gh` takes the token from a different variable for GitHub Enterprise Server, and has to be told which host to talk to.
+ * `gh` takes the token from a different variable for GitHub Enterprise Cloud with data residency and GitHub Enterprise Server, and has to be told which host to talk to.
  *
  * Public actions are still resolved against github.com from there, so pass a token for both hosts.
  */

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -136,6 +136,36 @@ describe('modules/manager/github-actions/extract', () => {
       ]);
     });
 
+    it('uses the GHEC source URL when configured with its API endpoint', async () => {
+      GlobalConfig.set({
+        platform: 'github',
+        endpoint: 'https://api.octocorp.ghe.com',
+      });
+      const res = await extractPackageFile(
+        Fixtures.get('workflow_2.yml'),
+        'workflow_2.yml',
+      );
+      expect(res?.deps[0].registryUrls).toEqual([
+        'https://octocorp.ghe.com',
+        'https://github.com',
+      ]);
+    });
+
+    it('uses the GHEC source URL when configured with its legacy API endpoint', async () => {
+      GlobalConfig.set({
+        platform: 'github',
+        endpoint: 'https://octocorp.ghe.com/api/v3',
+      });
+      const res = await extractPackageFile(
+        Fixtures.get('workflow_2.yml'),
+        'workflow_2.yml',
+      );
+      expect(res?.deps[0].registryUrls).toEqual([
+        'https://octocorp.ghe.com',
+        'https://github.com',
+      ]);
+    });
+
     it('use github.com only as registry when running against non-GitHub', async () => {
       GlobalConfig.set({
         platform: 'bitbucket',

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -33,7 +33,7 @@ import type {
   RepositoryReference,
 } from './types.ts';
 
-// detects if we run against a Github Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
+// detects if we run against a GitHub Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
 // This reflects the behavior of how GitHub looks up Actions
 // First on the Enterprise Server, then on GitHub.com
 function detectCustomGitHubRegistryUrlsForActions(): PackageDependency {

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -4,8 +4,9 @@ import { logger, withMeta } from '../../../logger/index.ts';
 import * as memCache from '../../../util/cache/memory/index.ts';
 import { detectPlatform } from '../../../util/common.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
+import { getSourceUrlBase } from '../../../util/github/url.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
-import { parseUrl } from '../../../util/url.ts';
+import { parseUrl, trimTrailingSlash } from '../../../util/url.ts';
 import { ForgejoTagsDatasource } from '../../datasource/forgejo-tags/index.ts';
 import { GiteaTagsDatasource } from '../../datasource/gitea-tags/index.ts';
 import { GithubDigestDatasource } from '../../datasource/github-digest/index.ts';
@@ -33,9 +34,9 @@ import type {
   RepositoryReference,
 } from './types.ts';
 
-// detects if we run against a GitHub Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
+// Detects if we run against GitHub Enterprise and adds its URL to the beginning of the registryURLs for looking up Actions
 // This reflects the behavior of how GitHub looks up Actions
-// First on the Enterprise Server, then on GitHub.com
+// First on the Enterprise instance, then on GitHub.com
 function detectCustomGitHubRegistryUrlsForActions(): PackageDependency {
   const endpoint = GlobalConfig.get('endpoint');
   const registryUrls = ['https://github.com'];
@@ -51,7 +52,7 @@ function detectCustomGitHubRegistryUrlsForActions(): PackageDependency {
       parsedEndpoint.host !== 'api.github.com'
     ) {
       registryUrls.unshift(
-        `${parsedEndpoint.protocol}//${parsedEndpoint.host}`,
+        trimTrailingSlash(getSourceUrlBase(parsedEndpoint.origin)),
       );
       return { registryUrls };
     }

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -141,7 +141,7 @@ You can also control the `gh` CLI version using `constraints.gh`.
 !!! note
   `gh actions-lock` resolves refs and repository IDs through the GitHub API, so it needs a token.
   Renovate takes the token from the `github` host rule matching your platform endpoint, and passes it as `GH_TOKEN`.
-  On GitHub Enterprise Server Renovate passes that token using `GH_ENTERPRISE_TOKEN` and `GH_HOST`, and additionally passes the token from your `github.com` host rule as `GH_TOKEN`, because public actions are still resolved against `github.com`.
+  On GitHub Enterprise Cloud with data residency and GitHub Enterprise Server, Renovate passes that token using `GH_ENTERPRISE_TOKEN` and `GH_HOST`, and additionally passes the token from your `github.com` host rule as `GH_TOKEN`, because public actions are still resolved against `github.com`.
 
 ### Non-semver refs (branches and feature tags)
 

--- a/lib/modules/manager/nix/extract.spec.ts
+++ b/lib/modules/manager/nix/extract.spec.ts
@@ -550,7 +550,7 @@ describe('modules/manager/nix/extract', () => {
     expect(await extractPackageFile('', 'flake.nix')).toBeNull();
   });
 
-  it('includes flake from GitHub Enterprise', async () => {
+  it('includes flake from GHES', async () => {
     const flakeLock = codeBlock`{
       "nodes": {
         "flake-utils": {

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -84,7 +84,7 @@ describe('modules/platform/github/index', () => {
       ).rejects.toThrow('Invalid GitHub endpoint URL: https://[invalid');
     });
 
-    it('should throw if using fine-grained token with GHE <3.10', async () => {
+    it('should throw if using fine-grained token with GHES <3.10', async () => {
       httpMock
         .scope('https://ghe.renovatebot.com')
         .head('/')
@@ -99,7 +99,7 @@ describe('modules/platform/github/index', () => {
       );
     });
 
-    it('should throw if using fine-grained token with GHE unknown version', async () => {
+    it('should throw if using fine-grained token with GHES unknown version', async () => {
       httpMock.scope('https://ghe.renovatebot.com').head('/').reply(200);
       await expect(
         github.initPlatform({
@@ -111,7 +111,7 @@ describe('modules/platform/github/index', () => {
       );
     });
 
-    it('should support fine-grained token with GHE >=3.10', async () => {
+    it('should support fine-grained token with GHES >=3.10', async () => {
       httpMock
         .scope('https://ghe.renovatebot.com')
         .head('/')
@@ -208,7 +208,7 @@ describe('modules/platform/github/index', () => {
             );
           });
 
-          it('if on GitHub Enterprise, a warning is not shown', async () => {
+          it('if on GHES, a warning is not shown', async () => {
             httpMock
               .scope('https://ghe.renovatebot.com')
               .head('/')
@@ -253,7 +253,7 @@ describe('modules/platform/github/index', () => {
             expect(logger.logger.once.warn).not.toHaveBeenCalled();
           });
 
-          it('if on GitHub Enterprise, a warning is not shown', async () => {
+          it('if on GHES, a warning is not shown', async () => {
             httpMock
               .scope('https://ghe.renovatebot.com')
               .head('/')
@@ -300,7 +300,7 @@ describe('modules/platform/github/index', () => {
           );
         });
 
-        it('if on GitHub Enterprise, a warning is not shown', async () => {
+        it('if on GHES, a warning is not shown', async () => {
           httpMock
             .scope('https://ghe.renovatebot.com')
             .head('/')
@@ -339,7 +339,7 @@ describe('modules/platform/github/index', () => {
           );
         });
 
-        it('if on GitHub Enterprise, a warning is not shown', async () => {
+        it('if on GHES, a warning is not shown', async () => {
           httpMock
             .scope('https://ghe.renovatebot.com')
             .head('/')
@@ -569,7 +569,7 @@ describe('modules/platform/github/index', () => {
       ]);
     });
 
-    it('should autodetect email/user on GHE Cloud endpoint with GitHub App', async () => {
+    it('should autodetect email/user on GHEC endpoint with GitHub App', async () => {
       httpMock
         .scope('https://octocorp.ghe.com', {
           reqheaders: {
@@ -4148,7 +4148,7 @@ describe('modules/platform/github/index', () => {
         ]);
       });
 
-      it('should skip automerge if GHE <3.3.0', async () => {
+      it('should skip automerge if GHES <3.3.0', async () => {
         const scope = httpMock
           .scope('https://github.company.com')
           .head('/')
@@ -4176,11 +4176,11 @@ describe('modules/platform/github/index', () => {
 
         expect(logger.logger.debug).toHaveBeenCalledWith(
           { prNumber: 123 },
-          'GitHub-native automerge: not supported on this version of GHE. Use 3.3.0 or newer.',
+          'GitHub-native automerge: not supported by this GHES version. Use 3.3.0 or newer.',
         );
       });
 
-      it('should perform automerge if GHE >=3.3.0', async () => {
+      it('should perform automerge if GHES >=3.3.0', async () => {
         const scope = httpMock
           .scope('https://github.company.com')
           .head('/')
@@ -4962,7 +4962,7 @@ describe('modules/platform/github/index', () => {
       ).rejects.toThrow(PLATFORM_RATE_LIMIT_EXCEEDED);
     });
 
-    it('skips merge queue check on GHE <3.12.0', async () => {
+    it('skips merge queue check on GHES <3.12.0', async () => {
       const scope = httpMock
         .scope('https://github.company.com')
         .head('/')
@@ -5376,7 +5376,7 @@ describe('modules/platform/github/index', () => {
       expect(github.massageMarkdown(input)).toMatchSnapshot();
     });
 
-    it('returns not-updated pr body for GHE', async () => {
+    it('returns not-updated pr body for GHES', async () => {
       const scope = httpMock
         .scope('https://github.company.com')
         .head('/')

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -227,6 +227,23 @@ describe('modules/platform/github/index', () => {
 
             expect(logger.logger.once.warn).not.toHaveBeenCalled();
           });
+
+          it('if on GHEC, a warning is not shown', async () => {
+            httpMock
+              .scope('https://api.octocorp.ghe.com')
+              .get('/user')
+              .reply(200, { login: 'renovate-bot' })
+              .get('/user/emails')
+              .reply(400);
+
+            await github.initPlatform({
+              token: 'anything',
+              endpoint: 'https://api.octocorp.ghe.com',
+              gitAuthor: undefined,
+            });
+
+            expect(logger.logger.once.warn).not.toHaveBeenCalled();
+          });
         });
 
         describe('when email access', () => {
@@ -571,24 +588,22 @@ describe('modules/platform/github/index', () => {
 
     it('should autodetect email/user on GHEC endpoint with GitHub App', async () => {
       httpMock
-        .scope('https://octocorp.ghe.com', {
+        .scope('https://api.octocorp.ghe.com', {
           reqheaders: {
             authorization: 'Bearer ghs_123test',
           },
         })
-        .head('/')
-        .reply(200, '', { 'x-github-enterprise-version': '3.0.15' })
         .post('/graphql')
         .reply(200, {
           data: { viewer: { login: 'my-app[bot]', databaseId: 12345 } },
         });
       expect(
         await github.initPlatform({
-          endpoint: 'https://octocorp.ghe.com',
+          endpoint: 'https://api.octocorp.ghe.com',
           token: 'x-access-token:ghs_123test',
         }),
       ).toEqual({
-        endpoint: 'https://octocorp.ghe.com/',
+        endpoint: 'https://api.octocorp.ghe.com/',
         gitAuthor: 'my-app[bot] <12345+my-app[bot]@users.noreply.ghe.com>',
         renovateUsername: 'my-app[bot]',
         token: 'x-access-token:ghs_123test',
@@ -596,6 +611,25 @@ describe('modules/platform/github/index', () => {
       expect(git.setPlatformIgnoredAuthors).toHaveBeenCalledWith([
         'noreply@ghe.com',
       ]);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'Detected GitHub Enterprise Cloud',
+      );
+    });
+
+    it('should not apply GHES version restrictions to GHEC', async () => {
+      await expect(
+        github.initPlatform({
+          endpoint: 'https://api.octocorp.ghe.com',
+          token: 'github_pat_XXXXXX',
+          username: 'renovate-bot',
+          gitAuthor: 'Renovate Bot <renovate@example.com>',
+        }),
+      ).resolves.toEqual({
+        endpoint: 'https://api.octocorp.ghe.com/',
+        gitAuthor: 'Renovate Bot <renovate@example.com>',
+        renovateUsername: 'renovate-bot',
+        token: 'github_pat_XXXXXX',
+      });
     });
 
     it('should support custom endpoint', async () => {
@@ -5390,6 +5424,26 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       await github.initPlatform({
         endpoint: 'https://github.company.com',
+        token: '123test',
+      });
+      await github.initRepo({ repository: 'some/repo' });
+      const input =
+        'https://github.com/foo/bar/issues/5 plus also [a link](https://github.com/foo/bar/issues/5)';
+      expect(github.massageMarkdown(input)).toEqual(input);
+    });
+
+    it('returns not-updated pr body for GHEC', async () => {
+      const scope = httpMock
+        .scope('https://api.octocorp.ghe.com')
+        .get('/user')
+        .reply(200, {
+          login: 'renovate-bot',
+        })
+        .get('/user/emails')
+        .reply(200, {});
+      initRepoMock(scope, 'some/repo');
+      await github.initPlatform({
+        endpoint: 'https://api.octocorp.ghe.com',
         token: '123test',
       });
       await github.initRepo({ repository: 'some/repo' });

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -135,6 +135,10 @@ export function isGHApp(): boolean {
   return !!platformConfig.isGHApp;
 }
 
+function isGheServer(): boolean {
+  return !!platformConfig.isGhe && !platformConfig.isGheCloud;
+}
+
 export async function detectGhe(token: string): Promise<void> {
   const parsedEndpoint = parseUrl(platformConfig.endpoint);
   /* v8 ignore next -- endpoint is validated in initPlatform before detectGhe is called */
@@ -145,6 +149,10 @@ export async function detectGhe(token: string): Promise<void> {
   platformConfig.isGhe = host !== 'api.github.com';
   platformConfig.isGheCloud = host.endsWith('.ghe.com');
   if (platformConfig.isGhe) {
+    if (platformConfig.isGheCloud) {
+      logger.debug('Detected GitHub Enterprise Cloud');
+      return;
+    }
     const gheHeaderKey = 'x-github-enterprise-version';
     const gheQueryRes = await githubApi.headJson('/', { token });
     const gheHeaders = coerceObject(gheQueryRes?.headers);
@@ -189,7 +197,7 @@ export async function initPlatform({
    */
   if (
     isGithubFineGrainedPersonalAccessToken(token) &&
-    platformConfig.isGhe &&
+    isGheServer() &&
     (!platformConfig.gheVersion ||
       semver.lt(platformConfig.gheVersion, '3.10.0'))
   ) {
@@ -544,7 +552,7 @@ export async function initRepo({
     // GitHub Enterprise Server <3.3.0 doesn't support autoMergeAllowed and hasIssuesEnabled objects
     // TODO #22198
     if (
-      platformConfig.isGhe &&
+      isGheServer() &&
       // semver not null safe, accepts null and undefined
       semver.satisfies(platformConfig.gheVersion!, '<3.3.0')
     ) {
@@ -554,7 +562,7 @@ export async function initRepo({
 
     // GitHub Enterprise Server <3.9.0 doesn't support hasVulnerabilityAlertsEnabled objects
     if (
-      platformConfig.isGhe &&
+      isGheServer() &&
       // semver not null safe, accepts null and undefined
       semver.satisfies(platformConfig.gheVersion!, '<3.9.0')
     ) {
@@ -566,7 +574,7 @@ export async function initRepo({
 
     // GitHub Enterprise Server <3.12.0 doesn't support merge queues
     if (
-      platformConfig.isGhe &&
+      isGheServer() &&
       // semver not null safe, accepts null and undefined
       semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
     ) {
@@ -1867,10 +1875,7 @@ async function tryPrAutomerge(
   // If GitHub Enterprise Server <3.3.0 it doesn't support automerge
   // TODO #22198
   // semver not null safe, accepts null and undefined
-  if (
-    platformConfig.isGhe &&
-    semver.satisfies(platformConfig.gheVersion!, '<3.3.0')
-  ) {
+  if (isGheServer() && semver.satisfies(platformConfig.gheVersion!, '<3.3.0')) {
     logger.debug(
       { prNumber },
       'GitHub-native automerge: not supported by this GHES version. Use 3.3.0 or newer.',
@@ -2008,7 +2013,7 @@ async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
   // TODO #22198
   // semver not null safe, accepts null and undefined
   if (
-    platformConfig.isGhe &&
+    isGheServer() &&
     semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
   ) {
     // Merge queues are only supported on GHES >=3.12.0

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -184,7 +184,7 @@ export async function initPlatform({
 
   await detectGhe(token);
   /**
-   * GHE requires version >=3.10 to support fine-grained access tokens
+   * GHES requires version >=3.10 to support fine-grained access tokens
    * https://docs.github.com/en/enterprise-server@3.10/admin/release-notes#authentication
    */
   if (
@@ -1192,7 +1192,7 @@ export async function getBranchStatus(
     }
   }
   let checkRuns: { name: string; status: string; conclusion: string }[] = [];
-  // API is supported in oldest available GHE version 2.19
+  // API is supported in oldest available GHES version 2.19
   try {
     const checkRunsUrl = `repos/${config.repository}/commits/${escapeHash(
       branchName,
@@ -1873,7 +1873,7 @@ async function tryPrAutomerge(
   ) {
     logger.debug(
       { prNumber },
-      'GitHub-native automerge: not supported on this version of GHE. Use 3.3.0 or newer.',
+      'GitHub-native automerge: not supported by this GHES version. Use 3.3.0 or newer.',
     );
     return;
   }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -103,6 +103,8 @@ import type {
   GhRepo,
   GhRestPr,
   GhRestRepo,
+  GithubEnterpriseServerHost,
+  GithubHost,
   LocalRepoConfig,
   PlatformConfig,
 } from './types.ts';
@@ -114,14 +116,18 @@ export const id = 'github';
 let config: LocalRepoConfig;
 let platformConfig: PlatformConfig;
 
+const defaultGithubApiUrl = 'https://api.github.com/';
+
 // GitHub's max is 60k but in the hosted app we've observed that content-length is ~1k longer
 const GitHubMaxPrBodyLen = 58000;
 
 export function resetConfigs(): void {
   config = {} as never;
   platformConfig = {
-    hostType: 'github',
-    endpoint: 'https://api.github.com/',
+    host: {
+      type: 'github',
+      apiUrl: parseUrl(defaultGithubApiUrl)!,
+    },
   };
 }
 
@@ -135,36 +141,36 @@ export function isGHApp(): boolean {
   return !!platformConfig.isGHApp;
 }
 
-function isGheServer(): boolean {
-  return !!platformConfig.isGhe && !platformConfig.isGheCloud;
+function isGithubEnterpriseServer(
+  host: GithubHost,
+): host is GithubEnterpriseServerHost {
+  return host.type === 'ghes';
 }
 
-export async function detectGhe(token: string): Promise<void> {
-  const parsedEndpoint = parseUrl(platformConfig.endpoint);
-  /* v8 ignore next -- endpoint is validated in initPlatform before detectGhe is called */
-  if (!parsedEndpoint) {
-    throw new Error(`Invalid GitHub endpoint: ${platformConfig.endpoint}`);
+async function detectGithubHost(
+  apiUrl: URL,
+  token: string,
+): Promise<GithubHost> {
+  const { hostname } = apiUrl;
+  if (hostname === 'api.github.com') {
+    return { type: 'github', apiUrl };
   }
-  const host = parsedEndpoint.host;
-  platformConfig.isGhe = host !== 'api.github.com';
-  platformConfig.isGheCloud = host.endsWith('.ghe.com');
-  if (platformConfig.isGhe) {
-    if (platformConfig.isGheCloud) {
-      logger.debug('Detected GitHub Enterprise Cloud');
-      return;
-    }
-    const gheHeaderKey = 'x-github-enterprise-version';
-    const gheQueryRes = await githubApi.headJson('/', { token });
-    const gheHeaders = coerceObject(gheQueryRes?.headers);
-    const gheVersionHeader = Object.entries(gheHeaders).find(
-      ([k]) => k.toLowerCase() === gheHeaderKey,
-    );
-    platformConfig.gheVersion =
-      semver.valid(gheVersionHeader?.[1] as string) ?? null;
-    logger.debug(
-      `Detected GitHub Enterprise Server, version: ${platformConfig.gheVersion}`,
-    );
+
+  if (hostname.endsWith('.ghe.com')) {
+    logger.debug('Detected GitHub Enterprise Cloud');
+    return { type: 'ghec', apiUrl };
   }
+
+  const versionHeaderKey = 'x-github-enterprise-version';
+
+  const hostQueryRes = await githubApi.headJson('/', { token });
+  const hostHeaders = coerceObject(hostQueryRes?.headers);
+  const versionHeader = Object.entries(hostHeaders).find(
+    ([k]) => k.toLowerCase() === versionHeaderKey,
+  );
+  const version = semver.valid(versionHeader?.[1] as string) ?? null;
+  logger.debug(`Detected GitHub Enterprise Server, version: ${version}`);
+  return { type: 'ghes', apiUrl, version };
 }
 
 export async function initPlatform({
@@ -180,26 +186,28 @@ export async function initPlatform({
   token = token.replace(regEx(/^ghs_/), 'x-access-token:ghs_');
   platformConfig.isGHApp = token.startsWith('x-access-token:');
 
+  let githubApiUrl = platformConfig.host.apiUrl;
   if (endpoint) {
-    if (!isHttpUrl(endpoint)) {
+    const parsedApiUrl = parseUrl(ensureTrailingSlash(endpoint));
+    if (!parsedApiUrl || !isHttpUrl(parsedApiUrl)) {
       throw new Error(`Init: Invalid GitHub endpoint URL: ${endpoint}`);
     }
-    platformConfig.endpoint = ensureTrailingSlash(endpoint);
-    githubHttp.setBaseUrl(platformConfig.endpoint);
+    githubApiUrl = parsedApiUrl;
+    githubHttp.setBaseUrl(githubApiUrl.href);
   } else {
-    logger.debug(`Using default github endpoint: ${platformConfig.endpoint}`);
+    logger.debug(`Using default github endpoint: ${githubApiUrl.href}`);
   }
 
-  await detectGhe(token);
+  platformConfig.host = await detectGithubHost(githubApiUrl, token);
   /**
    * GHES requires version >=3.10 to support fine-grained access tokens
    * https://docs.github.com/en/enterprise-server@3.10/admin/release-notes#authentication
    */
   if (
     isGithubFineGrainedPersonalAccessToken(token) &&
-    isGheServer() &&
-    (!platformConfig.gheVersion ||
-      semver.lt(platformConfig.gheVersion, '3.10.0'))
+    isGithubEnterpriseServer(platformConfig.host) &&
+    (!platformConfig.host.version ||
+      semver.lt(platformConfig.host.version, '3.10.0'))
   ) {
     throw new Error(
       'Init: Fine-grained Personal Access Tokens do not support GitHub Enterprise Server API version <3.10 and cannot be used with Renovate.',
@@ -214,20 +222,17 @@ export async function initPlatform({
     renovateUsername = platformConfig.userDetails.username;
   } else {
     platformConfig.userDetails ??= await getUserDetails(
-      platformConfig.endpoint,
+      platformConfig.host.apiUrl.href,
       token,
     );
     renovateUsername = platformConfig.userDetails.username;
   }
 
   let ghHostname: string;
-  /* v8 ignore next -- false negative due to V8/source-map artifact */
-  if (platformConfig.isGheCloud) {
+  if (platformConfig.host.type === 'ghec') {
     ghHostname = 'ghe.com';
-  } else if (platformConfig.isGhe) {
-    // valid url ensured at the function start
-    const parsedEndpoint = parseUrl(platformConfig.endpoint)!;
-    ghHostname = parsedEndpoint.hostname;
+  } else if (platformConfig.host.type === 'ghes') {
+    ghHostname = platformConfig.host.apiUrl.hostname;
   } else {
     ghHostname = 'github.com';
   }
@@ -236,16 +241,17 @@ export async function initPlatform({
   if (!gitAuthor) {
     if (platformConfig.isGHApp) {
       platformConfig.userDetails ??= await getAppDetails(token);
+      /* v8 ignore next -- false negative due to V8/source-map artifact */
       discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userDetails.id}+${platformConfig.userDetails.username}@users.noreply.${ghHostname}>`;
     } else {
       platformConfig.userDetails ??= await getUserDetails(
-        platformConfig.endpoint,
+        platformConfig.host.apiUrl.href,
         token,
       );
       // v8 ignore next -- TODO: coverage error #40625
       platformConfig.userEmail =
         platformConfig.userDetails.email ??
-        (await getUserEmail(platformConfig.endpoint, token));
+        (await getUserEmail(platformConfig.host.apiUrl.href, token));
       if (platformConfig.userEmail) {
         discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userEmail}>`;
       }
@@ -256,13 +262,16 @@ export async function initPlatform({
 
   logger.debug({ platformConfig, renovateUsername }, 'Platform config');
   const platformResult: PlatformResult = {
-    endpoint: platformConfig.endpoint,
+    endpoint: platformConfig.host.apiUrl.href,
     gitAuthor: gitAuthor ?? discoveredGitAuthor,
     renovateUsername,
     token,
   };
 
-  warnIfDefaultGitAuthorEmail(platformResult.gitAuthor, platformConfig.isGhe);
+  warnIfDefaultGitAuthorEmail(
+    platformResult.gitAuthor,
+    platformConfig.host.type !== 'github',
+  );
 
   if (
     getEnv().RENOVATE_X_GITHUB_HOST_RULES &&
@@ -475,7 +484,10 @@ export async function findFork(
   }
   logger.debug(`Searching for forked repo in user account`);
   try {
-    const { username } = await getUserDetails(platformConfig.endpoint, token);
+    const { username } = await getUserDetails(
+      platformConfig.host.apiUrl.href,
+      token,
+    );
     const forkedRepo = forks.find((repo) => repo.owner.login === username);
     if (forkedRepo) {
       logger.debug(`Found repo in user account: ${forkedRepo.full_name}`);
@@ -539,7 +551,7 @@ export async function initRepo({
   } as any;
   const opts = hostRules.find({
     hostType: 'github',
-    url: platformConfig.endpoint,
+    url: platformConfig.host.apiUrl.href,
     readOnly: true,
   });
   config.renovateUsername = renovateUsername;
@@ -552,9 +564,8 @@ export async function initRepo({
     // GitHub Enterprise Server <3.3.0 doesn't support autoMergeAllowed and hasIssuesEnabled objects
     // TODO #22198
     if (
-      isGheServer() &&
-      // semver not null safe, accepts null and undefined
-      semver.satisfies(platformConfig.gheVersion!, '<3.3.0')
+      isGithubEnterpriseServer(platformConfig.host) &&
+      semver.satisfies(platformConfig.host.version ?? '', '<3.3.0')
     ) {
       infoQuery = infoQuery.replace(regEx(/\n\s*autoMergeAllowed\s*\n/), '\n');
       infoQuery = infoQuery.replace(regEx(/\n\s*hasIssuesEnabled\s*\n/), '\n');
@@ -562,9 +573,8 @@ export async function initRepo({
 
     // GitHub Enterprise Server <3.9.0 doesn't support hasVulnerabilityAlertsEnabled objects
     if (
-      isGheServer() &&
-      // semver not null safe, accepts null and undefined
-      semver.satisfies(platformConfig.gheVersion!, '<3.9.0')
+      isGithubEnterpriseServer(platformConfig.host) &&
+      semver.satisfies(platformConfig.host.version ?? '', '<3.9.0')
     ) {
       infoQuery = infoQuery.replace(
         regEx(/\n\s*hasVulnerabilityAlertsEnabled\s*\n/),
@@ -574,9 +584,8 @@ export async function initRepo({
 
     // GitHub Enterprise Server <3.12.0 doesn't support merge queues
     if (
-      isGheServer() &&
-      // semver not null safe, accepts null and undefined
-      semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
+      isGithubEnterpriseServer(platformConfig.host) &&
+      semver.satisfies(platformConfig.host.version ?? '', '<3.12.0')
     ) {
       infoQuery = infoQuery.replace(
         regEx(/\n\s*mergeQueue\s*\{\s*id\s*\}\s*\n/),
@@ -783,14 +792,12 @@ export async function initRepo({
     logger.debug(`Using ${tokenType} token for git init`);
     authToken = opts.token ?? null;
   }
-  // endpoint is validated during initPlatform
-  const parsedEndpoint = parseUrl(platformConfig.endpoint)!;
   const workingSshUrl = forkToken ? forkSshUrl : repo.sshUrl;
   const url = getRepoUrl(
     config.repository!,
     gitUrl,
     workingSshUrl,
-    parsedEndpoint,
+    platformConfig.host.apiUrl,
     authToken,
   );
   let upstreamUrl: string | undefined;
@@ -799,7 +806,7 @@ export async function initRepo({
       config.parentRepo,
       gitUrl,
       repo.sshUrl,
-      parsedEndpoint,
+      platformConfig.host.apiUrl,
       authToken,
     );
   }
@@ -811,7 +818,7 @@ export async function initRepo({
   const repoConfig: RepoResult = {
     defaultBranch: config.defaultBranch,
     isFork: repo.isFork === true,
-    repoFingerprint: repoFingerprint(repo.id, platformConfig.endpoint),
+    repoFingerprint: repoFingerprint(repo.id, platformConfig.host.apiUrl.href),
   };
   return repoConfig;
 }
@@ -1874,8 +1881,10 @@ async function tryPrAutomerge(
 
   // If GitHub Enterprise Server <3.3.0 it doesn't support automerge
   // TODO #22198
-  // semver not null safe, accepts null and undefined
-  if (isGheServer() && semver.satisfies(platformConfig.gheVersion!, '<3.3.0')) {
+  if (
+    isGithubEnterpriseServer(platformConfig.host) &&
+    semver.satisfies(platformConfig.host.version ?? '', '<3.3.0')
+  ) {
     logger.debug(
       { prNumber },
       'GitHub-native automerge: not supported by this GHES version. Use 3.3.0 or newer.',
@@ -2011,10 +2020,9 @@ async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
   }
 
   // TODO #22198
-  // semver not null safe, accepts null and undefined
   if (
-    isGheServer() &&
-    semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
+    isGithubEnterpriseServer(platformConfig.host) &&
+    semver.satisfies(platformConfig.host.version ?? '', '<3.12.0')
   ) {
     // Merge queues are only supported on GHES >=3.12.0
     config.mergeQueueEnabled[baseBranch] = false;
@@ -2267,7 +2275,7 @@ export async function mergePr({
 }
 
 export function massageMarkdown(input: string): string {
-  if (platformConfig.isGhe) {
+  if (platformConfig.host.type !== 'github') {
     return smartTruncate(input, maxBodyLength());
   }
   const massagedInput = massageMarkdownLinks(input)

--- a/lib/modules/platform/github/readme.md
+++ b/lib/modules/platform/github/readme.md
@@ -1,10 +1,10 @@
-# GitHub and GitHub Enterprise Server
+# GitHub and GitHub Enterprise
 
-Most of the information on this page is meant for users who want to self-host Renovate on GitHub or GitHub Enterprise Server.
+Most of the information on this page is meant for users who want to self-host Renovate on GitHub.com, GitHub Enterprise Cloud or GitHub Enterprise Server.
 
 ## Easiest way to run Renovate
 
-For users on GitHub Cloud (`github.com`), the easiest way to get started is to install [the Mend Renovate app](https://github.com/marketplace/renovate) from the GitHub marketplace.
+For users on GitHub.com, the easiest way to get started is to install [the Mend Renovate app](https://github.com/marketplace/renovate) from the GitHub marketplace.
 When you use the app, Mend will:
 
 - authenticate the Renovate app to GitHub
@@ -36,6 +36,7 @@ Let Renovate use your PAT by doing _one_ of the following:
 Remember to set `platform=github` somewhere in your Renovate config file.
 
 If you use GitHub Enterprise Server then `endpoint` must point to `https://github-enterprise.example.com/api/v3/`.
+If you use GitHub Enterprise Cloud with data residency then `endpoint` must point to `https://api.SUBDOMAIN.ghe.com/`, where `SUBDOMAIN` is your enterprise's unique subdomain.
 You can choose where you want to set `endpoint`:
 
 - In your `config.js` file
@@ -120,8 +121,8 @@ The slug name of your app with `[bot]` appended
 **`gitAuthor:"Self-hosted Renovate Bot <123456+self-hosted-renovate[bot]@users.noreply.github.enterprise.com>"`** (optional, autodetected if not supplied)
 
 The [GitHub App associated email](https://github.community/t/logging-into-git-as-a-github-app/115916/2) to match commits to the bot.
-It needs to have the user id _and_ the username followed by the `users.noreply.`-domain of either github.com or the GitHub Enterprise Server.
-A way to get the user id of a GitHub app is to [query the user API](https://docs.github.com/en/rest/reference/users#get-a-user) at `api.github.com/users/self-hosted-renovate[bot]` (github.com) or `github.enterprise.com/api/v3/users/self-hosted-renovate[bot]` (GitHub Enterprise Server).
+It needs to have the user id _and_ the username followed by the appropriate `users.noreply.` domain: `users.noreply.github.com` for GitHub.com, `users.noreply.ghe.com` for GitHub Enterprise Cloud with data residency, or `users.noreply.HOSTNAME` for GitHub Enterprise Server.
+A way to get the user id of a GitHub App is to [query the user API](https://docs.github.com/en/rest/reference/users#get-a-user) at `https://api.github.com/users/self-hosted-renovate[bot]` (GitHub.com), `https://api.SUBDOMAIN.ghe.com/users/self-hosted-renovate[bot]` (GitHub Enterprise Cloud with data residency), or `https://HOSTNAME/api/v3/users/self-hosted-renovate[bot]` (GitHub Enterprise Server).
 
 ## Package Registry Credentials
 

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -87,12 +87,30 @@ export interface UserDetails {
   email: EmailAddress | null;
 }
 
+interface GithubHostBase {
+  apiUrl: URL;
+}
+
+export interface GithubComHost extends GithubHostBase {
+  type: 'github';
+}
+
+export interface GithubEnterpriseCloudHost extends GithubHostBase {
+  type: 'ghec';
+}
+
+export interface GithubEnterpriseServerHost extends GithubHostBase {
+  type: 'ghes';
+  version: string | null;
+}
+
+export type GithubHost =
+  | GithubComHost
+  | GithubEnterpriseCloudHost
+  | GithubEnterpriseServerHost;
+
 export interface PlatformConfig {
-  hostType: string;
-  endpoint: string;
-  isGhe?: boolean;
-  isGheCloud?: boolean;
-  gheVersion?: string | null;
+  host: GithubHost;
   isGHApp?: boolean;
   existingRepos?: string[];
   userDetails?: UserDetails;

--- a/lib/util/common.spec.ts
+++ b/lib/util/common.spec.ts
@@ -58,6 +58,8 @@ describe('util/common', () => {
       ${'https://codefloe.com/some-org/some-repo'}                           | ${'forgejo'}
       ${'https://github.com/semantic-release/gitlab'}                        | ${'github'}
       ${'https://github-enterprise.example.com/chalk/chalk'}                 | ${'github'}
+      ${'https://octocorp.ghe.com/chalk/chalk'}                              | ${'github'}
+      ${'https://api.octocorp.ghe.com/repos/chalk/chalk'}                    | ${'github'}
       ${'https://gitlab.com/chalk/chalk'}                                    | ${'gitlab'}
       ${'https://gitlab-enterprise.example.com/chalk/chalk'}                 | ${'gitlab'}
     `('("$url") === $hostType', ({ url, hostType }) => {

--- a/lib/util/common.ts
+++ b/lib/util/common.ts
@@ -59,7 +59,11 @@ export function detectPlatform(
   ) {
     return 'gitea';
   }
-  if (hostname === 'github.com' || hostname?.includes('github')) {
+  if (
+    hostname === 'github.com' ||
+    hostname?.includes('github') ||
+    hostname?.endsWith('.ghe.com')
+  ) {
     return 'github';
   }
   if (hostname === 'gitlab.com' || hostname?.includes('gitlab')) {

--- a/lib/util/github/graphql/datasource-fetcher.ts
+++ b/lib/util/github/graphql/datasource-fetcher.ts
@@ -100,7 +100,7 @@ export class GithubGraphqlDatasourceFetcher<
     this.datasourceAdapter = datasourceAdapter;
     const { packageName, registryUrl } = packageConfig;
     [this.repoOwner, this.repoName] = packageName.split('/');
-    this.baseUrl = getApiBaseUrl(registryUrl).replace(regEx(/\/v3\/$/), '/'); // Replace for GHE
+    this.baseUrl = getApiBaseUrl(registryUrl).replace(regEx(/\/v3\/$/), '/'); // Replace for GHES
   }
 
   private getCacheNs(): PackageCacheNamespace {

--- a/lib/util/github/url.spec.ts
+++ b/lib/util/github/url.spec.ts
@@ -11,6 +11,18 @@ describe('util/github/url', () => {
       const sourceUrl = getSourceUrlBase(undefined);
       expect(sourceUrl).toBe('https://github.com/');
     });
+
+    it('maps the GitHub.com API URL to its source URL', () => {
+      expect(getSourceUrlBase('https://api.github.com')).toBe(
+        'https://github.com/',
+      );
+    });
+
+    it('maps a GHEC API URL to its source URL', () => {
+      expect(getSourceUrlBase('https://api.octocorp.ghe.com')).toBe(
+        'https://octocorp.ghe.com/',
+      );
+    });
   });
 
   describe('getApiBaseUrl', () => {
@@ -25,6 +37,24 @@ describe('util/github/url', () => {
       );
       expect(getApiBaseUrl('https://gh.my-company.com/api/v3/')).toBe(
         'https://gh.my-company.com/api/v3/',
+      );
+    });
+
+    it('maps a GHEC source URL to its API URL', () => {
+      expect(getApiBaseUrl('https://octocorp.ghe.com/')).toBe(
+        'https://api.octocorp.ghe.com/',
+      );
+    });
+
+    it('preserves a GHEC API URL', () => {
+      expect(getApiBaseUrl('https://api.octocorp.ghe.com/')).toBe(
+        'https://api.octocorp.ghe.com/',
+      );
+    });
+
+    it('preserves a legacy GHEC API URL', () => {
+      expect(getApiBaseUrl('https://octocorp.ghe.com/api/v3/')).toBe(
+        'https://octocorp.ghe.com/api/v3/',
       );
     });
   });

--- a/lib/util/github/url.ts
+++ b/lib/util/github/url.ts
@@ -4,7 +4,7 @@ const defaultSourceUrlBase = 'https://github.com/';
 const defaultApiBaseUrl = 'https://api.github.com/';
 
 export function getSourceUrlBase(registryUrl: string | undefined): string {
-  // default to GitHub.com if no GHE host is specified.
+  // Default to GitHub.com if no GitHub Enterprise Cloud or Server host is specified.
   return ensureTrailingSlash(registryUrl ?? defaultSourceUrlBase);
 }
 

--- a/lib/util/github/url.ts
+++ b/lib/util/github/url.ts
@@ -1,11 +1,27 @@
-import { ensureTrailingSlash } from '../url.ts';
+import { ensureTrailingSlash, parseUrl } from '../url.ts';
 
 const defaultSourceUrlBase = 'https://github.com/';
 const defaultApiBaseUrl = 'https://api.github.com/';
 
 export function getSourceUrlBase(registryUrl: string | undefined): string {
   // Default to GitHub.com if no GitHub Enterprise Cloud or Server host is specified.
-  return ensureTrailingSlash(registryUrl ?? defaultSourceUrlBase);
+  const sourceUrlBase = ensureTrailingSlash(
+    registryUrl ?? defaultSourceUrlBase,
+  );
+  if (sourceUrlBase === defaultApiBaseUrl) {
+    return defaultSourceUrlBase;
+  }
+
+  const parsedUrl = parseUrl(sourceUrlBase);
+  if (
+    parsedUrl?.hostname.startsWith('api.') &&
+    parsedUrl.hostname.endsWith('.ghe.com')
+  ) {
+    parsedUrl.hostname = parsedUrl.hostname.slice('api.'.length);
+    return parsedUrl.toString();
+  }
+
+  return sourceUrlBase;
 }
 
 export function getApiBaseUrl(registryUrl: string | undefined): string {
@@ -20,6 +36,12 @@ export function getApiBaseUrl(registryUrl: string | undefined): string {
 
   if (sourceUrlBase.endsWith('/api/v3/')) {
     return sourceUrlBase;
+  }
+
+  const parsedUrl = parseUrl(sourceUrlBase);
+  if (parsedUrl?.hostname.endsWith('.ghe.com')) {
+    parsedUrl.hostname = `api.${parsedUrl.hostname}`;
+    return parsedUrl.toString();
   }
 
   return `${sourceUrlBase}api/v3/`;

--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -276,7 +276,7 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a', 'b', 'c', 'd', 'e']);
     });
 
-    it('paginates with auth and repo on GHE', async () => {
+    it('paginates with auth and repo on GHES', async () => {
       const url = '/api/v3/some-url?per_page=2';
       hostRules.add({
         hostType: 'github',
@@ -332,15 +332,15 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a']);
     });
 
-    it('rebases GHE Server pagination links', async () => {
+    it('rebases GHES pagination links', async () => {
       vi.stubEnv('RENOVATE_X_REBASE_PAGINATION_LINKS', '1');
-      // The origin and base URL which Renovate uses (from its config) to reach GHE:
+      // The origin and base URL which Renovate uses (from its config) to reach GHES:
       const baseUrl = 'http://ghe.alternative.domain.com/api/v3';
       setBaseUrl(baseUrl);
-      // The hostname from GHE settings, which users use through their browsers to reach GHE:
+      // The hostname from GHES settings, which users use through their browsers to reach GHES:
       // https://docs.github.com/en/enterprise-server@3.5/admin/configuration/configuring-network-settings/configuring-a-hostname
       const gheHostname = 'ghe.mycompany.com';
-      // GHE replies to paginated requests with a Link response header whose URLs have this base
+      // GHES replies to paginated requests with a Link response header whose URLs have this base
       const gheBaseUrl = `https://${gheHostname}/api/v3`;
       const apiUrl = '/some-url?per_page=2';
       httpMock
@@ -550,7 +550,7 @@ describe('util/http/github', () => {
         );
       });
 
-      it('when the rate limit is exceeded to GitHub Enterprise, but no host rules are set, a warn is logged', async () => {
+      it('when the rate limit is exceeded to GHES, but no host rules are set, a warn is logged', async () => {
         async function fail(
           code: number,
           body?: any,

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -584,7 +584,7 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
     const body = variables ? { query, variables } : { query };
 
     const opts: GithubBaseHttpOptions = {
-      baseUrl: baseUrl.replace('/v3/', '/'), // GHE uses unversioned graphql path
+      baseUrl: baseUrl.replace('/v3/', '/'), // GHES uses unversioned graphql path
       body,
       headers: { accept: options?.acceptHeader },
       readOnly: options.readOnly,

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -566,7 +566,7 @@ describe('util/http/host-rules', () => {
     });
   });
 
-  describe('GHE platform endpoint fallback', () => {
+  describe('GHES platform endpoint fallback', () => {
     beforeEach(() => {
       GlobalConfig.set({
         platform: 'github',
@@ -580,9 +580,9 @@ describe('util/http/host-rules', () => {
       });
     });
 
-    it('fallback to github for non-listed hostType targeting GHE endpoint', () => {
+    it('fallback to github for non-listed hostType targeting GHES endpoint', () => {
       // github-digest is NOT in GITHUB_API_USING_HOST_TYPES,
-      // but should still get credentials when targeting the GHE endpoint
+      // but should still get credentials when targeting the GHES endpoint
       const opts = { hostType: 'github-digest' };
       const hostRule = findMatchingRule(
         'https://ghe.example.com/api/v3/',

--- a/lib/workers/global/config/parse/__snapshots__/env.spec.ts.snap
+++ b/lib/workers/global/config/parse/__snapshots__/env.spec.ts.snap
@@ -31,14 +31,14 @@ exports[`workers/global/config/parse/env > .getConfig(env) > supports Bitbucket 
 
 exports[`workers/global/config/parse/env > .getConfig(env) > supports GitHub custom endpoint 1`] = `
 {
-  "endpoint": "a ghe endpoint",
+  "endpoint": "a GHES endpoint",
   "hostRules": [],
 }
 `;
 
 exports[`workers/global/config/parse/env > .getConfig(env) > supports GitHub custom endpoint and github.com 1`] = `
 {
-  "endpoint": "a ghe endpoint",
+  "endpoint": "a GHES endpoint",
   "hostRules": [
     {
       "hostType": "github",
@@ -46,15 +46,15 @@ exports[`workers/global/config/parse/env > .getConfig(env) > supports GitHub cus
       "token": "a github.com token",
     },
   ],
-  "token": "a ghe token",
+  "token": "a GHES token",
 }
 `;
 
 exports[`workers/global/config/parse/env > .getConfig(env) > supports GitHub custom endpoint and gitlab.com 1`] = `
 {
-  "endpoint": "a ghe endpoint",
+  "endpoint": "a GHES endpoint",
   "hostRules": [],
-  "token": "a ghe token",
+  "token": "a GHES token",
 }
 `;
 

--- a/lib/workers/global/config/parse/env.spec.ts
+++ b/lib/workers/global/config/parse/env.spec.ts
@@ -139,21 +139,21 @@ describe('workers/global/config/parse/env', () => {
 
     it('supports GitHub custom endpoint', async () => {
       const envParam: NodeJS.ProcessEnv = {
-        RENOVATE_ENDPOINT: 'a ghe endpoint',
+        RENOVATE_ENDPOINT: 'a GHES endpoint',
       };
       expect(await env.getConfig(envParam)).toMatchSnapshot({
-        endpoint: 'a ghe endpoint',
+        endpoint: 'a GHES endpoint',
       });
     });
 
     it('supports GitHub custom endpoint and github.com', async () => {
       const envParam: NodeJS.ProcessEnv = {
         GITHUB_COM_TOKEN: 'a github.com token',
-        RENOVATE_ENDPOINT: 'a ghe endpoint',
-        RENOVATE_TOKEN: 'a ghe token',
+        RENOVATE_ENDPOINT: 'a GHES endpoint',
+        RENOVATE_TOKEN: 'a GHES token',
       };
       expect(await env.getConfig(envParam)).toMatchSnapshot({
-        endpoint: 'a ghe endpoint',
+        endpoint: 'a GHES endpoint',
         hostRules: [
           {
             hostType: 'github',
@@ -161,7 +161,7 @@ describe('workers/global/config/parse/env', () => {
             token: 'a github.com token',
           },
         ],
-        token: 'a ghe token',
+        token: 'a GHES token',
       });
     });
 
@@ -219,12 +219,12 @@ describe('workers/global/config/parse/env', () => {
 
     it('supports GitHub custom endpoint and gitlab.com', async () => {
       const envParam: NodeJS.ProcessEnv = {
-        RENOVATE_ENDPOINT: 'a ghe endpoint',
-        RENOVATE_TOKEN: 'a ghe token',
+        RENOVATE_ENDPOINT: 'a GHES endpoint',
+        RENOVATE_TOKEN: 'a GHES token',
       };
       expect(await env.getConfig(envParam)).toMatchSnapshot({
-        endpoint: 'a ghe endpoint',
-        token: 'a ghe token',
+        endpoint: 'a GHES endpoint',
+        token: 'a GHES token',
       });
     });
 

--- a/lib/workers/repository/update/pr/changelog/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/update/pr/changelog/__snapshots__/index.spec.ts.snap
@@ -60,7 +60,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > filte
 }
 `;
 
-exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > supports github enterprise and github enterprise changelog 1`] = `
+exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > supports GHES and GHES changelog 1`] = `
 {
   "hasReleaseNotes": true,
   "project": {
@@ -120,7 +120,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > suppo
 }
 `;
 
-exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > supports github enterprise and github.com changelog 1`] = `
+exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > supports GHES and github.com changelog 1`] = `
 {
   "hasReleaseNotes": true,
   "project": {
@@ -180,7 +180,7 @@ exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > suppo
 }
 `;
 
-exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > supports github.com and github enterprise changelog 1`] = `
+exports[`workers/repository/update/pr/changelog/index > getChangeLogJSON > supports github.com and GHES changelog 1`] = `
 {
   "hasReleaseNotes": true,
   "project": {

--- a/lib/workers/repository/update/pr/changelog/github/__snapshots__/index.spec.ts.snap
+++ b/lib/workers/repository/update/pr/changelog/github/__snapshots__/index.spec.ts.snap
@@ -60,7 +60,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
 }
 `;
 
-exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON > supports github enterprise and github enterprise changelog 1`] = `
+exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON > supports GHES and GHES changelog 1`] = `
 {
   "hasReleaseNotes": true,
   "project": {
@@ -120,7 +120,7 @@ exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON 
 }
 `;
 
-exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON > supports github enterprise and github.com changelog 1`] = `
+exports[`workers/repository/update/pr/changelog/github/index > getChangeLogJSON > supports GHES and github.com changelog 1`] = `
 {
   "hasReleaseNotes": true,
   "project": {

--- a/lib/workers/repository/update/pr/changelog/github/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.spec.ts
@@ -294,7 +294,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
       });
     });
 
-    it('supports github enterprise and github.com changelog', async () => {
+    it('supports GHES and github.com changelog', async () => {
       hostRules.add({
         hostType: 'github',
         token: 'super_secret',
@@ -325,7 +325,7 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
       });
     });
 
-    it('supports github enterprise and github enterprise changelog', async () => {
+    it('supports GHES and GHES changelog', async () => {
       hostRules.add({
         hostType: 'github',
         matchHost: 'https://github-enterprise.example.com/',

--- a/lib/workers/repository/update/pr/changelog/github/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/github/index.spec.ts
@@ -358,6 +358,33 @@ describe('workers/repository/update/pr/changelog/github/index', () => {
       });
     });
 
+    it('uses the GHEC API host for a GHEC changelog', async () => {
+      httpMock
+        .scope('https://api.octocorp.ghe.com')
+        .persist()
+        .get(/.*/)
+        .reply(200, []);
+      hostRules.add({
+        hostType: 'github',
+        matchHost: 'https://api.octocorp.ghe.com/',
+        token: 'abc',
+      });
+      const result = await getChangeLogJSON({
+        ...upgrade,
+        sourceUrl: 'https://octocorp.ghe.com/chalk/chalk',
+      });
+      expect(result).toMatchObject({
+        hasReleaseNotes: true,
+        project: {
+          apiBaseUrl: 'https://api.octocorp.ghe.com/',
+          baseUrl: 'https://octocorp.ghe.com/',
+          repository: 'chalk/chalk',
+          sourceUrl: 'https://octocorp.ghe.com/chalk/chalk',
+          type: 'github',
+        },
+      });
+    });
+
     it('works with same version releases but different prefix', async () => {
       const githubTagsMock = vi.spyOn(githubGraphql, 'queryTags');
       githubTagsMock.mockResolvedValue(

--- a/lib/workers/repository/update/pr/changelog/github/source.ts
+++ b/lib/workers/repository/update/pr/changelog/github/source.ts
@@ -1,5 +1,6 @@
 import { GlobalConfig } from '../../../../../../config/global.ts';
 import { logger } from '../../../../../../logger/index.ts';
+import { getApiBaseUrl } from '../../../../../../util/github/url.ts';
 import * as hostRules from '../../../../../../util/host-rules.ts';
 import { parseUrl } from '../../../../../../util/url.ts';
 import type { BranchUpgradeConfig } from '../../../../../types.ts';
@@ -11,10 +12,7 @@ export class GitHubChangeLogSource extends ChangeLogSource {
   }
 
   getAPIBaseUrl(config: BranchUpgradeConfig): string {
-    const baseUrl = this.getBaseUrl(config);
-    return baseUrl.startsWith('https://github.com/')
-      ? 'https://api.github.com/'
-      : `${baseUrl}api/v3/`;
+    return getApiBaseUrl(this.getBaseUrl(config));
   }
 
   getCompareURL(
@@ -46,9 +44,10 @@ export class GitHubChangeLogSource extends ChangeLogSource {
     const manager = config.manager;
     const packageName = config.packageName;
 
-    const url = sourceUrl.startsWith('https://github.com/')
-      ? 'https://api.github.com/'
-      : sourceUrl;
+    const url =
+      sourceUrl.startsWith('https://github.com/') || host?.endsWith('.ghe.com')
+        ? this.getAPIBaseUrl(config)
+        : sourceUrl;
     const { token } = hostRules.find({
       hostType: 'github',
       url,

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -288,7 +288,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
       expect(getInRangeReleasesMock).toHaveBeenCalledExactlyOnceWith(param);
     });
 
-    it('supports github enterprise and github.com changelog', async () => {
+    it('supports GHES and github.com changelog', async () => {
       githubTagsMock.mockRejectedValue([]);
       githubReleasesMock.mockRejectedValue([]);
       httpMock.scope(githubApiHost).persist().get(/.*/).reply(200, []);
@@ -322,7 +322,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
       });
     });
 
-    it('supports github enterprise and github enterprise changelog', async () => {
+    it('supports GHES and GHES changelog', async () => {
       githubTagsMock.mockRejectedValue([]);
       githubReleasesMock.mockRejectedValue([]);
       httpMock
@@ -361,7 +361,7 @@ describe('workers/repository/update/pr/changelog/index', () => {
       });
     });
 
-    it('supports github.com and github enterprise changelog', async () => {
+    it('supports github.com and GHES changelog', async () => {
       githubTagsMock.mockRejectedValue([]);
       githubReleasesMock.mockRejectedValue([]);
       httpMock

--- a/lib/workers/repository/update/pr/changelog/index.spec.ts
+++ b/lib/workers/repository/update/pr/changelog/index.spec.ts
@@ -361,6 +361,35 @@ describe('workers/repository/update/pr/changelog/index', () => {
       });
     });
 
+    it('uses the GHEC API host for a GHEC changelog', async () => {
+      githubTagsMock.mockRejectedValue([]);
+      githubReleasesMock.mockRejectedValue([]);
+      httpMock
+        .scope('https://api.octocorp.ghe.com')
+        .persist()
+        .get(/.*/)
+        .reply(200, []);
+      hostRules.add({
+        hostType: 'github',
+        matchHost: 'https://api.octocorp.ghe.com/',
+        token: 'abc',
+      });
+      const result = await getChangeLogJSON({
+        ...upgrade,
+        sourceUrl: 'https://octocorp.ghe.com/chalk/chalk',
+      });
+      expect(result).toMatchObject({
+        hasReleaseNotes: true,
+        project: {
+          apiBaseUrl: 'https://api.octocorp.ghe.com/',
+          baseUrl: 'https://octocorp.ghe.com/',
+          repository: 'chalk/chalk',
+          sourceUrl: 'https://octocorp.ghe.com/chalk/chalk',
+          type: 'github',
+        },
+      });
+    });
+
     it('supports github.com and GHES changelog', async () => {
       githubTagsMock.mockRejectedValue([]);
       githubReleasesMock.mockRejectedValue([]);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Adds explicit support for GitHub Enterprise Cloud (GHEC) with data residency, which uses dedicated web and API hosts (`SUBDOMAIN.ghe.com` and `api.SUBDOMAIN.ghe.com`) rather than the GHES-style `HOSTNAME/api/v3` layout.

Previously, several URL conversion paths treated any non-GitHub.com host as GHES:

- Resolving internal GitHub Actions treadted the platform endpoint `https://api.SUBDOMAIN.ghe.com`) as a registry URL, which datasources then turned into a nonexistent `https://api.SUBDOMAIN.ghe.com/api/v3/` endpoint
- Changelog fetching, and the `bitrise` and `pod` datasources, appended `/api/v3` to GHEC hosts
- `detectPlatform` did not recognise `*.ghe.com` hosts as GitHub
- Platform init logged `Detected GitHub Enterprise Server, version: null` for GHEC and applied GHES version checks to it, e.g. rejecting fine-grained PATs with an error about GHES < 3.10

This PR:

- Ensures platform init detects GHEC explicitly
  - GHES version checks are only applied to GHES hosts
  - Correct platform type is logged
- Updates several datasources (`bitrise`, `github-tags`, `pod`) and managers (`github-actions`) to construct valid GHEC API URLs instead of the GHES-style URLs
  - Added extra tests for GHEC
- Updates documentation to note support for GHEC
- Cleans up numerous references in the code/comments for "GitHub Enterprise" to distinguish GHEC from GHES
  - Happy to remove this / split it out to another PR
- Refactors GitHub `PlatformConfig` to have a clearer distinction between GitHub.com, GHEC and GHES, cleaning up some complex boolean state management
  - Happy to remove this / split it out to another PR

Some things to note:

- If someone is using Renovate on GHEC and is using the legacy `https://SUBDOMAIN.ghe.com/api/v3/` endpoint, everything should continue to work without issue
- Previously, when detecting info about the GHE host (which included GHEC), Renovate would make a `HEAD /` request in order to determine the GHES version (from a header in the response). This meant that if a token was invalid we would immediately fail. With this PR, that now only happens on GHES servers; GHEC hosts skip this probe, so an invalid token will fail at the first request instead

Full background, reproduction details, and logs available in #45599.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used GPT-5.6 Sol in Codex extensively during my investigation and while preparing the initial patches, and Claude Fable 5 in Claude Code to review the patches. I have reviewed, refactored and tested all changes, including running a custom Renovate image containing them against my company's GHEC instance.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @JackMyers001 will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: N/A. GHEC enterprises with data residency do not support public repositories. I verified a custom image containing this patch against my company's GHEC enterprise (internal Actions resolution and changelog fetching), and can run maintainer-provided builds or additional diagnostics there.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
