### PR TITLE
fix(workers/repository): ensure internal checks are applied when a rebase is requested

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -443,6 +443,13 @@ Other valid cache namespaces are as follows:
 
 This array will allow you to set the names of the branches you want to rebase/create, as if you selected their checkboxes in the Dependency Dashboard issue.
 
+!!! warning
+  When using `checkedBranches`, Renovate treats this as you, the self-hosted administrator, consenting to any updates the given branch introduces.
+  This can lead to branches that have not yet passed their `internalChecksFilter` / `minimumReleaseAge` to be created.
+  <br>
+  There is [not currently](https://github.com/renovatebot/renovate/issues/45668) a way to control this.
+  <!-- TODO: #45668 -->
+
 It has been designed with the intention of being run on one repository, in a one-off manner, e.g. to "force" the rebase of a known existing branch.
 It is highly unlikely that you should ever need to add this to your permanent global config.
 

--- a/lib/workers/repository/__fixtures__/dependency-dashboard-with-3-PR-in-approval.txt
+++ b/lib/workers/repository/__fixtures__/dependency-dashboard-with-3-PR-in-approval.txt
@@ -12,7 +12,7 @@ The following branches exist but PR creation requires approval. To approve PR cr
 
 The following updates await pending status checks. To force their creation now, click on a checkbox below.
 
- - [ ] <!-- approvePr-branch=branchName4 -->pr4
+ - [ ] <!-- unpend-branch=branchName4 -->pr4
 
 ## Detected Dependencies
 

--- a/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
+++ b/lib/workers/repository/__snapshots__/dependency-dashboard.spec.ts.snap
@@ -534,7 +534,7 @@ Renovate tried to run on this repository, but found these problems.
 
 The following updates await pending status checks. To force their creation now, click on a checkbox below.
 
- - [ ] <!-- approvePr-branch=branchName1 -->pr1
+ - [ ] <!-- unpend-branch=branchName1 -->pr1
 
 ## Detected Dependencies
 
@@ -556,7 +556,7 @@ platform is github
 
 The following updates await pending status checks. To force their creation now, click on a checkbox below.
 
- - [ ] <!-- approvePr-branch=branchName1 -->pr1
+ - [ ] <!-- unpend-branch=branchName1 -->pr1
 
 ## Detected Dependencies
 

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -563,6 +563,7 @@ export async function ensureDependencyDashboard(
     (branch) => branch.result === 'pending',
     'Pending Status Checks',
     'The following updates await pending status checks. To force their creation now, click on a checkbox below.',
+    'unpend',
   );
   issueBody += getBranchesListMd(
     branches,

--- a/lib/workers/repository/dependency-dashboard.ts
+++ b/lib/workers/repository/dependency-dashboard.ts
@@ -23,6 +23,10 @@ import { getDepWarningsDashboard } from './errors-warnings.ts';
 import { PackageFiles } from './package-files.ts';
 import type { Vulnerability } from './process/types.ts';
 import { Vulnerabilities } from './process/vulnerabilities.ts';
+import type {
+  DependencyDashboardCheck,
+  DependencyDashboardListItemType,
+} from './types.ts';
 
 interface DependencyDashboard {
   dependencyDashboardChecks: Record<string, string>;
@@ -199,9 +203,10 @@ export async function readDashboardBody(
 
   const checkedBranches = GlobalConfig.get('checkedBranches');
   if (isNonEmptyArray(checkedBranches)) {
-    const checkedBranchesRec: Record<string, string> = Object.fromEntries(
-      checkedBranches.map((branchName) => [branchName, 'global-config']),
-    );
+    const checkedBranchesRec: Record<string, DependencyDashboardCheck> =
+      Object.fromEntries(
+        checkedBranches.map((branchName) => [branchName, 'global-config']),
+      );
     dashboardChecks.dependencyDashboardChecks = {
       ...dashboardChecks.dependencyDashboardChecks,
       ...checkedBranchesRec,
@@ -219,7 +224,10 @@ function formatAsMarkdownLink(name: string, url?: string | null): string {
   return url ? `[${name}](${url})` : `\`${name}\``;
 }
 
-function getListItem(branch: BranchConfig, type: string): string {
+function getListItem(
+  branch: BranchConfig,
+  type: DependencyDashboardListItemType,
+): string {
   let item = getCheckbox(`${type}-branch=${branch.branchName}`);
   if (branch.prNo) {
     // TODO: types (#22198)
@@ -260,7 +268,10 @@ function splitBranchesByCategory(filteredBranches: BranchConfig[]): {
   return { categories, uncategorized, hasCategorized, hasUncategorized };
 }
 
-function getBranchList(branches: BranchConfig[], listItemType: string): string {
+function getBranchList(
+  branches: BranchConfig[],
+  listItemType: DependencyDashboardListItemType,
+): string {
   return branches
     .map((branch: BranchConfig): string => getListItem(branch, listItemType))
     .join('');
@@ -275,7 +286,7 @@ function getBranchesListMd(
   ) => unknown,
   title: string,
   description: string,
-  listItemType = 'approvePr',
+  listItemType: DependencyDashboardListItemType = 'approvePr',
   bulkComment?: string,
   bulkMessage?: string,
   bulkIcon?: '🔐',

--- a/lib/workers/repository/types.ts
+++ b/lib/workers/repository/types.ts
@@ -1,0 +1,24 @@
+/**
+ * A per-branch checkbox on the Dependency Dashboard, rendered into the issue body as `<type>-branch=<branchName>`.
+ *
+ * This is then read back out to determine what has been requested for a given branch.
+ */
+export type DependencyDashboardListItemType =
+  | 'approve'
+  | 'approveGroup'
+  | 'approvePr'
+  | 'other'
+  | 'rebase'
+  | 'recreate'
+  | 'retry'
+  | 'unlimit'
+  | 'unschedule';
+
+/**
+ * Whether a branch is checked by an actual checkbox on the Dependency Dashboard, or has been requested a rebase using `checkedBranches`.
+ *
+ *`checkedBranches` is never rendered as a checkbox.
+ */
+export type DependencyDashboardCheck =
+  | DependencyDashboardListItemType
+  | 'global-config';

--- a/lib/workers/repository/types.ts
+++ b/lib/workers/repository/types.ts
@@ -12,6 +12,7 @@ export type DependencyDashboardListItemType =
   | 'recreate'
   | 'retry'
   | 'unlimit'
+  | 'unpend'
   | 'unschedule';
 
 /**

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -914,6 +914,287 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('returns if pending checks - even when rebase requested via PR checkbox', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+          bodyStruct: {
+            hash: hashBody(`- [x] <!-- rebase-check -->`),
+            rebaseRequested: true,
+          },
+        }),
+      );
+      config.pendingChecks = true;
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: true,
+        prNo: 5,
+        result: 'pending',
+      });
+      expect(commit.commitFilesToBranch).not.toHaveBeenCalled();
+      expect(platform.ensureComment).toHaveBeenCalledWith(
+        expect.objectContaining({
+          number: 5,
+          topic: '⚠️ Rebase not applied',
+          content: expect.stringContaining('This branch has not been rebased'),
+        }),
+      );
+    });
+
+    it('returns if pending checks - and does not comment when there is no PR', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      const inconfig = {
+        ...config,
+        pendingChecks: true,
+        rebaseRequested: true,
+      } satisfies BranchConfig;
+      expect(await branchWorker.processBranch(inconfig)).toEqual({
+        branchExists: true,
+        prNo: undefined,
+        result: 'pending',
+      });
+      expect(platform.ensureComment).not.toHaveBeenCalled();
+    });
+
+    it('returns if pending checks - even when rebase requested via PR checkbox (dry run)', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+          bodyStruct: {
+            hash: hashBody(`- [x] <!-- rebase-check -->`),
+            rebaseRequested: true,
+          },
+        }),
+      );
+      config.pendingChecks = true;
+      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: true,
+        prNo: 5,
+        result: 'pending',
+      });
+      expect(logger.info).toHaveBeenCalledWith(
+        'DRY-RUN: Would ensure pending rebase comment in PR #5',
+      );
+      expect(platform.ensureComment).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      'approve',
+      'approveGroup',
+      'unschedule',
+      'unlimit',
+      'retry',
+      'approvePr',
+      'rebase',
+      'other',
+      'recreate',
+    ])(
+      'returns if pending checks - Dependency Dashboard check %s does not unpend an existing branch',
+      async (dependencyDashboardCheck) => {
+        getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+          ...updatedPackageFiles,
+        });
+        npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+          artifactErrors: [],
+          updatedArtifacts: [],
+        });
+        scm.branchExists.mockResolvedValue(true);
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            number: 5,
+            state: 'open',
+          }),
+        );
+        const inconfig = {
+          ...config,
+          pendingChecks: true,
+          dependencyDashboardChecks: {
+            'renovate/some-branch': dependencyDashboardCheck,
+          },
+        } satisfies BranchConfig;
+        expect(await branchWorker.processBranch(inconfig)).toEqual({
+          branchExists: true,
+          prNo: 5,
+          result: 'pending',
+        });
+        expect(commit.commitFilesToBranch).not.toHaveBeenCalled();
+      },
+    );
+
+    it('removes the rebase comment once a requested rebase is applied', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+          bodyStruct: {
+            hash: hashBody(`- [x] <!-- rebase-check -->`),
+            rebaseRequested: true,
+          },
+        }),
+      );
+      scm.isBranchModified.mockResolvedValueOnce(false);
+      expect(await branchWorker.processBranch(config)).toEqual({
+        branchExists: true,
+        updatesVerified: true,
+        prNo: 5,
+        result: 'done',
+        commitSha,
+      });
+      expect(platform.ensureCommentRemoval).toHaveBeenCalledWith({
+        type: 'by-topic',
+        number: 5,
+        topic: '⚠️ Rebase not applied',
+      });
+    });
+
+    it('removes the rebase comment once a requested rebase is applied (dry run)', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValueOnce(
+        partial<Pr>({
+          number: 5,
+          state: 'open',
+          bodyStruct: {
+            hash: hashBody(`- [x] <!-- rebase-check -->`),
+            rebaseRequested: true,
+          },
+        }),
+      );
+      scm.isBranchModified.mockResolvedValueOnce(false);
+      GlobalConfig.set({ ...adminConfig, dryRun: 'full' });
+      await branchWorker.processBranch(config);
+      expect(logger.info).toHaveBeenCalledWith(
+        'DRY-RUN: Would ensure pending rebase comment removal in PR #5',
+      );
+      expect(platform.ensureCommentRemoval).not.toHaveBeenCalled();
+    });
+
+    it.each(['unpend', 'global-config'])(
+      'updates branch with pending checks if Dependency Dashboard check is %s',
+      async (dependencyDashboardCheck) => {
+        getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+          ...updatedPackageFiles,
+        });
+        npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+          artifactErrors: [],
+          updatedArtifacts: [],
+        });
+        scm.branchExists.mockResolvedValue(true);
+        platform.getBranchPr.mockResolvedValueOnce(
+          partial<Pr>({
+            number: 5,
+            state: 'open',
+          }),
+        );
+        scm.isBranchModified.mockResolvedValueOnce(false);
+        const inconfig = {
+          ...config,
+          pendingChecks: true,
+          dependencyDashboardChecks: {
+            'renovate/some-branch': dependencyDashboardCheck,
+          },
+        } satisfies BranchConfig;
+        expect(await branchWorker.processBranch(inconfig)).toEqual({
+          branchExists: true,
+          updatesVerified: true,
+          prNo: 5,
+          result: 'done',
+          commitSha,
+        });
+        expect(commit.commitFilesToBranch).toHaveBeenCalled();
+      },
+    );
+
+    it('returns if pending checks - Dependency Dashboard rebase check does not unpend branch creation', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+        ...updatedPackageFiles,
+      });
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [],
+      });
+      scm.branchExists.mockResolvedValue(false);
+      const inconfig = {
+        ...config,
+        pendingChecks: true,
+        dependencyDashboardChecks: { 'renovate/some-branch': 'rebase' },
+      } satisfies BranchConfig;
+      expect(await branchWorker.processBranch(inconfig)).toEqual({
+        branchExists: false,
+        prNo: undefined,
+        result: 'pending',
+      });
+      expect(commit.commitFilesToBranch).not.toHaveBeenCalled();
+    });
+
+    it.each(['unpend', 'global-config'])(
+      'creates branch with pending checks if Dependency Dashboard check is %s',
+      async (dependencyDashboardCheck) => {
+        getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce({
+          ...updatedPackageFiles,
+        });
+        npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+          artifactErrors: [],
+          updatedArtifacts: [],
+        });
+        scm.branchExists.mockResolvedValue(false);
+        const inconfig = {
+          ...config,
+          pendingChecks: true,
+          dependencyDashboardChecks: {
+            'renovate/some-branch': dependencyDashboardCheck,
+          },
+        } satisfies BranchConfig;
+        expect(await branchWorker.processBranch(inconfig)).toEqual({
+          branchExists: true,
+          updatesVerified: true,
+          prNo: 5,
+          result: 'pr-created',
+          commitSha,
+        });
+        expect(commit.commitFilesToBranch).toHaveBeenCalled();
+      },
+    );
+
     // automerge should respect only automergeSchedule
     // mock a case where branchPr does not exist, pr-creation is off-schedule, and the branch is configured for automerge
     it('automerges when there is no pr and, pr-creation is off-schedule', async () => {

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -143,6 +143,10 @@ export async function processBranch(
   let branchExists = await scm.branchExists(config.branchName);
   const dependencyDashboardCheck =
     config.dependencyDashboardChecks?.[config.branchName];
+  // Only allow a branch to be recreated with updates that are `pending` if we've explicitly constented with an `unpend` on the Dependency Dashboard, or when using `checkedBranches`
+  const unpendRequested =
+    dependencyDashboardCheck === 'unpend' ||
+    dependencyDashboardCheck === 'global-config';
   let updatesVerified = false;
   if (!branchExists && config.branchPrefix !== config.branchPrefixOld) {
     const branchName = config.branchName.replace(
@@ -183,6 +187,7 @@ export async function processBranch(
     logger.debug(`PR rebase requested=${config.rebaseRequested}`);
   }
   const keepUpdatedLabel = config.keepUpdatedLabel;
+  const pendingRebaseTopic = emojify(':warning: Rebase not applied');
   const artifactErrorTopic = emojify(':warning: Artifact update problem');
   const artifactNoticeTopic = emojify(
     ':information_source: Artifact update notice',
@@ -212,11 +217,7 @@ export async function processBranch(
         result: 'already-existed',
       };
     }
-    if (
-      !branchExists &&
-      branchConfig.pendingChecks &&
-      !dependencyDashboardCheck
-    ) {
+    if (!branchExists && branchConfig.pendingChecks && !unpendRequested) {
       logger.debug(
         `Branch ${config.branchName} creation is disabled because internalChecksFilter was not met`,
       );
@@ -296,28 +297,52 @@ export async function processBranch(
 
       const prRebaseChecked = !!branchPr?.bodyStruct?.rebaseRequested;
 
-      if (branchExists && !dependencyDashboardCheck && !prRebaseChecked) {
-        if (config.stopUpdating) {
-          logger.info(
-            'Branch updating is skipped because stopUpdatingLabel is present in config',
-          );
-          return {
-            branchExists: true,
-            prNo: branchPr?.number,
-            result: 'no-work',
-          };
-        }
+      if (
+        !dependencyDashboardCheck &&
+        !prRebaseChecked &&
+        config.stopUpdating
+      ) {
+        logger.info(
+          'Branch updating is skipped because stopUpdatingLabel is present in config',
+        );
+        return {
+          branchExists: true,
+          prNo: branchPr?.number,
+          result: 'no-work',
+        };
+      }
 
-        if (config.pendingChecks) {
+      // A rebase or retry request is not consent to add an upgrade which has not met its internal checks, so only an unpend of this branch may override this
+      if (!unpendRequested && config.pendingChecks) {
+        if (config.rebaseRequested) {
+          logger.info(
+            'Branch updating is skipped because internalChecksFilter was not met, despite the requested rebase',
+          );
+          if (branchPr) {
+            const content =
+              'This branch has not been rebased, as its update has not yet met the internal checks configured for it, such as `minimumReleaseAge`. Rebasing it now would add a dependency version which is still within its configured observation period.\n\nRenovate will rebase this branch once its update has met those checks.';
+            if (GlobalConfig.get('dryRun')) {
+              logger.info(
+                `DRY-RUN: Would ensure pending rebase comment in PR #${branchPr.number}`,
+              );
+            } else {
+              await ensureComment({
+                number: branchPr.number,
+                topic: pendingRebaseTopic,
+                content,
+              });
+            }
+          }
+        } else {
           logger.info(
             'Branch updating is skipped because internalChecksFilter was not met',
           );
-          return {
-            branchExists: true,
-            prNo: branchPr?.number,
-            result: 'pending',
-          };
         }
+        return {
+          branchExists: true,
+          prNo: branchPr?.number,
+          result: 'pending',
+        };
       }
 
       logger.debug('Checking if PR has been edited');
@@ -775,6 +800,21 @@ export async function processBranch(
       // also do before platform automerge reattempt
       if (commitSha) {
         await setArtifactErrorStatus(config);
+      }
+
+      // a requested rebase has now been applied, so any comment explaining why we'd skipped it no longer applies
+      if (commitSha && branchPr && config.rebaseRequested) {
+        if (GlobalConfig.get('dryRun')) {
+          logger.info(
+            `DRY-RUN: Would ensure pending rebase comment removal in PR #${branchPr.number}`,
+          );
+        } else {
+          await ensureCommentRemoval({
+            type: 'by-topic',
+            number: branchPr.number,
+            topic: pendingRebaseTopic,
+          });
+        }
       }
     }
 

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -190,6 +190,22 @@ describe('workers/repository/update/pr/index', () => {
         expect(prCache.setPrCache).not.toHaveBeenCalled();
       });
 
+      it('creates PR for unapproved dependencies which have been unpended', async () => {
+        checks.resolveBranchStatus.mockResolvedValueOnce('yellow');
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          prCreation: 'approval',
+          dependencyDashboardChecks: {
+            'renovate-branch': 'unpend',
+          },
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(prCache.setPrCache).toHaveBeenCalled();
+      });
+
       it('skips PR creation before prNotPendingHours is hit', async () => {
         const now = DateTime.now();
         const then = now.minus({ hours: 1 });
@@ -598,6 +614,23 @@ describe('workers/repository/update/pr/index', () => {
           reviewers: ['somebody'],
           dependencyDashboardChecks: {
             'renovate-branch': 'approvePr',
+          },
+        });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        expect(prCache.setPrCache).toHaveBeenCalled();
+      });
+
+      it('forces PR on dashboard unpend check', async () => {
+        platform.createPr.mockResolvedValueOnce(pr);
+
+        const res = await ensurePr({
+          ...config,
+          automerge: true,
+          automergeType: 'branch',
+          reviewers: ['somebody'],
+          dependencyDashboardChecks: {
+            'renovate-branch': 'unpend',
           },
         });
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -178,6 +178,9 @@ export async function ensurePr(
   );
   const dependencyDashboardCheck =
     config.dependencyDashboardChecks?.[config.branchName];
+  const dependencyDashboardApproved =
+    dependencyDashboardCheck === 'approvePr' ||
+    dependencyDashboardCheck === 'unpend';
   // Check if PR already exists
   const existingPr =
     (await platform.getBranchPr(branchName, config.baseBranch)) ??
@@ -206,7 +209,7 @@ export async function ensurePr(
     config.forcePr = true;
   }
 
-  if (dependencyDashboardCheck === 'approvePr') {
+  if (dependencyDashboardApproved) {
     logger.debug('Forcing PR because of dependency dashboard approval');
     config.forcePr = true;
   }
@@ -249,7 +252,7 @@ export async function ensurePr(
       logger.debug('Branch status success');
     } else if (
       config.prCreation === 'approval' &&
-      dependencyDashboardCheck !== 'approvePr'
+      !dependencyDashboardApproved
     ) {
       return { type: 'without-pr', prBlockedBy: 'NeedsApproval' };
     } else if (config.prCreation === 'not-pending' && !config.forcePr) {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
