### PR TITLE
feat(config): keep configured repositories entries for CLI repositories

### DIFF
--- a/docs/usage/config-overview.md
+++ b/docs/usage/config-overview.md
@@ -152,6 +152,7 @@ For example, the CLI parameter `--platform=gitlab` is the same as setting `"plat
 
 CLI config is read last and takes precedence over Environment and File config.
 For example, if you configure conflicting values in Environment, File config and CLI config, then the CLI config will be merged last and "win" if values conflict.
+The exception is `repositories`: repositories passed as CLI arguments select which repositories Renovate runs against, but each keeps any matching object entry from the [`repositories`](./self-hosted-configuration.md#repositories) array in File or Environment config.
 
 It is important that you:
 

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1324,6 +1324,9 @@ module.exports = {
 };
 ```
 
+If you also pass repositories as CLI arguments, then Renovate only runs against the repositories named on the CLI.
+Each of those keeps its matching object from the `repositories` array in your file or environment config, so any per-repository configuration still applies.
+
 ## `repositoryCache`
 
 Set this to `"enabled"` to have Renovate maintain a JSON file cache per-repository to speed up extractions.

--- a/lib/config/utils.ts
+++ b/lib/config/utils.ts
@@ -1,8 +1,9 @@
+import { isString } from '@sindresorhus/is';
 import { logger } from '../logger/index.ts';
 import { clone } from '../util/clone.ts';
 import { getHighestVulnerabilitySeverity } from '../util/vulnerability/utils.ts';
 import * as options from './options/index.ts';
-import type { RenovateConfig } from './types.ts';
+import type { RenovateConfig, RenovateRepository } from './types.ts';
 
 export function mergeChildConfig<
   T extends Record<string, any>,
@@ -54,4 +55,13 @@ export function mergeChildConfig<
     }
   }
   return { ...config, ...config.force };
+}
+
+/**
+ * Lower-cased name of a `repositories[]` entry, for matching entries that came from different sources.
+ */
+export function getRepositoryName(repository: RenovateRepository): string {
+  return String(
+    isString(repository) ? repository : repository.repository,
+  ).toLowerCase();
 }

--- a/lib/workers/global/autodiscover.ts
+++ b/lib/workers/global/autodiscover.ts
@@ -1,16 +1,12 @@
 import { isString } from '@sindresorhus/is';
 import type { AllConfig } from '../../config/types.ts';
+import { getRepositoryName } from '../../config/utils.ts';
 import { logger } from '../../logger/index.ts';
 import {
   type AutodiscoverConfig,
   platform,
 } from '../../modules/platform/index.ts';
 import { matchRegexOrGlobList } from '../../util/string-match.ts';
-
-// istanbul ignore next
-function repoName(value: string | { repository: string }): string {
-  return String(isString(value) ? value : value.repository).toLowerCase();
-}
 
 export async function autodiscoverRepositories(
   config: AllConfig,
@@ -88,10 +84,10 @@ export async function autodiscoverRepositories(
       'Checking autodiscovered repositories against configured repositories',
     );
     for (const configuredRepo of config.repositories) {
-      const repository = repoName(configuredRepo);
+      const repository = getRepositoryName(configuredRepo);
       let found = false;
       for (let i = discovered.length - 1; i > -1; i -= 1) {
-        if (repository === repoName(discovered[i])) {
+        if (repository === getRepositoryName(discovered[i])) {
           found = true;
           logger.debug({ repository }, 'Using configured repository settings');
           // TODO: fix typings

--- a/lib/workers/global/config/parse/index.spec.ts
+++ b/lib/workers/global/config/parse/index.spec.ts
@@ -400,103 +400,102 @@ describe('workers/global/config/parse/index', () => {
       expect(getConfigFileNames()[1]).toBe('.github/myrenovate.json');
     });
 
-    // TODO #41551
-    describe('when `repositories` is being overridden', () => {
-      it('warns when CLI config overrides repositories from file config', async () => {
+    describe('repositories named on the CLI', () => {
+      it('keeps matching repositories entries from file config', async () => {
         fileConfigParser.getConfig.mockResolvedValue({
-          repositories: ['org/repo1', 'org/repo2'],
+          repositories: [
+            { repository: 'org/repo1', repositoryCache: 'disabled' },
+            'org/repo2',
+            { repository: 'org/repo3', repositoryCache: 'reset' },
+          ],
         });
-        defaultArgv = defaultArgv.concat(['org/repo3']);
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
+        defaultArgv = defaultArgv.concat(['org/repo3', 'org/repo4']);
+        const parsedConfig = await configParser.parseConfigs(
+          defaultEnv,
+          defaultArgv,
+        );
+        expect(parsedConfig.repositories).toEqual([
+          { repository: 'org/repo3', repositoryCache: 'reset' },
+          'org/repo4',
+        ]);
+        expect(logger.debug).toHaveBeenCalledWith(
+          { repositories: ['org/repo3'] },
+          'Using configured `repositories` entries for repositories named on the CLI',
         );
       });
 
-      it('warns when CLI config overrides repositories from env config', async () => {
+      it('keeps matching repositories entries from env config', async () => {
         fileConfigParser.getConfig.mockResolvedValue({});
         const env: NodeJS.ProcessEnv = {
           ...defaultEnv,
-          RENOVATE_REPOSITORIES: '["org/repo1"]',
+          RENOVATE_REPOSITORIES:
+            '[{"repository":"org/repo1","repositoryCache":"disabled"}]',
         };
+        defaultArgv = defaultArgv.concat(['org/repo1']);
+        const parsedConfig = await configParser.parseConfigs(env, defaultArgv);
+        expect(parsedConfig.repositories).toEqual([
+          { repository: 'org/repo1', repositoryCache: 'disabled' },
+        ]);
+      });
+
+      it('matches repository names case-insensitively', async () => {
+        fileConfigParser.getConfig.mockResolvedValue({
+          repositories: [
+            { repository: 'Org/Repo1', repositoryCache: 'disabled' },
+          ],
+        });
+        defaultArgv = defaultArgv.concat(['org/repo1']);
+        const parsedConfig = await configParser.parseConfigs(
+          defaultEnv,
+          defaultArgv,
+        );
+        expect(parsedConfig.repositories).toEqual([
+          { repository: 'Org/Repo1', repositoryCache: 'disabled' },
+        ]);
+      });
+
+      it('uses the CLI repositories when none match configured entries', async () => {
+        fileConfigParser.getConfig.mockResolvedValue({
+          repositories: [
+            'org/repo1',
+            { repository: 'org/repo2', repositoryCache: 'disabled' },
+          ],
+        });
         defaultArgv = defaultArgv.concat(['org/repo3']);
-        await configParser.parseConfigs(env, defaultArgv);
-        expect(logger.warn).toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
+        const parsedConfig = await configParser.parseConfigs(
+          defaultEnv,
+          defaultArgv,
+        );
+        expect(parsedConfig.repositories).toEqual(['org/repo3']);
+        expect(logger.debug).not.toHaveBeenCalledWith(
+          expect.anything(),
+          'Using configured `repositories` entries for repositories named on the CLI',
         );
       });
 
-      it('does not warn when CLI config sets repositories without override', async () => {
+      it('uses the CLI repositories when none are configured', async () => {
         fileConfigParser.getConfig.mockResolvedValue({});
         defaultArgv = defaultArgv.concat(['org/repo1']);
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).not.toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
+        const parsedConfig = await configParser.parseConfigs(
+          defaultEnv,
+          defaultArgv,
         );
+        expect(parsedConfig.repositories).toEqual(['org/repo1']);
       });
 
-      it('does not warn when CLI config has no repositories', async () => {
-        fileConfigParser.getConfig.mockResolvedValue({
-          repositories: ['org/repo1'],
-        });
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).not.toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
-        );
-      });
-
-      it('does not warn when CLI config has same repositories as file config', async () => {
-        fileConfigParser.getConfig.mockResolvedValue({
-          repositories: ['org/repo1'],
-        });
-        defaultArgv = defaultArgv.concat(['org/repo1']);
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).not.toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
-        );
-      });
-
-      it('warns when CLI overrides repositories with repo-specific configuration', async () => {
+      it('keeps configured repositories when the CLI names none', async () => {
         fileConfigParser.getConfig.mockResolvedValue({
           repositories: [
-            {
-              repository: 'org/simple-repo',
-              repositoryCache: 'disabled',
-            },
+            { repository: 'org/repo1', repositoryCache: 'disabled' },
           ],
         });
-        defaultArgv = defaultArgv.concat(['org/simple-repo']);
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
+        const parsedConfig = await configParser.parseConfigs(
+          defaultEnv,
+          defaultArgv,
         );
-      });
-
-      it('does not warn when both values are the same', async () => {
-        fileConfigParser.getConfig.mockResolvedValue({
-          repositories: ['org/simple-repo'],
-        });
-        defaultArgv = defaultArgv.concat(['org/simple-repo']);
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).not.toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
-        );
-      });
-
-      // TODO
-      it('warns when both values are effectively the same', async () => {
-        fileConfigParser.getConfig.mockResolvedValue({
-          repositories: [
-            {
-              repository: 'org/simple-repo',
-            },
-          ],
-        });
-        defaultArgv = defaultArgv.concat(['org/simple-repo']);
-        await configParser.parseConfigs(defaultEnv, defaultArgv);
-        expect(logger.warn).toHaveBeenCalledWith(
-          'CLI config is overridding the `repositories` config previously set',
-        );
+        expect(parsedConfig.repositories).toEqual([
+          { repository: 'org/repo1', repositoryCache: 'disabled' },
+        ]);
       });
     });
   });

--- a/lib/workers/global/config/parse/index.ts
+++ b/lib/workers/global/config/parse/index.ts
@@ -1,11 +1,17 @@
-import { isNonEmptyArray, isNonEmptyObject, isString } from '@sindresorhus/is';
+import { isNonEmptyArray, isNonEmptyObject } from '@sindresorhus/is';
 import { setUserConfigFileNames } from '../../../../config/app-strings.ts';
 import { setPrivateKeys } from '../../../../config/decrypt.ts';
 import * as defaultsParser from '../../../../config/defaults.ts';
 import { resolveConfigPresets } from '../../../../config/presets/index.ts';
 import { applySecretsAndVariablesToConfig } from '../../../../config/secrets.ts';
-import type { AllConfig } from '../../../../config/types.ts';
-import { mergeChildConfig } from '../../../../config/utils.ts';
+import type {
+  AllConfig,
+  RenovateRepository,
+} from '../../../../config/types.ts';
+import {
+  getRepositoryName,
+  mergeChildConfig,
+} from '../../../../config/utils.ts';
 import { CONFIG_PRESETS_INVALID } from '../../../../constants/error-messages.ts';
 import { logger, setContext } from '../../../../logger/index.ts';
 import { coerceArray } from '../../../../util/array.ts';
@@ -34,6 +40,36 @@ export async function resolveGlobalExtends(
   }
 }
 
+/**
+ * Repositories named on the CLI select which repositories run, but each keeps the matching
+ * `repositories[]` entry from file or env config so that its per-repository config still applies.
+ */
+function mergeCliRepositories(
+  cliRepositories: RenovateRepository[],
+  configuredRepositories: RenovateRepository[],
+): RenovateRepository[] {
+  const matched: string[] = [];
+  const repositories = cliRepositories.map((cliRepository) => {
+    const configured = configuredRepositories.find(
+      (configuredRepository) =>
+        getRepositoryName(configuredRepository) ===
+        getRepositoryName(cliRepository),
+    );
+    if (configured === undefined) {
+      return cliRepository;
+    }
+    matched.push(getRepositoryName(cliRepository));
+    return configured;
+  });
+  if (matched.length) {
+    logger.debug(
+      { repositories: matched },
+      'Using configured `repositories` entries for repositories named on the CLI',
+    );
+  }
+  return repositories;
+}
+
 export async function parseConfigs(
   env: NodeJS.ProcessEnv,
   argv: string[],
@@ -56,7 +92,17 @@ export async function parseConfigs(
     config.extends = [...fileConfig.extends, ...coerceArray(config.extends)];
   }
   config = mergeChildConfig(config, envConfig);
+  const configuredRepositories = config.repositories;
   config = mergeChildConfig(config, cliConfig);
+  if (
+    isNonEmptyArray(cliConfig.repositories) &&
+    isNonEmptyArray(configuredRepositories)
+  ) {
+    config.repositories = mergeCliRepositories(
+      cliConfig.repositories,
+      configuredRepositories,
+    );
+  }
 
   config = await codespaces.setConfig(config);
 
@@ -119,38 +165,6 @@ export async function parseConfigs(
   logger.debug({ config: envConfig }, 'Env config');
   logger.debug({ config: resolvedGlobalExtends }, 'Resolved global extends');
   logger.debug({ config: combinedConfig }, 'Combined config');
-
-  // TODO #41551
-  if (isNonEmptyArray(cliConfig.repositories)) {
-    const existingRepos = [
-      ...coerceArray(fileConfig.repositories),
-      ...coerceArray(additionalFileConfig.repositories),
-      ...coerceArray(envConfig.repositories),
-    ];
-
-    if (isNonEmptyArray(existingRepos)) {
-      const allStrings = existingRepos.every((repo) => isString(repo));
-      let shouldWarn = true;
-
-      if (allStrings) {
-        const areEqual =
-          cliConfig.repositories.length === existingRepos.length &&
-          cliConfig.repositories.every(
-            (repo, idx) => repo === existingRepos[idx],
-          );
-
-        if (areEqual) {
-          shouldWarn = false;
-        }
-      }
-
-      if (shouldWarn) {
-        logger.warn(
-          'CLI config is overridding the `repositories` config previously set',
-        );
-      }
-    }
-  }
 
   if (config.detectGlobalManagerConfig) {
     logger.debug('Detecting global manager config');


### PR DESCRIPTION
## Changes

When file or environment config defines `repositories` with per-repository objects (e.g. `{ repository: "org/repo", repositoryCache: "disabled" }`) and repositories are also passed as CLI arguments, the CLI list replaced the whole array and silently dropped those overrides (#41551). #41553 added a warning as a stopgap.

Now repositories named on the CLI still select which repositories run, but each keeps its matching entry from file/env config so its per-repository configuration applies. Matching reuses the existing case-insensitive name normalization from autodiscover, now shared as `getRepositoryName` in `lib/config/utils.ts`. CLI repositories without a configured entry run as before, and configured repositories not named on the CLI are not run. The stopgap warning is replaced by a debug log listing which CLI repositories picked up a configured entry, and the `TODO #41551` markers are removed.

Questions for maintainers:

- `repositories` from `globalExtends` presets are not merged (they resolve after the CLI merge and already rank below file config). Should they be?
- `RENOVATE_REPOSITORIES` takes part exactly like file config: it still replaces a file `repositories` array (non-mergeable option) and the CLI then matches against the result.
- `forceCli` still copies the raw CLI string list into `config.force.repositories` (pre-existing, untouched).

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #41551
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, tests and docs were produced with substantive assistance from Claude Code (Anthropic), directed and reviewed by the contributor.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @Sanjay-doppalapudi will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
