### PR TITLE
fix(bitbucket): check if development branch truly exist before assuming

### DIFF
--- a/lib/modules/platform/bitbucket/index.spec.ts
+++ b/lib/modules/platform/bitbucket/index.spec.ts
@@ -345,6 +345,10 @@ describe('modules/platform/bitbucket/index', () => {
         .get('/2.0/repositories/some/repo/effective-branching-model')
         .reply(200, {
           development: { name: 'develop' },
+        })
+        .get('/2.0/repositories/some/repo/refs/branches?q=name="develop"')
+        .reply(200, {
+          values: [{ name: 'develop' }],
         });
 
       const res = await bitbucket.initRepo({
@@ -368,6 +372,34 @@ describe('modules/platform/bitbucket/index', () => {
         })
         .get('/2.0/repositories/some/repo/effective-branching-model')
         .reply(200, {});
+
+      const res = await bitbucket.initRepo({
+        repository: 'some/repo',
+      });
+
+      expect(res.defaultBranch).toBe('master');
+    });
+
+    it('enabled: falls back to mainbranch if development branch does not exist as an actual branch', async () => {
+      GlobalConfig.set({
+        bbUseDevelopmentBranch: true,
+      });
+      httpMock
+        .scope(baseUrl)
+        .get('/2.0/repositories/some/repo')
+        .reply(200, {
+          mainbranch: { name: 'master' },
+          uuid: '123',
+          full_name: 'some/repo',
+        })
+        .get('/2.0/repositories/some/repo/effective-branching-model')
+        .reply(200, {
+          development: { name: 'develop' },
+        })
+        .get('/2.0/repositories/some/repo/refs/branches?q=name="develop"')
+        .reply(200, {
+          values: [],
+        });
 
       const res = await bitbucket.initRepo({
         repository: 'some/repo',

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -42,6 +42,7 @@ import { smartTruncate } from '../utils/pr-body.ts';
 import * as comments from './comments.ts';
 import { BitbucketPrCache } from './pr-cache.ts';
 import {
+  BranchNames,
   RepoInfo,
   Repositories,
   UnresolvedPrTasks,
@@ -262,10 +263,21 @@ export async function initRepo({
       ).body.development?.name;
 
       if (developmentBranch) {
-        mainBranch = developmentBranch;
-        logger.debug(
-          `${developmentBranch} is BitBucket's development branch - using it as default branch`,
+        const { body: branchNames } = await bitbucketHttp.getJson(
+          `/2.0/repositories/${repository}/refs/branches?q=name="${developmentBranch}"`,
+          BranchNames,
         );
+
+        if (new Set(branchNames).has(developmentBranch)) {
+          mainBranch = developmentBranch;
+          logger.debug(
+            `${developmentBranch} is BitBucket's development branch - using it as default branch`,
+          );
+        } else {
+          logger.debug(
+            `BitBucket's development branch '${developmentBranch}' does not exist as a branch - keeping '${mainBranch}' as default branch`,
+          );
+        }
       }
     }
 

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -274,7 +274,7 @@ export async function initRepo({
             `${developmentBranch} is BitBucket's development branch - using it as default branch`,
           );
         } else {
-          logger.debug(
+          logger.warn(
             `BitBucket's development branch '${developmentBranch}' does not exist as a branch - keeping '${mainBranch}' as default branch`,
           );
         }

--- a/lib/modules/platform/bitbucket/index.ts
+++ b/lib/modules/platform/bitbucket/index.ts
@@ -275,7 +275,8 @@ export async function initRepo({
           );
         } else {
           logger.warn(
-            `BitBucket's development branch '${developmentBranch}' does not exist as a branch - keeping '${mainBranch}' as default branch`,
+            { developmentBranch, mainBranch },
+            `BitBucket's development branch does not exist as a branch - keeping default branch`,
           );
         }
       }

--- a/lib/modules/platform/bitbucket/schema.ts
+++ b/lib/modules/platform/bitbucket/schema.ts
@@ -71,6 +71,16 @@ export const Repositories = z
   })
   .transform((body) => body.values);
 
+const BitbucketBranch = z.object({
+  name: z.string(),
+});
+
+export const BranchNames = z
+  .object({
+    values: z.array(BitbucketBranch),
+  })
+  .transform((body) => body.values.map(({ name }) => name));
+
 const TaskState = z.union([z.literal('RESOLVED'), z.literal('UNRESOLVED')]);
 
 const PrTask = z.object({


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Follow-up of #45626 
I discovered afterwards that the effective-branching-model endpoint returns the inherited project settings, regardless if the branches exist or not (they seem to be not so "effective" 😁😁), which was not a limitation that existed in the other endpoint.
Hence, we need another request (at this point git is not ready yet) to check if the branch exists or not to be sure.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @ferferga  will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: *Private repo*

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
