### PR TITLE
feat(logger): add optional pretty timestamps

### DIFF
--- a/docs/usage/config-overview.md
+++ b/docs/usage/config-overview.md
@@ -144,6 +144,7 @@ Finally, there are some special environment variables that are loaded _before_ c
 - `LOG_FILE_LEVEL`: log file logging level, defaults to `debug`
 - `LOG_FORMAT`: defaults to a "pretty" human-readable output, but can be changed to "json"
 - `LOG_LEVEL`: most commonly used to change from the default `info` to `debug` logging
+- `LOG_PRETTY_TIMESTAMP`: set to `true` to prefix human-readable stdout and pretty log-file entries with an ISO 8601 UTC timestamp
 
 #### CLI config
 

--- a/lib/logger/bunyan.ts
+++ b/lib/logger/bunyan.ts
@@ -21,6 +21,7 @@ export function createDefaultStreams(
   problems: ProblemStream,
   logFile: string | undefined,
 ): BunyanStream[] {
+  const includePrettyTimestamp = getEnv('LOG_PRETTY_TIMESTAMP') === 'true';
   const stdout: BunyanStream = {
     name: 'stdout',
     level: stdoutLevel,
@@ -29,7 +30,7 @@ export function createDefaultStreams(
 
   // v8 ignore else -- TODO: add test #40625
   if (getEnv('LOG_FORMAT') !== 'json') {
-    const prettyStdOut = new PrettyStdoutStream();
+    const prettyStdOut = new PrettyStdoutStream(includePrettyTimestamp);
     stdout.stream = prettyStdOut;
     stdout.type = 'raw';
   }
@@ -42,13 +43,16 @@ export function createDefaultStreams(
   };
 
   const logFileStream: BunyanStream | undefined = isString(logFile)
-    ? createLogFileStream(logFile)
+    ? createLogFileStream(logFile, includePrettyTimestamp)
     : undefined;
 
   return [stdout, problemsStream, logFileStream].filter(isTruthy);
 }
 
-function createLogFileStream(logFile: string): BunyanStream {
+function createLogFileStream(
+  logFile: string,
+  includePrettyTimestamp: boolean,
+): BunyanStream {
   // Ensure log file directory exists
   const directoryName = upath.dirname(logFile);
   fs.ensureDirSync(directoryName);
@@ -66,7 +70,10 @@ function createLogFileStream(logFile: string): BunyanStream {
       stream: {
         writable: true,
         write: (rec: unknown) => {
-          fs.writeSync(fd, formatRecord(rec as BunyanRecord, false));
+          fs.writeSync(
+            fd,
+            formatRecord(rec as BunyanRecord, false, includePrettyTimestamp),
+          );
         },
       },
     };

--- a/lib/logger/index.spec.ts
+++ b/lib/logger/index.spec.ts
@@ -205,6 +205,8 @@ describe('logger/index', () => {
   describe('createDefaultStreams', () => {
     beforeEach(() => {
       vi.stubEnv('LOG_FILE_FORMAT', undefined);
+      vi.stubEnv('LOG_FORMAT', undefined);
+      vi.stubEnv('LOG_PRETTY_TIMESTAMP', undefined);
     });
 
     it('creates log file stream', () => {
@@ -288,6 +290,58 @@ describe('logger/index', () => {
       stream.write({ level: 30, msg: 'test message' });
 
       expect(await fs.readFile('file.log', 'utf8')).toContain('test message');
+    });
+
+    it('writes timestamps to pretty stdout when configured', () => {
+      vi.stubEnv('LOG_PRETTY_TIMESTAMP', 'true');
+      const stdoutSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      const streams = createDefaultStreams(
+        'info',
+        new ProblemStream(),
+        undefined,
+      );
+
+      const stream = streams[0].stream as {
+        write: (record: Record<string, unknown>) => void;
+      };
+      stream.write({
+        level: 30,
+        msg: 'test message',
+        time: new Date('2026-08-31T11:30:45.123Z'),
+        v: 0,
+      });
+
+      expect(stdoutSpy.mock.calls[0][0]).toMatch(/^2026-08-31T11:30:45\.123Z /);
+    });
+
+    it('writes timestamps to pretty log files when configured', async () => {
+      vi.stubEnv('LOG_FILE_FORMAT', 'pretty');
+      vi.stubEnv('LOG_PRETTY_TIMESTAMP', 'true');
+
+      const streams = createDefaultStreams(
+        'info',
+        new ProblemStream(),
+        'file.log',
+      );
+
+      const logFileStream = streams[2];
+      const stream = logFileStream.stream as {
+        write: (...args: unknown[]) => void;
+      };
+
+      stream.write({
+        level: 30,
+        msg: 'timestamped message',
+        time: new Date('2026-08-31T11:30:45.123Z'),
+        v: 0,
+      });
+
+      expect(await fs.readFile('file.log', 'utf8')).toContain(
+        '2026-08-31T11:30:45.123Z  INFO: timestamped message',
+      );
     });
 
     it('writes json data synchronously to log file', async () => {

--- a/lib/logger/pretty-stdout.spec.ts
+++ b/lib/logger/pretty-stdout.spec.ts
@@ -199,6 +199,19 @@ describe('logger/pretty-stdout', () => {
         `}\n`,
       );
     });
+
+    it('formats the record timestamp when requested', () => {
+      const rec = partial<BunyanRecord>({
+        level: 10,
+        msg: 'test message',
+        time: new Date('2026-08-31T11:30:45.123Z'),
+        v: 0,
+      });
+
+      expect(prettyStdout.formatRecord(rec, false, true)).toBe(
+        '2026-08-31T11:30:45.123Z TRACE: test message\n',
+      );
+    });
   });
 
   describe('PrettyStdoutStream', () => {
@@ -217,6 +230,23 @@ describe('logger/pretty-stdout', () => {
       stream.write(rec);
       expect(stdoutSpy).toHaveBeenCalledOnce();
       expect(stdoutSpy.mock.calls[0][0]).toContain('test message');
+    });
+
+    it('writes timestamps when requested', () => {
+      const stdoutSpy = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+
+      const stream = new prettyStdout.PrettyStdoutStream(true);
+      const rec: BunyanRecord = {
+        level: 10,
+        msg: 'test message',
+        time: new Date('2026-08-31T11:30:45.123Z'),
+        v: 0,
+      };
+
+      stream.write(rec);
+      expect(stdoutSpy.mock.calls[0][0]).toMatch(/^2026-08-31T11:30:45\.123Z /);
     });
   });
 });

--- a/lib/logger/pretty-stdout.ts
+++ b/lib/logger/pretty-stdout.ts
@@ -5,6 +5,7 @@ import { Writable } from 'node:stream';
 import * as util from 'node:util';
 import { isNonEmptyObject, isPlainObject, isString } from '@sindresorhus/is';
 import stringify from 'json-stringify-pretty-compact';
+import { DateTime } from 'luxon';
 import { regEx } from '../util/regex.ts';
 import type { BunyanRecord } from './types.ts';
 
@@ -113,17 +114,27 @@ export function getDetails(rec: BunyanRecord): string {
     .join(',\n')}\n`;
 }
 
-export function formatRecord(rec: BunyanRecord, colorize = true): string {
+export function formatRecord(
+  rec: BunyanRecord,
+  colorize = true,
+  includeTimestamp = false,
+): string {
+  const timestamp = includeTimestamp
+    ? `${DateTime.fromJSDate(rec.time).toUTC().toISO()} `
+    : '';
   const level = colorize ? colorizedLevels[rec.level] : levels[rec.level];
   const msg = `${indent(rec.msg)}`;
   const meta = getMeta(rec, colorize);
   const details = getDetails(rec);
-  return util.format('%s: %s%s\n%s', level, msg, meta, details);
+  return util.format('%s%s: %s%s\n%s', timestamp, level, msg, meta, details);
 }
 
 export class PrettyStdoutStream extends Writable {
-  constructor() {
+  private readonly includeTimestamp: boolean;
+
+  constructor(includeTimestamp = false) {
     super({ objectMode: true });
+    this.includeTimestamp = includeTimestamp;
   }
 
   override _write(
@@ -131,7 +142,7 @@ export class PrettyStdoutStream extends Writable {
     _encoding: string,
     callback: (error?: Error | null) => void,
   ): void {
-    process.stdout.write(formatRecord(data));
+    process.stdout.write(formatRecord(data, true, this.includeTimestamp));
     callback();
   }
 }


### PR DESCRIPTION
## Changes

Adds an opt-in timestamp prefix to Renovate's human-readable logs.

- `LOG_PRETTY_TIMESTAMP=true` prefixes pretty stdout entries with their Bunyan record timestamp in ISO 8601 UTC form.
- The same setting applies to `LOG_FILE_FORMAT=pretty`, keeping stdout and pretty log files consistent.
- Default pretty output and JSON logging remain unchanged.
- The special logging environment variable is documented alongside the other `LOG_*` settings that are loaded before normal configuration parsing.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #5980
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation). OpenAI Codex using GPT-5 assisted with tracing logger initialization, implementing the opt-in formatter and stream wiring, adding regression tests and documentation, running validation, and reviewing the final diff. The implementation was checked against Renovate's existing special logging-variable conventions and both pretty output destinations.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable; the behavior is covered by focused logger formatter, stdout-stream, and pretty log-file unit tests.
