### PR TITLE
fix(versioning/apk): correctly implement APK's version constraint operators

### DIFF
--- a/lib/modules/datasource/apk/readme.md
+++ b/lib/modules/datasource/apk/readme.md
@@ -64,7 +64,10 @@ https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
 
 ## Versioning
 
-This datasource uses [`apk` versioning](../../versioning/apk/index.md) by default, which follows Alpine's version format (`3.2.1-r0`, `2.39.0_rc1-r0`, `6.5_p20250503-r0`).
+This datasource uses [`apk` versioning](../../versioning/apk/index.md) by default, which follows Alpine's version format (`3.2.1-r0`, `2.39.0_rc1-r0`, `6.5_p20250503-r0`) and understands APK's version constraints.
+
+This means a `currentValue` may be a constraint rather than a plain version, e.g. `=~8.12.1` to accept any `8.12.1-rN`.
+Read the [`apk` versioning](../../versioning/apk/index.md) docs for the operators it supports.
 
 Depending on which APK repository you are using, you may want to use [the `loose` versioning scheme](../../versioning/loose/index.md), like so:
 

--- a/lib/modules/versioning/apk/index.spec.ts
+++ b/lib/modules/versioning/apk/index.spec.ts
@@ -10,6 +10,17 @@ describe('modules/versioning/apk/index', () => {
       ${'foo'}              | ${false}
       ${'a.39.0-'}          | ${false}
       ${'6.5_p20250503-r0'} | ${true}
+      ${'~2.39.0'}          | ${true}
+      ${'=~2.39.0'}         | ${true}
+      ${'~=2.39.0'}         | ${true}
+      ${'>~2.39.0'}         | ${true}
+      ${'<~2.39.0'}         | ${true}
+      ${'>=2.39.0'}         | ${true}
+      ${'<=2.39.0'}         | ${true}
+      ${'><2.39.0'}         | ${false}
+      ${'~foo'}             | ${false}
+      ${'~'}                | ${false}
+      ${''}                 | ${false}
     `('isValid($version) === $expected', ({ version, expected }) => {
       expect(apk.isValid(version)).toBe(expected);
     });
@@ -99,6 +110,10 @@ describe('modules/versioning/apk/index', () => {
   });
 
   describe('isGreaterThan', () => {
+    it('treats an unparseable version as greater', () => {
+      expect(apk.isGreaterThan('invalid', '2.39.0-r0')).toBe(true);
+    });
+
     it.each`
       a               | b               | expected
       ${'2.39.1-r0'}  | ${'2.39.0-r0'}  | ${true}
@@ -120,6 +135,89 @@ describe('modules/versioning/apk/index', () => {
       ${'2.39.0'}    | ${'2.39.1'}    | ${false}
     `('equals($a, $b) === $expected', ({ a, b, expected }) => {
       expect(apk.equals(a, b)).toBe(expected);
+    });
+  });
+
+  describe('matches', () => {
+    // the examples given for `busybox~1.6` in apk-world(5)
+    it.each`
+      version         | expected
+      ${'1.6'}        | ${true}
+      ${'1.6.0_pre1'} | ${true}
+      ${'1.6.0'}      | ${true}
+      ${'1.6.5'}      | ${true}
+      ${'1.6.9_p1'}   | ${true}
+      ${'1.6.0-r3'}   | ${true}
+      ${'1.60'}       | ${false}
+      ${'1.7.0'}      | ${false}
+      ${'1.5.9'}      | ${false}
+    `('matches($version, ~1.6) === $expected', ({ version, expected }) => {
+      expect(apk.matches(version, '~1.6')).toBe(expected);
+    });
+
+    it.each`
+      version           | range           | expected
+      ${'8.12.1-r0'}    | ${'=~8.12.1'}   | ${true}
+      ${'8.12.1-r5'}    | ${'=~8.12.1'}   | ${true}
+      ${'8.12.2-r0'}    | ${'=~8.12.1'}   | ${false}
+      ${'8.12.10-r0'}   | ${'=~8.12.1'}   | ${false}
+      ${'8.12.1-r0'}    | ${'8.12.1-r0'}  | ${true}
+      ${'8.12.1-r1'}    | ${'8.12.1-r0'}  | ${false}
+      ${'8.12.1-r0'}    | ${'=8.12.1-r0'} | ${true}
+      ${'8.13.0'}       | ${'>8.12.1'}    | ${true}
+      ${'8.12.1'}       | ${'>8.12.1'}    | ${false}
+      ${'8.12.1'}       | ${'>=8.12.1'}   | ${true}
+      ${'8.11.0'}       | ${'<8.12.1'}    | ${true}
+      ${'8.13.0'}       | ${'>~8.12.1'}   | ${true}
+      ${'8.12.1-r2'}    | ${'>~8.12.1'}   | ${true}
+      ${'8.11.0'}       | ${'>~8.12.1'}   | ${false}
+      ${'8.11.0'}       | ${'<~8.12.1'}   | ${true}
+      ${'8.12.1-r2'}    | ${'<~8.12.1'}   | ${true}
+      ${'8.13.0'}       | ${'<~8.12.1'}   | ${false}
+      ${'1.6_rc1'}      | ${'~1.6.0'}     | ${false}
+      ${'8.12.1'}       | ${'~invalid'}   | ${false}
+      ${'invalid'}      | ${'~8.12.1'}    | ${false}
+      ${'8.12.1'}       | ${'><8.12.1'}   | ${false}
+      ${'8.12.1'}       | ${''}           | ${false}
+      ${'1.6'}          | ${'~1.6.0'}     | ${false}
+      ${'1.2.3.4'}      | ${'~1.2.3'}     | ${true}
+      ${'1.2.3.4'}      | ${'~1.2.3.5'}   | ${false}
+      ${'1.2.3a'}       | ${'~1.2.3'}     | ${true}
+      ${'1.2.3b'}       | ${'~1.2.3a'}    | ${false}
+      ${'6.5_p2025-r0'} | ${'~6.5_p2025'} | ${true}
+    `(
+      'matches($version, $range) === $expected',
+      ({ version, range, expected }) => {
+        expect(apk.matches(version, range)).toBe(expected);
+      },
+    );
+  });
+
+  describe('isVersion', () => {
+    it.each`
+      input          | expected
+      ${'2.39.0-r0'} | ${true}
+      ${'2.39.0'}    | ${true}
+      ${'~2.39.0'}   | ${false}
+      ${'=2.39.0'}   | ${false}
+      ${'>=2.39.0'}  | ${false}
+      ${'invalid'}   | ${false}
+    `('isVersion($input) === $expected', ({ input, expected }) => {
+      expect(apk.isVersion(input)).toBe(expected);
+    });
+  });
+
+  describe('minSatisfyingVersion', () => {
+    const versions = ['2.39.0-r0', '2.39.0-r1', '2.39.1-r0', '2.40.0-r0'];
+
+    it.each`
+      range         | expected
+      ${'~2.39.0'}  | ${'2.39.0-r0'}
+      ${'~2.39'}    | ${'2.39.0-r0'}
+      ${'>=2.39.1'} | ${'2.39.1-r0'}
+      ${'~2.41'}    | ${null}
+    `('minSatisfyingVersion($range) === $expected', ({ range, expected }) => {
+      expect(apk.minSatisfyingVersion(versions, range)).toBe(expected);
     });
   });
 
@@ -163,10 +261,27 @@ describe('modules/versioning/apk/index', () => {
 
     it.each`
       range           | expected
-      ${'~2.39.0-r0'} | ${'2.39.1-r0'}
-      ${'~2.40.0-r0'} | ${'2.40.0-r1'}
+      ${'~2.39.0-r0'} | ${'2.39.0-r0'}
+      ${'~2.40.0-r0'} | ${'2.40.0-r0'}
+      ${'~2.39.0'}    | ${'2.39.0-r1'}
+      ${'~2.39'}      | ${'2.39.1-r0'}
+      ${'~2'}         | ${'2.40.0-r1'}
+      ${'=~2.39.0'}   | ${'2.39.0-r1'}
+      ${'~=2.39.0'}   | ${'2.39.0-r1'}
+      ${'~2.41'}      | ${null}
     `(
-      'getSatisfyingVersion with tilde range ($range) === $expected',
+      'getSatisfyingVersion with prefix range ($range) === $expected',
+      ({ range, expected }) => {
+        expect(apk.getSatisfyingVersion(versions, range)).toBe(expected);
+      },
+    );
+
+    it.each`
+      range         | expected
+      ${'>~2.39.0'} | ${'3.0.0-r0'}
+      ${'<~2.39.0'} | ${'2.39.0-r1'}
+    `(
+      'getSatisfyingVersion with combined prefix range ($range) === $expected',
       ({ range, expected }) => {
         expect(apk.getSatisfyingVersion(versions, range)).toBe(expected);
       },
@@ -195,6 +310,10 @@ describe('modules/versioning/apk/index', () => {
       ${'2.39.0'}     | ${true}
       ${'~2.39.0-r0'} | ${false}
       ${'>2.39.0-r0'} | ${false}
+      ${'=2.39.0-r0'} | ${true}
+      ${'=~2.39.0'}   | ${false}
+      ${'>~2.39.0'}   | ${false}
+      ${'><2.39.0'}   | ${false}
     `('isSingleVersion($version) === $expected', ({ version, expected }) => {
       expect(apk.isSingleVersion(version)).toBe(expected);
     });
@@ -208,11 +327,23 @@ describe('modules/versioning/apk/index', () => {
 
   describe('isLessThanRange', () => {
     it.each`
-      version        | range          | expected
-      ${'2.39.0-r0'} | ${'2.39.0-r1'} | ${true}
-      ${'2.39.0-r1'} | ${'2.39.0-r0'} | ${false}
-      ${'2.39.0-r0'} | ${'2.39.0-r0'} | ${false}
-      ${'2.38.0-r0'} | ${'2.39.0-r0'} | ${true}
+      version                 | range          | expected
+      ${'2.39.0-r0'}          | ${'2.39.0-r1'} | ${true}
+      ${'2.39.0-r1'}          | ${'2.39.0-r0'} | ${false}
+      ${'2.39.0-r0'}          | ${'2.39.0-r0'} | ${false}
+      ${'2.38.0-r0'}          | ${'2.39.0-r0'} | ${true}
+      ${'2.38.0'}             | ${'~2.39.0'}   | ${true}
+      ${'2.39.0-r0'}          | ${'~2.39.0'}   | ${false}
+      ${'2.40.0'}             | ${'~2.39.0'}   | ${false}
+      ${'2.39.0'}             | ${'>2.39.0'}   | ${true}
+      ${'2.39.0_git20240101'} | ${'~2.39.0'}   | ${false}
+      ${'1.6.9_p1'}           | ${'~1.6.9'}    | ${false}
+      ${'1.2.3a'}             | ${'~1.2.3'}    | ${false}
+      ${'1.2.3a'}             | ${'>~1.2.3'}   | ${false}
+      ${'2.39.0'}             | ${'>=2.39.0'}  | ${false}
+      ${'2.39.0'}             | ${'<2.40.0'}   | ${false}
+      ${'invalid'}            | ${'2.39.0'}    | ${false}
+      ${'2.39.0'}             | ${'><2.39.0'}  | ${false}
     `(
       'isLessThanRange($version, $range) === $expected',
       ({ version, range, expected }) => {
@@ -420,6 +551,113 @@ describe('modules/versioning/apk/index', () => {
         }),
       ).toBe('2.51.1');
     });
+
+    it.each`
+      currentValue    | newVersion     | expected
+      ${'~8.12.1'}    | ${'8.13.0-r0'} | ${'~8.13.0'}
+      ${'=~8.12.1'}   | ${'8.13.0-r0'} | ${'=~8.13.0'}
+      ${'~=8.12.1'}   | ${'8.13.0-r0'} | ${'~=8.13.0'}
+      ${'~8.12'}      | ${'8.13.0-r0'} | ${'~8.13'}
+      ${'~8'}         | ${'9.1.0-r0'}  | ${'~9'}
+      ${'~8.12.1-r0'} | ${'8.13.0-r2'} | ${'~8.13.0-r2'}
+      ${'=8.12.1'}    | ${'8.13.0-r0'} | ${'=8.13.0'}
+      ${'8.12.1'}     | ${'8.13.0-r0'} | ${'8.13.0'}
+    `(
+      'keeps the constraint precision for $currentValue',
+      ({ currentValue, newVersion, expected }) => {
+        expect(
+          apk.getNewValue({
+            currentValue,
+            rangeStrategy: 'replace',
+            newVersion,
+          }),
+        ).toBe(expected);
+      },
+    );
+
+    it('pins to the exact version when asked to', () => {
+      expect(
+        apk.getNewValue({
+          currentValue: '~8.12.1',
+          rangeStrategy: 'pin',
+          newVersion: '8.13.0-r0',
+        }),
+      ).toBe('8.13.0-r0');
+    });
+
+    it.each`
+      currentValue     | newVersion     | expected
+      ${'>=8.12.1'}    | ${'8.13.0-r0'} | ${'>=8.13.0-r0'}
+      ${'=>8.12.1'}    | ${'8.13.0-r0'} | ${'=>8.13.0-r0'}
+      ${'>=8.12.1-r0'} | ${'8.13.0-r2'} | ${'>=8.13.0-r2'}
+      ${'>=8.12'}      | ${'8.13.0-r0'} | ${'>=8.13.0-r0'}
+      ${'>~8.12'}      | ${'8.13.0-r0'} | ${'>~8.13.0-r0'}
+      ${'>=8.12'}      | ${'8.12.5-r0'} | ${'>=8.12.5-r0'}
+      ${'>=8.12.1'}    | ${'8.12.1-r5'} | ${'>=8.12.1-r5'}
+    `(
+      'bumps the lower bound of $currentValue',
+      ({ currentValue, newVersion, expected }) => {
+        expect(
+          apk.getNewValue({
+            currentValue,
+            rangeStrategy: 'bump',
+            newVersion,
+          }),
+        ).toBe(expected);
+      },
+    );
+
+    it.each`
+      currentValue  | reason
+      ${'>8.12.1'}  | ${'excludes its boundary, so bumping it would exclude the new version'}
+      ${'<8.12.1'}  | ${'is an upper bound'}
+      ${'<=8.12.1'} | ${'is an upper bound'}
+    `('has no bump for a constraint which $reason', ({ currentValue }) => {
+      expect(
+        apk.getNewValue({
+          currentValue,
+          rangeStrategy: 'bump',
+          newVersion: '8.13.0-r0',
+        }),
+      ).toBeNull();
+    });
+
+    it.each`
+      rangeStrategy
+      ${'replace'}
+      ${'pin'}
+      ${'bump'}
+    `(
+      'has no $rangeStrategy for a constraint on an unparseable version',
+      ({ rangeStrategy }) => {
+        expect(
+          apk.getNewValue({
+            currentValue: '~foo',
+            rangeStrategy,
+            newVersion: '8.13.0-r0',
+          }),
+        ).toBeNull();
+      },
+    );
+
+    it.each`
+      currentValue  | reason
+      ${'>8.12.1'}  | ${'greater than'}
+      ${'>=8.12.1'} | ${'greater than or equal'}
+      ${'<8.12.1'}  | ${'less than'}
+      ${'>~8.12.1'} | ${'greater than or prefix'}
+      ${'<~8.12.1'} | ${'less than or prefix'}
+      ${'><8.12.1'} | ${'identity hash'}
+      ${''}         | ${'empty'}
+    `('has no replacement for a $reason constraint', ({ currentValue }) => {
+      expect(
+        apk.getNewValue({
+          currentValue,
+          rangeStrategy: 'replace',
+          newVersion: '8.13.0-r0',
+        }),
+      ).toBeNull();
+    });
   });
 
   describe('version comparison with prerelease identifiers', () => {
@@ -453,15 +691,24 @@ describe('modules/versioning/apk/index', () => {
       expect(apk.getSatisfyingVersion(versions, '#2.39.0-r0')).toBe(null);
     });
 
-    it('should handle unhandled range operators that match regex', () => {
+    it('builds the operator from its characters, as apk does', () => {
       const versions = ['2.39.0-r0', '2.40.0-r0'];
 
-      // These operators match the regex pattern [><=~]+ but are not handled by switch cases
-      // They hit the fallback return false path
-      expect(apk.getSatisfyingVersion(versions, '>>2.39.0-r0')).toBe(null);
+      // apk ORs one flag per operator character, so a repeated character is just another spelling of the same operator
+      expect(apk.getSatisfyingVersion(versions, '>>2.39.0-r0')).toBe(
+        '2.40.0-r0',
+      );
+      expect(apk.getSatisfyingVersion(versions, '~~~2.39.0-r0')).toBe(
+        '2.39.0-r0',
+      );
+    });
+
+    it('does not resolve an identity hash constraint', () => {
+      const versions = ['2.39.0-r0', '2.40.0-r0'];
+
+      // `><` constrains to an identity hash rather than to a version
       expect(apk.getSatisfyingVersion(versions, '<>2.39.0-r0')).toBe(null);
       expect(apk.getSatisfyingVersion(versions, '><2.39.0-r0')).toBe(null);
-      expect(apk.getSatisfyingVersion(versions, '~~~2.39.0-r0')).toBe(null);
     });
 
     it('should handle tilde range with invalid target version', () => {

--- a/lib/modules/versioning/apk/index.ts
+++ b/lib/modules/versioning/apk/index.ts
@@ -1,7 +1,9 @@
 import { isTruthy } from '@sindresorhus/is';
+import { logger } from '../../../logger/index.ts';
+import type { RangeStrategy } from '../../../types/versioning.ts';
 import { regEx } from '../../../util/regex.ts';
 import { GenericVersioningApi } from '../generic.ts';
-import type { VersioningApi } from '../types.ts';
+import type { NewValueConfig, VersioningApi } from '../types.ts';
 import type { ApkVersion } from './types.ts';
 
 export const id = 'apk';
@@ -10,7 +12,76 @@ export const urls = [
   '[Alpine Linux package policies](https://wiki.alpinelinux.org/wiki/Package_policies)',
   '[Alpine Package Keeper - Package pinning](https://wiki.alpinelinux.org/wiki/Alpine_Package_Keeper#Package_pinning)',
 ];
-export const supportsRanges = false;
+export const supportsRanges = true;
+export const supportedRangeStrategies: RangeStrategy[] = [
+  'bump',
+  'pin',
+  'replace',
+];
+
+/**
+ * APK constraint operators, as the bitmask `apk` builds them into.
+ *
+ * `apk` ORs one flag per operator character, so the characters may appear in any order and may repeat - `~`, `=~` and `~=` all mean the same thing.
+ *
+ * Based on `GPL-2.0` code in https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/src/version.c
+ */
+const OP_LESS = 1;
+const OP_GREATER = 2;
+const OP_EQUAL = 4;
+const OP_FUZZY = 8;
+
+/** A prefix match, e.g. `~1.6` - `apk` treats `~` as fuzzy /and/ equal */
+const OP_PREFIX = OP_FUZZY | OP_EQUAL;
+
+/** `><` constrains a package to an identity hash rather than to a version */
+const OP_CHECKSUM = OP_LESS | OP_GREATER;
+
+interface ApkConstraint {
+  /** the operator as written, so that an update can spell it the same way */
+  operator: string;
+  mask: number;
+  version: string;
+}
+
+const constraintRegex = regEx(/^(?<operator>[<>=~]*)(?<version>[^<>=~].*)$/);
+
+function operatorMask(operator: string): number | null {
+  let mask = 0;
+  for (const char of operator) {
+    if (char === '<') {
+      mask |= OP_LESS;
+    } else if (char === '>') {
+      mask |= OP_GREATER;
+    } else if (char === '=') {
+      mask |= OP_EQUAL;
+    } else {
+      mask |= OP_PREFIX;
+    }
+  }
+  // an absent operator constrains to an exact version, the same as `=`
+  if (mask === 0) {
+    return OP_EQUAL;
+  }
+  // an identity hash is not a version, so there is nothing to look up
+  return mask === OP_CHECKSUM ? null : mask;
+}
+
+/** Splits a constraint such as `~8.12.1` into its operator and version */
+function parseConstraint(input: string): ApkConstraint | null {
+  if (!input) {
+    return null;
+  }
+  const groups = constraintRegex.exec(input)?.groups;
+  if (!groups) {
+    return null;
+  }
+  const mask = operatorMask(groups.operator);
+  if (mask === null) {
+    return null;
+  }
+  return { operator: groups.operator, mask, version: groups.version };
+}
 
 // Regex with named capture groups for APK version parsing
 const versionRegex = regEx(
@@ -19,6 +90,110 @@ const versionRegex = regEx(
 
 // Regex for splitting version strings into alphanumeric parts
 const alphaNumRegex = regEx(/(?:[a-zA-Z]+)|(?:\d+)/g);
+
+const revisionRegex = regEx(/-r\d+$/);
+
+/**
+ * The kinds of token an APK version is made of, in the order `apk` reads them.
+ *
+ * A prefix match compares tokens pairwise, so a token's kind has to be part of the comparison - `1.6_rc1` is not a prefix of `1.6.0`, even though both start with `1.6`.
+ */
+const TOKEN_DIGIT = 0;
+const TOKEN_LETTER = 1;
+const TOKEN_PRERELEASE = 2;
+const TOKEN_PACKAGE_FIX = 3;
+const TOKEN_REVISION = 4;
+
+interface ApkToken {
+  kind: number;
+  value: string | number;
+}
+
+/** The numeric components of a version, e.g. `[1, 6, 0]` for `1.6.0_pre1` */
+function numericParts(groups: Record<string, string>): number[] {
+  const { major, minor, patch, extra } = groups;
+  const parts = [parseInt(major, 10)];
+  for (const part of [minor, patch]) {
+    if (part) {
+      parts.push(parseInt(part, 10));
+    }
+  }
+  if (extra) {
+    parts.push(...extra.substring(1).split('.').filter(isTruthy).map(Number));
+  }
+  return parts;
+}
+
+function tokenize(groups: Record<string, string>): ApkToken[] {
+  const {
+    letter,
+    prereleaseType,
+    prereleaseNum,
+    packageFixType,
+    packageFixNum,
+    releaseNum,
+  } = groups;
+
+  const tokens: ApkToken[] = numericParts(groups).map((value) => ({
+    kind: TOKEN_DIGIT,
+    value,
+  }));
+  if (letter) {
+    tokens.push({ kind: TOKEN_LETTER, value: letter });
+  }
+  if (prereleaseType) {
+    tokens.push({
+      kind: TOKEN_PRERELEASE,
+      value: prereleaseType + prereleaseNum,
+    });
+  }
+  if (packageFixType) {
+    tokens.push({
+      kind: TOKEN_PACKAGE_FIX,
+      value: packageFixType + packageFixNum,
+    });
+  }
+  if (releaseNum) {
+    tokens.push({ kind: TOKEN_REVISION, value: parseInt(releaseNum, 10) });
+  }
+  return tokens;
+}
+
+/**
+ * Whether `constraintVersion` is a token-wise prefix of `version`, which is what `apk` calls a fuzzy match.
+ *
+ * `~1.6` matches `1.6`, `1.6.0_pre1`, `1.6.0`, `1.6.5` and `1.6.9_p1`, but not `1.60` - the comparison is per token, not on the raw string.
+ */
+function isPrefixMatch(version: string, constraintVersion: string): boolean {
+  const versionGroups = versionRegex.exec(version)?.groups;
+  const constraintGroups = versionRegex.exec(constraintVersion)?.groups;
+  /* v8 ignore next -- `matches` parses both versions before calling this */
+  if (!versionGroups || !constraintGroups) {
+    return false;
+  }
+  const versionTokens = tokenize(versionGroups);
+  const constraintTokens = tokenize(constraintGroups);
+  // a constraint with more tokens than the version cannot be its prefix
+  if (constraintTokens.length > versionTokens.length) {
+    return false;
+  }
+  return constraintTokens.every(
+    (token, i) =>
+      token.kind === versionTokens[i].kind &&
+      token.value === versionTokens[i].value,
+  );
+}
+
+/** Drops the revision when the constraint was written without one */
+function withConstraintRevision(
+  newVersion: string,
+  constraintVersion: string,
+): string {
+  if (revisionRegex.test(constraintVersion)) {
+    return newVersion;
+  }
+  return newVersion.replace(revisionRegex, '');
+}
 
 class ApkVersioningApi extends GenericVersioningApi {
   /**
@@ -197,167 +372,206 @@ class ApkVersioningApi extends GenericVersioningApi {
     return 0;
   }
 
-  override isValid(version: string): boolean {
-    if (!version) {
-      return false;
-    }
-    // Strip any operators (=, >, <, ~) before validation
-    const cleanVersion = version.replace(regEx(/^[=><~][=]?/), '');
-    const parsed = this._parse(cleanVersion);
-    return parsed !== null;
+  override isValid(input: string): boolean {
+    const constraint = parseConstraint(input);
+    return !!constraint && this._parse(constraint.version) !== null;
   }
 
-  override isSingleVersion(version: string): boolean {
-    if (!version) {
-      return false;
-    }
-    // Range constraints (>, >=, <, <=, ~) are not single versions
-    if (regEx(/^[><~]/).test(version)) {
-      return false;
-    }
-    // Exact versions (starting with = or no operator) are single versions
-    return this.isValid(version);
+  /** A constraint is not itself a version, however valid it is */
+  override isVersion(input: string): boolean {
+    const constraint = parseConstraint(input);
+    return (
+      !!constraint &&
+      constraint.operator === '' &&
+      this._parse(constraint.version) !== null
+    );
   }
 
-  override isStable(version: string): boolean {
-    if (!version) {
+  override isSingleVersion(input: string): boolean {
+    const constraint = parseConstraint(input);
+    return (
+      !!constraint &&
+      constraint.mask === OP_EQUAL &&
+      this._parse(constraint.version) !== null
+    );
+  }
+
+  override isStable(input: string): boolean {
+    const constraint = parseConstraint(input);
+    if (!constraint) {
       return false;
     }
-    // Strip any operators (=, >, <, ~) before checking stability
-    const cleanVersion = version.replace(regEx(/^[=><~][=]?/), '');
-    const parsed = this._parse(cleanVersion);
-    if (!parsed) {
-      return false;
-    }
+    const parsed = this._parse(constraint.version);
     // Consider versions without prerelease identifiers as stable
-    return !parsed.prerelease;
+    return !!parsed && !parsed.prerelease;
+  }
+
+  /**
+   * Whether `version` satisfies the constraint, following `apk_version_match`: compare the two, fuzzily when the operator asks for it, then check the result against the operator's mask.
+   */
+  override matches(version: string, range: string): boolean {
+    const constraint = parseConstraint(range);
+    if (
+      !constraint ||
+      !this._parse(version) ||
+      !this._parse(constraint.version)
+    ) {
+      return false;
+    }
+
+    if (
+      (constraint.mask & OP_FUZZY) !== 0 &&
+      isPrefixMatch(version, constraint.version)
+    ) {
+      return (constraint.mask & OP_EQUAL) !== 0;
+    }
+
+    const compared = this._compare(version, constraint.version);
+    if (compared < 0) {
+      return (constraint.mask & OP_LESS) !== 0;
+    }
+    if (compared > 0) {
+      return (constraint.mask & OP_GREATER) !== 0;
+    }
+    return (constraint.mask & OP_EQUAL) !== 0;
+  }
+
+  override isLessThanRange(version: string, range: string): boolean {
+    const constraint = parseConstraint(range);
+    if (
+      !constraint ||
+      !this._parse(version) ||
+      !this._parse(constraint.version)
+    ) {
+      return false;
+    }
+    // a range with no lower bound has nothing below it
+    if ((constraint.mask & OP_LESS) !== 0) {
+      return false;
+    }
+    // a fuzzy match satisfies the constraint, so it cannot be below it, even though `_compare` ranks `2.39.0_git20240101` below `2.39.0`
+    if (
+      (constraint.mask & OP_FUZZY) !== 0 &&
+      isPrefixMatch(version, constraint.version)
+    ) {
+      return false;
+    }
+
+    const compared = this._compare(version, constraint.version);
+    if (compared !== 0) {
+      return compared < 0;
+    }
+    // equal to the boundary, so below the range only when it is excluded
+    return (constraint.mask & OP_EQUAL) === 0;
   }
 
   override getSatisfyingVersion(
     versions: string[],
     range: string,
   ): string | null {
-    // Handle range expressions like >5.2.37-r0, <5.2.37-r0, ~5.2.37-r0, etc.
-    const rangeMatch = regEx(/^(?<operator>[><=~]+)(?<targetVersion>.+)$/).exec(
-      range,
+    const satisfying = versions.filter((version) =>
+      this.matches(version, range),
     );
-    if (!rangeMatch) {
-      // If no range operator, look for exact match
-      return versions.find((v) => this.equals(v, range)) ?? null;
-    }
-
-    const { operator, targetVersion } = rangeMatch.groups!;
-
-    // Filter versions that satisfy the range
-    const satisfyingVersions = versions.filter((version) => {
-      if (!this.isValid(version) || !this.isValid(targetVersion)) {
-        return false;
-      }
-
-      switch (operator) {
-        case '>':
-          return this.isGreaterThan(version, targetVersion);
-        case '>=':
-          return (
-            this.isGreaterThan(version, targetVersion) ||
-            this.equals(version, targetVersion)
-          );
-        case '<':
-          return this.isLessThanRange(version, targetVersion);
-        case '<=':
-          return (
-            this.isLessThanRange(version, targetVersion) ||
-            this.equals(version, targetVersion)
-          );
-        case '=':
-        case '==':
-          return this.equals(version, targetVersion);
-        case '~': {
-          const targetParsed = this._parse(targetVersion)!;
-          const versionParsed = this._parse(version)!;
-
-          // Must have same major and minor versions
-          if (
-            targetParsed.release[0] !== versionParsed.release[0] ||
-            targetParsed.release[1] !== versionParsed.release[1]
-          ) {
-            return false;
-          }
-
-          // Version must be >= target
-          return (
-            this.isGreaterThan(version, targetVersion) ||
-            this.equals(version, targetVersion)
-          );
-        }
-      }
-      // Fallback for unhandled operator combinations like >>, <>, ><, ~~~
-      // These match the regex but aren't semantically valid APK range operators
-      return false;
-    });
-
-    if (satisfyingVersions.length === 0) {
+    if (!satisfying.length) {
       return null;
     }
-
-    // Return the highest satisfying version
-    return satisfyingVersions.sort((a, b) => this.sortVersions(b, a))[0];
+    return satisfying.sort((a, b) => this.sortVersions(b, a))[0];
   }
 
-  override getMajor(version: string): number | null {
-    if (!version) {
+  override minSatisfyingVersion(
+    versions: string[],
+    range: string,
+  ): string | null {
+    const satisfying = versions.filter((version) =>
+      this.matches(version, range),
+    );
+    if (!satisfying.length) {
       return null;
     }
-    // Strip any operators (=, >, <, ~) before parsing
-    const cleanVersion = version.replace(regEx(/^[=><~][=]?/), '');
-    const parsed = this._parse(cleanVersion);
-    return parsed?.release[0] ?? null;
+    return satisfying.sort((a, b) => this.sortVersions(a, b))[0];
   }
 
-  override getMinor(version: string): number | null {
-    if (!version) {
-      return null;
-    }
-    // Strip any operators (=, >, <, ~) before parsing
-    const cleanVersion = version.replace(regEx(/^[=><~][=]?/), '');
-    const parsed = this._parse(cleanVersion);
-    return parsed?.release[1] ?? null;
+  override getMajor(input: string): number | null {
+    const constraint = parseConstraint(input);
+    return constraint
+      ? (this._parse(constraint.version)?.release[0] ?? null)
+      : null;
   }
 
-  override getPatch(version: string): number | null {
-    if (!version) {
-      return null;
-    }
-    // Strip any operators (=, >, <, ~) before parsing
-    const cleanVersion = version.replace(regEx(/^[=><~][=]?/), '');
-    const parsed = this._parse(cleanVersion);
-    if (!parsed) {
-      return null;
-    }
-    return parsed.release[2] ?? null;
+  override getMinor(input: string): number | null {
+    const constraint = parseConstraint(input);
+    return constraint
+      ? (this._parse(constraint.version)?.release[1] ?? null)
+      : null;
+  }
+
+  override getPatch(input: string): number | null {
+    const constraint = parseConstraint(input);
+    return constraint
+      ? (this._parse(constraint.version)?.release[2] ?? null)
+      : null;
   }
 
   override getNewValue({
     currentValue,
+    rangeStrategy,
     newVersion,
-  }: {
-    currentValue: string;
-    rangeStrategy?: string;
-    currentVersion?: string;
-    newVersion: string;
-  }): string | null {
-    // APK packages in apko.yaml only use exact versions
-    // currentValue is stored without the = operator for cleaner PR display
-    const hasRevision = regEx(/-r\d+$/).test(currentValue);
-
-    // If current version has no revision, strip revision from newVersion
-    // This ensures both newValue and the displayed version are clean
-    if (!hasRevision) {
-      return newVersion.replace(regEx(/-r\d+$/), '');
+  }: NewValueConfig): string | null {
+    const constraint = parseConstraint(currentValue);
+    if (!constraint) {
+      return null;
     }
 
-    // If current version has revision, keep revision in newVersion
-    return newVersion;
+    const { operator, mask, version } = constraint;
+
+    // a constraint we cannot parse the version of is one we cannot rewrite
+    const parsed = this._parse(version);
+    if (!parsed) {
+      return null;
+    }
+
+    if (rangeStrategy === 'pin') {
+      return newVersion;
+    }
+
+    // an exact constraint identifies one version, so only the revision is written to the precision the user chose
+    if (mask === OP_EQUAL) {
+      return `${operator}${withConstraintRevision(newVersion, version)}`;
+    }
+
+    // `bump` raises a lower bound to the new version, which only makes sense when the bound includes its boundary - bumping `>8.12.1` to `>8.13.0` would exclude the very version it was bumped to
+    if (
+      rangeStrategy === 'bump' &&
+      (mask & OP_GREATER) !== 0 &&
+      (mask & OP_EQUAL) !== 0
+    ) {
+      // the whole point of the bump is to raise the bound, so unlike a prefix constraint we write `newVersion` in full rather than to the precision it was written with
+      return `${operator}${newVersion}`;
+    }
+
+    // a prefix constraint keeps the precision it was written with, so `~8.12.1` becomes `~8.13.0` rather than `~8.13.0-r0`, and stays revision-agnostic
+    if (mask === OP_PREFIX) {
+      const currentParts = parsed.release;
+      const newParts = this._parse(newVersion)?.release;
+      /* v8 ignore next -- newVersion comes from the datasource, so it parses */
+      if (!newParts) {
+        return null;
+      }
+      if (currentParts.length < newParts.length) {
+        return `${operator}${newParts.slice(0, currentParts.length).join('.')}`;
+      }
+      return `${operator}${withConstraintRevision(newVersion, version)}`;
+    }
+
+    // `>` cannot be bumped, and an upper bound is not a bound to bump
+    if (rangeStrategy === 'bump') {
+      logger.debug(
+        `Unsupported range type for rangeStrategy=bump: ${currentValue}`,
+      );
+    }
+
+    // there is no single obvious replacement for `>`, `>=`, `<`, `<=`, `>~` or `<~`, and a bound which already admits the new version needs no change
+    return null;
   }
 
   // Override to provide clean version for PR titles and display

--- a/lib/modules/versioning/apk/readme.md
+++ b/lib/modules/versioning/apk/readme.md
@@ -14,12 +14,36 @@ Versions are similar to other Linux distributions, e.g. 3.2.1-r0
 - `2.39.0-r0` - Standard version with release number
 - `2.39.0_rc1-r0` - Release candidate (pre-release)
 - `6.5_p20250503-r0` - Package fix with date-based patch
-- `2.39.0~beta-r0` - Beta pre-release
 
 ### Pre-release Handling
 
 - `_rc` patterns (e.g., `_rc1`, `_rc2`) are treated as pre-release identifiers
 - `_p` patterns (e.g., `_p20250503`) are treated as part of the version number
-- `~` patterns (e.g., `~beta`) are treated as pre-release identifiers
 
-Ranges are not supported by this versioning.
+### Version constraints
+
+Constraints follow [`apk-world(5)`](https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/master/doc/apk-world.5.scd), which builds the operator from its characters, so the characters may be given in any order and may repeat.
+This means `~`, `=~` and `~=` all mean the same thing.
+
+| Operator | Meaning                      |
+| -------- | ---------------------------- |
+| _(none)_ | exact version                |
+| `=`      | exact version                |
+| `<`      | less than                    |
+| `<=`     | less than or equal           |
+| `>`      | greater than                 |
+| `>=`     | greater than or equal        |
+| `~`      | prefix match                 |
+| `>~`     | greater than or prefix match |
+| `<~`     | less than or prefix match    |
+
+A prefix match compares token by token rather than by string, so `~1.6` matches `1.6`, `1.6.0_pre1`, `1.6.0`, `1.6.5` and `1.6.9_p1`, but not `1.60`.
+Because a revision is a token of its own, `~8.12.1` matches every `8.12.1-rN`, which is how Wolfi and Chainguard images commonly pin their packages.
+
+Renovate keeps the precision a prefix constraint was written with, so `~8.12.1` becomes `~8.13.0` rather than `~8.13.0-r0`, and `~8.12` becomes `~8.13`.
+
+With `rangeStrategy=bump`, Renovate raises a lower bound which includes its boundary to the new version, so `>=8.12.1` becomes `>=8.13.0-r0` and `>~8.12` becomes `>~8.13.0-r0`.
+A bare `>` is left alone, as `>8.13.0-r0` would exclude the very version it was bumped to, and `<` and `<=` are upper bounds so there is nothing to raise.
+
+Otherwise Renovate does not propose a replacement for the `<`, `<=`, `>`, `>=`, `>~` and `<~` operators, as there is no single obvious new bound for them.
+The `><` operator constrains a package to an identity hash rather than to a version, so it is not a version constraint Renovate can resolve.


### PR DESCRIPTION
## Changes



As part of future changes, we're introducing a means to parse
Dockerfiles for any `apk add` commands, so we can propose updates to any
packages using the APK datasource.

Before we do this, we need to correct a couple of bugs in our
implementation of the APK versioning scheme, so we can handle i.e.

    apk add curl=~8.12.1

When the `apk` CLI builds a version constraint, it `OR`s one flag per
operator character[0].

For instance, `~` sets both "fuzzy" and "equal".

These operator characters may be in any order and may repeat, so `~`,
`=~` and `~=` are all the same operator, and `>>` and `>` are the same.

To correct our parsing, we should take this into account, rather than
using known patterns.

When we perform a fuzzy match, this is performed over version _tokens_
not the version itself, which means that:

- `~1.6` matches `1.6`, `1.6.0_pre1`, `1.6.0`, `1.6.5` and `1.6.9_p1`
- `~1.6` does not match `1.60`
- `~8.12.1` matches every `8.12.1-rN` i.e. `8.12.1-r1` and `8.12.1-r100`

While doing this, we also fix related issues:

- `~` previously treated this as an npm-style tilde ("same major and
  minor, and greater than or equal"),
  - admitted fuzzy versions that `apk` rejects - `~2.39.0-r0` should not have
    matched `2.39.1-r0`
  - rejected fuzzy versions that `apk` accepts - `~2.39.0` should have
    matched `2.39.0-r1`
- `=~` and `~=` were not allowed
- `isSingleVersion('=~1.2.3')` was true, so a range looked like a pin
- `isLessThanRange` compared against the raw range, so `_parse` failed on
  the operator and it always returned false
- `minSatisfyingVersion` was inherited, so it only ever found an exact
  match
- `getNewValue` dropped the operator entirely, rewriting `~8.12.1` to a
  bare version

We also set `supportsRanges`, which we'd forgotten to set despite `~`
and `>=` being ranges, and note that we support `pin`, `replace` and
`bump` strategies.

When using `getNewValue`, we now keep the precision the constraint was
written with, as otherwise we'd quietly narrow what the user asked for:

- `~8.12.1` becomes `~8.13.0` (previously `~8.13.0-r0`)
- `~8.12` becomes `~8.13`
- `~8.12.1-r0` becomes `~8.13.0-r2` (with a new revision number)

For `bump`, we raise a lower bound which includes its boundary, as with
`npm` and `pep440`, so:

- `>=8.12.1` becomes `>=8.13.0`
- `>~8.12` becomes `>~8.13`

Otherwise we return `null`, logging which constraint we couldn't handle
in the `bump` case, as `npm` does:

- `>` on its own can't be bumped, as `>8.13.0` would exclude the version
  we bump to
- `<` and `<=` are upper bounds, so there's no lower bound to raise
- for `replace`, there's no single obvious new bound for `<`, `<=`, `>`,
  `>=`, `>~` or `<~`, and a bound which already admits the new version
  doesn't need one
- a prefix constraint whose version doesn't parse, i.e. `~foo`, which
  would otherwise throw

`><` constrains a package to an identity hash rather than to a version,
so it's rejected outright.

Additionally, `isLessThanRange` and `matches` weren't agreeing on how to
resolve a fuzzy constraint.

For instance, `_compare` ranks `2.39.0_git20240101` below `2.39.0`, but
`~2.39.0` matches it, this would lead to a rollback of sorts.

Instead, we can ignore the `_git` and `_p` suffixes, which are common in
Alpine and Wolfi packages.

[0]: https://gitlab.alpinelinux.org/alpine/apk-tools/-/blob/44dcdfc255c26a4e19a4a27f66a54169cce5ca72/src/version.c

Co-authored-by: Claude Opus 5 <jamie.tanna+claude-code@mend.io>



## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Written by Claude Opus 5 via Claude Code: code, tests and documentation.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
