### PR TITLE
fix(lookup): use pre-extractVersion tag for digest lookups

### DIFF
--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3276,8 +3276,7 @@ describe('workers/repository/process/lookup/index', () => {
 
       await Result.wrap(lookup.lookupUpdates(config)).unwrapOrThrow();
 
-      // both the version-bump and the digest-pin lookups must use the raw
-      // tag (v1.0.0), never the extractVersion-stripped value (1.0.0)
+      // digest lookups must use the raw tag (v1.0.0), not the stripped value (1.0.0)
       expect(getGithubTagsDigest).toHaveBeenCalledWith(
         expect.objectContaining({ currentValue: 'v1.0.0' }),
         'v2.0.0',

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3272,17 +3272,55 @@ describe('workers/repository/process/lookup/index', () => {
       });
       const getGithubTagsDigest = vi
         .spyOn(GithubTagsDatasource.prototype, 'getDigest')
-        .mockResolvedValueOnce('digest1234');
+        .mockResolvedValueOnce('digest1234')
+        .mockResolvedValueOnce('digest5678');
 
-      await Result.wrap(lookup.lookupUpdates(config)).unwrapOrThrow();
+      const { updates } = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
 
-      // digest lookups must use the raw tag (v1.0.0), not the stripped value (1.0.0)
-      expect(getGithubTagsDigest).toHaveBeenCalledWith(
-        expect.objectContaining({ currentValue: 'v1.0.0' }),
+      expect(updates).toEqual([
+        {
+          bucket: 'major',
+          hasAttestation: undefined,
+          isBreaking: true,
+          newDigest: 'digest1234',
+          newMajor: 2,
+          newMinor: 0,
+          newPatch: 0,
+          newValue: '2.0.0',
+          newVersion: '2.0.0',
+          newVersionAgeInDays: expect.any(Number),
+          releaseTimestamp: '2022-06-01T00:00:00.000Z',
+          updateType: 'major',
+        },
+        {
+          isPinDigest: true,
+          newDigest: 'digest5678',
+          newValue: '1.0.0',
+          updateType: 'pinDigest',
+        },
+      ]);
+      expect(getGithubTagsDigest).toHaveBeenNthCalledWith(
+        1,
+        {
+          currentDigest: undefined,
+          currentValue: 'v1.0.0',
+          lookupName: undefined,
+          packageName: 'angular/angular',
+          registryUrl: 'https://github.com',
+        },
         'v2.0.0',
       );
-      expect(getGithubTagsDigest).toHaveBeenCalledWith(
-        expect.objectContaining({ currentValue: 'v1.0.0' }),
+      expect(getGithubTagsDigest).toHaveBeenNthCalledWith(
+        2,
+        {
+          currentDigest: undefined,
+          currentValue: 'v1.0.0',
+          lookupName: undefined,
+          packageName: 'angular/angular',
+          registryUrl: 'https://github.com',
+        },
         'v1.0.0',
       );
     });

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -3256,6 +3256,38 @@ describe('workers/repository/process/lookup/index', () => {
       );
     });
 
+    it('resolves digests using the pre-extractVersion tag, not the stripped value', async () => {
+      config.currentValue = '1.0.0';
+      config.extractVersion = '^v(?<version>.*)$';
+      config.packageName = 'angular/angular';
+      config.pinDigests = true;
+      config.digestOneAndOnly = true;
+      config.datasource = GithubTagsDatasource.id;
+
+      getGithubTags.mockResolvedValueOnce({
+        releases: [
+          { version: 'v1.0.0', releaseTimestamp: '2022-01-01' as Timestamp },
+          { version: 'v2.0.0', releaseTimestamp: '2022-06-01' as Timestamp },
+        ],
+      });
+      const getGithubTagsDigest = vi
+        .spyOn(GithubTagsDatasource.prototype, 'getDigest')
+        .mockResolvedValueOnce('digest1234');
+
+      await Result.wrap(lookup.lookupUpdates(config)).unwrapOrThrow();
+
+      // both the version-bump and the digest-pin lookups must use the raw
+      // tag (v1.0.0), never the extractVersion-stripped value (1.0.0)
+      expect(getGithubTagsDigest).toHaveBeenCalledWith(
+        expect.objectContaining({ currentValue: 'v1.0.0' }),
+        'v2.0.0',
+      );
+      expect(getGithubTagsDigest).toHaveBeenCalledWith(
+        expect.objectContaining({ currentValue: 'v1.0.0' }),
+        'v1.0.0',
+      );
+    });
+
     it('should treat zero zero tilde ranges as 0.0.x', async () => {
       config.rangeStrategy = 'replace';
       config.currentValue = '~0.0.34';

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -851,6 +851,13 @@ export async function lookupUpdates(
         config.registryUrls = [res.registryUrl];
       }
 
+      // getDigest() needs the real tag; versionOrig holds it pre-extractVersion.
+      function origTag(v: string | undefined): string | undefined {
+        return (
+          dependency?.releases.find((r) => r.version === v)?.versionOrig ?? v
+        );
+      }
+
       // update digest for all
       for (const update of res.updates) {
         // only update the digest in the package file if it's managed by us
@@ -858,14 +865,9 @@ export async function lookupUpdates(
           (config.pinDigests === true && !config.digestManagedExternally) ||
           config.currentDigest
         ) {
-          // getDigest() needs the real tag; versionOrig holds it pre-extractVersion.
-          const currentValueOrig =
-            dependency?.releases.find((r) => r.version === config.currentValue)
-              ?.versionOrig ?? config.currentValue;
-
           const getDigestConfig: GetDigestInputConfig = {
             ...config,
-            currentValue: currentValueOrig,
+            currentValue: origTag(config.currentValue),
             registryUrl: update.registryUrl ?? res.registryUrl,
             lookupName: res.lookupName,
           };
@@ -885,10 +887,6 @@ export async function lookupUpdates(
             getDigestConfig.replacementName = update.newName;
           }
 
-          const newRelease = dependency?.releases.find(
-            (r) => r.version === update.newValue,
-          );
-
           // Don't use current releases if replacement changes name, otherwise we use the wrong new digest.
           // This happens on datasources which return the digest in release info like `github-tags`.
           // We can still use it when only version is changing.
@@ -896,12 +894,15 @@ export async function lookupUpdates(
             update.updateType !== 'replacement' ||
             update.newName === config.packageName
           ) {
-            update.newDigest ??= newRelease?.newDigest;
+            update.newDigest ??= dependency?.releases.find(
+              (r) => r.version === update.newValue,
+            )?.newDigest;
           }
 
-          const newValueOrig = newRelease?.versionOrig ?? update.newValue;
-
-          update.newDigest ??= await getDigest(getDigestConfig, newValueOrig);
+          update.newDigest ??= await getDigest(
+            getDigestConfig,
+            origTag(update.newValue),
+          );
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -858,9 +858,7 @@ export async function lookupUpdates(
           (config.pinDigests === true && !config.digestManagedExternally) ||
           config.currentDigest
         ) {
-          // `extractVersion` strips the release/tag prefix from the values we compare and
-          // write to the package file, but `getDigest()` implementations need the actual
-          // git tag. `versionOrig` on the matching release holds that pre-extraction value.
+          // getDigest() needs the real tag; versionOrig holds it pre-extractVersion.
           const currentValueOrig =
             dependency?.releases.find((r) => r.version === config.currentValue)
               ?.versionOrig ?? config.currentValue;
@@ -887,6 +885,10 @@ export async function lookupUpdates(
             getDigestConfig.replacementName = update.newName;
           }
 
+          const newRelease = dependency?.releases.find(
+            (r) => r.version === update.newValue,
+          );
+
           // Don't use current releases if replacement changes name, otherwise we use the wrong new digest.
           // This happens on datasources which return the digest in release info like `github-tags`.
           // We can still use it when only version is changing.
@@ -894,14 +896,10 @@ export async function lookupUpdates(
             update.updateType !== 'replacement' ||
             update.newName === config.packageName
           ) {
-            update.newDigest ??= dependency?.releases.find(
-              (r) => r.version === update.newValue,
-            )?.newDigest;
+            update.newDigest ??= newRelease?.newDigest;
           }
 
-          const newValueOrig =
-            dependency?.releases.find((r) => r.version === update.newValue)
-              ?.versionOrig ?? update.newValue;
+          const newValueOrig = newRelease?.versionOrig ?? update.newValue;
 
           update.newDigest ??= await getDigest(getDigestConfig, newValueOrig);
 

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -858,8 +858,16 @@ export async function lookupUpdates(
           (config.pinDigests === true && !config.digestManagedExternally) ||
           config.currentDigest
         ) {
+          // `extractVersion` strips the release/tag prefix from the values we compare and
+          // write to the package file, but `getDigest()` implementations need the actual
+          // git tag. `versionOrig` on the matching release holds that pre-extraction value.
+          const currentValueOrig =
+            dependency?.releases.find((r) => r.version === config.currentValue)
+              ?.versionOrig ?? config.currentValue;
+
           const getDigestConfig: GetDigestInputConfig = {
             ...config,
+            currentValue: currentValueOrig,
             registryUrl: update.registryUrl ?? res.registryUrl,
             lookupName: res.lookupName,
           };
@@ -891,10 +899,11 @@ export async function lookupUpdates(
             )?.newDigest;
           }
 
-          update.newDigest ??= await getDigest(
-            getDigestConfig,
-            update.newValue,
-          );
+          const newValueOrig =
+            dependency?.releases.find((r) => r.version === update.newValue)
+              ?.versionOrig ?? update.newValue;
+
+          update.newDigest ??= await getDigest(getDigestConfig, newValueOrig);
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -182,6 +182,18 @@ async function applyMinimumReleaseAgeToDigestUpdate(
   }
 }
 
+/**
+ * Resolve `v` back to its pre-`extractVersion` tag via `Release.versionOrig`,
+ * since `getDigest()` needs the real tag. Returns `v` unchanged if there's no
+ * matching release (e.g. extractVersion wasn't configured).
+ */
+function resolveOrigTag(
+  dependency: ReleaseResult | null,
+  v: string | undefined,
+): string | undefined {
+  return dependency?.releases.find((r) => r.version === v)?.versionOrig ?? v;
+}
+
 export async function lookupUpdates(
   inconfig: LookupUpdateConfig,
 ): Promise<Result<UpdateResult>> {
@@ -851,13 +863,6 @@ export async function lookupUpdates(
         config.registryUrls = [res.registryUrl];
       }
 
-      // getDigest() needs the real tag; versionOrig holds it pre-extractVersion.
-      function origTag(v: string | undefined): string | undefined {
-        return (
-          dependency?.releases.find((r) => r.version === v)?.versionOrig ?? v
-        );
-      }
-
       // update digest for all
       for (const update of res.updates) {
         // only update the digest in the package file if it's managed by us
@@ -867,7 +872,7 @@ export async function lookupUpdates(
         ) {
           const getDigestConfig: GetDigestInputConfig = {
             ...config,
-            currentValue: origTag(config.currentValue),
+            currentValue: resolveOrigTag(dependency, config.currentValue),
             registryUrl: update.registryUrl ?? res.registryUrl,
             lookupName: res.lookupName,
           };
@@ -901,7 +906,7 @@ export async function lookupUpdates(
 
           update.newDigest ??= await getDigest(
             getDigestConfig,
-            origTag(update.newValue),
+            resolveOrigTag(dependency, update.newValue),
           );
 
           // If the digest could not be determined, report this as otherwise the


### PR DESCRIPTION
## Changes

- At MongoDB we build an image that relies on `dyff` and `kustomize` and we try to verify its hash
- We specify those versions like `1.11.3` - although the git tags for `dyff` prefix that with `v`
- We tried using `github-release-attachments ... extractVersion=^v(?<version>.*)$` for this
- But our org-wide run failed with:
```
"message": "Request failed with status code 404 (Not Found): GET https://api.github.com/repos/homeport/dyff/releases/tags/1.11.3",
"stack": "HTTPError: Request failed with status code 404 (Not Found): GET https://**redacted**@14.6.6/node_modules/got/dist/source/as-promise/index.js:98:42)\n    at Request.wrapper (node:events:639:12)\n    at Request.emit (node:events:526:24)\n    at Request.emit (node:domain:489:12)\n    at Request._onResponseBase (file:///usr/local/renovate/node_modules/.pnpm/got@14.6.6/node_modules/got/dist/source/core/index.js:779:22)\n    at processTicksAndRejections (node:internal/process/task_queues:104:5)\n    at Request._onResponse (file:///usr/local/renovate/node_modules/.pnpm/got@14.6.6/node_modules/got/dist/source/core/index.js:829:13)",
```

We found that `getDigest()` expects a real git tag, but the lookup worker was passing the value stripped of its `v` prefix. This gave us 404s because extractVersion=^v(?<version>.*)$ with currentValue=1.11.3 looks up tag 1.11.3 instead of the real tag v1.11.3. 

Related Discussion: #22513.

We mitigated on our side by adding the `v` prefix to the versions, but `extractVersion` should work as expected...

To solve this, we can use the pre-extraction tag `Release.versionOrig` to resolve the real tag before calling `getDigest()`. When extractVersion isn't configured, versionOrig is unset and behavior is unchanged.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @username will read and reply directly. **Name the account.** - @sakib 
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
