### PR TITLE
test(presets): validate internal presets the way they are consumed

### DIFF
--- a/lib/config/presets/internal/index.spec.ts
+++ b/lib/config/presets/internal/index.spec.ts
@@ -1,6 +1,6 @@
 import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import { regEx } from '../../../util/regex.ts';
-import { massageConfig } from '../../massage.ts';
+import type { RenovateConfig } from '../../types.ts';
 import { validateConfig } from '../../validation.ts';
 import { resolveConfigPresets } from '../index.ts';
 import * as npm from '../npm/index.ts';
@@ -12,6 +12,20 @@ vi.mock('../../../modules/datasource/npm/index.ts');
 const getPresetSpy = vi.spyOn(npm, 'getPreset');
 
 const ignoredPresets = ['default:group', 'default:timezone'];
+
+// `packages:` and `monorepo:` presets are `packageRules` fragments made of selectors only.
+// They are consumed via `packageRules[].extends` (as the `group:` presets do), so they are validated there, next to the option a real rule carries.
+const packageRuleFragmentGroups = ['monorepo', 'packages'];
+
+// Every other preset is validated the way `inheritConfig` and repository config consume it: resolved into the config extending it and validated as a whole.
+// This deliberately does not use the `isPreset` leniency of `validateConfig()`, which lets a preset source keep selectors at its top level.
+function presetUsage(groupName: string, presetName: string): RenovateConfig {
+  const preset = `${groupName}:${presetName}`;
+  if (packageRuleFragmentGroups.includes(groupName)) {
+    return { packageRules: [{ extends: [preset], groupName: presetName }] };
+  }
+  return { extends: [preset] };
+}
 
 describe('config/presets/internal/index', () => {
   beforeEach(() => {
@@ -27,20 +41,18 @@ describe('config/presets/internal/index', () => {
   });
 
   for (const [groupName, groupPresets] of Object.entries(internal.groups)) {
-    for (const [presetName, presetConfig] of Object.entries(
-      groupPresets,
-    ).filter(
-      ([key]) =>
+    for (const presetName of Object.keys(groupPresets).filter(
+      (key) =>
         key !== 'description' &&
         !ignoredPresets.includes(`${groupName}:${key}`),
     )) {
       it(`${`${groupName}:${presetName}`} validates`, async () => {
         try {
           const { config } = await resolveConfigPresets(
-            massageConfig(presetConfig),
+            presetUsage(groupName, presetName),
           );
           const configType = groupName === 'global' ? 'global' : 'repo';
-          const res = await validateConfig(configType, config, true);
+          const res = await validateConfig(configType, config);
           expect(res.errors).toBeEmptyArray();
           expect(res.warnings).toBeEmptyArray();
         } catch (err) {


### PR DESCRIPTION
## Changes

The internal preset validation ran `validateConfig()` with `isPreset`, which lets a preset keep selectors such as `matchManagers` at its top level. That is how #39738 shipped `helpers:goXPackages*` with a bare `matchManagers` and broke `inheritConfig` users (#39789, fixed by #39790): the real resolution paths (`inherited.ts`, `merge.ts`) validate the resolved config without that leniency, so the test was more permissive than production.

Each internal preset is now resolved through `extends`, as a repository or inherited config would, and the result is validated without `isPreset`, asserting zero errors and warnings. `packages:` and `monorepo:` presets are selector-only `packageRules` fragments, so they are resolved from within a `packageRules` entry (the shape the `group:` presets use).

Resolving by name rather than from the raw object also removes a test-order dependency: `fetchPreset` deletes `description` from the shared internal preset objects it returns.

Verified by temporarily restoring the #39738 shape: the new test fails for the two helpers plus `config:recommended`, `config:best-practices`, `config:js-app`, `config:js-lib` and `security:only-security-updates` with the exact errors reported in #39789, while the previous test passed. All current presets pass.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #39793
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Produced with substantive assistance from Claude Code (Anthropic), directed and reviewed by the contributor: root-cause analysis of the validator's `isPreset` paths, the test rewrite, and the regression proof against the #39738 shape.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @Sanjay-doppalapudi will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
