### PR TITLE
fix(config/validation): allow only capturing `currentDigest` in Custom Managers

### DIFF
--- a/lib/config/validation-helpers/utils.ts
+++ b/lib/config/validation-helpers/utils.ts
@@ -135,15 +135,12 @@ export function validateRegexManagerFields(
 
   const versionFields = ['currentValue', 'currentDigest'];
   if (!versionFields.some((field) => hasField(customManager, field))) {
-    const msg = versionFields
-      .map(
-        (field) =>
-          `${field}Template configuration or regex group named ${field}`,
-      )
-      .join(', or ');
+    const templateFields = versionFields
+      .map((field) => `${field}Template`)
+      .join(' or ');
     errors.push({
       topic: ConfigValidationTopic.Error,
-      message: `Regex Managers must contain ${msg}`,
+      message: `Regex Managers must contain ${versionFields.join(' or ')}, their template variants (${templateFields}) or regex groups named after configuration fields`,
     });
   }
 
@@ -204,7 +201,7 @@ export function validateJSONataManagerFields(
   if (!versionFields.some((field) => hasField(customManager, field))) {
     errors.push({
       topic: ConfigValidationTopic.Error,
-      message: `JSONata Managers must contain ${versionFields.join(', or ')} in the query or their templates`,
+      message: `JSONata Managers must contain ${versionFields.join(' or ')} in the query or their templates`,
     });
   }
 

--- a/lib/config/validation-helpers/utils.ts
+++ b/lib/config/validation-helpers/utils.ts
@@ -123,7 +123,7 @@ export function validateRegexManagerFields(
     });
   }
 
-  const mandatoryFields = ['currentValue', 'datasource'];
+  const mandatoryFields = ['datasource'];
   for (const field of mandatoryFields) {
     if (!hasField(customManager, field)) {
       errors.push({
@@ -131,6 +131,20 @@ export function validateRegexManagerFields(
         message: `Regex Managers must contain ${field}Template configuration or regex group named ${field}`,
       });
     }
+  }
+
+  const versionFields = ['currentValue', 'currentDigest'];
+  if (!versionFields.some((field) => hasField(customManager, field))) {
+    const msg = versionFields
+      .map(
+        (field) =>
+          `${field}Template configuration or regex group named ${field}`,
+      )
+      .join(', or ');
+    errors.push({
+      topic: ConfigValidationTopic.Error,
+      message: `Regex Managers must contain ${msg}`,
+    });
   }
 
   const nameFields = ['depName', 'packageName'];
@@ -176,7 +190,7 @@ export function validateJSONataManagerFields(
     });
   }
 
-  const mandatoryFields = ['currentValue', 'datasource'];
+  const mandatoryFields = ['datasource'];
   for (const field of mandatoryFields) {
     if (!hasField(customManager, field)) {
       errors.push({
@@ -184,6 +198,14 @@ export function validateJSONataManagerFields(
         message: `JSONata Managers must contain ${field}Template configuration or ${field} in the query `,
       });
     }
+  }
+
+  const versionFields = ['currentValue', 'currentDigest'];
+  if (!versionFields.some((field) => hasField(customManager, field))) {
+    errors.push({
+      topic: ConfigValidationTopic.Error,
+      message: `JSONata Managers must contain ${versionFields.join(', or ')} in the query or their templates`,
+    });
   }
 
   const nameFields = ['depName', 'packageName'];

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1160,7 +1160,7 @@ describe('config/validation', () => {
         },
         {
           message:
-            'Regex Managers must contain currentValueTemplate configuration or regex group named currentValue, or currentDigestTemplate configuration or regex group named currentDigest',
+            'Regex Managers must contain currentValue or currentDigest, their template variants (currentValueTemplate or currentDigestTemplate) or regex groups named after configuration fields',
         },
         {
           message:
@@ -1253,7 +1253,7 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            'Regex Managers must contain currentValueTemplate configuration or regex group named currentValue, or currentDigestTemplate configuration or regex group named currentDigest',
+            'Regex Managers must contain currentValue or currentDigest, their template variants (currentValueTemplate or currentDigestTemplate) or regex groups named after configuration fields',
         },
       ]);
     });
@@ -1329,7 +1329,7 @@ describe('config/validation', () => {
         {
           topic: 'Configuration Error',
           message:
-            'JSONata Managers must contain currentValue, or currentDigest in the query or their templates',
+            'JSONata Managers must contain currentValue or currentDigest in the query or their templates',
         },
         {
           topic: 'Configuration Error',

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -1160,7 +1160,7 @@ describe('config/validation', () => {
         },
         {
           message:
-            'Regex Managers must contain currentValueTemplate configuration or regex group named currentValue',
+            'Regex Managers must contain currentValueTemplate configuration or regex group named currentValue, or currentDigestTemplate configuration or regex group named currentDigest',
         },
         {
           message:
@@ -1253,9 +1253,59 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           message:
-            'Regex Managers must contain currentValueTemplate configuration or regex group named currentValue',
+            'Regex Managers must contain currentValueTemplate configuration or regex group named currentValue, or currentDigestTemplate configuration or regex group named currentDigest',
         },
       ]);
+    });
+
+    // via https://github.com/renovatebot/renovate/discussions/45665
+    it('does not error if a customManager only uses `currentDigest`', async () => {
+      const config: RenovateConfig = {
+        customManagers: [
+          {
+            customType: 'regex',
+            managerFilePatterns: [
+              '/\\.gitlab-ci\\.yml$/',
+              '/\\.gitlab\\/pipelines\\/.*\\.yaml$/',
+            ],
+            matchStrings: [
+              '.*@(?<currentDigest>sha256:[^ ]+) *# renovate: image=(?<depName>[^ \\n]+)\\n',
+            ],
+            datasourceTemplate: 'docker',
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toBeEmptyArray();
+      expect(errors).toBeEmptyArray();
+    });
+
+    it('does not error if a customManager only uses `currentValue`', async () => {
+      const config: RenovateConfig = {
+        customManagers: [
+          {
+            customType: 'regex',
+            managerFilePatterns: [
+              '/\\.gitlab-ci\\.yml$/',
+              '/\\.gitlab\\/pipelines\\/.*\\.yaml$/',
+            ],
+            matchStrings: ['ENV YARN_VERSION=(?<currentValue>.*?)\\n'],
+            depNameTemplate: 'foo',
+            datasourceTemplate: 'docker',
+          },
+        ],
+      };
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+        true,
+      );
+      expect(warnings).toBeEmptyArray();
+      expect(errors).toBeEmptyArray();
     });
 
     it('errors if customManager fields are missing: JSONataManager', async () => {
@@ -1278,7 +1328,8 @@ describe('config/validation', () => {
       expect(errors).toMatchObject([
         {
           topic: 'Configuration Error',
-          message: `JSONata Managers must contain currentValueTemplate configuration or currentValue in the query `,
+          message:
+            'JSONata Managers must contain currentValue, or currentDigest in the query or their templates',
         },
         {
           topic: 'Configuration Error',

--- a/lib/modules/manager/custom/jsonata/readme.md
+++ b/lib/modules/manager/custom/jsonata/readme.md
@@ -34,7 +34,7 @@ Before Renovate can look up a dependency and decide about updates, it must have 
 
 You must:
 
-- Capture the `currentValue` of the dependency _or_ use the `currentValueTemplate` template field
+- Capture the `currentValue` or `currentDigest` of the dependency _or_ use the `currentValueTemplate` or `currentDigestTemplate` template field
 - Capture the `depName` or `packageName`. _Or_ use a template field: `depNameTemplate` and `packageNameTemplate`
 - Capture the `datasource`, _or_ use the `datasourceTemplate` template field
 
@@ -45,7 +45,6 @@ You may use any of these items:
 - `depType`, _or_ use the `depTypeTemplate` template field
 - `versioning`, _or_ the use `versioningTemplate` template field. If neither are present, Renovate defaults to `semver-coerced`
 - `extractVersion`, _or_ use the `extractVersionTemplate` template field
-- `currentDigest`
 - `registryUrl`, _or_ use the `registryUrlTemplate` template field. If it's a valid URL, it will be converted to the `registryUrls` field as a single-length array
 - `indentation`. Must be empty, _or_ whitespace. Else Renovate restes only `indentation` to an empty string
 

--- a/lib/modules/manager/custom/regex/readme.md
+++ b/lib/modules/manager/custom/regex/readme.md
@@ -36,7 +36,7 @@ Before Renovate can look up a dependency and decide about updates, it must have 
 
 You must:
 
-- Capture the `currentValue` of the dependency in a named capture group
+- Capture the `currentValue` or `currentDigest` of the dependency in a named capture group
 - Set a `depName` or `packageName` capture group. Or use a template field: `depNameTemplate` and `packageNameTemplate`
 - Set a `datasource` capture group, or a `datasourceTemplate` config field
 
@@ -47,7 +47,6 @@ You may use any of these items:
 - A `depType` capture group, or a `depTypeTemplate` config field
 - A `versioning` capture group, or a `versioningTemplate` config field. If neither are present, Renovate defaults to `semver-coerced`
 - An `extractVersion` capture group, or an `extractVersionTemplate` config field
-- A `currentDigest` capture group
 - A `registryUrl` capture group, or a `registryUrlTemplate` config field. If it's a valid URL, it will be converted to the `registryUrls` field as a single-length array
 - An `indentation` capture group. It must be either empty, or whitespace only (otherwise `indentation` will be reset to an empty string)
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

As reported in #45665, it was previously possible - through a preset
prior to 44.60.1 - to specify a Custom Manager (in this case, with
Regex) that only captured the `currentDigest` for a dependency.

This causes config validation in a repository, but as it appears to be
valid - with `currentValue` defaulting to `latest` - we should make it
possible to use either `currentValue` or `currentDigest`.

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

Using example from https://github.com/renovatebot/renovate/discussions/45665#discussioncomment-18270856
<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
