### PR TITLE
fix(datasource/go): don't cache `null` on non-404/410 goproxy errors

### DIFF
--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -3,7 +3,9 @@ import type { MockInstance } from 'vitest';
 import { Fixtures } from '~test/fixtures.ts';
 import { hostRules } from '~test/host-rules.ts';
 import * as httpMock from '~test/http-mock.ts';
+import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages.ts';
 import * as githubGraphql from '../../../util/github/graphql/index.ts';
+import { HttpError } from '../../../util/http/index.ts';
 import type { Timestamp } from '../../../util/timestamp.ts';
 import { GithubReleasesDatasource } from '../github-releases/index.ts';
 import { GithubTagsDatasource } from '../github-tags/index.ts';
@@ -627,7 +629,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
       });
     });
 
-    it('short-circuits for errors other than 404 or 410', async () => {
+    it('propagates errors other than 404 or 410, without falling back to further URLs', async () => {
       vi.stubEnv(
         'GOPROXY',
         [
@@ -653,10 +655,11 @@ describe('modules/datasource/go/releases-goproxy', () => {
         .get('/@v/list')
         .replyWithError('unknown');
 
-      const res = await datasource.getReleases({
-        packageName: 'github.com/foo/bar',
-      });
-      expect(res).toBeNull();
+      await expect(
+        datasource.getReleases({ packageName: 'github.com/foo/bar' }),
+      ).rejects.toThrow(HttpError);
+      expect(githubGetTags).not.toHaveBeenCalled();
+      expect(githubGetReleases).not.toHaveBeenCalled();
     });
 
     it('supports "direct" keyword', async () => {
@@ -719,10 +722,7 @@ describe('modules/datasource/go/releases-goproxy', () => {
       expect(res).toBeNull();
     });
 
-    // this is incorrect behaviour we're documenting to fix in a follow-up
-    // a `,`-separated GOPROXY entry should only fall back to the next entry on 404/410, and otherwise propagate the error. Instead
-    // the loop silently stops and `null` is returned, which then gets cached as a "no releases found" result.
-    it('silently swallows a non-404/410 HTTP error from the primary proxy', async () => {
+    it('propagates a non-404/410 HTTP error from the primary proxy instead of falling back', async () => {
       vi.stubEnv('GOPROXY', `${baseUrl},direct`);
 
       httpMock
@@ -730,18 +730,14 @@ describe('modules/datasource/go/releases-goproxy', () => {
         .get('/@v/list')
         .reply(500);
 
-      const res = await datasource.getReleases({
-        packageName: 'github.com/google/btree',
-      });
-
-      expect(res).toBeNull();
+      await expect(
+        datasource.getReleases({ packageName: 'github.com/google/btree' }),
+      ).rejects.toThrow(EXTERNAL_HOST_ERROR);
       expect(githubGetTags).not.toHaveBeenCalled();
       expect(githubGetReleases).not.toHaveBeenCalled();
     });
 
-    // this is incorrect behaviour we're documenting to fix in a follow-up
-    // a network-level error (no HTTP status code at all) is treated the same as any other non-404/410 error.
-    it('silently swallows a network error from the primary proxy', async () => {
+    it('propagates a network error from the primary proxy instead of falling back', async () => {
       vi.stubEnv('GOPROXY', `${baseUrl},direct`);
 
       httpMock
@@ -749,11 +745,9 @@ describe('modules/datasource/go/releases-goproxy', () => {
         .get('/@v/list')
         .replyWithError(httpMock.error({ code: 'ETIMEDOUT' }));
 
-      const res = await datasource.getReleases({
-        packageName: 'github.com/google/btree',
-      });
-
-      expect(res).toBeNull();
+      await expect(
+        datasource.getReleases({ packageName: 'github.com/google/btree' }),
+      ).rejects.toThrow(HttpError);
       expect(githubGetTags).not.toHaveBeenCalled();
       expect(githubGetReleases).not.toHaveBeenCalled();
     });

--- a/lib/modules/datasource/go/releases-goproxy.spec.ts
+++ b/lib/modules/datasource/go/releases-goproxy.spec.ts
@@ -719,6 +719,45 @@ describe('modules/datasource/go/releases-goproxy', () => {
       expect(res).toBeNull();
     });
 
+    // this is incorrect behaviour we're documenting to fix in a follow-up
+    // a `,`-separated GOPROXY entry should only fall back to the next entry on 404/410, and otherwise propagate the error. Instead
+    // the loop silently stops and `null` is returned, which then gets cached as a "no releases found" result.
+    it('silently swallows a non-404/410 HTTP error from the primary proxy', async () => {
+      vi.stubEnv('GOPROXY', `${baseUrl},direct`);
+
+      httpMock
+        .scope(`${baseUrl}/github.com/google/btree`)
+        .get('/@v/list')
+        .reply(500);
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/google/btree',
+      });
+
+      expect(res).toBeNull();
+      expect(githubGetTags).not.toHaveBeenCalled();
+      expect(githubGetReleases).not.toHaveBeenCalled();
+    });
+
+    // this is incorrect behaviour we're documenting to fix in a follow-up
+    // a network-level error (no HTTP status code at all) is treated the same as any other non-404/410 error.
+    it('silently swallows a network error from the primary proxy', async () => {
+      vi.stubEnv('GOPROXY', `${baseUrl},direct`);
+
+      httpMock
+        .scope(`${baseUrl}/github.com/google/btree`)
+        .get('/@v/list')
+        .replyWithError(httpMock.error({ code: 'ETIMEDOUT' }));
+
+      const res = await datasource.getReleases({
+        packageName: 'github.com/google/btree',
+      });
+
+      expect(res).toBeNull();
+      expect(githubGetTags).not.toHaveBeenCalled();
+      expect(githubGetReleases).not.toHaveBeenCalled();
+    });
+
     it('handles soureUrl fetch errors', async () => {
       vi.stubEnv('GOPROXY', baseUrl);
 

--- a/lib/modules/datasource/go/releases-goproxy.ts
+++ b/lib/modules/datasource/go/releases-goproxy.ts
@@ -159,13 +159,17 @@ export class GoProxyDatasource extends Datasource {
         const statusCode = potentialHttpError?.response?.statusCode;
         const canFallback =
           fallback === '|' ? true : statusCode === 404 || statusCode === 410;
-        const msg = canFallback
-          ? 'Goproxy error: trying next URL provided with GOPROXY'
-          : 'Goproxy error: skipping other URLs provided with GOPROXY';
-        logger.debug({ err }, msg);
         if (!canFallback) {
-          break;
+          logger.debug(
+            { err },
+            'Goproxy error: not falling back to other URLs provided with GOPROXY, rethrowing',
+          );
+          this.handleGenericErrors(err);
         }
+        logger.debug(
+          { err },
+          'Goproxy error: trying next URL provided with GOPROXY',
+        );
       }
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

We've previously been incorrectly caching the error responses from the
Go proxy occurs, which leads to a lot of "flapping" of PRs on
Mend-hosted apps, and can be rather frustrating as a user (and a service
owner).

Per the Go proxy protocol[0], a `,` fallback strategy should only
continue to the next entry on 404/410, and otherwise propagate the
error.

However, we currently break out of the loop and return `result` (which
may be `null` if no successful requests have been performed yet).

This `null` would be cached, leading to a "no releases found"
(`no-result`), stored in the "hard TTL" cache, which could lead to many
days without an update for given packages.

To fix this, we can make sure that we propagate errors, which would
mean that on an error:

- if we've previously successfully retrieved the package, serve the
  "last good" result
- if we haven't, it's a full error, and the datasource can retry

[0]: https://go.dev/ref/mod#goproxy-protocol

https://github.com/renovatebot/renovate/pull/45409 made me wonder if this may be the issue, and Claude Sonnet helped fix

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Sonnet 5 (via Claude Code) investigated the root cause, wrote the
fix and updated test coverage in this PR, and drafted this PR
description.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
