### PR TITLE
fix(logger): redact secrets in HTTP error URLs

### DIFF
--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -164,6 +164,9 @@ It is OK to not inline metadata if it's complex, but in that case first think wh
 `WARN`, `ERROR` and `FATAL` messages are often used in metrics or error catching services.
 These log messages should have a static `msg` component, so they can be automatically grouped or associated.
 
+Logger output passes through a shared sanitizer that redacts embedded URL credentials and query parameters whose names indicate tokens, keys, or secrets.
+Treat this as defense in depth: do not intentionally log credentials, and register dynamically obtained secrets with the sanitizer.
+
 Good:
 
 ```ts

--- a/lib/logger/utils.spec.ts
+++ b/lib/logger/utils.spec.ts
@@ -9,16 +9,19 @@ describe('logger/utils', () => {
   });
 
   it.each`
-    input                                                                 | output
-    ${' https://somepw@domain.com/gitlab/org/repo?go-get'}                | ${' https://**redacted**@domain.com/gitlab/org/repo?go-get'}
-    ${'https://someuser:somepw@domain.com'}                               | ${'https://**redacted**@domain.com'}
-    ${'https://someuser:pass%word_with-speci(a)l&chars@domain.com'}       | ${'https://**redacted**@domain.com'}
-    ${'https://someuser:@domain.com'}                                     | ${'https://**redacted**@domain.com'}
-    ${'redis://:somepw@172.32.11.71:6379/0'}                              | ${'redis://**redacted**@172.32.11.71:6379/0'}
-    ${'some text with\r\n url: https://somepw@domain.com\nand some more'} | ${'some text with\r\n url: https://**redacted**@domain.com\nand some more'}
-    ${'[git://domain.com](git://pw@domain.com)'}                          | ${'[git://domain.com](git://**redacted**@domain.com)'}
-    ${'data:text/vnd-example;foo=bar;base64,R0lGODdh'}                    | ${'data:text/vnd-example;**redacted**'}
-    ${'user@domain.com'}                                                  | ${'user@domain.com'}
+    input                                                                                                                   | output
+    ${' https://somepw@domain.com/gitlab/org/repo?go-get'}                                                                  | ${' https://**redacted**@domain.com/gitlab/org/repo?go-get'}
+    ${'https://someuser:somepw@domain.com'}                                                                                 | ${'https://**redacted**@domain.com'}
+    ${'https://someuser:pass%word_with-speci(a)l&chars@domain.com'}                                                         | ${'https://**redacted**@domain.com'}
+    ${'https://someuser:@domain.com'}                                                                                       | ${'https://**redacted**@domain.com'}
+    ${'redis://:somepw@172.32.11.71:6379/0'}                                                                                | ${'redis://**redacted**@172.32.11.71:6379/0'}
+    ${'HTTP error for https://user:password@example.com/api?token=token-value&key=key-value&secret=secret-value&view=full'} | ${'HTTP error for https://**redacted**@example.com/api?token=**redacted**&key=**redacted**&secret=**redacted**&view=full'}
+    ${'https://example.com/api?access_token=token-value&api-key=key-value&client_secret=secret-value#response'}             | ${'https://example.com/api?access_token=**redacted**&api-key=**redacted**&client_secret=**redacted**#response'}
+    ${'https://example.com/search?monkey=banana&page=2&sort=name'}                                                          | ${'https://example.com/search?monkey=banana&page=2&sort=name'}
+    ${'some text with\r\n url: https://somepw@domain.com\nand some more'}                                                   | ${'some text with\r\n url: https://**redacted**@domain.com\nand some more'}
+    ${'[git://domain.com](git://pw@domain.com)'}                                                                            | ${'[git://domain.com](git://**redacted**@domain.com)'}
+    ${'data:text/vnd-example;foo=bar;base64,R0lGODdh'}                                                                      | ${'data:text/vnd-example;**redacted**'}
+    ${'user@domain.com'}                                                                                                    | ${'user@domain.com'}
   `('sanitizeValue("$input") == "$output"', ({ input, output }) => {
     expect(sanitizeValue(input)).toBe(output);
   });

--- a/lib/logger/utils.ts
+++ b/lib/logger/utils.ts
@@ -244,15 +244,31 @@ export function sanitizeValue(
   return value;
 }
 
-const urlRe = regEx(/[a-z]{3,9}:\/\/[^@/]+@[a-z0-9.-]+/gi);
-const urlCredRe = regEx(/\/\/[^@]+@/g);
+const urlRe = regEx(/[a-z]{3,9}:\/\/[^\s<>"']+/gi);
+const urlCredRe = regEx(/\/\/[^/?#\s]+@/g);
+const urlQuerySecretRe = regEx(
+  /([?&](?:[a-z0-9]+[-_])*(?:access[-_]?token|api[-_]?key|client[-_]?secret|secret[-_]?key|token|key|secret)(?:[-_][a-z0-9]+)*=)[^&#\s]*/gi,
+);
 const dataUriCredRe = regEx(/^(data:[0-9a-z-]+\/[0-9a-z-]+;).+/i);
+
+function sanitizeUrl(url: string): string {
+  const sanitizedUrl = url.replace(urlCredRe, '//**redacted**@');
+  const queryStart = sanitizedUrl.indexOf('?');
+  if (queryStart === -1) {
+    return sanitizedUrl;
+  }
+
+  const fragmentStart = sanitizedUrl.indexOf('#', queryStart);
+  const queryEnd = fragmentStart === -1 ? sanitizedUrl.length : fragmentStart;
+  const query = sanitizedUrl
+    .slice(queryStart, queryEnd)
+    .replace(urlQuerySecretRe, '$1**redacted**');
+  return `${sanitizedUrl.slice(0, queryStart)}${query}${sanitizedUrl.slice(queryEnd)}`;
+}
 
 export function sanitizeUrls(text: string): string {
   return text
-    .replace(urlRe, (url) => {
-      return url.replace(urlCredRe, '//**redacted**@');
-    })
+    .replace(urlRe, sanitizeUrl)
     .replace(dataUriCredRe, '$1**redacted**');
 }
 


### PR DESCRIPTION
## Changes

- Redact embedded URL credentials and token/key/secret-style query parameter values through the shared logger sanitizer.
- Preserve non-sensitive query parameters and URL fragments.
- Add focused regression coverage for HTTP error text, common secret parameter variants, credentials, and unchanged non-sensitive URLs.
- Document URL sanitization guidance in the logging best practices.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Claude Code implemented and validated the code, tests, and documentation.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (unit tests only)

<!-- repo-agent-case:12f34a3c-68a1-4d49-bc09-bdc62ecdf426 -->