### PR TITLE
fix(manager/dockerfile): don't relabel the `syntax` dep as `final`

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -16,6 +16,27 @@ describe('modules/manager/dockerfile/extract', () => {
       expect(res).toBeNull();
     });
 
+    it('keeps the syntax dep type when there is no FROM', () => {
+      const res = extractPackageFile(
+        '# syntax=docker/dockerfile:1.9.0\n',
+        '',
+        {},
+      );
+      expect(res?.deps).toEqual([
+        {
+          autoReplaceStringTemplate:
+            '{{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}',
+          currentDigest: undefined,
+          currentValue: '1.9.0',
+          datasource: 'docker',
+          depName: 'docker/dockerfile',
+          depType: 'syntax',
+          packageName: 'docker/dockerfile',
+          replaceString: 'docker/dockerfile:1.9.0',
+        },
+      ]);
+    });
+
     it('handles naked dep', () => {
       const res = extractPackageFile('FROM node\n', '', {})?.deps;
       expect(res).toEqual([

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -476,6 +476,10 @@ export function extractPackageFile(
   for (const d of deps) {
     d.depType ??= 'stage';
   }
-  deps.at(-1)!.depType = 'final';
+  // find the last `stage`, and treat it as the `final` stage
+  const lastStage = deps.filter((d) => d.depType === 'stage').at(-1);
+  if (lastStage) {
+    lastStage.depType = 'final';
+  }
   return { deps };
 }


### PR DESCRIPTION
## Changes

The `dockerfile` manager's `extractPackageFile()` always relabelled the last extracted dep's `depType` as `final`, on the assumption that the last dep always comes from a `FROM` instruction. For a Dockerfile which only has a `# syntax=` parser directive and no `FROM`, this incorrectly relabelled the `syntax` dep as `final`, so it lost its own `depType`.

The fix picks the last dep whose `depType` is `stage` and relabels that one as `final` instead, so it can't be shadowed by other dep types. If there is no `stage` dep at all (i.e. no `FROM`), nothing is relabelled.

A new test, `keeps the syntax dep type when there is no FROM`, was added to `lib/modules/manager/dockerfile/extract.spec.ts`, asserting that extracting a Dockerfile containing only `# syntax=docker/dockerfile:1.9.0` keeps `depType: 'syntax'` on the resulting dep.

This is PR 1 of a 5-PR stack, sitting at the bottom on top of `main`. It's needed ahead of the APK extraction work higher in the stack, which appends non-`FROM` deps to the same `deps` array.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Written by Claude Opus 5 via Claude Code: code, tests and documentation.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
