### PR TITLE
test(linters): forbid file-based snapshot matchers

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -190,6 +190,16 @@
       { "assertFunctionNames": ["expect", "expectTypeOf", "checkKeysSorted"] }
     ],
     "vitest/no-conditional-expect": "error",
+    "vitest/no-restricted-matchers": [
+      "error",
+      {
+        "toMatchSnapshot": "Prefer explicit assertions; use toMatchInlineSnapshot for huge strings so the expected value stays visible in the test file.",
+        "toThrowErrorMatchingSnapshot": "Prefer toThrow with a message; use toThrowErrorMatchingInlineSnapshot for huge error messages.",
+        "rejects.toThrowErrorMatchingSnapshot": "Prefer rejects.toThrow with a message; use rejects.toThrowErrorMatchingInlineSnapshot for huge error messages.",
+        "resolves.toMatchSnapshot": "Prefer explicit assertions; use toMatchInlineSnapshot for huge strings so the expected value stays visible in the test file.",
+        "toMatchFileSnapshot": "Prefer explicit assertions; use toMatchInlineSnapshot for huge strings so the expected value stays visible in the test file."
+      }
+    ],
     "vitest/no-standalone-expect": "error",
     "vitest/prefer-snapshot-hint": "error",
     "vitest/require-to-throw-message": "error"

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -193,11 +193,11 @@
     "vitest/no-restricted-matchers": [
       "error",
       {
-        "toMatchSnapshot": "Prefer explicit assertions; use toMatchInlineSnapshot for huge strings so the expected value stays visible in the test file.",
-        "toThrowErrorMatchingSnapshot": "Prefer toThrow with a message; use toThrowErrorMatchingInlineSnapshot for huge error messages.",
-        "rejects.toThrowErrorMatchingSnapshot": "Prefer rejects.toThrow with a message; use rejects.toThrowErrorMatchingInlineSnapshot for huge error messages.",
-        "resolves.toMatchSnapshot": "Prefer explicit assertions; use toMatchInlineSnapshot for huge strings so the expected value stays visible in the test file.",
-        "toMatchFileSnapshot": "Prefer explicit assertions; use toMatchInlineSnapshot for huge strings so the expected value stays visible in the test file."
+        "toMatchSnapshot": "Use explicit assertions such as toEqual, toMatchObject or toBe so the expected value stays visible in the test file.",
+        "toThrowErrorMatchingSnapshot": "Use toThrow with the expected message.",
+        "rejects.toThrowErrorMatchingSnapshot": "Use rejects.toThrow with the expected message.",
+        "resolves.toMatchSnapshot": "Use explicit assertions such as resolves.toEqual or resolves.toMatchObject so the expected value stays visible in the test file.",
+        "toMatchFileSnapshot": "Use explicit assertions such as toEqual, toMatchObject or toBe so the expected value stays visible in the test file."
       }
     ],
     "vitest/no-standalone-expect": "error",

--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -293,7 +293,7 @@ if (end) {
 - Prefer `toEqual`
 - Use `toMatchObject` for huge objects when only parts need to be tested
 - Do not use snapshot matchers (`toMatchSnapshot`, `toMatchInlineSnapshot`, `toThrowErrorMatchingSnapshot`), write explicit assertions instead
-  - For huge strings like the Renovate PR body text, compare against a `codeBlock` template literal with `toBe` so the expected value stays visible in the test file
+  - For huge strings like the Renovate PR body text, assert on the sections the test is about with `toContain`, `toStartWith` or `toEndWith`; compare the whole string with `toBe` only when producing exactly that text is the point of the test
   - For huge complex objects where you only need to test parts, use `toMatchObject`
 - Avoid exporting functions purely for the purpose of testing unless you really need to
 - Avoid cast or prefer `x as T` instead of `<T>x` cast

--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -292,8 +292,8 @@ if (end) {
   - `mockDeep` returns a mock for any property access, so typos in mocked names won't fail the test
 - Prefer `toEqual`
 - Use `toMatchObject` for huge objects when only parts need to be tested
-- Do not use file-based snapshot matchers (`toMatchSnapshot`, `toThrowErrorMatchingSnapshot`), write explicit assertions instead
-  - For huge strings like the Renovate PR body text, use `toMatchInlineSnapshot` so the expected value stays visible in the test file
+- Do not use snapshot matchers (`toMatchSnapshot`, `toMatchInlineSnapshot`, `toThrowErrorMatchingSnapshot`), write explicit assertions instead
+  - For huge strings like the Renovate PR body text, compare against a `codeBlock` template literal with `toBe` so the expected value stays visible in the test file
   - For huge complex objects where you only need to test parts, use `toMatchObject`
 - Avoid exporting functions purely for the purpose of testing unless you really need to
 - Avoid cast or prefer `x as T` instead of `<T>x` cast

--- a/docs/development/best-practices.md
+++ b/docs/development/best-practices.md
@@ -292,9 +292,9 @@ if (end) {
   - `mockDeep` returns a mock for any property access, so typos in mocked names won't fail the test
 - Prefer `toEqual`
 - Use `toMatchObject` for huge objects when only parts need to be tested
-- Avoid `toMatchSnapshot`, only use it for:
-  - huge strings like the Renovate PR body text
-  - huge complex objects where you only need to test parts
+- Do not use file-based snapshot matchers (`toMatchSnapshot`, `toThrowErrorMatchingSnapshot`), write explicit assertions instead
+  - For huge strings like the Renovate PR body text, use `toMatchInlineSnapshot` so the expected value stays visible in the test file
+  - For huge complex objects where you only need to test parts, use `toMatchObject`
 - Avoid exporting functions purely for the purpose of testing unless you really need to
 - Avoid cast or prefer `x as T` instead of `<T>x` cast
   - Use `partial<T>()` from `test/util` if only a partial object is required


### PR DESCRIPTION
## Changes

Enables `vitest/no-restricted-matchers` in `.oxlintrc.json` so that `toMatchSnapshot`, `toThrowErrorMatchingSnapshot`, `resolves.toMatchSnapshot`, `rejects.toThrowErrorMatchingSnapshot` and `toMatchFileSnapshot` are rejected by the linter, and updates the testing best practices to ask for explicit assertions instead of any snapshot matcher.

## Context

This is the last PR in the stack. It only turns the rule on; all existing usages were removed in the PRs below it.

Part of a stacked series that replaces every file-based snapshot (`toMatchSnapshot`, `toMatchFileSnapshot`) with explicit assertions and then enforces this via `vitest/no-restricted-matchers`. Supersedes #44715, which was split up so that the individual parts stay reviewable.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The snapshot-to-assertion migration of the test files was generated with Claude Code (Claude Fable 5.1) and reviewed by hand.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
