### PR TITLE
docs(datasource/apk): remove reference to renamed matcher

### DIFF
--- a/lib/modules/datasource/apk/readme.md
+++ b/lib/modules/datasource/apk/readme.md
@@ -113,7 +113,7 @@ Besides the optional `branch=` pattern in the usage example, you can:
 
 1. **Several custom managers** with different `managerFilePatterns` / `matchFilePatterns` and a fixed `registryUrlTemplate` each (e.g. one for `docker/alpine-3.18/**`, another for `docker/alpine-3.19/**`).
 
-1. **`packageRules`** with `matchFileNames` / `matchPaths` and `registryUrls` to override the parameters for specific paths or packages.
+1. **`packageRules`** with `matchFileNames` and `registryUrls` to override the parameters for specific paths or packages.
 
 For example, this `packageRules` entry overrides the `registryUrl` for the `nginx` package:
 


### PR DESCRIPTION
## Changes



As this slipped past our code review, but `matchPaths` has been
deprecated for ~3 years, replaced by `matchFileNames`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Written by Claude Opus 5 via Claude Code: code, tests and documentation.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A
