### PR TITLE
feat(onboarding): note that `vulnerabilityAlerts` can be rate limited

### DIFF
--- a/lib/workers/repository/onboarding/pr/pr-list.spec.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.spec.ts
@@ -407,6 +407,7 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       expect(res).toContain(
         'plus 1 security update Pull Request which is not subject to this limit',
       );
+      expect(res).not.toContain('vulnerabilityAlerts.prConcurrentLimit');
     });
 
     it('does not count multiple security updates towards the concurrent limit, and notes they bypass it (plural)', () => {
@@ -491,6 +492,9 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       );
       expect(res).toContain(
         'plus 2 security update Pull Requests which are not subject to this limit',
+      );
+      expect(res).toContain(
+        'If you want to rate limit security update Pull Requests too, set [`vulnerabilityAlerts.prConcurrentLimit`]',
       );
     });
 
@@ -2066,6 +2070,253 @@ describe('workers/repository/onboarding/pr/pr-list', () => {
       );
       expect(res).toContain(
         'Security update Pull Request is not subject to this limit and will be created straight away.',
+      );
+      expect(res).not.toContain('vulnerabilityAlerts.prConcurrentLimit');
+    });
+
+    it('suggests vulnerabilityAlerts.prConcurrentLimit when security updates alone exceed prConcurrentLimit', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'CVE fix for a',
+          branchName: 'renovate/a-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for b',
+          branchName: 'renovate/b-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 1;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        'If you want to rate limit security update Pull Requests too, set [`vulnerabilityAlerts.prConcurrentLimit`]',
+      );
+    });
+
+    it('does not suggest vulnerabilityAlerts.prConcurrentLimit when prConcurrentLimit is unlimited', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'CVE fix for a',
+          branchName: 'renovate/a-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for b',
+          branchName: 'renovate/b-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.prConcurrentLimit = 0;
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).not.toContain('vulnerabilityAlerts.prConcurrentLimit');
+    });
+
+    it('notes when vulnerabilityAlerts.prConcurrentLimit is already configured and would throttle security updates', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'CVE fix for a',
+          branchName: 'renovate/a-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for b',
+          branchName: 'renovate/b-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.vulnerabilityAlerts = partial<RenovateConfig>({
+        prConcurrentLimit: 1,
+      });
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        'Renovate will only create 1 security update Pull Request at a time, up to a maximum of 2 over time, due to your [`vulnerabilityAlerts.prConcurrentLimit`]',
+      );
+      expect(res).not.toContain('If you want to rate limit');
+    });
+
+    it('pluralises the vulnerabilityAlerts.prConcurrentLimit note when the limit is more than one', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'CVE fix for a',
+          branchName: 'renovate/a-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for b',
+          branchName: 'renovate/b-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for c',
+          branchName: 'renovate/c-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'c',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.vulnerabilityAlerts = partial<RenovateConfig>({
+        prConcurrentLimit: 2,
+      });
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        'Renovate will only create 2 security update Pull Requests at a time, up to a maximum of 3 over time, due to your [`vulnerabilityAlerts.prConcurrentLimit`]',
+      );
+    });
+
+    it('does not note vulnerabilityAlerts.prConcurrentLimit when it is configured but not exceeded', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'CVE fix for a',
+          branchName: 'renovate/a-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.vulnerabilityAlerts = partial<RenovateConfig>({
+        prConcurrentLimit: 1,
+      });
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).not.toContain('vulnerabilityAlerts.prConcurrentLimit');
+    });
+
+    it('prefers vulnerabilityAlerts.branchConcurrentLimit over prConcurrentLimit when it is explicitly set and more restrictive', () => {
+      const branches: BranchConfig[] = [
+        {
+          prTitle: 'CVE fix for a',
+          branchName: 'renovate/a-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'a',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+        {
+          prTitle: 'CVE fix for b',
+          branchName: 'renovate/b-cve',
+          baseBranch: 'base',
+          manager: 'some-manager',
+          isVulnerabilityAlert: true,
+          upgrades: [
+            {
+              manager: 'some-manager',
+              depName: 'b',
+              newValue: '1.0.1',
+              branchName: 'ignored',
+            },
+          ],
+        },
+      ];
+      config.vulnerabilityAlerts = partial<RenovateConfig>({
+        prConcurrentLimit: 5,
+        branchConcurrentLimit: 1,
+      });
+      const res = getExpectedPrListSummary(config, branches);
+      expect(res).toContain(
+        'Renovate will only create 1 security update Pull Request at a time, up to a maximum of 2 over time, due to your [`vulnerabilityAlerts.branchConcurrentLimit`]',
       );
     });
 

--- a/lib/workers/repository/onboarding/pr/pr-list.ts
+++ b/lib/workers/repository/onboarding/pr/pr-list.ts
@@ -1,4 +1,6 @@
+import { getDefault } from '../../../../config/defaults.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
+import { getOptions } from '../../../../config/options/index.ts';
 import {
   type RenovateConfig,
   type UpdateType,
@@ -71,6 +73,53 @@ function resolveConcurrentLimit(config: RenovateConfig): ConcurrentLimit {
   return { limit: prConcurrentLimit, key: 'prConcurrentLimit' };
 }
 
+/**
+ * Vulnerability alert fixes get their own concurrent-limit budget via `vulnerabilityAlerts.prConcurrentLimit`/ `vulnerabilityAlerts.branchConcurrentLimit`, separate from repository-wide/dependency-specific rules.
+ * Falls back to the `vulnerabilityAlerts` option's own schema default (currently `0`, i.e. no limit) when
+ * unset, via `getDefault()`, rather than duplicating that value here.
+ */
+function resolveVulnerabilityConcurrentLimit(
+  config: RenovateConfig,
+): ConcurrentLimit {
+  // `vulnerabilityAlerts` is typed as `RenovateSharedConfig`, which doesn't declare `prConcurrentLimit`/
+  // `branchConcurrentLimit`, even though both are valid nested options (see docs for `vulnerabilityAlerts`).
+  // oxlint-disable-next-line typescript/no-unnecessary-type-assertion
+  const vulnerabilityAlerts = config.vulnerabilityAlerts as
+    | RenovateConfig
+    | undefined;
+  const vulnerabilityAlertsDefault = getDefault(
+    getOptions().find((option) => option.name === 'vulnerabilityAlerts')!,
+  ) as RenovateConfig;
+  const configAsUpgrade: BranchUpgradeConfig = {
+    branchName: '',
+    manager: '',
+    prConcurrentLimit:
+      vulnerabilityAlerts?.prConcurrentLimit ??
+      vulnerabilityAlertsDefault.prConcurrentLimit,
+    // `undefined` and `null` are handled identically by `calcLimit()` (both inherit `prConcurrentLimit`),
+    // so there's no default value to duplicate here - unlike `prConcurrentLimit` above.
+    branchConcurrentLimit: vulnerabilityAlerts?.branchConcurrentLimit,
+  };
+  const prConcurrentLimit = calcLimit([configAsUpgrade], 'prConcurrentLimit');
+  const branchConcurrentLimit = calcLimit(
+    [configAsUpgrade],
+    'branchConcurrentLimit',
+  );
+
+  if (
+    typeof vulnerabilityAlerts?.branchConcurrentLimit === 'number' &&
+    branchConcurrentLimit > 0 &&
+    (prConcurrentLimit === 0 || branchConcurrentLimit < prConcurrentLimit)
+  ) {
+    return {
+      limit: branchConcurrentLimit,
+      key: 'branchConcurrentLimit',
+    };
+  }
+
+  return { limit: prConcurrentLimit, key: 'prConcurrentLimit' };
+}
+
 export function getExpectedPrList(
   config: RenovateConfig,
   branches: BranchConfig[],
@@ -81,7 +130,8 @@ export function getExpectedPrList(
   if (!branches.length) {
     return `${prDesc}It looks like your repository dependencies are already up-to-date and no Pull Requests will be necessary right away.\n`;
   }
-  // Vulnerability alert branches bypass all rate/concurrency limits, so they shouldn't count towards them.
+  // Vulnerability alert branches bypass the repository-wide rate/concurrency limits, so they shouldn't
+  // count towards them - they get their own budget, see `resolveVulnerabilityConcurrentLimit()`.
   const securityBranchCount = branches.filter(
     (b) => b.isVulnerabilityAlert,
   ).length;
@@ -99,6 +149,11 @@ export function getExpectedPrList(
     prDesc += `With your current configuration, Renovate will create ${branches.length} Pull Request`;
     prDesc += branches.length > 1 ? `s:\n\n` : `:\n\n`;
   }
+  prDesc += getSecurityConcurrentLimitNote(
+    securityBranchCount,
+    concurrentLimit,
+    resolveVulnerabilityConcurrentLimit(config),
+  );
 
   for (const branch of branches) {
     const prTitleRe = regEx(/@(?<scope>[a-z]+\/[a-z]+)/);
@@ -169,6 +224,42 @@ export function getExpectedPrList(
     );
   }
   return prDesc;
+}
+
+/**
+ * Security update Pull Requests bypass the repository-wide `prConcurrentLimit`/`branchConcurrentLimit`
+ * by default, but they can be rate limited on their own via `vulnerabilityAlerts.prConcurrentLimit`/
+ * `branchConcurrentLimit`.
+ *
+ * - If the user has already opted in to that limit, and it would actually throttle the security updates,
+ *   say so - the "not subject to this limit" wording elsewhere refers only to the repository-wide limit.
+ * - Otherwise, once the number of security updates alone would exceed the repository-wide limit, suggest
+ *   that the user may want to opt in to limiting them too.
+ */
+function getSecurityConcurrentLimitNote(
+  securityCount: number,
+  concurrentLimit: number,
+  vulnerabilityLimit: ConcurrentLimit,
+): string {
+  if (securityCount === 0) {
+    return '';
+  }
+
+  if (vulnerabilityLimit.limit > 0) {
+    if (securityCount <= vulnerabilityLimit.limit) {
+      return '';
+    }
+    return emojify(
+      `:information_source: Renovate will only create ${vulnerabilityLimit.limit} security update Pull Request${vulnerabilityLimit.limit > 1 ? 's' : ''} at a time, up to a maximum of ${securityCount} over time, due to your [\`vulnerabilityAlerts.${vulnerabilityLimit.key}\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#vulnerabilityalerts) setting.\n\n`,
+    );
+  }
+
+  if (concurrentLimit <= 0 || securityCount <= concurrentLimit) {
+    return '';
+  }
+  return emojify(
+    `:information_source: If you want to rate limit security update Pull Requests too, set [\`vulnerabilityAlerts.prConcurrentLimit\`](${GlobalConfig.get('productLinks').documentation}configuration-options/#vulnerabilityalerts).\n\n`,
+  );
 }
 
 function getBranchUpgradeTypes(branch: BranchConfig): Set<SummaryCategory> {
@@ -383,7 +474,9 @@ export function getExpectedPrListSummary(
   const prHourlyLimit = coerceNumber(config.prHourlyLimit);
   const commitHourlyLimit = coerceNumber(config.commitHourlyLimit);
   const concurrentLimit = resolveConcurrentLimit(config);
-  // Vulnerability alert branches bypass all rate/concurrency limits, so they shouldn't count towards them.
+  const vulnerabilityLimit = resolveVulnerabilityConcurrentLimit(config);
+  // Vulnerability alert branches bypass the repository-wide rate/concurrency limits, so they shouldn't
+  // count towards them - they get their own budget, see `resolveVulnerabilityConcurrentLimit()`.
   const securityCount = Object.keys(stats.securityGroups).length;
 
   if (hasMultipleBaseBranches) {
@@ -452,6 +545,14 @@ export function getExpectedPrListSummary(
     prDesc += `\n**Security updates**:\n\n`;
     for (const groupBranches of Object.values(stats.securityGroups)) {
       prDesc += describeSecurityGroup(groupBranches);
+    }
+    const securityConcurrentLimitNote = getSecurityConcurrentLimitNote(
+      securityCount,
+      concurrentLimit.limit,
+      vulnerabilityLimit,
+    );
+    if (securityConcurrentLimitNote) {
+      prDesc += `\n${securityConcurrentLimitNote}`;
     }
   }
 


### PR DESCRIPTION

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

For instance, when a repository is onboarding with many dependency
updates (some of which have many security releases), it would be
useful to let the user know that they're not unlimited, but that the
rate limit is taken into account.

Now we have the capability to specify these, we should:

- take them into account when determining how many PR(s) may be raised
  at a given time
- point users to the documentation when they may want to limit them, if
  the number of security PRs is more than the
  `prConcurrentLimit`/`branchConcurrentLimit`

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/JamieTanna-Mend-testing/ag-ui/pull/3

---

### What to Expect

With your current configuration, Renovate will create 355 Pull Requests (at a maximum of 10 Pull Requests open at a time and a maximum of 2 PRs per hour, plus 36 security updates which aren't subject to these limits):

| Manager | security | major | minor | patch | digest |
| --- | --- | --- | --- | --- | --- |
| maven | 7 | 8 | 17 | 5 | 0 |
| npm | 10 | 40 | 80 | 22 | 0 |
| pip_requirements | 1 | 0 | 0 | 0 | 0 |
| pep621 | 12 | 0 | 3 | 1 | 0 |
| poetry | 2 | 2 | 5 | 1 | 0 |
| gomod | 1 | 4 | 5 | 2 | 1 |
| cargo | 2 | 0 | 2 | 3 | 0 |
| bundler | 1 | 1 | 1 | 0 | 0 |
| github-actions | 0 | 15 | 12 | 2 | 1 |
| gradle | 0 | 6 | 72 | 5 | 0 |
| gradle-wrapper | 0 | 1 | 2 | 1 | 0 |
| nuget | 0 | 0 | 2 | 2 | 0 |
| pub | 0 | 1 | 0 | 0 | 0 |
| dockerfile | 0 | 3 | 0 | 0 | 0 |
| **Total** | 36 | 81 | 201 | 44 | 2 |

...

...

ℹ️ If you want to rate limit security update Pull Requests too, set [`vulnerabilityAlerts.prConcurrentLimit`](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts).



🚸 Renovate will only keep 10 Pull Requests open at a time, so not all of the above will be opened straight away. See [docs for `prConcurrentLimit`](https://docs.renovatebot.com/configuration-options/#prconcurrentlimit) for details. Security update Pull Requests are not subject to this limit and will be created straight away.



🚸 PR creation will be limited to maximum 2 per hour, so it doesn't swamp any CI resources or overwhelm the project. See [docs for `prHourlyLimit`](https://docs.renovatebot.com/configuration-options/#prhourlylimit) for details. Security update Pull Requests are not subject to this limit and will be created straight away.


