### PR TITLE
Cursor/fix 45591 hosttype warning main 1c58

### DIFF
--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2255,20 +2255,47 @@ describe('config/validation', () => {
       ]);
     });
 
+    it('warns once with all hostRules missing hostType', async () => {
+      const config = {
+        hostRules: [
+          { hostType: 'npm', matchHost: 'registry.npmjs.org' },
+          { matchHost: 'registry.example.com' },
+          { hostType: '', matchHost: 'registry.example.org' },
+        ],
+      };
+
+      const { errors, warnings } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+
+      expect(errors).toBeEmptyArray();
+      expect(warnings).toEqual([
+        {
+          topic: 'Deprecation Warning',
+          message:
+            'Host rules without a `hostType` are deprecated and will no longer be supported in a future major release. Add a `hostType` to: hostRules[1], hostRules[2].',
+        },
+      ]);
+    });
+
     it('errors if invalid matchHost values in hostRules', async () => {
       GlobalConfig.set({ allowedHeaders: ['X-*'] });
 
       const config = {
         hostRules: [
           {
+            hostType: 'github',
             matchHost: '://',
             token: 'token',
           },
           {
+            hostType: 'github',
             matchHost: '',
             token: 'token',
           },
           {
+            hostType: 'github',
             matchHost: undefined,
             token: 'token',
           },

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -47,6 +47,7 @@ describe('config/validation', () => {
           // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid/removed HostRule property
           {
             dnsCache: true,
+            hostType: 'npm',
           } as HostRule,
         ],
       };
@@ -127,6 +128,7 @@ describe('config/validation', () => {
       const config = {
         hostRules: [
           {
+            hostType: 'npm',
             username: 'user',
             token: 'token',
             password: 'pass',
@@ -2334,6 +2336,7 @@ describe('config/validation', () => {
       const config = {
         hostRules: [
           {
+            hostType: 'npm',
             matchHost: 'https://domain.com/all-versions',
             headers: {
               'X-Auth-Token': 'token',
@@ -2362,6 +2365,7 @@ describe('config/validation', () => {
       const config = {
         hostRules: [
           {
+            hostType: 'npm',
             matchHost: 'https://domain.com/all-versions',
             // oxlint-disable-next-line renovate/prefer-partial-in-specs -- intentionally invalid header value type
             headers: {
@@ -2390,6 +2394,7 @@ describe('config/validation', () => {
       const config = {
         hostRules: [
           {
+            hostType: 'npm',
             matchHost: 'https://domain.com/all-versions',
             headers: {
               'X-Auth-Token': 'token',
@@ -2569,6 +2574,7 @@ describe('config/validation', () => {
       const config = {
         hostRules: [
           {
+            hostType: 'npm',
             matchHost: 'https://domain.com/all-versions',
             headers: {
               'X-Auth-Token': 'token',
@@ -2589,6 +2595,7 @@ describe('config/validation', () => {
       const config = {
         hostRules: [
           {
+            hostType: 'npm',
             matchHost: 'https://domain.com/all-versions',
             headers: {
               'X-Auth-Token': 'token',
@@ -2699,6 +2706,7 @@ describe('config/validation', () => {
           {
             artifactAuth: null,
             concurrentRequestLimit: null,
+            hostType: 'npm',
             httpsCertificate: null,
             httpsPrivateKey: null,
             httpsCertificateAuthority: null,
@@ -3217,6 +3225,7 @@ describe('config/validation', () => {
             repository: 'owner/repo1',
             hostRules: [
               {
+                hostType: 'github',
                 matchHost: 'github.com',
                 headers: { 'X-Custom-Token': 'value' },
               },
@@ -3240,6 +3249,7 @@ describe('config/validation', () => {
             repository: 'owner/repo1',
             hostRules: [
               {
+                hostType: 'github',
                 matchHost: 'github.com',
                 headers: { Authorization: 'Bearer token' },
               },

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -1012,6 +1012,18 @@ export async function validateConfig(
             configType === 'global'
               ? (config.allowedHeaders ?? [])
               : GlobalConfig.get('allowedHeaders');
+          const rulesWithoutHostType: string[] = [];
+          for (const [index, rule] of (val as HostRule[]).entries()) {
+            if (!isNonEmptyString(rule.hostType)) {
+              rulesWithoutHostType.push(`${currentPath}[${index}]`);
+            }
+          }
+          if (isNonEmptyArray(rulesWithoutHostType)) {
+            warnings.push({
+              topic: ConfigValidationTopic.Deprecation,
+              message: `Host rules without a \`hostType\` are deprecated and will no longer be supported in a future major release. Add a \`hostType\` to: ${rulesWithoutHostType.join(', ')}.`,
+            });
+          }
           for (const rule of val as HostRule[]) {
             if (isNonEmptyString(rule.matchHost)) {
               if (


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
