### PR TITLE
fix(http): retry EBADF and use stale cache for transient errors

### DIFF
--- a/lib/modules/datasource/npm/get.spec.ts
+++ b/lib/modules/datasource/npm/get.spec.ts
@@ -255,6 +255,17 @@ describe('modules/datasource/npm/get', () => {
     ).rejects.toThrow(ExternalHostError);
   });
 
+  it('throws ExternalHostError for EBADF without stale cache', async () => {
+    httpMock
+      .scope(defaultRegistryUrl)
+      .get('/some-package')
+      .replyWithError(httpMock.error({ code: 'EBADF' }));
+
+    await expect(
+      getDependency(http, defaultRegistryUrl, 'some-package'),
+    ).rejects.toThrow(ExternalHostError);
+  });
+
   it('redact body for ExternalHostError when error happens on registry.npmjs.org', async () => {
     httpMock
       .scope(defaultRegistryUrl)
@@ -604,6 +615,31 @@ describe('modules/datasource/npm/get', () => {
       headers: { 'cache-control': 'max-age=180, public' },
     };
 
+    const cachedDependency = {
+      releases: [
+        {
+          attestation: false,
+          dependencies: undefined,
+          devDependencies: undefined,
+          gitRef: undefined,
+          version: '1.0.0',
+        },
+      ],
+      sourceDirectory: 'packages/foo',
+      sourceUrl:
+        'https://github.com/octocat/Hello-World/tree/master/packages/test',
+      tags: { latest: '1.0.0' },
+    };
+
+    function mockExpiredCache(): void {
+      vi.setSystemTime('2024-06-15T00:15:00.000Z');
+      packageCache.get.mockResolvedValue({
+        etag: 'some-etag',
+        timestamp: '2024-06-15T00:00:00.000Z',
+        httpResponse,
+      });
+    }
+
     it('stores a trimmed packument body in cache', async () => {
       httpMock
         .scope('https://example.com')
@@ -837,36 +873,42 @@ describe('modules/datasource/npm/get', () => {
     });
 
     it('returns soft expired cache on npmjs error', async () => {
-      vi.setSystemTime('2024-06-15T00:15:00.000Z');
-      packageCache.get.mockResolvedValue({
-        etag: 'some-etag',
-        timestamp: '2024-06-15T00:00:00.000Z',
-        httpResponse,
-      });
-      setNpmrc('registry=https://example.com\n_authToken=XXX');
-      httpMock.scope('https://example.com').get('/some-package').reply(500);
+      mockExpiredCache();
+      httpMock.scope(defaultRegistryUrl).get('/some-package').reply(500);
 
-      const dep = await getDependency(
-        http,
-        'https://example.com',
-        'some-package',
-      );
+      const dep = await getDependency(http, defaultRegistryUrl, 'some-package');
 
       expect(dep).toEqual({
-        registryUrl: 'https://example.com',
-        releases: [
-          {
-            attestation: false,
-            dependencies: undefined,
-            devDependencies: undefined,
-            gitRef: undefined,
-            version: '1.0.0',
-          },
-        ],
-        sourceDirectory: 'packages/foo',
-        sourceUrl:
-          'https://github.com/octocat/Hello-World/tree/master/packages/test',
-        tags: { latest: '1.0.0' },
+        registryUrl: defaultRegistryUrl,
+        ...cachedDependency,
+      });
+    });
+
+    it('honors explicit npmjs abortOnError before stale cache', async () => {
+      mockExpiredCache();
+      hostRules.add({
+        matchHost: defaultRegistryUrl,
+        abortOnError: true,
+      });
+      httpMock.scope(defaultRegistryUrl).get('/some-package').reply(500);
+
+      await expect(
+        getDependency(http, defaultRegistryUrl, 'some-package'),
+      ).rejects.toThrow(ExternalHostError);
+    });
+
+    it('returns soft expired cache on npmjs EBADF', async () => {
+      mockExpiredCache();
+      httpMock
+        .scope(defaultRegistryUrl)
+        .get('/some-package')
+        .replyWithError(httpMock.error({ code: 'EBADF' }));
+
+      const dep = await getDependency(http, defaultRegistryUrl, 'some-package');
+
+      expect(dep).toEqual({
+        registryUrl: defaultRegistryUrl,
+        ...cachedDependency,
       });
     });
   });

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -3,7 +3,6 @@ import { z } from 'zod/v4';
 import { HOST_DISABLED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
-import * as hostRules from '../../../util/host-rules.ts';
 import { PackageHttpCacheProvider } from '../../../util/http/cache/package-http-cache-provider.ts';
 import type { Http } from '../../../util/http/index.ts';
 import type { HttpOptions } from '../../../util/http/types.ts';
@@ -84,22 +83,10 @@ export async function getDependency(
       checkCacheControlHeader: true,
       writeSchema: CachedPackument,
     });
-    const options: HttpOptions = { cacheProvider };
-
-    // set abortOnError for registry.npmjs.org if no hostRule with explicit abortOnError exists
-    if (
-      registryUrl === defaultRegistryUrl &&
-      hostRules.find({ url: defaultRegistryUrl })?.abortOnError === undefined
-    ) {
-      logger.trace(
-        { packageName, registry: defaultRegistryUrl },
-        'setting abortOnError hostRule for well known host',
-      );
-      hostRules.add({
-        matchHost: defaultRegistryUrl,
-        abortOnError: true,
-      });
-    }
+    const options: HttpOptions = {
+      abortOnError: registryUrl === defaultRegistryUrl,
+      cacheProvider,
+    };
 
     const resp = await http.getJson(packageUrl, options, NpmResponse);
     const { body: res } = resp;

--- a/lib/util/http/cache/package-http-cache-provider.spec.ts
+++ b/lib/util/http/cache/package-http-cache-provider.spec.ts
@@ -4,8 +4,10 @@ import { z } from 'zod/v4';
 import * as httpMock from '~test/http-mock.ts';
 import { partial } from '~test/util.ts';
 import { GlobalConfig } from '../../../config/global.ts';
+import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import * as _packageCache from '../../cache/package/index.ts';
-import { Http, type HttpResponse } from '../index.ts';
+import * as hostRules from '../../host-rules.ts';
+import { Http, HttpError, type HttpResponse } from '../index.ts';
 import {
   PackageHttpCacheProvider,
   type PackageHttpCacheProviderOptions,
@@ -54,6 +56,7 @@ describe('util/http/cache/package-http-cache-provider', () => {
     });
 
     GlobalConfig.reset();
+    hostRules.clear();
   });
 
   function mockTime(time: string) {
@@ -70,6 +73,16 @@ describe('util/http/cache/package-http-cache-provider', () => {
       checkCacheControlHeader: false,
       ...options,
     });
+  }
+
+  function mockStaleCache(body: unknown = 'cached response'): void {
+    mockTime('2024-06-15T00:15:00.000Z');
+    cache[url] = {
+      etag: 'etag-value',
+      lastModified: 'Fri, 15 Jun 2024 00:00:00 GMT',
+      httpResponse: { statusCode: 200, body },
+      timestamp: '2024-06-15T00:00:00.000Z',
+    };
   }
 
   it('skips persisting null cache values', async () => {
@@ -271,20 +284,83 @@ describe('util/http/cache/package-http-cache-provider', () => {
     expect(packageCache.setWithRawTtl).toHaveBeenCalled();
   });
 
-  it('serves stale response during revalidation error', async () => {
-    mockTime('2024-06-15T00:15:00.000Z');
-    cache[url] = {
-      etag: 'etag-value',
-      lastModified: 'Fri, 15 Jun 2024 00:00:00 GMT',
-      httpResponse: { statusCode: 200, body: 'cached response' },
-      timestamp: '2024-06-15T00:00:00.000Z',
-    };
+  it.each([500, 502, 503, 504])(
+    'serves stale response during %i revalidation error',
+    async (statusCode) => {
+      mockStaleCache();
+      const cacheProvider = createCacheProvider();
+      httpMock.scope(url).get('').reply(statusCode);
+
+      const res = await http.getText(url, { cacheProvider });
+
+      expect(res.body).toBe('cached response');
+    },
+  );
+
+  it('serves stale response for a response-bearing retryable error', async () => {
+    mockStaleCache();
+    const readError = httpMock.error({
+      code: 'ECONNRESET',
+      response: { statusCode: 200 },
+    });
+    Object.setPrototypeOf(readError, HttpError.prototype);
+    packageCache.setWithRawTtl.mockRejectedValueOnce(readError);
     const cacheProvider = createCacheProvider();
-    httpMock.scope(url).get('').reply(500);
+    httpMock.scope(url).get('').reply(200, 'partial response');
 
     const res = await http.getText(url, { cacheProvider });
 
     expect(res.body).toBe('cached response');
+  });
+
+  it('honors explicit abortOnError before stale cache fallback', async () => {
+    mockStaleCache();
+    hostRules.add({
+      matchHost: 'http://example.com',
+      abortOnError: true,
+    });
+    const cacheProvider = createCacheProvider();
+    httpMock.scope(url).get('').reply(500);
+
+    await expect(http.getText(url, { cacheProvider })).rejects.toThrow(
+      ExternalHostError,
+    );
+  });
+
+  it.each([401, 404])(
+    'does not serve stale response during %i response',
+    async (statusCode) => {
+      mockStaleCache();
+      const cacheProvider = createCacheProvider();
+      httpMock.scope(url).get('').reply(statusCode);
+
+      await expect(http.getText(url, { cacheProvider })).rejects.toThrow(
+        HttpError,
+      );
+    },
+  );
+
+  it('does not serve stale response for malformed JSON', async () => {
+    mockStaleCache({ cached: true });
+    const cacheProvider = createCacheProvider();
+    httpMock.scope(url).get('').reply(200, '{');
+
+    await expect(http.getJsonUnchecked(url, { cacheProvider })).rejects.toThrow(
+      "Expected property name or '}' in JSON at position 1",
+    );
+  });
+
+  it('does not serve stale response for cache write errors', async () => {
+    mockStaleCache();
+    packageCache.setWithRawTtl.mockRejectedValueOnce(
+      new Error('cache write failed'),
+    );
+    const cacheProvider = createCacheProvider();
+    httpMock.scope(url).get('').reply(200, 'new response');
+
+    await expect(http.getText(url, { cacheProvider })).rejects.toThrow(
+      'cache write failed',
+    );
   });
 
   it('stores a trimmed body when refreshing cache after 304', async () => {

--- a/lib/util/http/got.ts
+++ b/lib/util/http/got.ts
@@ -18,6 +18,11 @@ import {
 
 export { RequestError } from 'got';
 
+export const retryableErrorCodes = [
+  ...got.defaults.options.retry.errorCodes,
+  'EBADF',
+];
+
 type QueueStatsData = Pick<HttpRequestStatsDataPoint, 'queueMs'>;
 
 export function configureRejectUnauth(options: OptionsInit): void {

--- a/lib/util/http/host-rules.spec.ts
+++ b/lib/util/http/host-rules.spec.ts
@@ -119,6 +119,18 @@ describe('util/http/host-rules', () => {
     });
   });
 
+  it('applies abortOnError=false', () => {
+    const opts: GotOptions = {
+      ...options,
+      abortOnError: true,
+    };
+
+    expect(applyHostRule(url, opts, { abortOnError: false })).toEqual({
+      hostType: 'github',
+      abortOnError: false,
+    });
+  });
+
   it('skips', () => {
     const opts = { ...options, token: 'xxx' };
     const hostRule = findMatchingRule(url, opts);

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -1,4 +1,4 @@
-import { isNonEmptyString } from '@sindresorhus/is';
+import { isNonEmptyString, isUndefined } from '@sindresorhus/is';
 import { GlobalConfig } from '../../config/global.ts';
 import {
   BITBUCKET_API_USING_HOST_TYPES,
@@ -210,7 +210,7 @@ export function applyHostRule<GotOptions extends HostRulesGotOptions>(
     logger.once.debug(`hostRules: no authentication for ${host}`);
   }
   // Apply optional params
-  if (hostRule.abortOnError) {
+  if (!isUndefined(hostRule.abortOnError)) {
     options.abortOnError = hostRule.abortOnError;
   }
 

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -21,7 +21,13 @@ import { isHttpUrl, parseUrl, resolveBaseUrl } from '../url.ts';
 import { parseSingleYaml } from '../yaml.ts';
 import { applyAuthorization } from './auth.ts';
 import type { HttpCacheProvider } from './cache/types.ts';
-import { fetch, normalize, stream } from './got.ts';
+import {
+  RequestError,
+  fetch,
+  normalize,
+  retryableErrorCodes,
+  stream,
+} from './got.ts';
 import { applyHostRule, findMatchingRule } from './host-rules.ts';
 import { getQueue } from './queue.ts';
 import { getRetryAfter, wrapWithRetry } from './retry-after.ts';
@@ -62,6 +68,24 @@ export interface InternalHttpOptions extends HttpOptions {
   parseJson?: Options['parseJson'];
 }
 
+const staleCacheStatusCodes = new Set([500, 502, 503, 504]);
+
+function canUseStaleCache(err: unknown): boolean {
+  if (!(err instanceof RequestError)) {
+    return false;
+  }
+
+  if (retryableErrorCodes.includes(err.code)) {
+    return true;
+  }
+
+  if (err.response && staleCacheStatusCodes.has(err.response.statusCode)) {
+    return true;
+  }
+
+  return false;
+}
+
 export function applyDefaultHeaders(options: OptionsInit): void {
   const userAgentTemplate = GlobalConfig.get('userAgent');
   options.headers = {
@@ -93,6 +117,7 @@ export abstract class HttpBase<
         retry: {
           calculateDelay: (retryObject) =>
             this.calculateRetryDelay(retryObject),
+          errorCodes: retryableErrorCodes,
           limit: retryLimit,
           maxRetryAfter: 0, // Don't rely on `got` retry-after handling, just let it fail and then we'll handle it
         },
@@ -251,21 +276,33 @@ export abstract class HttpBase<
       return resCopy;
     } catch (err) {
       const { abortOnError, abortIgnoreStatusCodes } = options;
-      if (abortOnError && !abortIgnoreStatusCodes?.includes(err.statusCode)) {
+      const shouldAbort =
+        abortOnError && !abortIgnoreStatusCodes?.includes(err.statusCode);
+      // Explicit host rules take precedence over cache fallback. A request-local
+      // default only aborts when no eligible stale response exists.
+      const abortBeforeStaleCache =
+        shouldAbort && hostRule.abortOnError === true;
+      if (abortBeforeStaleCache) {
         throw new ExternalHostError(err);
       }
 
-      const staleResponse = await cacheProvider?.bypassServer<string | Buffer>(
-        method,
-        url,
-        true,
-      );
-      if (staleResponse) {
-        logger.debug(
-          { err },
-          `Request error: returning stale cache instead for ${url}`,
+      if (canUseStaleCache(err)) {
+        const staleResponse = await cacheProvider?.bypassServer(
+          method,
+          url,
+          true,
         );
-        return staleResponse;
+        if (staleResponse) {
+          logger.debug(
+            { err },
+            `Request error: returning stale cache instead for ${url}`,
+          );
+          return staleResponse;
+        }
+      }
+
+      if (shouldAbort) {
+        throw new ExternalHostError(err);
       }
 
       this.handleError(requestUrl, httpOptions, err);

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -1,3 +1,4 @@
+import type { RetryObject } from 'got';
 import { ZodError, z } from 'zod/v4';
 import * as httpMock from '~test/http-mock.ts';
 import { logger } from '~test/util.ts';
@@ -17,6 +18,12 @@ import * as throttle from './throttle.ts';
 import type { HttpResponse } from './types.ts';
 
 const baseUrl = 'http://renovate.com';
+
+class FastRetryHttp extends Http {
+  protected override calculateRetryDelay(retryObject: RetryObject): number {
+    return super.calculateRetryDelay(retryObject) > 0 ? 1 : 0;
+  }
+}
 
 describe('util/http/index', () => {
   let http: Http;
@@ -438,7 +445,7 @@ describe('util/http/index', () => {
   describe('retry', () => {
     beforeEach(() => {
       vi.stubEnv('NODE_ENV', undefined);
-      http = new Http('dummy');
+      http = new FastRetryHttp('dummy');
     });
 
     it('works', async () => {
@@ -456,6 +463,20 @@ describe('util/http/index', () => {
         },
         statusCode: 200,
       });
+      expect(httpMock.allUsed()).toBeTrue();
+    });
+
+    it('retries EBADF errors for GET requests', async () => {
+      httpMock
+        .scope(baseUrl)
+        .get('/test')
+        .replyWithError(httpMock.error({ code: 'EBADF' }))
+        .get('/test')
+        .reply(200, 'retried');
+
+      const res = await http.getText(`${baseUrl}/test`);
+
+      expect(res.body).toBe('retried');
       expect(httpMock.allUsed()).toBeTrue();
     });
   });

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -75,7 +75,7 @@ export interface GraphqlOptions {
  * Renovate http options that are partly not part of `got` options.
  * Remember to delete these in `normalizeGotOptions` before passing to `got`.
  */
-export interface HttpOptions {
+export interface HttpOptions extends Pick<GotExtraOptions, 'abortOnError'> {
   body?: any;
   username?: string;
   password?: string;


### PR DESCRIPTION
## Changes

A single `EBADF` write failure from `registry.npmjs.org` currently skips Got's retry path, then reaches npm's automatic `abortOnError` handling before Renovate checks for a stale cached packument. This can stop a repository run even when the lookup has usable cached data. This PR addresses the failure reported in [discussion #45532](https://github.com/renovatebot/renovate/discussions/45532).

HTTP recovery now follows this order:

`request → bounded Got retries → eligible stale cache → existing error handling`

`EBADF` is added to Got's existing retryable error codes and uses the existing retry limits and method restrictions. After retries are exhausted, stale cache is eligible for Got's retryable transport errors and for `500`, `502`, `503`, and `504` responses. Response-bearing read errors remain eligible when their transport code is retryable, so a partial `200` followed by `ECONNRESET` does not lose the fallback. Authentication and not-found responses, malformed response bodies, and local cache failures do not use stale data.

The automatic `abortOnError` behavior for `registry.npmjs.org` is now request-local instead of being added as a global host rule. A matching explicit `hostRules.abortOnError: true` still aborts before stale cache is considered, while an explicit `false` overrides the automatic npm default. If retries and eligible stale cache cannot satisfy the request, the existing `ExternalHostError` and repository-abort behavior remains unchanged.

As a result, automatic npm lookup failures with status `500`, `502`, `503`, or `504` may now return a stale packument instead of aborting the repository run. Explicit abort rules retain their documented behavior.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). GPT-5.6 Sol was used to analyze the failure, draft parts of the implementation and unit tests, and prepare this description.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
