### PR TITLE
docs(conda): clarify `minimumReleaseAge` is supported

### DIFF
--- a/lib/modules/datasource/conda/index.ts
+++ b/lib/modules/datasource/conda/index.ts
@@ -26,6 +26,9 @@ export class CondaDatasource extends Datasource {
 
   override readonly caching = true;
 
+  override readonly releaseTimestampSupport = true;
+  override readonly releaseTimestampNote =
+    'The release timestamp is determined from the `upload_time` field of the files of a version when using the Anaconda.org API, or from the `createdAt` field of the variants of a version when using prefix.dev. All files of a version are assumed to be published at roughly the same time.';
   override readonly sourceUrlSupport = 'package';
   override readonly sourceUrlNote =
     'The source URL is determined from the `dev_url` field in the results.';


### PR DESCRIPTION
## Changes

The `conda` datasource has returned `releaseTimestamp`s since it was first added, but it never declared `releaseTimestampSupport`, so it inherited the `false` default from `Datasource`. Both generated tables therefore listed conda as having no release timestamp support:

- `modules/datasource/conda/index.md` → `| Release timestamp support | No |`
- `key-concepts/minimum-release-age.md` → ❌

This declares `releaseTimestampSupport = true` and adds a `releaseTimestampNote`, which corrects both tables. There is no runtime behavior change: `releaseTimestampSupport` is only read by the docs generators (`tools/docs/datasources.ts`, `tools/docs/minimum-release-age.ts`).

Where the timestamps come from today:

| Registry | Field | Code |
| --- | --- | --- |
| Anaconda.org API | `upload_time` of a version's files | `lib/modules/datasource/conda/index.ts` |
| prefix.dev | `createdAt` of a version's variants | `lib/modules/datasource/conda/prefix-dev.ts` |

This is the same omission, and the same fix, as #38717 for `pypi`.

### Verification

Existing unit tests already assert the timestamps for both registries — explicitly for prefix.dev in `index.spec.ts`, and via the snapshot for Anaconda.org — so the support itself is already covered and no new tests are added.

To confirm the docs claim holds against the real registries rather than only against fixtures, I checked timestamp coverage for `conda-forge/pytest`:

- Anaconda.org (`GET /package/conda-forge/pytest`): 1904 files across 135 versions; **135/135 versions** have at least one file with an `upload_time`.
- prefix.dev (GraphQL `variants`): **50/50 variants** on the first page carry a `createdAt`, covering all 34 distinct versions on that page.

I also ran `pnpm build:docs` and confirmed the two generated tables now read `Yes` and 🟠 respectively.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The metadata change, the note wording, the verification above and this PR description were drafted by Claude Opus 5 running in Claude Code, then reviewed by @nielspardon.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @nielspardon will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

The changed metadata *is* the documentation — both affected pages are generated from it.

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Plus the generated-docs and live-registry checks described under "Verification" above. I did not run Renovate end-to-end on a public repository, since this PR changes no runtime behavior.
