### PR TITLE
fix(github): model GitHub hosts explicitly

### DIFF
--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -227,6 +227,23 @@ describe('modules/platform/github/index', () => {
 
             expect(logger.logger.once.warn).not.toHaveBeenCalled();
           });
+
+          it('if on GHEC, a warning is not shown', async () => {
+            httpMock
+              .scope('https://api.octocorp.ghe.com')
+              .get('/user')
+              .reply(200, { login: 'renovate-bot' })
+              .get('/user/emails')
+              .reply(400);
+
+            await github.initPlatform({
+              token: 'anything',
+              endpoint: 'https://api.octocorp.ghe.com',
+              gitAuthor: undefined,
+            });
+
+            expect(logger.logger.once.warn).not.toHaveBeenCalled();
+          });
         });
 
         describe('when email access', () => {
@@ -571,24 +588,22 @@ describe('modules/platform/github/index', () => {
 
     it('should autodetect email/user on GHE Cloud endpoint with GitHub App', async () => {
       httpMock
-        .scope('https://octocorp.ghe.com', {
+        .scope('https://api.octocorp.ghe.com', {
           reqheaders: {
             authorization: 'Bearer ghs_123test',
           },
         })
-        .head('/')
-        .reply(200, '', { 'x-github-enterprise-version': '3.0.15' })
         .post('/graphql')
         .reply(200, {
           data: { viewer: { login: 'my-app[bot]', databaseId: 12345 } },
         });
       expect(
         await github.initPlatform({
-          endpoint: 'https://octocorp.ghe.com',
+          endpoint: 'https://api.octocorp.ghe.com',
           token: 'x-access-token:ghs_123test',
         }),
       ).toEqual({
-        endpoint: 'https://octocorp.ghe.com/',
+        endpoint: 'https://api.octocorp.ghe.com/',
         gitAuthor: 'my-app[bot] <12345+my-app[bot]@users.noreply.ghe.com>',
         renovateUsername: 'my-app[bot]',
         token: 'x-access-token:ghs_123test',
@@ -596,6 +611,26 @@ describe('modules/platform/github/index', () => {
       expect(git.setPlatformIgnoredAuthors).toHaveBeenCalledWith([
         'noreply@ghe.com',
       ]);
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        'Detected GitHub Enterprise Cloud',
+      );
+    });
+
+    // Older GHES versions (pre-3.10) do not support fine-grained tokens. This (or any other) version restriction should not be applied to GHEC
+    it('should not apply GHES version restrictions to GHEC', async () => {
+      await expect(
+        github.initPlatform({
+          endpoint: 'https://api.octocorp.ghe.com',
+          token: 'github_pat_XXXXXX',
+          username: 'renovate-bot',
+          gitAuthor: 'Renovate Bot <renovate@example.com>',
+        }),
+      ).resolves.toEqual({
+        endpoint: 'https://api.octocorp.ghe.com/',
+        gitAuthor: 'Renovate Bot <renovate@example.com>',
+        renovateUsername: 'renovate-bot',
+        token: 'github_pat_XXXXXX',
+      });
     });
 
     it('should support custom endpoint', async () => {
@@ -5390,6 +5425,26 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       await github.initPlatform({
         endpoint: 'https://github.company.com',
+        token: '123test',
+      });
+      await github.initRepo({ repository: 'some/repo' });
+      const input =
+        'https://github.com/foo/bar/issues/5 plus also [a link](https://github.com/foo/bar/issues/5)';
+      expect(github.massageMarkdown(input)).toEqual(input);
+    });
+
+    it('returns not-updated pr body for GHEC', async () => {
+      const scope = httpMock
+        .scope('https://api.octocorp.ghe.com')
+        .get('/user')
+        .reply(200, {
+          login: 'renovate-bot',
+        })
+        .get('/user/emails')
+        .reply(200, {});
+      initRepoMock(scope, 'some/repo');
+      await github.initPlatform({
+        endpoint: 'https://api.octocorp.ghe.com',
         token: '123test',
       });
       await github.initRepo({ repository: 'some/repo' });

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -136,6 +136,22 @@ describe('modules/platform/github/index', () => {
       ]);
     });
 
+    it('should support fine-grained personal access tokens on GHEC', async () => {
+      await expect(
+        github.initPlatform({
+          endpoint: 'https://api.octocorp.ghe.com',
+          token: 'github_pat_XXXXXX',
+          username: 'renovate-bot',
+          gitAuthor: 'Renovate Bot <renovate@example.com>',
+        }),
+      ).resolves.toEqual({
+        endpoint: 'https://api.octocorp.ghe.com/',
+        gitAuthor: 'Renovate Bot <renovate@example.com>',
+        renovateUsername: 'renovate-bot',
+        token: 'github_pat_XXXXXX',
+      });
+    });
+
     it('should throw if user failure', async () => {
       httpMock.scope(githubApiHost).get('/user').reply(404);
       await expect(github.initPlatform({ token: '123test' })).rejects.toThrow(
@@ -616,23 +632,6 @@ describe('modules/platform/github/index', () => {
       );
     });
 
-    // Older GHES versions (pre-3.10) do not support fine-grained tokens. This (or any other) version restriction should not be applied to GHEC
-    it('should not apply GHES version restrictions to GHEC', async () => {
-      await expect(
-        github.initPlatform({
-          endpoint: 'https://api.octocorp.ghe.com',
-          token: 'github_pat_XXXXXX',
-          username: 'renovate-bot',
-          gitAuthor: 'Renovate Bot <renovate@example.com>',
-        }),
-      ).resolves.toEqual({
-        endpoint: 'https://api.octocorp.ghe.com/',
-        gitAuthor: 'Renovate Bot <renovate@example.com>',
-        renovateUsername: 'renovate-bot',
-        token: 'github_pat_XXXXXX',
-      });
-    });
-
     it('should support custom endpoint', async () => {
       httpMock
         .scope('https://ghe.renovatebot.com')
@@ -878,6 +877,37 @@ describe('modules/platform/github/index', () => {
       initRepoMock(scope, 'some/repo');
       const config = await github.initRepo({ repository: 'some/repo' });
       expect(config).toMatchSnapshot();
+    });
+
+    it('queries all version-gated fields if the GHES version is unknown', async () => {
+      const scope = httpMock
+        .scope('https://github.company.com')
+        .head('/')
+        .reply(200);
+      initRepoMock(scope, 'some/repo');
+      await github.initPlatform({
+        endpoint: 'https://github.company.com',
+        token: '123test',
+        username: 'renovate-bot',
+        gitAuthor: 'Renovate Bot <renovate@example.com>',
+      });
+
+      await github.initRepo({ repository: 'some/repo' });
+
+      expect(httpMock.getTrace()).toContainEqual(
+        expect.objectContaining({
+          graphql: expect.objectContaining({
+            query: expect.objectContaining({
+              repository: expect.objectContaining({
+                autoMergeAllowed: null,
+                hasIssuesEnabled: null,
+                hasVulnerabilityAlertsEnabled: null,
+                mergeQueue: { id: null },
+              }),
+            }),
+          }),
+        }),
+      );
     });
 
     // for coverage
@@ -4258,6 +4288,49 @@ describe('modules/platform/github/index', () => {
         );
       });
 
+      it('should perform automerge if the GHES version is unknown', async () => {
+        const scope = httpMock
+          .scope('https://github.company.com')
+          .head('/')
+          .reply(200)
+          .get('/user')
+          .reply(200, {
+            login: 'renovate-bot',
+          })
+          .get('/user/emails')
+          .reply(200, {})
+          .post('/repos/some/repo/pulls')
+          .reply(200, {
+            number: 123,
+          })
+          .post('/repos/some/repo/issues/123/labels')
+          .reply(200, [])
+          .post('/graphql')
+          .reply(200, {
+            data: {
+              repository: {
+                defaultBranchRef: {
+                  name: 'main',
+                },
+                nameWithOwner: 'some/repo',
+                autoMergeAllowed: true,
+              },
+            },
+          });
+
+        initRepoMock(scope, 'some/repo');
+        await github.initPlatform({
+          endpoint: 'https://github.company.com',
+          token: '123test',
+        });
+        await github.initRepo({ repository: 'some/repo' });
+        await github.createPr(prConfig);
+
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'GitHub-native automerge: success...PrNo: 123',
+        );
+      });
+
       it('should set automatic merge', async () => {
         const scope = await mockScope();
         scope.post('/graphql').reply(200, graphqlAutomergeResp);
@@ -5012,6 +5085,28 @@ describe('modules/platform/github/index', () => {
         token: '123test',
       });
       await github.initRepo({ repository: 'some/repo' });
+
+      await expect(
+        github.assertPrNotInMergeQueue('somebranch', 'main'),
+      ).toResolve();
+    });
+
+    it('checks the merge queue if the GHES version is unknown', async () => {
+      const scope = httpMock
+        .scope('https://github.company.com')
+        .head('/')
+        .reply(200)
+        .get('/user')
+        .reply(200, { login: 'renovate-bot' })
+        .get('/user/emails')
+        .reply(200, {});
+      initRepoMock(scope, 'some/repo');
+      await github.initPlatform({
+        endpoint: 'https://github.company.com',
+        token: '123test',
+      });
+      await github.initRepo({ repository: 'some/repo' });
+      mergeQueueEnabledMock(scope, null);
 
       await expect(
         github.assertPrNotInMergeQueue('somebranch', 'main'),

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -103,6 +103,8 @@ import type {
   GhRepo,
   GhRestPr,
   GhRestRepo,
+  GithubEnterpriseServerHost,
+  GithubHost,
   LocalRepoConfig,
   PlatformConfig,
 } from './types.ts';
@@ -114,14 +116,18 @@ export const id = 'github';
 let config: LocalRepoConfig;
 let platformConfig: PlatformConfig;
 
+const defaultGithubApiUrl = 'https://api.github.com/';
+
 // GitHub's max is 60k but in the hosted app we've observed that content-length is ~1k longer
 const GitHubMaxPrBodyLen = 58000;
 
 export function resetConfigs(): void {
   config = {} as never;
   platformConfig = {
-    hostType: 'github',
-    endpoint: 'https://api.github.com/',
+    host: {
+      type: 'github',
+      apiUrl: parseUrl(defaultGithubApiUrl)!,
+    },
   };
 }
 
@@ -135,28 +141,37 @@ export function isGHApp(): boolean {
   return !!platformConfig.isGHApp;
 }
 
-export async function detectGhe(token: string): Promise<void> {
-  const parsedEndpoint = parseUrl(platformConfig.endpoint);
-  /* v8 ignore next -- endpoint is validated in initPlatform before detectGhe is called */
-  if (!parsedEndpoint) {
-    throw new Error(`Invalid GitHub endpoint: ${platformConfig.endpoint}`);
+function isGithubEnterpriseServer(
+  host: GithubHost,
+): host is GithubEnterpriseServerHost {
+  return host.type === 'ghes';
+}
+
+async function detectGithubHost(
+  apiUrl: URL,
+  token: string,
+): Promise<GithubHost> {
+  const { hostname } = apiUrl;
+
+  if (hostname === 'api.github.com') {
+    return { type: 'github', apiUrl };
   }
-  const host = parsedEndpoint.host;
-  platformConfig.isGhe = host !== 'api.github.com';
-  platformConfig.isGheCloud = host.endsWith('.ghe.com');
-  if (platformConfig.isGhe) {
-    const gheHeaderKey = 'x-github-enterprise-version';
-    const gheQueryRes = await githubApi.headJson('/', { token });
-    const gheHeaders = coerceObject(gheQueryRes?.headers);
-    const gheVersionHeader = Object.entries(gheHeaders).find(
-      ([k]) => k.toLowerCase() === gheHeaderKey,
-    );
-    platformConfig.gheVersion =
-      semver.valid(gheVersionHeader?.[1] as string) ?? null;
-    logger.debug(
-      `Detected GitHub Enterprise Server, version: ${platformConfig.gheVersion}`,
-    );
+
+  if (hostname.endsWith('.ghe.com')) {
+    logger.debug('Detected GitHub Enterprise Cloud');
+    return { type: 'ghec', apiUrl };
   }
+
+  const gheHeaderKey = 'x-github-enterprise-version';
+  const gheQueryRes = await githubApi.headJson('/', { token });
+  const gheHeaders = coerceObject(gheQueryRes?.headers);
+  const gheVersionHeader = Object.entries(gheHeaders).find(
+    ([k]) => k.toLowerCase() === gheHeaderKey,
+  );
+
+  const version = semver.valid(gheVersionHeader?.[1] as string) ?? null;
+  logger.debug(`Detected GitHub Enterprise Server, version: ${version}`);
+  return { type: 'ghes', apiUrl, version };
 }
 
 export async function initPlatform({
@@ -172,26 +187,28 @@ export async function initPlatform({
   token = token.replace(regEx(/^ghs_/), 'x-access-token:ghs_');
   platformConfig.isGHApp = token.startsWith('x-access-token:');
 
+  let githubApiUrl = platformConfig.host.apiUrl;
   if (endpoint) {
-    if (!isHttpUrl(endpoint)) {
+    const parsedApiUrl = parseUrl(ensureTrailingSlash(endpoint));
+    if (!parsedApiUrl || !isHttpUrl(parsedApiUrl)) {
       throw new Error(`Init: Invalid GitHub endpoint URL: ${endpoint}`);
     }
-    platformConfig.endpoint = ensureTrailingSlash(endpoint);
-    githubHttp.setBaseUrl(platformConfig.endpoint);
+    githubApiUrl = parsedApiUrl;
+    githubHttp.setBaseUrl(githubApiUrl.href);
   } else {
-    logger.debug(`Using default github endpoint: ${platformConfig.endpoint}`);
+    logger.debug(`Using default github endpoint: ${githubApiUrl.href}`);
   }
 
-  await detectGhe(token);
+  platformConfig.host = await detectGithubHost(githubApiUrl, token);
   /**
    * GHE requires version >=3.10 to support fine-grained access tokens
    * https://docs.github.com/en/enterprise-server@3.10/admin/release-notes#authentication
    */
   if (
     isGithubFineGrainedPersonalAccessToken(token) &&
-    platformConfig.isGhe &&
-    (!platformConfig.gheVersion ||
-      semver.lt(platformConfig.gheVersion, '3.10.0'))
+    isGithubEnterpriseServer(platformConfig.host) &&
+    (!platformConfig.host.version ||
+      semver.lt(platformConfig.host.version, '3.10.0'))
   ) {
     throw new Error(
       'Init: Fine-grained Personal Access Tokens do not support GitHub Enterprise Server API version <3.10 and cannot be used with Renovate.',
@@ -206,20 +223,17 @@ export async function initPlatform({
     renovateUsername = platformConfig.userDetails.username;
   } else {
     platformConfig.userDetails ??= await getUserDetails(
-      platformConfig.endpoint,
+      platformConfig.host.apiUrl.href,
       token,
     );
     renovateUsername = platformConfig.userDetails.username;
   }
 
   let ghHostname: string;
-  /* v8 ignore next -- false negative due to V8/source-map artifact */
-  if (platformConfig.isGheCloud) {
+  if (platformConfig.host.type === 'ghec') {
     ghHostname = 'ghe.com';
-  } else if (platformConfig.isGhe) {
-    // valid url ensured at the function start
-    const parsedEndpoint = parseUrl(platformConfig.endpoint)!;
-    ghHostname = parsedEndpoint.hostname;
+  } else if (platformConfig.host.type === 'ghes') {
+    ghHostname = platformConfig.host.apiUrl.hostname;
   } else {
     ghHostname = 'github.com';
   }
@@ -231,13 +245,13 @@ export async function initPlatform({
       discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userDetails.id}+${platformConfig.userDetails.username}@users.noreply.${ghHostname}>`;
     } else {
       platformConfig.userDetails ??= await getUserDetails(
-        platformConfig.endpoint,
+        platformConfig.host.apiUrl.href,
         token,
       );
       // v8 ignore next -- TODO: coverage error #40625
       platformConfig.userEmail =
         platformConfig.userDetails.email ??
-        (await getUserEmail(platformConfig.endpoint, token));
+        (await getUserEmail(platformConfig.host.apiUrl.href, token));
       if (platformConfig.userEmail) {
         discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userEmail}>`;
       }
@@ -248,13 +262,16 @@ export async function initPlatform({
 
   logger.debug({ platformConfig, renovateUsername }, 'Platform config');
   const platformResult: PlatformResult = {
-    endpoint: platformConfig.endpoint,
+    endpoint: platformConfig.host.apiUrl.href,
     gitAuthor: gitAuthor ?? discoveredGitAuthor,
     renovateUsername,
     token,
   };
 
-  warnIfDefaultGitAuthorEmail(platformResult.gitAuthor, platformConfig.isGhe);
+  warnIfDefaultGitAuthorEmail(
+    platformResult.gitAuthor,
+    platformConfig.host.type !== 'github',
+  );
 
   if (
     getEnv().RENOVATE_X_GITHUB_HOST_RULES &&
@@ -467,7 +484,10 @@ export async function findFork(
   }
   logger.debug(`Searching for forked repo in user account`);
   try {
-    const { username } = await getUserDetails(platformConfig.endpoint, token);
+    const { username } = await getUserDetails(
+      platformConfig.host.apiUrl.href,
+      token,
+    );
     const forkedRepo = forks.find((repo) => repo.owner.login === username);
     if (forkedRepo) {
       logger.debug(`Found repo in user account: ${forkedRepo.full_name}`);
@@ -531,7 +551,7 @@ export async function initRepo({
   } as any;
   const opts = hostRules.find({
     hostType: 'github',
-    url: platformConfig.endpoint,
+    url: platformConfig.host.apiUrl.href,
     readOnly: true,
   });
   config.renovateUsername = renovateUsername;
@@ -544,9 +564,8 @@ export async function initRepo({
     // GitHub Enterprise Server <3.3.0 doesn't support autoMergeAllowed and hasIssuesEnabled objects
     // TODO #22198
     if (
-      platformConfig.isGhe &&
-      // semver not null safe, accepts null and undefined
-      semver.satisfies(platformConfig.gheVersion!, '<3.3.0')
+      isGithubEnterpriseServer(platformConfig.host) &&
+      semver.satisfies(platformConfig.host.version ?? '', '<3.3.0')
     ) {
       infoQuery = infoQuery.replace(regEx(/\n\s*autoMergeAllowed\s*\n/), '\n');
       infoQuery = infoQuery.replace(regEx(/\n\s*hasIssuesEnabled\s*\n/), '\n');
@@ -554,9 +573,8 @@ export async function initRepo({
 
     // GitHub Enterprise Server <3.9.0 doesn't support hasVulnerabilityAlertsEnabled objects
     if (
-      platformConfig.isGhe &&
-      // semver not null safe, accepts null and undefined
-      semver.satisfies(platformConfig.gheVersion!, '<3.9.0')
+      isGithubEnterpriseServer(platformConfig.host) &&
+      semver.satisfies(platformConfig.host.version ?? '', '<3.9.0')
     ) {
       infoQuery = infoQuery.replace(
         regEx(/\n\s*hasVulnerabilityAlertsEnabled\s*\n/),
@@ -566,9 +584,8 @@ export async function initRepo({
 
     // GitHub Enterprise Server <3.12.0 doesn't support merge queues
     if (
-      platformConfig.isGhe &&
-      // semver not null safe, accepts null and undefined
-      semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
+      isGithubEnterpriseServer(platformConfig.host) &&
+      semver.satisfies(platformConfig.host.version ?? '', '<3.12.0')
     ) {
       infoQuery = infoQuery.replace(
         regEx(/\n\s*mergeQueue\s*\{\s*id\s*\}\s*\n/),
@@ -775,14 +792,12 @@ export async function initRepo({
     logger.debug(`Using ${tokenType} token for git init`);
     authToken = opts.token ?? null;
   }
-  // endpoint is validated during initPlatform
-  const parsedEndpoint = parseUrl(platformConfig.endpoint)!;
   const workingSshUrl = forkToken ? forkSshUrl : repo.sshUrl;
   const url = getRepoUrl(
     config.repository!,
     gitUrl,
     workingSshUrl,
-    parsedEndpoint,
+    platformConfig.host.apiUrl,
     authToken,
   );
   let upstreamUrl: string | undefined;
@@ -791,7 +806,7 @@ export async function initRepo({
       config.parentRepo,
       gitUrl,
       repo.sshUrl,
-      parsedEndpoint,
+      platformConfig.host.apiUrl,
       authToken,
     );
   }
@@ -803,7 +818,7 @@ export async function initRepo({
   const repoConfig: RepoResult = {
     defaultBranch: config.defaultBranch,
     isFork: repo.isFork === true,
-    repoFingerprint: repoFingerprint(repo.id, platformConfig.endpoint),
+    repoFingerprint: repoFingerprint(repo.id, platformConfig.host.apiUrl.href),
   };
   return repoConfig;
 }
@@ -1866,10 +1881,9 @@ async function tryPrAutomerge(
 
   // If GitHub Enterprise Server <3.3.0 it doesn't support automerge
   // TODO #22198
-  // semver not null safe, accepts null and undefined
   if (
-    platformConfig.isGhe &&
-    semver.satisfies(platformConfig.gheVersion!, '<3.3.0')
+    isGithubEnterpriseServer(platformConfig.host) &&
+    semver.satisfies(platformConfig.host.version ?? '', '<3.3.0')
   ) {
     logger.debug(
       { prNumber },
@@ -2006,10 +2020,9 @@ async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
   }
 
   // TODO #22198
-  // semver not null safe, accepts null and undefined
   if (
-    platformConfig.isGhe &&
-    semver.satisfies(platformConfig.gheVersion!, '<3.12.0')
+    isGithubEnterpriseServer(platformConfig.host) &&
+    semver.satisfies(platformConfig.host.version ?? '', '<3.12.0')
   ) {
     // Merge queues are only supported on GHES >=3.12.0
     config.mergeQueueEnabled[baseBranch] = false;
@@ -2262,7 +2275,7 @@ export async function mergePr({
 }
 
 export function massageMarkdown(input: string): string {
-  if (platformConfig.isGhe) {
+  if (platformConfig.host.type !== 'github') {
     return smartTruncate(input, maxBodyLength());
   }
   const massagedInput = massageMarkdownLinks(input)

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -103,13 +103,16 @@ import type {
   GhRepo,
   GhRestPr,
   GhRestRepo,
-  GithubEnterpriseServerHost,
   GithubHost,
   LocalRepoConfig,
   PlatformConfig,
 } from './types.ts';
 import { getAppDetails, getUserDetails, getUserEmail } from './user.ts';
-import { getRepoUrl, warnIfDefaultGitAuthorEmail } from './utils.ts';
+import {
+  getRepoUrl,
+  isGithubEnterpriseServer,
+  warnIfDefaultGitAuthorEmail,
+} from './utils.ts';
 
 export const id = 'github';
 
@@ -139,12 +142,6 @@ function escapeHash(input: string): string {
 
 export function isGHApp(): boolean {
   return !!platformConfig.isGHApp;
-}
-
-function isGithubEnterpriseServer(
-  host: GithubHost,
-): host is GithubEnterpriseServerHost {
-  return host.type === 'ghes';
 }
 
 async function detectGithubHost(

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -87,12 +87,30 @@ export interface UserDetails {
   email: EmailAddress | null;
 }
 
+interface GithubHostBase {
+  apiUrl: URL;
+}
+
+export interface GithubComHost extends GithubHostBase {
+  type: 'github';
+}
+
+export interface GithubEnterpriseCloudHost extends GithubHostBase {
+  type: 'ghec';
+}
+
+export interface GithubEnterpriseServerHost extends GithubHostBase {
+  type: 'ghes';
+  version: string | null;
+}
+
+export type GithubHost =
+  | GithubComHost
+  | GithubEnterpriseCloudHost
+  | GithubEnterpriseServerHost;
+
 export interface PlatformConfig {
-  hostType: string;
-  endpoint: string;
-  isGhe?: boolean;
-  isGheCloud?: boolean;
-  gheVersion?: string | null;
+  host: GithubHost;
   isGHApp?: boolean;
   existingRepos?: string[];
   userDetails?: UserDetails;

--- a/lib/modules/platform/github/utils.ts
+++ b/lib/modules/platform/github/utils.ts
@@ -3,6 +3,7 @@ import { logger } from '../../../logger/index.ts';
 import { parseGitAuthor } from '../../../util/git/author.ts';
 import { parseUrl } from '../../../util/url.ts';
 import type { GitUrlOption } from '../types.ts';
+import type { GithubEnterpriseServerHost, GithubHost } from './types.ts';
 
 export function warnIfDefaultGitAuthorEmail(
   gitAuthor: string | undefined,
@@ -50,4 +51,10 @@ export function getRepoUrl(
   url.host = url.host.replace('api.github.com', 'github.com');
   url.pathname = `${repository}.git`;
   return url.href;
+}
+
+export function isGithubEnterpriseServer(
+  host: GithubHost,
+): host is GithubEnterpriseServerHost {
+  return host.type === 'ghes';
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Split out from #45601.

Refactors GitHub `PlatformConfig` to have a clearer distinction between GitHub.com, GHEC and GHES, cleaning up some complex boolean state management.

Previously, when detecting info about the GHE host (which included GHEC), Renovate would make a `HEAD /` request in order to determine the GHES version (from a header in the response). GHEC doesn't send this header. With this PR, that request only happens on GHES servers; GHEC hosts skip this probe.

This comes with two side effects:

- When making the `HEAD /` request, Renovate uses a token to authenticate to GitHub. If this token is invalid, we would immediately fail. Because we no longer make a request on GHEC, we will fail on the first actual request to GitHub, rather than the version probe
- We are no longer applying GHES version checks to GHEC; all features should be available. Previously, the detected version would be `null` and Renovate would disable features that "weren't available on this version" like fine-grained PATs

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

I used GPT-5.6 Sol in Codex extensively during my investigation and while preparing the initial patches, and Claude Fable 5 in Claude Code to review the patches. I have reviewed, refactored and tested all changes, including running a custom Renovate image containing them against my company's GHEC instance.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @JackMyers001 will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
