### PR TITLE
fix(datasource/apk): cache `APKINDEX.tar.gz` between runs

### DIFF
--- a/lib/modules/datasource/apk/cache.ts
+++ b/lib/modules/datasource/apk/cache.ts
@@ -1,0 +1,188 @@
+import { randomUUID } from 'node:crypto';
+import type { IncomingMessage } from 'node:http';
+import { extract as tarExtract } from 'tar';
+import upath from 'upath';
+import { logger } from '../../../logger/index.ts';
+import * as fs from '../../../util/fs/index.ts';
+import { toSha256 } from '../../../util/hash.ts';
+import type { Http } from '../../../util/http/index.ts';
+import type { OutgoingHttpHeaders } from '../../../util/http/types.ts';
+import { Json } from '../../../util/schema-utils/index.ts';
+import { joinUrlParts } from '../../../util/url.ts';
+import { ApkIndexValidators } from './schema.ts';
+
+const cacheSubDir = 'apk';
+const archiveFileName = 'APKINDEX.tar.gz';
+const indexFileName = 'APKINDEX';
+const validatorsFileName = 'APKINDEX.validators.json';
+
+/**
+ * Downloads and extracts `APKINDEX.tar.gz` for a component, unless the copy in
+ * the cache directory is still current.
+ *
+ * An index holds thousands of packages and is several megabytes in size, so the
+ * `ETag` and `Last-Modified` of the archive are cached next to the extracted
+ * index. A later run only downloads the archive again once the registry answers
+ * the conditional request with something other than `304 Not Modified`.
+ *
+ * The validators are cached on disk rather than in the package cache, because
+ * they describe the copy which this cache directory holds. A package cache can
+ * be shared between machines, which would let one machine revalidate an index
+ * that another machine downloaded.
+ *
+ * @param http - The HTTP client to download with.
+ * @param componentUrl - The `APKINDEX` directory URL of the component.
+ * @returns The path of the extracted `APKINDEX`, or `null` when the archive holds no index.
+ */
+export async function getIndexFile(
+  http: Http,
+  componentUrl: string,
+): Promise<string | null> {
+  const componentCacheDir = upath.join(cacheSubDir, toSha256(componentUrl));
+  const componentDir = await fs.ensureCacheDir(componentCacheDir);
+  const indexFile = upath.join(componentDir, indexFileName);
+  const validatorsFile = upath.join(componentDir, validatorsFileName);
+
+  const cachedValidators = await readValidators(validatorsFile, indexFile);
+
+  const indexUrl = joinUrlParts(componentUrl, archiveFileName);
+  const extractDir = await fs.ensureCacheDir(
+    upath.join(componentCacheDir, randomUUID()),
+  );
+
+  try {
+    const archiveFile = upath.join(extractDir, archiveFileName);
+    const { statusCode, validators } = await downloadArchive(
+      http,
+      indexUrl,
+      archiveFile,
+      cachedValidators,
+    );
+
+    if (cachedValidators && statusCode === 304) {
+      logger.debug(`APK index ${indexUrl} is unchanged, using the cached copy`);
+      return indexFile;
+    }
+
+    await tarExtract({
+      file: archiveFile,
+      cwd: extractDir,
+      filter: (path) => upath.basename(path) === indexFileName,
+    });
+
+    const extractedFile = upath.join(extractDir, indexFileName);
+    if (!(await fs.cachePathExists(extractedFile))) {
+      logger.warn({ componentUrl }, 'APKINDEX file not found in tar archive');
+      return null;
+    }
+
+    logger.debug('Successfully extracted APKINDEX content');
+
+    // The validators are written last, so that a failure never leaves them
+    // describing an index which was not stored
+    await fs.renameCacheFile(extractedFile, indexFile);
+    await fs.outputCacheFile(validatorsFile, JSON.stringify(validators));
+
+    return indexFile;
+  } finally {
+    await fs.rmCache(extractDir);
+  }
+}
+
+interface ArchiveResponse {
+  statusCode: number | undefined;
+  validators: ApkIndexValidators;
+}
+
+/**
+ * Downloads the archive of a component, asking the registry to answer with
+ * `304 Not Modified` when the cached copy is still current.
+ *
+ * @param http - The HTTP client to download with.
+ * @param indexUrl - The URL of the archive.
+ * @param archiveFile - The path to download the archive to.
+ * @param cachedValidators - The validators of the cached copy, if there is one.
+ * @returns The status code and the validators of the response, whose body is
+ * empty when the index is unchanged.
+ */
+async function downloadArchive(
+  http: Http,
+  indexUrl: string,
+  archiveFile: string,
+  cachedValidators: ApkIndexValidators | null,
+): Promise<ArchiveResponse> {
+  logger.debug(`Attempting to download ${indexUrl}`);
+
+  const readStream = http.stream(indexUrl, {
+    headers: conditionalHeaders(cachedValidators),
+  });
+
+  // A stream exposes the status code and the headers on its response event only
+  const result: ArchiveResponse = { statusCode: undefined, validators: {} };
+  readStream.on('response', (response: IncomingMessage) => {
+    result.statusCode = response.statusCode;
+    result.validators = {
+      etag: response.headers.etag,
+      lastModified: response.headers['last-modified'],
+    };
+  });
+
+  const writeStream = fs.createCacheWriteStream(archiveFile);
+  await fs.pipeline(readStream, writeStream);
+
+  return result;
+}
+
+function conditionalHeaders(
+  cachedValidators: ApkIndexValidators | null,
+): OutgoingHttpHeaders {
+  const headers: OutgoingHttpHeaders = {};
+
+  if (cachedValidators?.etag) {
+    headers['If-None-Match'] = cachedValidators.etag;
+  }
+
+  if (cachedValidators?.lastModified) {
+    headers['If-Modified-Since'] = cachedValidators.lastModified;
+  }
+
+  return headers;
+}
+
+/**
+ * Reads the validators of the cached index.
+ *
+ * @param validatorsFile - The path of the validators file.
+ * @param indexFile - The path of the extracted index they describe.
+ * @returns The validators, or `null` when there is no index to revalidate.
+ */
+async function readValidators(
+  validatorsFile: string,
+  indexFile: string,
+): Promise<ApkIndexValidators | null> {
+  if (!(await fs.cachePathExists(indexFile))) {
+    return null;
+  }
+
+  let content: string;
+  try {
+    content = await fs.readCacheFile(validatorsFile, 'utf8');
+  } catch (err) {
+    logger.debug(
+      { validatorsFile, err },
+      'Could not read the cached APK index validators',
+    );
+    return null;
+  }
+
+  const validators = Json.pipe(ApkIndexValidators).safeParse(content);
+  if (!validators.success) {
+    logger.debug(
+      { validatorsFile, err: validators.error },
+      'Could not parse the cached APK index validators',
+    );
+    return null;
+  }
+
+  return validators.data;
+}

--- a/lib/modules/datasource/apk/cache.ts
+++ b/lib/modules/datasource/apk/cache.ts
@@ -9,23 +9,19 @@ import type { Http } from '../../../util/http/index.ts';
 import type { OutgoingHttpHeaders } from '../../../util/http/types.ts';
 import { Json } from '../../../util/schema-utils/index.ts';
 import { joinUrlParts } from '../../../util/url.ts';
-import { ApkIndexValidators } from './schema.ts';
+import { ApkIndexCache } from './schema.ts';
 
 const cacheSubDir = 'apk';
 const archiveFileName = 'APKINDEX.tar.gz';
 const indexFileName = 'APKINDEX';
-const validatorsFileName = 'APKINDEX.validators.json';
+const cacheFileName = 'APKINDEX.cache.json';
 
 /**
  * Downloads and extracts `APKINDEX.tar.gz` for a component, or return the path to the cached version if it is still current.
  *
  * Alongside the extracted archive, we also store the `ETag` and `Last-Modified` to allow re-using them on subsequent requests.
  *
- * The validators live on disk next to the index they describe, rather than in
- * the package cache. A package cache can be shared between machines, so a
- * validator stored there may describe an archive which this machine never
- * downloaded: the registry would answer `304 Not Modified`, and we would go on
- * serving whatever older index this cache directory happens to hold.
+ * The extracted index (and the cache headers) are only ever kept on-disk, rather than in the package cache, due to their size.
  *
  * @param http - The HTTP client to download with.
  * @param componentUrl - The `APKINDEX` directory URL of the component.
@@ -38,9 +34,9 @@ export async function getIndexFile(
   const componentCacheDir = upath.join(cacheSubDir, toSha256(componentUrl));
   const componentDir = await fs.ensureCacheDir(componentCacheDir);
   const indexFile = upath.join(componentDir, indexFileName);
-  const validatorsFile = upath.join(componentDir, validatorsFileName);
+  const cacheFile = upath.join(componentDir, cacheFileName);
 
-  const cachedValidators = await readValidators(validatorsFile, indexFile);
+  const cached = await readIndexCache(cacheFile, indexFile);
 
   const indexUrl = joinUrlParts(componentUrl, archiveFileName);
   const extractDir = await fs.ensureCacheDir(
@@ -49,14 +45,14 @@ export async function getIndexFile(
 
   try {
     const archiveFile = upath.join(extractDir, archiveFileName);
-    const { statusCode, validators } = await downloadArchive(
+    const { statusCode, etag, lastModified } = await downloadArchive(
       http,
       indexUrl,
       archiveFile,
-      cachedValidators,
+      cached,
     );
 
-    if (cachedValidators && statusCode === 304) {
+    if (cached && statusCode === 304) {
       logger.debug(`APK index ${indexUrl} is unchanged, using the cached copy`);
       return indexFile;
     }
@@ -75,10 +71,10 @@ export async function getIndexFile(
 
     logger.debug('Successfully extracted APKINDEX content');
 
-    // The validators are written last, so that a failure never leaves them
+    // The cache headers are written last, so that a failure never leaves them
     // describing an index which was not stored
     await fs.renameCacheFile(extractedFile, indexFile);
-    await fs.outputCacheFile(validatorsFile, JSON.stringify(validators));
+    await fs.outputCacheFile(cacheFile, JSON.stringify({ etag, lastModified }));
 
     return indexFile;
   } finally {
@@ -86,9 +82,8 @@ export async function getIndexFile(
   }
 }
 
-interface ArchiveResponse {
+interface ArchiveResponse extends ApkIndexCache {
   statusCode: number | undefined;
-  validators: ApkIndexValidators;
 }
 
 /**
@@ -98,30 +93,28 @@ interface ArchiveResponse {
  * @param http - The HTTP client to download with.
  * @param indexUrl - The URL of the archive.
  * @param archiveFile - The path to download the archive to.
- * @param cachedValidators - The validators of the cached copy, if there is one.
- * @returns The status code and the validators of the response, whose body is
+ * @param cached - The cache headers of the cached copy, if there is one.
+ * @returns The status code and the cache headers of the response, whose body is
  * empty when the index is unchanged.
  */
 async function downloadArchive(
   http: Http,
   indexUrl: string,
   archiveFile: string,
-  cachedValidators: ApkIndexValidators | null,
+  cached: ApkIndexCache | null,
 ): Promise<ArchiveResponse> {
   logger.debug(`Attempting to download ${indexUrl}`);
 
   const readStream = http.stream(indexUrl, {
-    headers: conditionalHeaders(cachedValidators),
+    headers: conditionalHeaders(cached),
   });
 
   // A stream exposes the status code and the headers on its response event only
-  const result: ArchiveResponse = { statusCode: undefined, validators: {} };
+  const result: ArchiveResponse = { statusCode: undefined };
   readStream.on('response', (response: IncomingMessage) => {
     result.statusCode = response.statusCode;
-    result.validators = {
-      etag: response.headers.etag,
-      lastModified: response.headers['last-modified'],
-    };
+    result.etag = response.headers.etag;
+    result.lastModified = response.headers['last-modified'];
   });
 
   const writeStream = fs.createCacheWriteStream(archiveFile);
@@ -130,56 +123,51 @@ async function downloadArchive(
   return result;
 }
 
-function conditionalHeaders(
-  cachedValidators: ApkIndexValidators | null,
-): OutgoingHttpHeaders {
+function conditionalHeaders(cached: ApkIndexCache | null): OutgoingHttpHeaders {
   const headers: OutgoingHttpHeaders = {};
 
-  if (cachedValidators?.etag) {
-    headers['If-None-Match'] = cachedValidators.etag;
+  if (cached?.etag) {
+    headers['If-None-Match'] = cached.etag;
   }
 
-  if (cachedValidators?.lastModified) {
-    headers['If-Modified-Since'] = cachedValidators.lastModified;
+  if (cached?.lastModified) {
+    headers['If-Modified-Since'] = cached.lastModified;
   }
 
   return headers;
 }
 
 /**
- * Reads the validators of the cached index.
+ * Reads the cache headers of the cached index.
  *
- * @param validatorsFile - The path of the validators file.
+ * @param cacheFile - The path of the cache headers file.
  * @param indexFile - The path of the extracted index they describe.
- * @returns The validators, or `null` when there is no index to revalidate.
+ * @returns The cache headers, or `null` when there is no index to revalidate.
  */
-async function readValidators(
-  validatorsFile: string,
+async function readIndexCache(
+  cacheFile: string,
   indexFile: string,
-): Promise<ApkIndexValidators | null> {
+): Promise<ApkIndexCache | null> {
   if (!(await fs.cachePathIsFile(indexFile))) {
     return null;
   }
 
   let content: string;
   try {
-    content = await fs.readCacheFile(validatorsFile, 'utf8');
+    content = await fs.readCacheFile(cacheFile, 'utf8');
   } catch (err) {
+    logger.debug({ cacheFile, err }, 'Could not read the APK index cache');
+    return null;
+  }
+
+  const cached = Json.pipe(ApkIndexCache).safeParse(content);
+  if (!cached.success) {
     logger.debug(
-      { validatorsFile, err },
-      'Could not read the cached APK index validators',
+      { cacheFile, err: cached.error },
+      'Could not parse the APK index cache',
     );
     return null;
   }
 
-  const validators = Json.pipe(ApkIndexValidators).safeParse(content);
-  if (!validators.success) {
-    logger.debug(
-      { validatorsFile, err: validators.error },
-      'Could not parse the cached APK index validators',
-    );
-    return null;
-  }
-
-  return validators.data;
+  return cached.data;
 }

--- a/lib/modules/datasource/apk/cache.ts
+++ b/lib/modules/datasource/apk/cache.ts
@@ -21,10 +21,11 @@ const validatorsFileName = 'APKINDEX.validators.json';
  *
  * Alongside the extracted archive, we also store the `ETag` and `Last-Modified` to allow re-using them on subsequent requests.
  *
- * The validators are cached on disk rather than in the package cache, because
- * they describe the copy which this cache directory holds. A package cache can
- * be shared between machines, which would let one machine revalidate an index
- * that another machine downloaded.
+ * The validators live on disk next to the index they describe, rather than in
+ * the package cache. A package cache can be shared between machines, so a
+ * validator stored there may describe an archive which this machine never
+ * downloaded: the registry would answer `304 Not Modified`, and we would go on
+ * serving whatever older index this cache directory happens to hold.
  *
  * @param http - The HTTP client to download with.
  * @param componentUrl - The `APKINDEX` directory URL of the component.
@@ -67,7 +68,7 @@ export async function getIndexFile(
     });
 
     const extractedFile = upath.join(extractDir, indexFileName);
-    if (!(await fs.cachePathExists(extractedFile))) {
+    if (!(await fs.cachePathIsFile(extractedFile))) {
       logger.warn({ componentUrl }, 'APKINDEX file not found in tar archive');
       return null;
     }
@@ -156,7 +157,7 @@ async function readValidators(
   validatorsFile: string,
   indexFile: string,
 ): Promise<ApkIndexValidators | null> {
-  if (!(await fs.cachePathExists(indexFile))) {
+  if (!(await fs.cachePathIsFile(indexFile))) {
     return null;
   }
 

--- a/lib/modules/datasource/apk/cache.ts
+++ b/lib/modules/datasource/apk/cache.ts
@@ -87,6 +87,11 @@ interface ArchiveResponse extends ApkIndexCache {
 }
 
 /**
+ * Download a given Index's archive to a specific path.
+ *
+ * Will **??**
+ *
+ *
  * Downloads the archive of a component, asking the registry to answer with
  * `304 Not Modified` when the cached copy is still current.
  *

--- a/lib/modules/datasource/apk/cache.ts
+++ b/lib/modules/datasource/apk/cache.ts
@@ -17,13 +17,9 @@ const indexFileName = 'APKINDEX';
 const validatorsFileName = 'APKINDEX.validators.json';
 
 /**
- * Downloads and extracts `APKINDEX.tar.gz` for a component, unless the copy in
- * the cache directory is still current.
+ * Downloads and extracts `APKINDEX.tar.gz` for a component, or return the path to the cached version if it is still current.
  *
- * An index holds thousands of packages and is several megabytes in size, so the
- * `ETag` and `Last-Modified` of the archive are cached next to the extracted
- * index. A later run only downloads the archive again once the registry answers
- * the conditional request with something other than `304 Not Modified`.
+ * Alongside the extracted archive, we also store the `ETag` and `Last-Modified` to allow re-using them on subsequent requests.
  *
  * The validators are cached on disk rather than in the package cache, because
  * they describe the copy which this cache directory holds. A package cache can

--- a/lib/modules/datasource/apk/index.spec.ts
+++ b/lib/modules/datasource/apk/index.spec.ts
@@ -1,13 +1,16 @@
+import * as nodeFs from 'node:fs/promises';
 import { promisify } from 'node:util';
 import * as zlib from 'node:zlib';
 import { codeBlock } from 'common-tags';
 import { Header, Pack, ReadEntry } from 'tar';
 import type { DirectoryResult } from 'tmp-promise';
 import { dir } from 'tmp-promise';
+import upath from 'upath';
 import { vi } from 'vitest';
 import * as httpMock from '~test/http-mock.ts';
 import { GlobalConfig } from '../../../config/global.ts';
 import { EXTERNAL_HOST_ERROR } from '../../../constants/error-messages.ts';
+import { toSha256 } from '../../../util/hash.ts';
 import { getPkgReleases } from '../index.ts';
 import type { GetPkgReleasesConfig } from '../types.ts';
 import { ApkDatasource } from './index.ts';
@@ -778,6 +781,142 @@ describe('modules/datasource/apk/index', () => {
       });
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('caching', () => {
+    const registryUrl = 'https://packages.wolfi.dev/os?arch=x86_64';
+    const componentUrl = 'https://packages.wolfi.dev/os/x86_64';
+    const indexPath = '/os/x86_64/APKINDEX.tar.gz';
+    const lastModified = 'Fri, 26 Apr 2024 22:27:14 GMT';
+
+    function validatorsFile(): string {
+      return upath.join(
+        cacheDir!.path,
+        'others/apk',
+        toSha256(componentUrl),
+        'APKINDEX.validators.json',
+      );
+    }
+
+    const nginxReleases = [
+      {
+        version: '1.24.0-r16',
+        releaseTimestamp: '2024-04-26T22:27:14.000Z',
+      },
+    ];
+
+    it('should reuse the cached index when the registry reports it unchanged', async () => {
+      httpMock
+        .scope('https://packages.wolfi.dev')
+        .get(indexPath)
+        .reply(200, apkIndexArchive, {
+          etag: '"v1"',
+          'last-modified': lastModified,
+        })
+        .get(indexPath)
+        .matchHeader('if-none-match', '"v1"')
+        .matchHeader('if-modified-since', lastModified)
+        .reply(304);
+
+      const first = await apkDatasource.getReleases({
+        packageName: 'nginx',
+        registryUrl,
+      });
+      const second = await apkDatasource.getReleases({
+        packageName: 'nginx',
+        registryUrl,
+      });
+
+      expect(first).toEqual({
+        homepage: 'https://www.nginx.org/',
+        registryUrl,
+        releases: nginxReleases,
+      });
+      expect(second).toEqual(first);
+    });
+
+    it('should download the index again once the registry reports it changed', async () => {
+      const updatedArchive = await createTarGz([
+        {
+          name: 'APKINDEX',
+          content: ['P:nginx', 'V:1.26.2-r0', 't:1747894670'].join('\n'),
+        },
+      ]);
+
+      httpMock
+        .scope('https://packages.wolfi.dev')
+        .get(indexPath)
+        .reply(200, apkIndexArchive, { etag: '"v1"' })
+        .get(indexPath)
+        .matchHeader('if-none-match', '"v1"')
+        .reply(200, updatedArchive, { etag: '"v2"' });
+
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+      const second = await apkDatasource.getReleases({
+        packageName: 'nginx',
+        registryUrl,
+      });
+
+      expect(second).toEqual({
+        registryUrl,
+        releases: [
+          {
+            version: '1.26.2-r0',
+            releaseTimestamp: '2025-05-22T06:17:50.000Z',
+          },
+        ],
+      });
+    });
+
+    it('should not revalidate when the registry provides no validators', async () => {
+      httpMock
+        .scope('https://packages.wolfi.dev')
+        .get(indexPath)
+        .reply(200, apkIndexArchive)
+        .get(indexPath)
+        .reply(200, apkIndexArchive);
+
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+
+      const [, secondRequest] = httpMock.getTrace();
+      expect(secondRequest.headers).not.toContainKeys([
+        'if-none-match',
+        'if-modified-since',
+      ]);
+    });
+
+    it('should not revalidate when the cached validators are gone', async () => {
+      httpMock
+        .scope('https://packages.wolfi.dev')
+        .get(indexPath)
+        .reply(200, apkIndexArchive, { etag: '"v1"' })
+        .get(indexPath)
+        .reply(200, apkIndexArchive, { etag: '"v1"' });
+
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+      await nodeFs.rm(validatorsFile());
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+
+      const [, secondRequest] = httpMock.getTrace();
+      expect(secondRequest.headers).not.toContainKey('if-none-match');
+    });
+
+    it('should not revalidate when the cached validators are unreadable', async () => {
+      httpMock
+        .scope('https://packages.wolfi.dev')
+        .get(indexPath)
+        .reply(200, apkIndexArchive, { etag: '"v1"' })
+        .get(indexPath)
+        .reply(200, apkIndexArchive, { etag: '"v1"' });
+
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+      await nodeFs.writeFile(validatorsFile(), 'not json');
+      await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+
+      const [, secondRequest] = httpMock.getTrace();
+      expect(secondRequest.headers).not.toContainKey('if-none-match');
     });
   });
 });

--- a/lib/modules/datasource/apk/index.spec.ts
+++ b/lib/modules/datasource/apk/index.spec.ts
@@ -795,12 +795,12 @@ describe('modules/datasource/apk/index', () => {
     const indexPath = '/os/x86_64/APKINDEX.tar.gz';
     const lastModified = 'Fri, 26 Apr 2024 22:27:14 GMT';
 
-    function validatorsFile(): string {
+    function cacheFile(): string {
       return upath.join(
         cacheDir!.path,
         'others/apk',
         toSha256(componentUrl),
-        'APKINDEX.validators.json',
+        'APKINDEX.cache.json',
       );
     }
 
@@ -874,7 +874,7 @@ describe('modules/datasource/apk/index', () => {
       });
     });
 
-    it('should not revalidate when the registry provides no validators', async () => {
+    it('should not revalidate when the registry provides no cache headers', async () => {
       httpMock
         .scope('https://packages.wolfi.dev')
         .get(indexPath)
@@ -892,7 +892,7 @@ describe('modules/datasource/apk/index', () => {
       ]);
     });
 
-    it('should not revalidate when the cached validators are gone', async () => {
+    it('should not revalidate when the cached headers are gone', async () => {
       httpMock
         .scope('https://packages.wolfi.dev')
         .get(indexPath)
@@ -901,7 +901,7 @@ describe('modules/datasource/apk/index', () => {
         .reply(200, apkIndexArchive, { etag: '"v1"' });
 
       await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
-      await nodeFs.rm(validatorsFile());
+      await nodeFs.rm(cacheFile());
       await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
 
       const [, secondRequest] = httpMock.getTrace();
@@ -940,7 +940,7 @@ describe('modules/datasource/apk/index', () => {
       expect(secondRequest.headers).not.toContainKey('if-none-match');
     });
 
-    it('should not revalidate when the cached validators are unreadable', async () => {
+    it('should not revalidate when the cached headers are unreadable', async () => {
       httpMock
         .scope('https://packages.wolfi.dev')
         .get(indexPath)
@@ -949,7 +949,7 @@ describe('modules/datasource/apk/index', () => {
         .reply(200, apkIndexArchive, { etag: '"v1"' });
 
       await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
-      await nodeFs.writeFile(validatorsFile(), 'not json');
+      await nodeFs.writeFile(cacheFile(), 'not json');
       await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
 
       const [, secondRequest] = httpMock.getTrace();

--- a/lib/modules/datasource/apk/index.spec.ts
+++ b/lib/modules/datasource/apk/index.spec.ts
@@ -19,19 +19,24 @@ import * as parser from './parser.ts';
 const gzip = promisify(zlib.gzip);
 
 async function createTarGz(
-  entries: { name: string; content: string }[],
+  entries: { name: string; content: string; type?: 'File' | 'Directory' }[],
 ): Promise<Buffer> {
   const pack = new Pack({ gzip: true });
 
   for (const entry of entries) {
+    const type = entry.type ?? 'File';
     const data = Buffer.from(entry.content, 'utf8');
     const header = new Header({
       path: entry.name,
-      size: data.length,
-      type: 'File',
+      size: type === 'Directory' ? 0 : data.length,
+      type,
     });
     const readEntry = new ReadEntry(header);
-    readEntry.end(data);
+    if (type === 'Directory') {
+      readEntry.end();
+    } else {
+      readEntry.end(data);
+    }
     pack.add(readEntry);
   }
 
@@ -898,6 +903,38 @@ describe('modules/datasource/apk/index', () => {
       await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
       await nodeFs.rm(validatorsFile());
       await apkDatasource.getReleases({ packageName: 'nginx', registryUrl });
+
+      const [, secondRequest] = httpMock.getTrace();
+      expect(secondRequest.headers).not.toContainKey('if-none-match');
+    });
+
+    it('should not cache an archive whose `APKINDEX` is a directory', async () => {
+      const directoryArchive = await createTarGz([
+        { name: 'APKINDEX', content: '', type: 'Directory' },
+      ]);
+
+      httpMock
+        .scope('https://packages.wolfi.dev')
+        .get(indexPath)
+        .reply(200, directoryArchive, { etag: '"v1"' })
+        .get(indexPath)
+        .reply(200, apkIndexArchive, { etag: '"v2"' });
+
+      const first = await apkDatasource.getReleases({
+        packageName: 'nginx',
+        registryUrl,
+      });
+      const second = await apkDatasource.getReleases({
+        packageName: 'nginx',
+        registryUrl,
+      });
+
+      expect(first).toBeNull();
+      expect(second).toEqual({
+        homepage: 'https://www.nginx.org/',
+        registryUrl,
+        releases: nginxReleases,
+      });
 
       const [, secondRequest] = httpMock.getTrace();
       expect(secondRequest.headers).not.toContainKey('if-none-match');

--- a/lib/modules/datasource/apk/index.ts
+++ b/lib/modules/datasource/apk/index.ts
@@ -1,17 +1,13 @@
-import { randomUUID } from 'node:crypto';
 import { isNonEmptyObject } from '@sindresorhus/is';
-import { extract as tarExtract } from 'tar';
-import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
-import * as fs from '../../../util/fs/index.ts';
 import { HttpError } from '../../../util/http/index.ts';
 import { asTimestamp } from '../../../util/timestamp.ts';
-import { joinUrlParts } from '../../../util/url.ts';
 import { id as looseVersioning } from '../../versioning/loose/index.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, Release, ReleaseResult } from '../types.ts';
+import { getIndexFile } from './cache.ts';
 import { parseApkIndexFile } from './parser.ts';
 import type { ApkPackage } from './types.ts';
 import { constructComponentUrls } from './url.ts';
@@ -90,34 +86,15 @@ export class ApkDatasource extends Datasource {
   ): Promise<Record<string, ApkPackage[]>> {
     logger.debug(`Fetching APK packages from ${componentUrl}`);
 
-    const extractId = randomUUID();
-    const cacheDir = await fs.ensureCacheDir(upath.join('apk', extractId));
-    const tarFile = upath.join(cacheDir, 'APKINDEX.tar.gz');
-    const extractedFile = upath.join(cacheDir, 'APKINDEX');
-
     try {
-      const indexUrl = joinUrlParts(componentUrl, 'APKINDEX.tar.gz');
-      logger.debug(`Attempting to download ${indexUrl}`);
-      const readStream = this.http.stream(indexUrl);
-      const writeStream = fs.createCacheWriteStream(tarFile);
-      await fs.pipeline(readStream, writeStream);
-
-      await tarExtract({
-        file: tarFile,
-        cwd: cacheDir,
-        filter: (path) => upath.basename(path) === 'APKINDEX',
-      });
-
-      if (!(await fs.cachePathExists(extractedFile))) {
-        logger.warn({ componentUrl }, 'APKINDEX file not found in tar archive');
+      const indexFile = await getIndexFile(this.http, componentUrl);
+      if (!indexFile) {
         return {};
       }
 
-      logger.debug('Successfully extracted APKINDEX content');
-
       let packages: ApkPackage[] = [];
       try {
-        packages = await parseApkIndexFile(extractedFile);
+        packages = await parseApkIndexFile(indexFile);
       } catch (err) {
         logger.warn({ componentUrl, err }, 'Error parsing APK index file');
         return {};
@@ -144,8 +121,6 @@ export class ApkDatasource extends Datasource {
         'Error extracting APK index from tar.gz',
       );
       return {};
-    } finally {
-      await fs.rmCache(cacheDir);
     }
   }
 

--- a/lib/modules/datasource/apk/readme.md
+++ b/lib/modules/datasource/apk/readme.md
@@ -64,6 +64,12 @@ https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
 
 <!-- TODO #43711 -->
 
+## Caching
+
+An index holds thousands of packages and is several megabytes in size, so Renovate keeps the extracted index in its cache directory.
+Renovate also stores the `ETag` and `Last-Modified` of each downloaded `APKINDEX.tar.gz`, and sends them with the next request for that index.
+When the registry answers with `304 Not Modified`, Renovate reuses the cached index instead of downloading the archive again.
+
 ## Usage example
 
 Say you pin Alpine packages in a `Dockerfile` and want Renovate to bump the versions.

--- a/lib/modules/datasource/apk/readme.md
+++ b/lib/modules/datasource/apk/readme.md
@@ -66,9 +66,12 @@ https://dl-cdn.alpinelinux.org/alpine/v3.19/community/x86_64/APKINDEX.tar.gz
 
 ## Caching
 
-An index holds thousands of packages and is several megabytes in size, so Renovate keeps the extracted index in its cache directory.
-Renovate also stores the `ETag` and `Last-Modified` of each downloaded `APKINDEX.tar.gz`, and sends them with the next request for that index.
-When the registry answers with `304 Not Modified`, Renovate reuses the cached index instead of downloading the archive again.
+!!! note
+  The cache is only persisted in local storage, and not stored in the Package Cache.
+  If you do not persist local storage between Renovate runs, this caching does not affect you.
+
+An index holds thousands of packages and is anywhere from 1-100MB in size, so Renovate keeps the extracted index in its cache directory.
+Renovate stores the `ETag` and `Last-Modified` of each downloaded `APKINDEX.tar.gz` to avoid re-downloading if it already has an up-to-date version of the index.
 
 ## Usage example
 

--- a/lib/modules/datasource/apk/schema.ts
+++ b/lib/modules/datasource/apk/schema.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod/v4';
+
+/**
+ * The cache validators of a downloaded `APKINDEX.tar.gz`.
+ *
+ * They are stored next to the extracted index so that a later run can ask the
+ * registry whether the index changed, instead of downloading it again.
+ */
+export const ApkIndexValidators = z.object({
+  etag: z.string().optional(),
+  lastModified: z.string().optional(),
+});
+export type ApkIndexValidators = z.infer<typeof ApkIndexValidators>;

--- a/lib/modules/datasource/apk/schema.ts
+++ b/lib/modules/datasource/apk/schema.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod/v4';
 
 /**
- * The cache validators of a downloaded `APKINDEX.tar.gz`.
+ * The cache headers of a downloaded `APKINDEX.tar.gz`.
  *
  * They are stored next to the extracted index so that a later run can ask the
  * registry whether the index changed, instead of downloading it again.
  */
-export const ApkIndexValidators = z.object({
+export const ApkIndexCache = z.object({
   etag: z.string().optional(),
   lastModified: z.string().optional(),
 });
-export type ApkIndexValidators = z.infer<typeof ApkIndexValidators>;
+export type ApkIndexCache = z.infer<typeof ApkIndexCache>;


### PR DESCRIPTION
## Changes

An `APKINDEX.tar.gz` holds thousands of packages and is several megabytes in size, but we downloaded and extracted it afresh every time the parsed index expired from the package cache.

Now the extracted `APKINDEX` is kept in the cache directory, keyed by a hash of the component URL, with the archive's `ETag` and `Last-Modified` stored alongside it. The next lookup sends those as `If-None-Match`/`If-Modified-Since`, and a `304 Not Modified` reuses the cached index without downloading or extracting anything.

Details worth a reviewer's attention:

- **Validators are stored on disk, not in the package cache.** They describe the copy that _this_ cache directory holds. A package cache can be shared between machines (Redis), which would otherwise let one machine revalidate — and then reuse — an older index that it holds locally.
- **We cache the extracted `APKINDEX`, not the archive it arrived in**, matching what the `deb` and `rpm` datasources do. Measured against the live indexes, compression is consistently ~4:1, so this costs ~4x the disk in return for skipping the extraction on every revalidation:

  | Component | `.tar.gz` | Extracted | Packages | Extract time |
  |---|---:|---:|---:|---:|
  | alpine v3.21 main | 0.46 MiB | 2.10 MiB | 5,542 | 9 ms |
  | alpine v3.21 community | 1.90 MiB | 8.32 MiB | 19,856 | — |
  | alpine edge community | 2.43 MiB | 10.28 MiB | 22,985 | 48 ms |
  | wolfi os | 9.80 MiB | 38.87 MiB | 119,148 | 156 ms |

  A typical Alpine user (one branch, `main` + `community`, one arch) goes from 0 to ~10 MiB. Wolfi is the outlier at ~39 MiB for a single component, because it carries every historical version. Happy to switch to caching the archive and re-extracting if maintainers would rather have the disk back.
- Download and extraction happen in a temp subdirectory; the index is only renamed into place, and the validators only written, after a successful extract — so a failed run never leaves validators describing an index that isn't there.
- The existing `withCache` layer over the parsed index (60 minute soft TTL) is untouched, so revalidation costs at most one conditional request per component per hour.
- Error handling in `_getPackages` is unchanged: 429/5xx still become `ExternalHostError`, other HTTP errors are still rethrown for the caller to skip the component, and parse/extract failures still resolve to an empty index.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45033
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Written with Claude Code, using Claude Opus 5, which produced the implementation, the unit tests, and the `readme.md` section, under human direction and review.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Five new tests cover: reuse on `304`, re-download once the registry reports a change, a registry that sends no validators, and validators that are missing or corrupt on disk. The `apk` module is at 100% statements/branches/functions.

The public repository: n/a — not yet run against a real repository.
