### PR TITLE
feat(github): add support for using merge queues without auto merge

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -338,6 +338,8 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 - Automerge the branch commit if it's: (a) up-to-date with the base branch, and (b) passing all tests
 - As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 25 hours, see [`prNotPendingHours`](#prnotpendinghours))
 
+Note that `"automergeType": "branch"` is not compatible with GitHub merge queues, because the merge queue does not allow pushing directly to the base branch.
+
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.
 
@@ -4603,7 +4605,7 @@ By default this label is `"rebase"` but you can configure it to anything you wan
 
 Possible values and meanings:
 
-- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead
+- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the experimental environment variable `RENOVATE_X_GITHUB_MERGE_QUEUE` is set and the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
 - `automerging`: Renovate will use `behind-base-branch` if configured to automerge, Otherwise, `never` will be used instead
 - `never`: Renovate will never rebase the branch or update it unless manually requested
 - `conflicted`: Renovate will rebase only if the branch is conflicted

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4605,7 +4605,7 @@ By default this label is `"rebase"` but you can configure it to anything you wan
 
 Possible values and meanings:
 
-- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the experimental environment variable `RENOVATE_X_GITHUB_MERGE_QUEUE` is set and the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
+- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
 - `automerging`: Renovate will use `behind-base-branch` if configured to automerge, Otherwise, `never` will be used instead
 - `never`: Renovate will never rebase the branch or update it unless manually requested
 - `conflicted`: Renovate will rebase only if the branch is conflicted

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -133,6 +133,19 @@ Read the [GitHub Docs, managing a merge queue](https://docs.github.com/en/reposi
 
 The steps to enable GitHub's Merge Queue differ based on whether you use GitHub Actions or another CI provider.
 
+By default, merge queues need `platformAutomerge` enabled (which is the default), because GitHub's auto-merge takes care of adding the PR to the merge queue.
+This requires the "Allow auto-merge" checkbox in the repository settings to be enabled, as described in the steps below.
+
+If you self-host Renovate and set the experimental environment variable [`RENOVATE_X_GITHUB_MERGE_QUEUE`](../self-hosted-experimental.md#renovate_x_github_merge_queue), merge queues also work with `platformAutomerge=false`: Renovate then adds the PR to the merge queue itself once all checks have passed.
+In that case the "Allow auto-merge" checkbox is not needed.
+We recommend enabling the "Automatically delete head branches" repository setting, so branches get cleaned up after the merge queue merges the PR.
+
+<!-- prettier-ignore -->
+!!! warning
+  Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
+  With `RENOVATE_X_GITHUB_MERGE_QUEUE` set, Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
+  Configure `automergeType=pr` in such repositories.
+
 !!! tip "GitHub Merge Queue overview page"
   GitHub has a page that shows all the PRs in the Merge Queue.
   The page link follows this pattern: `https://github.com/organization-name/repository-name/queue/base-branch-name`.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -141,7 +141,6 @@ In that case the "Allow auto-merge" checkbox is not needed.
 PRs that are already waiting in the merge queue are left untouched on later runs.
 We recommend enabling the "Automatically delete head branches" repository setting, so branches get cleaned up after the merge queue merges the PR.
 
-<!-- prettier-ignore -->
 !!! warning
   Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
   Renovate detects this misconfiguration, logs a warning, and creates a PR instead.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -133,17 +133,18 @@ Read the [GitHub Docs, managing a merge queue](https://docs.github.com/en/reposi
 
 The steps to enable GitHub's Merge Queue differ based on whether you use GitHub Actions or another CI provider.
 
-By default, merge queues need `platformAutomerge` enabled (which is the default), because GitHub's auto-merge takes care of adding the PR to the merge queue.
+With `platformAutomerge` enabled (which is the default), GitHub's auto-merge takes care of adding the PR to the merge queue.
 This requires the "Allow auto-merge" checkbox in the repository settings to be enabled, as described in the steps below.
 
-If you self-host Renovate and set the experimental environment variable [`RENOVATE_X_GITHUB_MERGE_QUEUE`](../self-hosted-experimental.md#renovate_x_github_merge_queue), merge queues also work with `platformAutomerge=false`: Renovate then adds the PR to the merge queue itself once all checks have passed.
+Merge queues also work with `platformAutomerge=false`: Renovate detects whether the base branch has a merge queue, configured via classic branch protection or repository rulesets, and adds the PR to the merge queue itself once all checks have passed.
 In that case the "Allow auto-merge" checkbox is not needed.
+PRs that are already waiting in the merge queue are left untouched on later runs.
 We recommend enabling the "Automatically delete head branches" repository setting, so branches get cleaned up after the merge queue merges the PR.
 
 <!-- prettier-ignore -->
 !!! warning
   Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
-  With `RENOVATE_X_GITHUB_MERGE_QUEUE` set, Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
+  Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
   Configure `automergeType=pr` in such repositories.
 
 !!! tip "GitHub Merge Queue overview page"

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -57,6 +57,15 @@ If set to `"true"`, a config error Issue will be raised in case repository confi
 
 If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.
 
+## `RENOVATE_X_GITHUB_MERGE_QUEUE`
+
+If set to any value, Renovate will detect if a GitHub merge queue is required for the base branch, whether configured via classic branch protection or repository rulesets.
+If a merge queue is detected, then:
+
+- Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
+- branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
+- `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
+
 ## `RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN`
 
 If set, when `autoApprove` is enabled, the provided token is used to authenticate GitLab approve requests instead of the default one.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -63,6 +63,7 @@ If set to any value, Renovate will detect if a GitHub merge queue is required fo
 If a merge queue is detected, then:
 
 - Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
+- PRs that are already waiting in the merge queue are left untouched on later runs
 - branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
 - `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -57,16 +57,6 @@ If set to `"true"`, a config error Issue will be raised in case repository confi
 
 If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.
 
-## `RENOVATE_X_GITHUB_MERGE_QUEUE`
-
-If set to any value, Renovate will detect if a GitHub merge queue is required for the base branch, whether configured via classic branch protection or repository rulesets.
-If a merge queue is detected, then:
-
-- Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
-- PRs that are already waiting in the merge queue are left untouched on later runs
-- branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
-- `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
-
 ## `RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN`
 
 If set, when `autoApprove` is enabled, the provided token is used to authenticate GitLab approve requests instead of the default one.

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -90,6 +90,23 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 `;
 
+export const enqueuePullRequestMutation = `
+mutation EnqueuePullRequest(
+  $pullRequestId: ID!,
+) {
+  enqueuePullRequest(
+    input: {
+      pullRequestId: $pullRequestId,
+    }
+  ) {
+    mergeQueueEntry {
+      id
+      position
+    }
+  }
+}
+`;
+
 export const enableAutoMergeMutation = `
 mutation EnablePullRequestAutoMerge(
   $pullRequestId: ID!,

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1635,15 +1635,15 @@ describe('modules/platform/github/index', () => {
 
   describe('isBranchMergeQueueEnabled', () => {
     beforeEach(() => {
-      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
     });
 
     afterEach(() => {
-      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
     });
 
     it('should return false if the experimental flag is not set', async () => {
-      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
 
       const res = await github.isBranchMergeQueueEnabled('main');
 
@@ -5668,11 +5668,11 @@ describe('modules/platform/github/index', () => {
     };
 
     beforeEach(() => {
-      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
     });
 
     afterEach(() => {
-      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
     });
 
     function mergeQueueMock(
@@ -5725,7 +5725,7 @@ describe('modules/platform/github/index', () => {
         },
       ]);
       // The PR is not merged yet, so it must not be cached as merged
-      expect(await github.getPr(1234)).toMatchObject({
+      await expect(github.getPr(1234)).resolves.toMatchObject({
         number: 1234,
         state: 'open',
       });

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1633,6 +1633,99 @@ describe('modules/platform/github/index', () => {
     });
   });
 
+  describe('isBranchMergeQueueEnabled', () => {
+    beforeEach(() => {
+      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+    });
+
+    it('should return false if the experimental flag is not set', async () => {
+      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return true if the branch has a merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue: { id: 'MQ_kwDOBJLedM0dmQ' } } },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeTrue();
+    });
+
+    it('should return false if the branch has no merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue: null } },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return cached result on subsequent calls', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue: { id: 'MQ_kwDOBJLedM0dmQ' } } },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      // First call should make the HTTP request and cache the result
+      const firstResult = await github.isBranchMergeQueueEnabled('main');
+      // Second call should return cached result without making HTTP request
+      const secondResult = await github.isBranchMergeQueueEnabled('main');
+
+      expect(firstResult).toBeTrue();
+      expect(secondResult).toBeTrue();
+    });
+
+    it('should return false if the query returns errors', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        errors: [
+          {
+            message: "Field 'mergeQueue' doesn't exist on type 'Repository'",
+          },
+        ],
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return false on request error', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').replyWithError('unknown error');
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Merge queue detection: request error',
+      );
+    });
+  });
+
   describe('getPrList()', () => {
     const t = DateTime.fromISO('2000-01-01T00:00:00.000+00:00');
     const t1 = t.plus({ minutes: 1 }).toISO()!;
@@ -5561,6 +5654,198 @@ describe('modules/platform/github/index', () => {
         },
         'mergePr',
       );
+    });
+  });
+
+  describe('mergePr(prNo) - merge queue', () => {
+    const pullsListItem = {
+      number: 1234,
+      node_id: 'abcd',
+      head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+      state: 'open',
+      title: 'Some PR',
+      updated_at: '01-09-2022',
+    };
+
+    beforeEach(() => {
+      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+    });
+
+    function mergeQueueMock(
+      scope: httpMock.Scope,
+      mergeQueue: { id: string } | null,
+    ): void {
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue } },
+      });
+    }
+
+    it('should add PR to the merge queue instead of merging', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .reply(200, {
+          data: {
+            enqueuePullRequest: {
+              mergeQueueEntry: { id: 'MQE_1', position: 1 },
+            },
+          },
+        });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeTrue();
+      expect(httpMock.getTrace()).toMatchObject([
+        { url: 'https://api.github.com/graphql' },
+        { url: 'https://api.github.com/graphql' },
+        {
+          url: 'https://api.github.com/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        },
+        {
+          url: 'https://api.github.com/graphql',
+          graphql: {
+            mutation: { enqueuePullRequest: {} },
+            variables: { pullRequestId: 'abcd' },
+          },
+        },
+      ]);
+      // The PR is not merged yet, so it must not be cached as merged
+      expect(await github.getPr(1234)).toMatchObject({
+        number: 1234,
+        state: 'open',
+      });
+    });
+
+    it('should return true if the PR is already in the merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .reply(200, {
+          errors: [
+            {
+              type: 'UNPROCESSABLE',
+              message: 'The pull request is already enqueued',
+            },
+          ],
+        });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeTrue();
+    });
+
+    it('should return false if adding to the merge queue fails', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .reply(200, {
+          errors: [
+            {
+              type: 'UNPROCESSABLE',
+              message: 'Pull request is in unstable status',
+            },
+          ],
+        });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return false on merge queue request error', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .replyWithError('unknown error');
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeFalse();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { prNumber: 1234, err: expect.any(Error) },
+        'Failed to add PR to the merge queue',
+      );
+    });
+
+    it('should return false if the PR cannot be found', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [])
+        .get('/repos/some/repo/pulls/1234')
+        .reply(404);
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeFalse();
+    });
+
+    it('should merge directly if the branch has no merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, null);
+      scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeTrue();
     });
   });
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -853,6 +853,22 @@ describe('modules/platform/github/index', () => {
     });
   }
 
+  function prListMock(scope: httpMock.Scope, prNo: number): void {
+    scope
+      .get(
+        '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+      )
+      .reply(200, [
+        {
+          number: prNo,
+          base: { ref: 'master' },
+          head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+          state: 'open',
+          title: 'Some PR',
+        },
+      ]);
+  }
+
   function forkInitRepoMock(
     scope: httpMock.Scope,
     repository: string,
@@ -1634,22 +1650,6 @@ describe('modules/platform/github/index', () => {
   });
 
   describe('isBranchMergeQueueEnabled', () => {
-    beforeEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
-    });
-
-    afterEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
-    });
-
-    it('should return false if the experimental flag is not set', async () => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
-
-      const res = await github.isBranchMergeQueueEnabled('main');
-
-      expect(res).toBeFalse();
-    });
-
     it('should return true if the branch has a merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
@@ -5576,6 +5576,7 @@ describe('modules/platform/github/index', () => {
     it('should handle merge error', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope
         .put('/repos/some/repo/pulls/1234/merge')
         .replyWithError('merge error');
@@ -5597,6 +5598,7 @@ describe('modules/platform/github/index', () => {
     it('should handle merge block', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope
         .put('/repos/some/repo/pulls/1234/merge')
         .reply(405, { message: 'Required status check "build" is expected.' });
@@ -5623,6 +5625,7 @@ describe('modules/platform/github/index', () => {
     ])('should handle approvers required: %j', async (message) => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope.put('/repos/some/repo/pulls/1234/merge').reply(405, {
         message,
       });
@@ -5645,6 +5648,7 @@ describe('modules/platform/github/index', () => {
     it('should warn if automergeStrategy is not supported', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
@@ -5664,6 +5668,7 @@ describe('modules/platform/github/index', () => {
     it('should use configured automergeStrategy', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
@@ -5697,14 +5702,6 @@ describe('modules/platform/github/index', () => {
       title: 'Some PR',
       updated_at: '01-09-2022',
     };
-
-    beforeEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
-    });
-
-    afterEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
-    });
 
     function mergeQueueMock(
       scope: httpMock.Scope,
@@ -5938,6 +5935,7 @@ describe('modules/platform/github/index', () => {
     it('should try squash first', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1235);
       scope.put('/repos/some/repo/pulls/1235/merge').reply(200);
       await github.initRepo({ repository: 'some/repo' });
       const pr = {
@@ -5957,6 +5955,7 @@ describe('modules/platform/github/index', () => {
     it('should try merge after squash', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1236);
       scope
         .put('/repos/some/repo/pulls/1236/merge')
         .reply(400, 'no squashing allowed');
@@ -5978,6 +5977,7 @@ describe('modules/platform/github/index', () => {
     it('should try rebase after merge', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1237);
       scope
         .put('/repos/some/repo/pulls/1237/merge')
         .reply(405, 'no squashing allowed')
@@ -6003,6 +6003,7 @@ describe('modules/platform/github/index', () => {
     it('should give up', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1237);
       scope
         .put('/repos/some/repo/pulls/1237/merge')
         .reply(405, 'no squashing allowed')

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1693,7 +1693,19 @@ describe('modules/platform/github/index', () => {
       expect(secondResult).toBeTrue();
     });
 
-    it('should return false if the query returns errors', async () => {
+    it('should reuse the default branch result from initRepo', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo', {
+        mergeQueue: { id: 'MQ_kwDOBJLedM0dmQ' },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('master');
+
+      expect(res).toBeTrue();
+    });
+
+    it('should assume a merge queue if the query returns errors', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope.post('/graphql').reply(200, {
@@ -1707,10 +1719,10 @@ describe('modules/platform/github/index', () => {
 
       const res = await github.isBranchMergeQueueEnabled('main');
 
-      expect(res).toBeFalse();
+      expect(res).toBeTrue();
     });
 
-    it('should return false on request error', async () => {
+    it('should assume a merge queue on request error', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope.post('/graphql').replyWithError('unknown error');
@@ -1718,11 +1730,7 @@ describe('modules/platform/github/index', () => {
 
       const res = await github.isBranchMergeQueueEnabled('main');
 
-      expect(res).toBeFalse();
-      expect(logger.logger.warn).toHaveBeenCalledWith(
-        { err: expect.any(Error) },
-        'Merge queue detection: request error',
-      );
+      expect(res).toBeTrue();
     });
   });
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -5692,6 +5692,7 @@ describe('modules/platform/github/index', () => {
       number: 1234,
       node_id: 'abcd',
       head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+      base: { ref: 'main' },
       state: 'open',
       title: 'Some PR',
       updated_at: '01-09-2022',
@@ -5736,16 +5737,15 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeTrue();
       expect(httpMock.getTrace()).toMatchObject([
         { url: 'https://api.github.com/graphql' },
-        { url: 'https://api.github.com/graphql' },
         {
           url: 'https://api.github.com/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
         },
+        { url: 'https://api.github.com/graphql' },
         {
           url: 'https://api.github.com/graphql',
           graphql: {
@@ -5783,7 +5783,6 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeTrue();
@@ -5811,7 +5810,6 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeFalse();
@@ -5832,7 +5830,6 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeFalse();
@@ -5842,37 +5839,43 @@ describe('modules/platform/github/index', () => {
       );
     });
 
-    it('should return false if the PR cannot be found', async () => {
+    it('should merge directly if the PR cannot be found', async () => {
       const scope = httpMock.scope(githubApiHost);
-      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      initRepoMock(scope, 'some/repo');
       scope
         .get(
           '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
-        .reply(404);
+        .reply(404)
+        .put('/repos/some/repo/pulls/1234/merge')
+        .reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
-      expect(res).toBeFalse();
+      expect(res).toBeTrue();
     });
 
     it('should merge directly if the branch has no merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       mergeQueueMock(scope, null);
-      scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .put('/repos/some/repo/pulls/1234/merge')
+        .reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeTrue();

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1726,6 +1726,28 @@ describe('modules/platform/github/index', () => {
     });
   });
 
+  describe('isPrInMergeQueue', () => {
+    it.each`
+      isInMergeQueue
+      ${true}
+      ${false}
+    `(
+      'returns $isInMergeQueue from the pull request merge queue status',
+      async ({ isInMergeQueue }) => {
+        const scope = httpMock.scope(githubApiHost);
+        initRepoMock(scope, 'some/repo');
+        await github.initRepo({ repository: 'some/repo' });
+        scope.post('/graphql').reply(200, {
+          data: { repository: { pullRequest: { isInMergeQueue } } },
+        });
+
+        const res = await github.isPrInMergeQueue(1234);
+
+        expect(res).toBe(isInMergeQueue);
+      },
+    );
+  });
+
   describe('getPrList()', () => {
     const t = DateTime.fromISO('2000-01-01T00:00:00.000+00:00');
     const t1 = t.plus({ minutes: 1 }).toISO()!;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -80,6 +80,7 @@ import { remoteBranchExists } from './branch.ts';
 import { coerceRestPr, githubApi, mapMergeStartegy } from './common.ts';
 import {
   enableAutoMergeMutation,
+  enqueuePullRequestMutation,
   getIssuesQuery,
   repoInfoQuery,
   repoMergeQueueQuery,
@@ -99,6 +100,8 @@ import type {
   Comment,
   GhAutomergeResponse,
   GhBranchStatus,
+  GhEnqueuePullRequestResponse,
+  GhMergeQueueResponse,
   GhPr,
   GhRepo,
   GhRestPr,
@@ -897,6 +900,51 @@ export async function getBranchForceRebase(
   }
 
   return config.branchForceRebase[branchName];
+}
+
+export async function isBranchMergeQueueEnabled(
+  branchName: string,
+): Promise<boolean> {
+  if (!getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
+    return false;
+  }
+
+  config.branchMergeQueueEnabled ??= {};
+
+  const cachedResult = config.branchMergeQueueEnabled[branchName];
+  if (cachedResult !== undefined) {
+    return cachedResult;
+  }
+
+  // Merge queues configured via classic branch protection are only visible
+  // through the GraphQL mergeQueue field, which also covers repository rulesets
+  const [owner, name] = (config.parentRepo ?? config.repository!).split('/');
+  let result = false;
+  try {
+    const res = await githubApi.requestGraphql<GhMergeQueueResponse>(
+      repoMergeQueueQuery,
+      {
+        variables: { owner, name, branch: branchName },
+        readOnly: true,
+        count: 1, // set count to one to bypass graphql check
+      },
+    );
+    if (res?.errors) {
+      // e.g. GitHub Enterprise Server versions without merge queue support
+      logger.once.debug(
+        { errors: res.errors },
+        'Merge queue detection: query failed',
+      );
+    } else {
+      result = isNonEmptyString(res?.data?.repository?.mergeQueue?.id);
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Merge queue detection: request error');
+  }
+
+  logger.debug(`Branch ${branchName} has merge queue enabled: ${result}`);
+  config.branchMergeQueueEnabled[branchName] = result;
+  return result;
 }
 
 function handleBranchProtectionError(
@@ -2165,12 +2213,60 @@ export async function reattemptPlatformAutomerge({
   }
 }
 
+async function tryEnqueuePr(prNo: number): Promise<boolean> {
+  const pr = await getPr(prNo);
+  if (!pr) {
+    logger.debug(`Could not find PR #${prNo} to add to the merge queue`);
+    return false;
+  }
+
+  try {
+    const res = await githubApi.requestGraphql<GhEnqueuePullRequestResponse>(
+      enqueuePullRequestMutation,
+      {
+        variables: { pullRequestId: pr.node_id },
+        count: 1, // set count to one to bypass graphql check
+      },
+    );
+
+    if (res?.errors) {
+      // GitHub does not document the exact message, so match loosely.
+      // "enqueue" contains "queue", so both wordings are covered.
+      if (
+        res.errors.some((error) => regEx(/already.*queue/i).test(error.message))
+      ) {
+        logger.debug(`PR #${prNo} is already in the merge queue`);
+        return true;
+      }
+      logger.debug(
+        { prNumber: prNo, errors: res.errors },
+        'Failed to add PR to the merge queue',
+      );
+      return false;
+    }
+
+    logger.debug(`PR #${prNo} added to the merge queue`);
+    return true;
+  } catch (err) {
+    logger.warn({ prNumber: prNo, err }, 'Failed to add PR to the merge queue');
+    return false;
+  }
+}
+
 export async function mergePr({
   branchName,
   id: prNo,
   strategy,
+  targetBranch,
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${prNo}, ${branchName})`);
+
+  if (targetBranch && (await isBranchMergeQueueEnabled(targetBranch))) {
+    // The PR is not merged directly but through the merge queue, so it must
+    // not be cached as merged nor may its branch be deleted yet
+    return tryEnqueuePr(prNo);
+  }
+
   const url = `repos/${
     config.parentRepo ?? config.repository
   }/pulls/${prNo}/merge`;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -87,7 +87,11 @@ import {
 } from './graphql.ts';
 import { GithubIssueCache } from './issue.ts';
 import { massageMarkdownLinks } from './massage-markdown-links.ts';
-import { getPrCache, isPrInMergeQueue, updatePrCache } from './pr.ts';
+import {
+  isPrInMergeQueue as checkPrInMergeQueue,
+  getPrCache,
+  updatePrCache,
+} from './pr.ts';
 import {
   GithubBranchProtection,
   GithubBranchRulesets,
@@ -2111,6 +2115,15 @@ async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
   return result;
 }
 
+export function isPrInMergeQueue(prNo: number): Promise<boolean> {
+  return checkPrInMergeQueue(
+    githubApi,
+    config.repositoryOwner,
+    config.repositoryName,
+    prNo,
+  );
+}
+
 export async function assertPrNotInMergeQueue(
   branchName: string,
   baseBranch?: string,
@@ -2124,14 +2137,7 @@ export async function assertPrNotInMergeQueue(
     return;
   }
 
-  if (
-    await isPrInMergeQueue(
-      githubApi,
-      config.repositoryOwner,
-      config.repositoryName,
-      pr.number,
-    )
-  ) {
+  if (await isPrInMergeQueue(pr.number)) {
     logger.debug(`PR #${pr.number} is in the merge queue - aborting push`);
     throw new Error(PR_ALREADY_IN_MERGE_QUEUE);
   }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -2183,13 +2183,8 @@ export async function reattemptPlatformAutomerge({
   }
 }
 
-async function tryEnqueuePr(prNo: number): Promise<boolean> {
-  const pr = await getPr(prNo);
-  if (!pr) {
-    logger.debug(`Could not find PR #${prNo} to add to the merge queue`);
-    return false;
-  }
-
+async function tryEnqueuePr(pr: GhPr): Promise<boolean> {
+  const prNo = pr.number;
   try {
     const res = await githubApi.requestGraphql<GhEnqueuePullRequestResponse>(
       enqueuePullRequestMutation,
@@ -2227,14 +2222,21 @@ export async function mergePr({
   branchName,
   id: prNo,
   strategy,
-  targetBranch,
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${prNo}, ${branchName})`);
 
-  if (targetBranch && (await isBranchMergeQueueEnabled(targetBranch))) {
-    // The PR is not merged directly but through the merge queue, so it must
-    // not be cached as merged nor may its branch be deleted yet
-    return tryEnqueuePr(prNo);
+  // Only look up the PR when merge queues are enabled, so the direct merge
+  // path stays free of extra requests
+  if (getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
+    const pr = await getPr(prNo);
+    if (
+      pr?.targetBranch &&
+      (await isBranchMergeQueueEnabled(pr.targetBranch))
+    ) {
+      // The PR is not merged directly but through the merge queue, so it must
+      // not be cached as merged nor may its branch be deleted yet
+      return tryEnqueuePr(pr);
+    }
   }
 
   const url = `repos/${

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -905,16 +905,6 @@ export async function getBranchForceRebase(
   return config.branchForceRebase[branchName];
 }
 
-export async function isBranchMergeQueueEnabled(
-  branchName: string,
-): Promise<boolean> {
-  if (!getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
-    return false;
-  }
-
-  return isMergeQueueEnabled(branchName);
-}
-
 function handleBranchProtectionError(
   protection: 'branch-protection' | 'rulesets',
   err: any,
@@ -2026,7 +2016,9 @@ export async function createPr({
   return result;
 }
 
-async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
+export async function isBranchMergeQueueEnabled(
+  baseBranch: string,
+): Promise<boolean> {
   const cachedResult = config.mergeQueueEnabled[baseBranch];
   if (cachedResult !== undefined) {
     return cachedResult;
@@ -2092,7 +2084,7 @@ export async function assertPrNotInMergeQueue(
   branchName: string,
   baseBranch?: string,
 ): Promise<void> {
-  if (!(await isMergeQueueEnabled(baseBranch ?? config.defaultBranch))) {
+  if (!(await isBranchMergeQueueEnabled(baseBranch ?? config.defaultBranch))) {
     return;
   }
 
@@ -2225,18 +2217,11 @@ export async function mergePr({
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${prNo}, ${branchName})`);
 
-  // Only look up the PR when merge queues are enabled, so the direct merge
-  // path stays free of extra requests
-  if (getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
-    const pr = await getPr(prNo);
-    if (
-      pr?.targetBranch &&
-      (await isBranchMergeQueueEnabled(pr.targetBranch))
-    ) {
-      // The PR is not merged directly but through the merge queue, so it must
-      // not be cached as merged nor may its branch be deleted yet
-      return tryEnqueuePr(pr);
-    }
+  const pr = await getPr(prNo);
+  if (pr?.targetBranch && (await isBranchMergeQueueEnabled(pr.targetBranch))) {
+    // The PR is not merged directly but through the merge queue, so it must
+    // not be cached as merged nor may its branch be deleted yet
+    return tryEnqueuePr(pr);
   }
 
   const url = `repos/${

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -105,7 +105,6 @@ import type {
   GhAutomergeResponse,
   GhBranchStatus,
   GhEnqueuePullRequestResponse,
-  GhMergeQueueResponse,
   GhPr,
   GhRepo,
   GhRestPr,
@@ -913,42 +912,7 @@ export async function isBranchMergeQueueEnabled(
     return false;
   }
 
-  config.branchMergeQueueEnabled ??= {};
-
-  const cachedResult = config.branchMergeQueueEnabled[branchName];
-  if (cachedResult !== undefined) {
-    return cachedResult;
-  }
-
-  // Merge queues configured via classic branch protection are only visible
-  // through the GraphQL mergeQueue field, which also covers repository rulesets
-  const [owner, name] = (config.parentRepo ?? config.repository!).split('/');
-  let result = false;
-  try {
-    const res = await githubApi.requestGraphql<GhMergeQueueResponse>(
-      repoMergeQueueQuery,
-      {
-        variables: { owner, name, branch: branchName },
-        readOnly: true,
-        count: 1, // set count to one to bypass graphql check
-      },
-    );
-    if (res?.errors) {
-      // e.g. GitHub Enterprise Server versions without merge queue support
-      logger.once.debug(
-        { errors: res.errors },
-        'Merge queue detection: query failed',
-      );
-    } else {
-      result = isNonEmptyString(res?.data?.repository?.mergeQueue?.id);
-    }
-  } catch (err) {
-    logger.warn({ err }, 'Merge queue detection: request error');
-  }
-
-  logger.debug(`Branch ${branchName} has merge queue enabled: ${result}`);
-  config.branchMergeQueueEnabled[branchName] = result;
-  return result;
+  return isMergeQueueEnabled(branchName);
 }
 
 function handleBranchProtectionError(

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -122,6 +122,7 @@ export interface LocalRepoConfig {
   pushProtection: boolean;
   prReviewsRequired: boolean;
   branchForceRebase?: Record<string, boolean>;
+  branchMergeQueueEnabled?: Record<string, boolean>;
   parentRepo: string | null;
   forkOrg?: string;
   forkToken?: string;
@@ -169,6 +170,18 @@ export interface GhRepo {
 export interface GhAutomergeResponse {
   enablePullRequestAutoMerge: {
     pullRequest: { number: number };
+  };
+}
+
+export interface GhMergeQueueResponse {
+  repository: {
+    mergeQueue: { id: string } | null;
+  };
+}
+
+export interface GhEnqueuePullRequestResponse {
+  enqueuePullRequest: {
+    mergeQueueEntry: { id: string; position: number } | null;
   };
 }
 

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -122,7 +122,6 @@ export interface LocalRepoConfig {
   pushProtection: boolean;
   prReviewsRequired: boolean;
   branchForceRebase?: Record<string, boolean>;
-  branchMergeQueueEnabled?: Record<string, boolean>;
   parentRepo: string | null;
   forkOrg?: string;
   forkToken?: string;
@@ -170,12 +169,6 @@ export interface GhRepo {
 export interface GhAutomergeResponse {
   enablePullRequestAutoMerge: {
     pullRequest: { number: number };
-  };
-}
-
-export interface GhMergeQueueResponse {
-  repository: {
-    mergeQueue: { id: string } | null;
   };
 }
 

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -180,6 +180,7 @@ export interface MergePRConfig {
   branchName?: string;
   id: number;
   strategy?: MergeStrategy;
+  targetBranch?: string;
 }
 export interface EnsureCommentConfig {
   number: number;
@@ -272,6 +273,11 @@ export interface Platform {
   createPr(prConfig: CreatePRConfig): Promise<Pr | null>;
   getRepos(config?: AutodiscoverConfig): Promise<string[]>;
   getBranchForceRebase?(branchName: string): Promise<boolean>;
+  /**
+   * Returns true if the given branch is protected by a merge queue,
+   * so PRs targeting it must be merged through the queue.
+   */
+  isBranchMergeQueueEnabled?(branchName: string): Promise<boolean>;
   deleteLabel(number: number, label: string): Promise<void>;
   addLabel?(number: number, label: string): Promise<void>;
   setBranchStatus(branchStatusConfig: BranchStatusConfig): Promise<void>;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -278,6 +278,11 @@ export interface Platform {
    * so PRs targeting it must be merged through the queue.
    */
   isBranchMergeQueueEnabled?(branchName: string): Promise<boolean>;
+  /**
+   * Returns true if the PR is currently waiting in a merge queue, so it must
+   * not be enqueued or modified again.
+   */
+  isPrInMergeQueue?(number: number): Promise<boolean>;
   deleteLabel(number: number, label: string): Promise<void>;
   addLabel?(number: number, label: string): Promise<void>;
   setBranchStatus(branchStatusConfig: BranchStatusConfig): Promise<void>;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -180,7 +180,6 @@ export interface MergePRConfig {
   branchName?: string;
   id: number;
   strategy?: MergeStrategy;
-  targetBranch?: string;
 }
 export interface EnsureCommentConfig {
   number: number;

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -1,4 +1,4 @@
-import { partial, platform, scm } from '~test/util.ts';
+import { logger, partial, platform, scm } from '~test/util.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
 import type { RenovateConfig } from '../../../../config/types.ts';
 import type { Pr } from '../../../../modules/platform/types.ts';
@@ -58,6 +58,22 @@ describe('workers/repository/update/branch/automerge', () => {
       await expect(tryBranchAutomerge(config)).resolves.toBe(
         'automerge aborted - PR exists',
       );
+    });
+
+    it('aborts if the base branch has a merge queue', async () => {
+      config.automerge = true;
+      config.automergeType = 'branch';
+      config.baseBranch = 'test-branch';
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+
+      const res = await tryBranchAutomerge(config);
+
+      expect(res).toBe('automerge aborted - merge queue');
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { baseBranch: 'test-branch' },
+        'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead.',
+      );
+      expect(scm.mergeAndPush).toHaveBeenCalledTimes(0);
     });
 
     it('returns false if automerge fails', async () => {

--- a/lib/workers/repository/update/branch/automerge.ts
+++ b/lib/workers/repository/update/branch/automerge.ts
@@ -8,6 +8,7 @@ import { resolveBranchStatus } from './status-checks.ts';
 
 export type AutomergeResult =
   | 'automerged'
+  | 'automerge aborted - merge queue'
   | 'automerge aborted - PR exists'
   | 'branch status error'
   | 'failed'
@@ -32,6 +33,13 @@ export async function tryBranchAutomerge(
   );
   if (existingPr) {
     return 'automerge aborted - PR exists';
+  }
+  if (await platform.isBranchMergeQueueEnabled?.(config.baseBranch!)) {
+    logger.warn(
+      { baseBranch: config.baseBranch },
+      'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead.',
+    );
+    return 'automerge aborted - merge queue';
   }
   const branchStatus = await resolveBranchStatus(
     config.branchName!,

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -1328,6 +1328,36 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('raises a PR if branch automerge is aborted due to a merge queue', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>()],
+        }),
+      );
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>()],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      commit.commitFilesToBranch.mockResolvedValueOnce(null);
+      automerge.tryBranchAutomerge.mockResolvedValueOnce(
+        'automerge aborted - merge queue',
+      );
+      prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
+        prBlockedBy: 'AwaitingTests',
+      });
+
+      await branchWorker.processBranch(config);
+
+      expect(prWorker.ensurePr).toHaveBeenCalledWith(
+        expect.objectContaining({
+          forcePr: true,
+          branchAutomergeFailureMessage: 'automerge aborted - merge queue',
+        }),
+      );
+    });
+
     it('returns if branch automerge is pending', async () => {
       expect.assertions(2);
       const setArtifactErrorStatus = vi.spyOn(

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -913,6 +913,7 @@ export async function processBranch(
         config.branchAutomergeFailureMessage = mergeStatus;
       }
       if (
+        mergeStatus === 'automerge aborted - merge queue' ||
         mergeStatus === 'automerge aborted - PR exists' ||
         mergeStatus === 'branch status error' ||
         mergeStatus === 'failed'

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -263,6 +263,44 @@ describe('workers/repository/update/branch/reuse', () => {
       expect(result.rebaseWhen).toBe('conflicted');
     });
 
+    it('converts rebaseWhen=auto to conflicted if the base branch has a merge queue', async () => {
+      config.rebaseWhen = 'auto';
+      config.automerge = true;
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      scm.branchExists.mockResolvedValueOnce(true);
+
+      const result = await shouldReuseExistingBranch(config);
+
+      expect(config.rebaseWhen).toBe('auto');
+      expect(result.rebaseWhen).toBe('conflicted');
+    });
+
+    it('converts rebaseWhen=auto to behind-base-branch if keepUpdatedLabel although the base branch has a merge queue', async () => {
+      config.rebaseWhen = 'auto';
+      config.keepUpdatedLabel = 'keep-updated';
+      platform.isBranchMergeQueueEnabled.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValue(pr);
+      scm.branchExists.mockResolvedValueOnce(true);
+      scm.isBranchBehindBase.mockResolvedValueOnce(false);
+
+      const result = await shouldReuseExistingBranch(config);
+
+      expect(config.rebaseWhen).toBe('auto');
+      expect(result.rebaseWhen).toBe('behind-base-branch');
+    });
+
+    it('converts rebaseWhen=automerging to conflicted if the base branch has a merge queue', async () => {
+      config.rebaseWhen = 'automerging';
+      config.automerge = true;
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      scm.branchExists.mockResolvedValueOnce(true);
+
+      const result = await shouldReuseExistingBranch(config);
+
+      expect(config.rebaseWhen).toBe('automerging');
+      expect(result.rebaseWhen).toBe('conflicted');
+    });
+
     it('converts rebaseWhen=automerging to behind-base-branch', async () => {
       config.rebaseWhen = 'automerging';
       config.automerge = true;

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -125,10 +125,15 @@ async function determineRebaseWhenValue(
   if (result.rebaseWhen === 'auto' || result.rebaseWhen === 'automerging') {
     let reason;
     let newValue = 'behind-base-branch';
-    if (result.automerge === true) {
-      reason = 'automerge=true';
-    } else if (keepUpdated) {
+    if (keepUpdated) {
       reason = 'keep-updated label is set';
+    } else if (await platform.isBranchMergeQueueEnabled?.(result.baseBranch)) {
+      // The merge queue tests each PR against the base branch head, so
+      // rebasing when behind the base branch is unnecessary
+      newValue = 'conflicted';
+      reason = 'base branch has a merge queue';
+    } else if (result.automerge === true) {
+      reason = 'automerge=true';
     } else if (result.rebaseWhen === 'automerging') {
       newValue = 'never';
       reason = 'no keep-updated label and automerging is set';

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -80,6 +80,22 @@ describe('workers/repository/update/pr/automerge', () => {
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
     });
 
+    it('should skip branch deletion if the PR was added to a merge queue', async () => {
+      config.automerge = true;
+      config.pruneBranchAfterAutomerge = true;
+      platform.getBranchStatus.mockResolvedValueOnce('green');
+      platform.mergePr.mockResolvedValueOnce(true);
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+
+      const res = await prAutomerge.checkAutoMerge(pr, config);
+
+      expect(res).toEqual({ automerged: true, branchRemoved: false });
+      expect(platform.mergePr).toHaveBeenCalledWith(
+        expect.objectContaining({ targetBranch: 'base-branch' }),
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
+    });
+
     it('should skip branch deletion after automerge if prune is disabled', async () => {
       config.automerge = true;
       config.pruneBranchAfterAutomerge = false;

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -94,9 +94,7 @@ describe('workers/repository/update/pr/automerge', () => {
         automerged: false,
         prAutomergeBlockReason: 'InMergeQueue',
       });
-      expect(platform.mergePr).toHaveBeenCalledWith(
-        expect.objectContaining({ targetBranch: 'base-branch' }),
-      );
+      expect(platform.mergePr).toHaveBeenCalledOnce();
       expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
     });
 

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -80,20 +80,40 @@ describe('workers/repository/update/pr/automerge', () => {
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
     });
 
-    it('should skip branch deletion if the PR was added to a merge queue', async () => {
+    it('should not report automerged if the PR was added to a merge queue', async () => {
       config.automerge = true;
       config.pruneBranchAfterAutomerge = true;
       platform.getBranchStatus.mockResolvedValueOnce('green');
       platform.mergePr.mockResolvedValueOnce(true);
       platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      platform.isPrInMergeQueue.mockResolvedValueOnce(false);
 
       const res = await prAutomerge.checkAutoMerge(pr, config);
 
-      expect(res).toEqual({ automerged: true, branchRemoved: false });
+      expect(res).toEqual({
+        automerged: false,
+        prAutomergeBlockReason: 'InMergeQueue',
+      });
       expect(platform.mergePr).toHaveBeenCalledWith(
         expect.objectContaining({ targetBranch: 'base-branch' }),
       );
       expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should skip a PR which is already in the merge queue', async () => {
+      config.automerge = true;
+      pr = partial<Pr>({ number: 123 });
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      platform.isPrInMergeQueue.mockResolvedValueOnce(true);
+
+      const res = await prAutomerge.checkAutoMerge(pr, config);
+
+      expect(res).toEqual({
+        automerged: false,
+        prAutomergeBlockReason: 'InMergeQueue',
+      });
+      expect(platform.isPrInMergeQueue).toHaveBeenCalledWith(123);
+      expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });
 
     it('should skip branch deletion after automerge if prune is disabled', async () => {

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -137,8 +137,18 @@ export async function checkAutoMerge(
     branchName,
     id: pr.number,
     strategy: automergeStrategy,
+    targetBranch: baseBranch,
   });
   if (res) {
+    if (await platform.isBranchMergeQueueEnabled?.(baseBranch)) {
+      logger.info(
+        { pr: pr.number, prTitle: pr.title },
+        'PR added to the merge queue',
+      );
+      // The PR is not merged yet - deleting the branch would close the PR
+      // and drop the merge queue entry
+      return { automerged: true, branchRemoved: false };
+    }
     logger.info({ pr: pr.number, prTitle: pr.title }, 'PR automerged');
     if (!pruneBranchAfterAutomerge) {
       logger.info('Skipping pruning of merged branch');

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -147,7 +147,6 @@ export async function checkAutoMerge(
     branchName,
     id: pr.number,
     strategy: automergeStrategy,
-    targetBranch: baseBranch,
   });
   if (res) {
     if (mergeQueueEnabled) {

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -17,6 +17,7 @@ export type PrAutomergeBlockReason =
   | 'BranchNotGreen'
   | 'Conflicted'
   | 'DryRun'
+  | 'InMergeQueue'
   | 'PlatformNotReady'
   | 'PlatformRejection'
   | 'off schedule';
@@ -48,6 +49,15 @@ export async function checkAutoMerge(
     return {
       automerged: false,
       prAutomergeBlockReason: 'off schedule',
+    };
+  }
+  const mergeQueueEnabled =
+    await platform.isBranchMergeQueueEnabled?.(baseBranch);
+  if (mergeQueueEnabled && (await platform.isPrInMergeQueue?.(pr.number))) {
+    logger.debug(`PR #${pr.number} is already in the merge queue`);
+    return {
+      automerged: false,
+      prAutomergeBlockReason: 'InMergeQueue',
     };
   }
   const isConflicted =
@@ -140,14 +150,18 @@ export async function checkAutoMerge(
     targetBranch: baseBranch,
   });
   if (res) {
-    if (await platform.isBranchMergeQueueEnabled?.(baseBranch)) {
+    if (mergeQueueEnabled) {
       logger.info(
         { pr: pr.number, prTitle: pr.title },
         'PR added to the merge queue',
       );
-      // The PR is not merged yet - deleting the branch would close the PR
-      // and drop the merge queue entry
-      return { automerged: true, branchRemoved: false };
+      // The PR is not merged yet and the base branch is unchanged, so this is
+      // not reported as automerged. Deleting the branch would close the PR
+      // and drop the merge queue entry.
+      return {
+        automerged: false,
+        prAutomergeBlockReason: 'InMergeQueue',
+      };
     }
     logger.info({ pr: pr.number, prTitle: pr.title }, 'PR automerged');
     if (!pruneBranchAfterAutomerge) {

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -762,6 +762,32 @@ describe('workers/repository/update/pr/index', () => {
         });
       });
 
+      it('comments on automerge failure due to merge queue', async () => {
+        platform.createPr.mockResolvedValueOnce(pr);
+        checks.resolveBranchStatus.mockResolvedValueOnce('red');
+        platform.massageMarkdown.mockReturnValueOnce('markdown content');
+
+        await ensurePr({
+          ...config,
+          automerge: true,
+          automergeType: 'branch',
+          branchAutomergeFailureMessage: 'automerge aborted - merge queue',
+          suppressNotifications: [],
+        });
+
+        expect(platform.massageMarkdown).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'The base branch has a merge queue, so branch automerge is not possible. Please set `automergeType=pr` instead.',
+          ),
+          undefined,
+        );
+        expect(comment.ensureComment).toHaveBeenCalledExactlyOnceWith({
+          content: 'markdown content',
+          number: 123,
+          topic: 'Branch automerge failure',
+        });
+      });
+
       it('handles ensureComment error', async () => {
         platform.createPr.mockResolvedValueOnce(pr);
         checks.resolveBranchStatus.mockResolvedValueOnce('red');

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -597,6 +597,13 @@ export async function ensurePr(
       if (config.branchAutomergeFailureMessage === 'branch status error') {
         content += '\n___\n * Branch has one or more failed status checks';
       }
+      if (
+        config.branchAutomergeFailureMessage ===
+        'automerge aborted - merge queue'
+      ) {
+        content +=
+          '\n___\n * The base branch has a merge queue, so branch automerge is not possible. Please set `automergeType=pr` instead.';
+      }
       content = platform.massageMarkdown(content, config.rebaseLabel);
       logger.debug('Adding branch automerge failure message to PR');
       if (GlobalConfig.get('dryRun')) {


### PR DESCRIPTION
## Changes

Adds support for merging PRs through a GitHub merge queue when `platformAutomerge=false`. Detection is always on; there is no experimental flag.

Today, merge queues only work with GitHub's own auto-merge (`platformAutomerge=true`), which requires the "Allow auto-merge" repository setting. With the flag set, Renovate detects whether the base branch has a merge queue (via the GraphQL `mergeQueue` field, which covers both classic branch protection and repository rulesets) and then:

- **Renovate-native PR automerge** adds the PR to the merge queue via the `enqueuePullRequest` mutation instead of merging directly, even if Renovate is on the queue's bypass list. The PR is not cached as merged and its branch is not deleted, since the queue merges it later.
- **PRs already waiting in the queue** are left untouched on later runs (checked through the existing `isPrInMergeQueue` query from #45252). Enqueuing is not reported as an automerge, because the base branch has not changed yet, so no repository restart is triggered and the remaining branches are still processed.
- **Branch automerge** (`automergeType=branch`) is skipped with a warning and a PR is created instead, because pushing directly to the base branch is not possible. The PR body explains the misconfiguration.
- **`rebaseWhen=auto`** resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests each PR against the head of the base branch.

Implementation details:

- New optional `Platform.isBranchMergeQueueEnabled(branchName)` and `Platform.isPrInMergeQueue(number)` APIs, implemented for GitHub only. Branch results are cached per branch.
- `mergePr` reads the base branch from the cached PR to decide whether to enqueue, so `MergePRConfig` is unchanged. The PR comes from the PR cache, which is already populated by the time automerge runs.
- Merge queue detection is the `isMergeQueueEnabled` function from #45252, renamed to `isBranchMergeQueueEnabled` and exported as the platform method (same per-branch cache, default branch result seeded by `initRepo`, GHES <3.12 guard, fails open on query errors).
- Detection failures (e.g. GHES without merge queue support) fall back to `false`, so existing behaviour is unchanged.

Docs updated in `docs/usage/key-concepts/automerge.md` and `docs/usage/configuration-options.md`.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #31525
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Fable 5.1) was used to write parts of the code, tests and docs, to rebase the branch onto `main` and resolve the conflict with #45252, and to draft this PR description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

