### PR TITLE
fix(bitbucket): bbUseDevelopmentBranch fetching

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -342,9 +342,9 @@ describe('modules/platform/bitbucket/index', () => {
           uuid: '123',
           full_name: 'some/repo',
         })
-        .get('/2.0/repositories/some/repo/branching-model')
+        .get('/2.0/repositories/some/repo/effective-branching-model')
         .reply(200, {
-          development: { name: 'develop', branch: { name: 'develop' } },
+          development: { name: 'develop', branch: { type: '<string>' } },
         });
 
       const res = await bitbucket.initRepo({

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -344,7 +344,7 @@ describe('modules/platform/bitbucket/index', () => {
         })
         .get('/2.0/repositories/some/repo/effective-branching-model')
         .reply(200, {
-          development: { name: 'develop', branch: { type: '<string>' } },
+          development: { name: 'develop' },
         });
 
       const res = await bitbucket.initRepo({
@@ -367,9 +367,7 @@ describe('modules/platform/bitbucket/index', () => {
           full_name: 'some/repo',
         })
         .get('/2.0/repositories/some/repo/effective-branching-model')
-        .reply(200, {
-          development: { name: 'develop' },
-        });
+        .reply(200, {});
 
       const res = await bitbucket.initRepo({
         repository: 'some/repo',

--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -366,7 +366,7 @@ describe('modules/platform/bitbucket/index', () => {
           uuid: '123',
           full_name: 'some/repo',
         })
-        .get('/2.0/repositories/some/repo/branching-model')
+        .get('/2.0/repositories/some/repo/effective-branching-model')
         .reply(200, {
           development: { name: 'develop' },
         });

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -252,7 +252,9 @@ export async function initRepo({
     mainBranch = info.mainbranch;
 
     if (getInheritedOrGlobal('bbUseDevelopmentBranch')) {
-      // Fetch Bitbucket development branch
+      logger.info(
+        "bbUseDevelopmentBranch is true - Checking BitBucket's development branch",
+      );
       const developmentBranch = (
         await bitbucketHttp.getJsonUnchecked<RepoBranchingModel>(
           `/2.0/repositories/${repository}/effective-branching-model`,
@@ -261,6 +263,9 @@ export async function initRepo({
 
       if (developmentBranch) {
         mainBranch = developmentBranch;
+        logger.info(
+          `${developmentBranch} is BitBucket's development branch - using it as default branch`,
+        );
       }
     }
 

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -252,7 +252,7 @@ export async function initRepo({
     mainBranch = info.mainbranch;
 
     if (getInheritedOrGlobal('bbUseDevelopmentBranch')) {
-      logger.info(
+      logger.debug(
         "bbUseDevelopmentBranch is true - Checking BitBucket's development branch",
       );
       const developmentBranch = (
@@ -263,7 +263,7 @@ export async function initRepo({
 
       if (developmentBranch) {
         mainBranch = developmentBranch;
-        logger.info(
+        logger.debug(
           `${developmentBranch} is BitBucket's development branch - using it as default branch`,
         );
       }

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -255,9 +255,9 @@ export async function initRepo({
       // Fetch Bitbucket development branch
       const developmentBranch = (
         await bitbucketHttp.getJsonUnchecked<RepoBranchingModel>(
-          `/2.0/repositories/${repository}/branching-model`,
+          `/2.0/repositories/${repository}/effective-branching-model`,
         )
-      ).body.development?.branch?.name;
+      ).body.development?.name;
 
       if (developmentBranch) {
         mainBranch = developmentBranch;

--- a/lib/modules/platform/bitbucket/types.ts
+++ b/lib/modules/platform/bitbucket/types.ts
@@ -26,11 +26,8 @@ export interface PagedResult<T = any> {
 }
 
 export interface RepoBranchingModel {
-  development: {
+  development?: {
     name: string;
-    branch?: {
-      name: string;
-    };
   };
 }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

BitBucket's branching model fetching has been broken for repositories that are inheriting their settings from project-level settings. I opened a thread in [Atlassian forums](https://community.atlassian.com/forums/Bitbucket-questions/GET-repositories-workspace-repo-slug-branching-model-doesn-t/qaq-p/3283551) with this exact problem and it seems that they are migrating to that new endpoint to fetch that setting reliably, regardless of the source of the repository setting.

## Context

Please select one of the following:

- [ ] This closes an existing Issue
- [X] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [X] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [X] @ferferga will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [X] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [X] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: *Private repo*

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
