### PR TITLE
feat(gitlab): merge MRs through merge trains via the platform merge queue API

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -338,6 +338,8 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 - Automerge the branch commit if it's: (a) up-to-date with the base branch, and (b) passing all tests
 - As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 25 hours, see [`prNotPendingHours`](#prnotpendinghours))
 
+Note that `"automergeType": "branch"` is not compatible with GitHub merge queues, because the merge queue does not allow pushing directly to the base branch.
+
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.
 
@@ -4603,7 +4605,7 @@ By default this label is `"rebase"` but you can configure it to anything you wan
 
 Possible values and meanings:
 
-- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead
+- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the experimental environment variable `RENOVATE_X_GITHUB_MERGE_QUEUE` is set and the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
 - `automerging`: Renovate will use `behind-base-branch` if configured to automerge, Otherwise, `never` will be used instead
 - `never`: Renovate will never rebase the branch or update it unless manually requested
 - `conflicted`: Renovate will rebase only if the branch is conflicted

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -338,7 +338,7 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 - Automerge the branch commit if it's: (a) up-to-date with the base branch, and (b) passing all tests
 - As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 25 hours, see [`prNotPendingHours`](#prnotpendinghours))
 
-Note that `"automergeType": "branch"` is not compatible with GitHub merge queues, because the merge queue does not allow pushing directly to the base branch.
+Note that `"automergeType": "branch"` is not compatible with GitHub merge queues or GitLab merge trains, because the merge queue does not allow pushing directly to the base branch.
 
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.
@@ -4605,7 +4605,7 @@ By default this label is `"rebase"` but you can configure it to anything you wan
 
 Possible values and meanings:
 
-- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the experimental environment variable `RENOVATE_X_GITHUB_MERGE_QUEUE` is set and the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
+- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the experimental environment variable `RENOVATE_X_GITHUB_MERGE_QUEUE` is set and the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch. The same applies on GitLab if merge trains are enabled on the project
 - `automerging`: Renovate will use `behind-base-branch` if configured to automerge, Otherwise, `never` will be used instead
 - `never`: Renovate will never rebase the branch or update it unless manually requested
 - `conflicted`: Renovate will rebase only if the branch is conflicted

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4605,7 +4605,7 @@ By default this label is `"rebase"` but you can configure it to anything you wan
 
 Possible values and meanings:
 
-- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the experimental environment variable `RENOVATE_X_GITHUB_MERGE_QUEUE` is set and the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
+- `auto`: Renovate will autodetect the best setting. It will use `behind-base-branch` if configured to automerge or repository has been set to require PRs to be up to date. Otherwise, `conflicted` will be used instead. On GitHub, if the base branch has a merge queue, `conflicted` is used because the merge queue already tests PRs against the head of the base branch
 - `automerging`: Renovate will use `behind-base-branch` if configured to automerge, Otherwise, `never` will be used instead
 - `never`: Renovate will never rebase the branch or update it unless manually requested
 - `conflicted`: Renovate will rebase only if the branch is conflicted

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -133,6 +133,19 @@ Read the [GitHub Docs, managing a merge queue](https://docs.github.com/en/reposi
 
 The steps to enable GitHub's Merge Queue differ based on whether you use GitHub Actions or another CI provider.
 
+By default, merge queues need `platformAutomerge` enabled (which is the default), because GitHub's auto-merge takes care of adding the PR to the merge queue.
+This requires the "Allow auto-merge" checkbox in the repository settings to be enabled, as described in the steps below.
+
+If you self-host Renovate and set the experimental environment variable [`RENOVATE_X_GITHUB_MERGE_QUEUE`](../self-hosted-experimental.md#renovate_x_github_merge_queue), merge queues also work with `platformAutomerge=false`: Renovate then adds the PR to the merge queue itself once all checks have passed.
+In that case the "Allow auto-merge" checkbox is not needed.
+We recommend enabling the "Automatically delete head branches" repository setting, so branches get cleaned up after the merge queue merges the PR.
+
+<!-- prettier-ignore -->
+!!! warning
+  Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
+  With `RENOVATE_X_GITHUB_MERGE_QUEUE` set, Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
+  Configure `automergeType=pr` in such repositories.
+
 !!! tip "GitHub Merge Queue overview page"
   GitHub has a page that shows all the PRs in the Merge Queue.
   The page link follows this pattern: `https://github.com/organization-name/repository-name/queue/base-branch-name`.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -194,6 +194,21 @@ Confirm you've set the correct "required checks" for your base branch.
 
 Finally, allow Renovate to automerge by setting `automerge=true` in your Renovate config file (see earlier example).
 
+### GitLab Merge Trains
+
+Renovate supports GitLab's [merge trains](https://docs.gitlab.com/ci/pipelines/merge_trains/).
+Renovate detects whether merge trains are enabled on the project and then:
+
+- With `platformAutomerge` enabled (the default), Renovate asks GitLab to add the MR to the merge train once its pipeline succeeds. This requires GitLab 17.11 or later.
+- With `platformAutomerge=false`, Renovate adds the MR to the merge train itself once all checks have passed, instead of merging it directly.
+- `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge train already tests MRs against the head of the target branch.
+
+<!-- prettier-ignore -->
+!!! warning
+  Branch automerge (`automergeType=branch`) cannot work if merge trains are enabled, because pushing directly to the target branch is not possible.
+  Renovate detects this misconfiguration, logs a warning, and creates a MR instead.
+  Configure `automergeType=pr` in such projects.
+
 ## Automerging and scheduling
 
 Automerging is particularly beneficial if you have configured a schedule, because Renovate on its own may be able to automerge the majority of your updates.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -141,7 +141,6 @@ In that case the "Allow auto-merge" checkbox is not needed.
 PRs that are already waiting in the merge queue are left untouched on later runs.
 We recommend enabling the "Automatically delete head branches" repository setting, so branches get cleaned up after the merge queue merges the PR.
 
-<!-- prettier-ignore -->
 !!! warning
   Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
   Renovate detects this misconfiguration, logs a warning, and creates a PR instead.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -133,17 +133,18 @@ Read the [GitHub Docs, managing a merge queue](https://docs.github.com/en/reposi
 
 The steps to enable GitHub's Merge Queue differ based on whether you use GitHub Actions or another CI provider.
 
-By default, merge queues need `platformAutomerge` enabled (which is the default), because GitHub's auto-merge takes care of adding the PR to the merge queue.
+With `platformAutomerge` enabled (which is the default), GitHub's auto-merge takes care of adding the PR to the merge queue.
 This requires the "Allow auto-merge" checkbox in the repository settings to be enabled, as described in the steps below.
 
-If you self-host Renovate and set the experimental environment variable [`RENOVATE_X_GITHUB_MERGE_QUEUE`](../self-hosted-experimental.md#renovate_x_github_merge_queue), merge queues also work with `platformAutomerge=false`: Renovate then adds the PR to the merge queue itself once all checks have passed.
+Merge queues also work with `platformAutomerge=false`: Renovate detects whether the base branch has a merge queue, configured via classic branch protection or repository rulesets, and adds the PR to the merge queue itself once all checks have passed.
 In that case the "Allow auto-merge" checkbox is not needed.
+PRs that are already waiting in the merge queue are left untouched on later runs.
 We recommend enabling the "Automatically delete head branches" repository setting, so branches get cleaned up after the merge queue merges the PR.
 
 <!-- prettier-ignore -->
 !!! warning
   Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
-  With `RENOVATE_X_GITHUB_MERGE_QUEUE` set, Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
+  Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
   Configure `automergeType=pr` in such repositories.
 
 !!! tip "GitHub Merge Queue overview page"

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -204,7 +204,6 @@ Renovate detects whether merge trains are enabled on the project and then:
 - With `platformAutomerge=false`, Renovate adds the MR to the merge train itself once all checks have passed, instead of merging it directly.
 - `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge train already tests MRs against the head of the target branch.
 
-<!-- prettier-ignore -->
 !!! warning
   Branch automerge (`automergeType=branch`) cannot work if merge trains are enabled, because pushing directly to the target branch is not possible.
   Renovate detects this misconfiguration, logs a warning, and creates a MR instead.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -57,6 +57,15 @@ If set to `"true"`, a config error Issue will be raised in case repository confi
 
 If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.
 
+## `RENOVATE_X_GITHUB_MERGE_QUEUE`
+
+If set to any value, Renovate will detect if a GitHub merge queue is required for the base branch, whether configured via classic branch protection or repository rulesets.
+If a merge queue is detected, then:
+
+- Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
+- branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
+- `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
+
 ## `RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN`
 
 If set, when `autoApprove` is enabled, the provided token is used to authenticate GitLab approve requests instead of the default one.

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -63,6 +63,7 @@ If set to any value, Renovate will detect if a GitHub merge queue is required fo
 If a merge queue is detected, then:
 
 - Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
+- PRs that are already waiting in the merge queue are left untouched on later runs
 - branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
 - `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -57,16 +57,6 @@ If set to `"true"`, a config error Issue will be raised in case repository confi
 
 If set, Renovate will terminate the whole process group of a terminated child process spawned by Renovate.
 
-## `RENOVATE_X_GITHUB_MERGE_QUEUE`
-
-If set to any value, Renovate will detect if a GitHub merge queue is required for the base branch, whether configured via classic branch protection or repository rulesets.
-If a merge queue is detected, then:
-
-- Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
-- PRs that are already waiting in the merge queue are left untouched on later runs
-- branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
-- `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
-
 ## `RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN`
 
 If set, when `autoApprove` is enabled, the provided token is used to authenticate GitLab approve requests instead of the default one.

--- a/lib/modules/platform/github/graphql.ts
+++ b/lib/modules/platform/github/graphql.ts
@@ -90,6 +90,23 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 `;
 
+export const enqueuePullRequestMutation = `
+mutation EnqueuePullRequest(
+  $pullRequestId: ID!,
+) {
+  enqueuePullRequest(
+    input: {
+      pullRequestId: $pullRequestId,
+    }
+  ) {
+    mergeQueueEntry {
+      id
+      position
+    }
+  }
+}
+`;
+
 export const enableAutoMergeMutation = `
 mutation EnablePullRequestAutoMerge(
   $pullRequestId: ID!,

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1635,15 +1635,15 @@ describe('modules/platform/github/index', () => {
 
   describe('isBranchMergeQueueEnabled', () => {
     beforeEach(() => {
-      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
     });
 
     afterEach(() => {
-      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
     });
 
     it('should return false if the experimental flag is not set', async () => {
-      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
 
       const res = await github.isBranchMergeQueueEnabled('main');
 
@@ -5668,11 +5668,11 @@ describe('modules/platform/github/index', () => {
     };
 
     beforeEach(() => {
-      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
     });
 
     afterEach(() => {
-      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
     });
 
     function mergeQueueMock(
@@ -5725,7 +5725,7 @@ describe('modules/platform/github/index', () => {
         },
       ]);
       // The PR is not merged yet, so it must not be cached as merged
-      expect(await github.getPr(1234)).toMatchObject({
+      await expect(github.getPr(1234)).resolves.toMatchObject({
         number: 1234,
         state: 'open',
       });

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1633,6 +1633,99 @@ describe('modules/platform/github/index', () => {
     });
   });
 
+  describe('isBranchMergeQueueEnabled', () => {
+    beforeEach(() => {
+      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+    });
+
+    it('should return false if the experimental flag is not set', async () => {
+      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return true if the branch has a merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue: { id: 'MQ_kwDOBJLedM0dmQ' } } },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeTrue();
+    });
+
+    it('should return false if the branch has no merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue: null } },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return cached result on subsequent calls', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue: { id: 'MQ_kwDOBJLedM0dmQ' } } },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      // First call should make the HTTP request and cache the result
+      const firstResult = await github.isBranchMergeQueueEnabled('main');
+      // Second call should return cached result without making HTTP request
+      const secondResult = await github.isBranchMergeQueueEnabled('main');
+
+      expect(firstResult).toBeTrue();
+      expect(secondResult).toBeTrue();
+    });
+
+    it('should return false if the query returns errors', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        errors: [
+          {
+            message: "Field 'mergeQueue' doesn't exist on type 'Repository'",
+          },
+        ],
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return false on request error', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').replyWithError('unknown error');
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('main');
+
+      expect(res).toBeFalse();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Merge queue detection: request error',
+      );
+    });
+  });
+
   describe('getPrList()', () => {
     const t = DateTime.fromISO('2000-01-01T00:00:00.000+00:00');
     const t1 = t.plus({ minutes: 1 }).toISO()!;
@@ -5561,6 +5654,198 @@ describe('modules/platform/github/index', () => {
         },
         'mergePr',
       );
+    });
+  });
+
+  describe('mergePr(prNo) - merge queue', () => {
+    const pullsListItem = {
+      number: 1234,
+      node_id: 'abcd',
+      head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+      state: 'open',
+      title: 'Some PR',
+      updated_at: '01-09-2022',
+    };
+
+    beforeEach(() => {
+      process.env.RENOVATE_X_GITHUB_MERGE_QUEUE = 'true';
+    });
+
+    afterEach(() => {
+      delete process.env.RENOVATE_X_GITHUB_MERGE_QUEUE;
+    });
+
+    function mergeQueueMock(
+      scope: httpMock.Scope,
+      mergeQueue: { id: string } | null,
+    ): void {
+      initRepoMock(scope, 'some/repo');
+      scope.post('/graphql').reply(200, {
+        data: { repository: { mergeQueue } },
+      });
+    }
+
+    it('should add PR to the merge queue instead of merging', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .reply(200, {
+          data: {
+            enqueuePullRequest: {
+              mergeQueueEntry: { id: 'MQE_1', position: 1 },
+            },
+          },
+        });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeTrue();
+      expect(httpMock.getTrace()).toMatchObject([
+        { url: 'https://api.github.com/graphql' },
+        { url: 'https://api.github.com/graphql' },
+        {
+          url: 'https://api.github.com/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        },
+        {
+          url: 'https://api.github.com/graphql',
+          graphql: {
+            mutation: { enqueuePullRequest: {} },
+            variables: { pullRequestId: 'abcd' },
+          },
+        },
+      ]);
+      // The PR is not merged yet, so it must not be cached as merged
+      expect(await github.getPr(1234)).toMatchObject({
+        number: 1234,
+        state: 'open',
+      });
+    });
+
+    it('should return true if the PR is already in the merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .reply(200, {
+          errors: [
+            {
+              type: 'UNPROCESSABLE',
+              message: 'The pull request is already enqueued',
+            },
+          ],
+        });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeTrue();
+    });
+
+    it('should return false if adding to the merge queue fails', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .reply(200, {
+          errors: [
+            {
+              type: 'UNPROCESSABLE',
+              message: 'Pull request is in unstable status',
+            },
+          ],
+        });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeFalse();
+    });
+
+    it('should return false on merge queue request error', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .post('/graphql')
+        .replyWithError('unknown error');
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeFalse();
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { prNumber: 1234, err: expect.any(Error) },
+        'Failed to add PR to the merge queue',
+      );
+    });
+
+    it('should return false if the PR cannot be found', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [])
+        .get('/repos/some/repo/pulls/1234')
+        .reply(404);
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeFalse();
+    });
+
+    it('should merge directly if the branch has no merge queue', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      mergeQueueMock(scope, null);
+      scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.mergePr({
+        id: 1234,
+        branchName: 'somebranch',
+        targetBranch: 'main',
+      });
+
+      expect(res).toBeTrue();
     });
   });
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -853,6 +853,22 @@ describe('modules/platform/github/index', () => {
     });
   }
 
+  function prListMock(scope: httpMock.Scope, prNo: number): void {
+    scope
+      .get(
+        '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+      )
+      .reply(200, [
+        {
+          number: prNo,
+          base: { ref: 'master' },
+          head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+          state: 'open',
+          title: 'Some PR',
+        },
+      ]);
+  }
+
   function forkInitRepoMock(
     scope: httpMock.Scope,
     repository: string,
@@ -1634,22 +1650,6 @@ describe('modules/platform/github/index', () => {
   });
 
   describe('isBranchMergeQueueEnabled', () => {
-    beforeEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
-    });
-
-    afterEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
-    });
-
-    it('should return false if the experimental flag is not set', async () => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
-
-      const res = await github.isBranchMergeQueueEnabled('main');
-
-      expect(res).toBeFalse();
-    });
-
     it('should return true if the branch has a merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
@@ -5576,6 +5576,7 @@ describe('modules/platform/github/index', () => {
     it('should handle merge error', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope
         .put('/repos/some/repo/pulls/1234/merge')
         .replyWithError('merge error');
@@ -5597,6 +5598,7 @@ describe('modules/platform/github/index', () => {
     it('should handle merge block', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope
         .put('/repos/some/repo/pulls/1234/merge')
         .reply(405, { message: 'Required status check "build" is expected.' });
@@ -5623,6 +5625,7 @@ describe('modules/platform/github/index', () => {
     ])('should handle approvers required: %j', async (message) => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope.put('/repos/some/repo/pulls/1234/merge').reply(405, {
         message,
       });
@@ -5645,6 +5648,7 @@ describe('modules/platform/github/index', () => {
     it('should warn if automergeStrategy is not supported', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
@@ -5664,6 +5668,7 @@ describe('modules/platform/github/index', () => {
     it('should use configured automergeStrategy', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1234);
       scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
@@ -5697,14 +5702,6 @@ describe('modules/platform/github/index', () => {
       title: 'Some PR',
       updated_at: '01-09-2022',
     };
-
-    beforeEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', 'true');
-    });
-
-    afterEach(() => {
-      vi.stubEnv('RENOVATE_X_GITHUB_MERGE_QUEUE', undefined);
-    });
 
     function mergeQueueMock(
       scope: httpMock.Scope,
@@ -5938,6 +5935,7 @@ describe('modules/platform/github/index', () => {
     it('should try squash first', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1235);
       scope.put('/repos/some/repo/pulls/1235/merge').reply(200);
       await github.initRepo({ repository: 'some/repo' });
       const pr = {
@@ -5957,6 +5955,7 @@ describe('modules/platform/github/index', () => {
     it('should try merge after squash', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1236);
       scope
         .put('/repos/some/repo/pulls/1236/merge')
         .reply(400, 'no squashing allowed');
@@ -5978,6 +5977,7 @@ describe('modules/platform/github/index', () => {
     it('should try rebase after merge', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1237);
       scope
         .put('/repos/some/repo/pulls/1237/merge')
         .reply(405, 'no squashing allowed')
@@ -6003,6 +6003,7 @@ describe('modules/platform/github/index', () => {
     it('should give up', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
+      prListMock(scope, 1237);
       scope
         .put('/repos/some/repo/pulls/1237/merge')
         .reply(405, 'no squashing allowed')

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1693,7 +1693,19 @@ describe('modules/platform/github/index', () => {
       expect(secondResult).toBeTrue();
     });
 
-    it('should return false if the query returns errors', async () => {
+    it('should reuse the default branch result from initRepo', async () => {
+      const scope = httpMock.scope(githubApiHost);
+      initRepoMock(scope, 'some/repo', {
+        mergeQueue: { id: 'MQ_kwDOBJLedM0dmQ' },
+      });
+      await github.initRepo({ repository: 'some/repo' });
+
+      const res = await github.isBranchMergeQueueEnabled('master');
+
+      expect(res).toBeTrue();
+    });
+
+    it('should assume a merge queue if the query returns errors', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope.post('/graphql').reply(200, {
@@ -1707,10 +1719,10 @@ describe('modules/platform/github/index', () => {
 
       const res = await github.isBranchMergeQueueEnabled('main');
 
-      expect(res).toBeFalse();
+      expect(res).toBeTrue();
     });
 
-    it('should return false on request error', async () => {
+    it('should assume a merge queue on request error', async () => {
       const scope = httpMock.scope(githubApiHost);
       initRepoMock(scope, 'some/repo');
       scope.post('/graphql').replyWithError('unknown error');
@@ -1718,11 +1730,7 @@ describe('modules/platform/github/index', () => {
 
       const res = await github.isBranchMergeQueueEnabled('main');
 
-      expect(res).toBeFalse();
-      expect(logger.logger.warn).toHaveBeenCalledWith(
-        { err: expect.any(Error) },
-        'Merge queue detection: request error',
-      );
+      expect(res).toBeTrue();
     });
   });
 

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -5692,6 +5692,7 @@ describe('modules/platform/github/index', () => {
       number: 1234,
       node_id: 'abcd',
       head: { ref: 'somebranch', repo: { full_name: 'some/repo' } },
+      base: { ref: 'main' },
       state: 'open',
       title: 'Some PR',
       updated_at: '01-09-2022',
@@ -5736,16 +5737,15 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeTrue();
       expect(httpMock.getTrace()).toMatchObject([
         { url: 'https://api.github.com/graphql' },
-        { url: 'https://api.github.com/graphql' },
         {
           url: 'https://api.github.com/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
         },
+        { url: 'https://api.github.com/graphql' },
         {
           url: 'https://api.github.com/graphql',
           graphql: {
@@ -5783,7 +5783,6 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeTrue();
@@ -5811,7 +5810,6 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeFalse();
@@ -5832,7 +5830,6 @@ describe('modules/platform/github/index', () => {
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeFalse();
@@ -5842,37 +5839,43 @@ describe('modules/platform/github/index', () => {
       );
     });
 
-    it('should return false if the PR cannot be found', async () => {
+    it('should merge directly if the PR cannot be found', async () => {
       const scope = httpMock.scope(githubApiHost);
-      mergeQueueMock(scope, { id: 'MQ_kwDOBJLedM0dmQ' });
+      initRepoMock(scope, 'some/repo');
       scope
         .get(
           '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
         )
         .reply(200, [])
         .get('/repos/some/repo/pulls/1234')
-        .reply(404);
+        .reply(404)
+        .put('/repos/some/repo/pulls/1234/merge')
+        .reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
-      expect(res).toBeFalse();
+      expect(res).toBeTrue();
     });
 
     it('should merge directly if the branch has no merge queue', async () => {
       const scope = httpMock.scope(githubApiHost);
       mergeQueueMock(scope, null);
-      scope.put('/repos/some/repo/pulls/1234/merge').reply(200);
+      scope
+        .get(
+          '/repos/some/repo/pulls?per_page=100&state=all&sort=updated&direction=desc&page=1',
+        )
+        .reply(200, [pullsListItem])
+        .put('/repos/some/repo/pulls/1234/merge')
+        .reply(200);
       await github.initRepo({ repository: 'some/repo' });
 
       const res = await github.mergePr({
         id: 1234,
         branchName: 'somebranch',
-        targetBranch: 'main',
       });
 
       expect(res).toBeTrue();

--- a/lib/modules/platform/github/index.spec.ts
+++ b/lib/modules/platform/github/index.spec.ts
@@ -1726,6 +1726,28 @@ describe('modules/platform/github/index', () => {
     });
   });
 
+  describe('isPrInMergeQueue', () => {
+    it.each`
+      isInMergeQueue
+      ${true}
+      ${false}
+    `(
+      'returns $isInMergeQueue from the pull request merge queue status',
+      async ({ isInMergeQueue }) => {
+        const scope = httpMock.scope(githubApiHost);
+        initRepoMock(scope, 'some/repo');
+        await github.initRepo({ repository: 'some/repo' });
+        scope.post('/graphql').reply(200, {
+          data: { repository: { pullRequest: { isInMergeQueue } } },
+        });
+
+        const res = await github.isPrInMergeQueue(1234);
+
+        expect(res).toBe(isInMergeQueue);
+      },
+    );
+  });
+
   describe('getPrList()', () => {
     const t = DateTime.fromISO('2000-01-01T00:00:00.000+00:00');
     const t1 = t.plus({ minutes: 1 }).toISO()!;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -80,6 +80,7 @@ import { remoteBranchExists } from './branch.ts';
 import { coerceRestPr, githubApi, mapMergeStartegy } from './common.ts';
 import {
   enableAutoMergeMutation,
+  enqueuePullRequestMutation,
   getIssuesQuery,
   repoInfoQuery,
   repoMergeQueueQuery,
@@ -99,6 +100,8 @@ import type {
   Comment,
   GhAutomergeResponse,
   GhBranchStatus,
+  GhEnqueuePullRequestResponse,
+  GhMergeQueueResponse,
   GhPr,
   GhRepo,
   GhRestPr,
@@ -897,6 +900,51 @@ export async function getBranchForceRebase(
   }
 
   return config.branchForceRebase[branchName];
+}
+
+export async function isBranchMergeQueueEnabled(
+  branchName: string,
+): Promise<boolean> {
+  if (!getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
+    return false;
+  }
+
+  config.branchMergeQueueEnabled ??= {};
+
+  const cachedResult = config.branchMergeQueueEnabled[branchName];
+  if (cachedResult !== undefined) {
+    return cachedResult;
+  }
+
+  // Merge queues configured via classic branch protection are only visible
+  // through the GraphQL mergeQueue field, which also covers repository rulesets
+  const [owner, name] = (config.parentRepo ?? config.repository!).split('/');
+  let result = false;
+  try {
+    const res = await githubApi.requestGraphql<GhMergeQueueResponse>(
+      repoMergeQueueQuery,
+      {
+        variables: { owner, name, branch: branchName },
+        readOnly: true,
+        count: 1, // set count to one to bypass graphql check
+      },
+    );
+    if (res?.errors) {
+      // e.g. GitHub Enterprise Server versions without merge queue support
+      logger.once.debug(
+        { errors: res.errors },
+        'Merge queue detection: query failed',
+      );
+    } else {
+      result = isNonEmptyString(res?.data?.repository?.mergeQueue?.id);
+    }
+  } catch (err) {
+    logger.warn({ err }, 'Merge queue detection: request error');
+  }
+
+  logger.debug(`Branch ${branchName} has merge queue enabled: ${result}`);
+  config.branchMergeQueueEnabled[branchName] = result;
+  return result;
 }
 
 function handleBranchProtectionError(
@@ -2165,12 +2213,60 @@ export async function reattemptPlatformAutomerge({
   }
 }
 
+async function tryEnqueuePr(prNo: number): Promise<boolean> {
+  const pr = await getPr(prNo);
+  if (!pr) {
+    logger.debug(`Could not find PR #${prNo} to add to the merge queue`);
+    return false;
+  }
+
+  try {
+    const res = await githubApi.requestGraphql<GhEnqueuePullRequestResponse>(
+      enqueuePullRequestMutation,
+      {
+        variables: { pullRequestId: pr.node_id },
+        count: 1, // set count to one to bypass graphql check
+      },
+    );
+
+    if (res?.errors) {
+      // GitHub does not document the exact message, so match loosely.
+      // "enqueue" contains "queue", so both wordings are covered.
+      if (
+        res.errors.some((error) => regEx(/already.*queue/i).test(error.message))
+      ) {
+        logger.debug(`PR #${prNo} is already in the merge queue`);
+        return true;
+      }
+      logger.debug(
+        { prNumber: prNo, errors: res.errors },
+        'Failed to add PR to the merge queue',
+      );
+      return false;
+    }
+
+    logger.debug(`PR #${prNo} added to the merge queue`);
+    return true;
+  } catch (err) {
+    logger.warn({ prNumber: prNo, err }, 'Failed to add PR to the merge queue');
+    return false;
+  }
+}
+
 export async function mergePr({
   branchName,
   id: prNo,
   strategy,
+  targetBranch,
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${prNo}, ${branchName})`);
+
+  if (targetBranch && (await isBranchMergeQueueEnabled(targetBranch))) {
+    // The PR is not merged directly but through the merge queue, so it must
+    // not be cached as merged nor may its branch be deleted yet
+    return tryEnqueuePr(prNo);
+  }
+
   const url = `repos/${
     config.parentRepo ?? config.repository
   }/pulls/${prNo}/merge`;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -87,7 +87,11 @@ import {
 } from './graphql.ts';
 import { GithubIssueCache } from './issue.ts';
 import { massageMarkdownLinks } from './massage-markdown-links.ts';
-import { getPrCache, isPrInMergeQueue, updatePrCache } from './pr.ts';
+import {
+  isPrInMergeQueue as checkPrInMergeQueue,
+  getPrCache,
+  updatePrCache,
+} from './pr.ts';
 import {
   GithubBranchProtection,
   GithubBranchRulesets,
@@ -2111,6 +2115,15 @@ async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
   return result;
 }
 
+export function isPrInMergeQueue(prNo: number): Promise<boolean> {
+  return checkPrInMergeQueue(
+    githubApi,
+    config.repositoryOwner,
+    config.repositoryName,
+    prNo,
+  );
+}
+
 export async function assertPrNotInMergeQueue(
   branchName: string,
   baseBranch?: string,
@@ -2124,14 +2137,7 @@ export async function assertPrNotInMergeQueue(
     return;
   }
 
-  if (
-    await isPrInMergeQueue(
-      githubApi,
-      config.repositoryOwner,
-      config.repositoryName,
-      pr.number,
-    )
-  ) {
+  if (await isPrInMergeQueue(pr.number)) {
     logger.debug(`PR #${pr.number} is in the merge queue - aborting push`);
     throw new Error(PR_ALREADY_IN_MERGE_QUEUE);
   }

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -2183,13 +2183,8 @@ export async function reattemptPlatformAutomerge({
   }
 }
 
-async function tryEnqueuePr(prNo: number): Promise<boolean> {
-  const pr = await getPr(prNo);
-  if (!pr) {
-    logger.debug(`Could not find PR #${prNo} to add to the merge queue`);
-    return false;
-  }
-
+async function tryEnqueuePr(pr: GhPr): Promise<boolean> {
+  const prNo = pr.number;
   try {
     const res = await githubApi.requestGraphql<GhEnqueuePullRequestResponse>(
       enqueuePullRequestMutation,
@@ -2227,14 +2222,21 @@ export async function mergePr({
   branchName,
   id: prNo,
   strategy,
-  targetBranch,
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${prNo}, ${branchName})`);
 
-  if (targetBranch && (await isBranchMergeQueueEnabled(targetBranch))) {
-    // The PR is not merged directly but through the merge queue, so it must
-    // not be cached as merged nor may its branch be deleted yet
-    return tryEnqueuePr(prNo);
+  // Only look up the PR when merge queues are enabled, so the direct merge
+  // path stays free of extra requests
+  if (getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
+    const pr = await getPr(prNo);
+    if (
+      pr?.targetBranch &&
+      (await isBranchMergeQueueEnabled(pr.targetBranch))
+    ) {
+      // The PR is not merged directly but through the merge queue, so it must
+      // not be cached as merged nor may its branch be deleted yet
+      return tryEnqueuePr(pr);
+    }
   }
 
   const url = `repos/${

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -905,16 +905,6 @@ export async function getBranchForceRebase(
   return config.branchForceRebase[branchName];
 }
 
-export async function isBranchMergeQueueEnabled(
-  branchName: string,
-): Promise<boolean> {
-  if (!getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
-    return false;
-  }
-
-  return isMergeQueueEnabled(branchName);
-}
-
 function handleBranchProtectionError(
   protection: 'branch-protection' | 'rulesets',
   err: any,
@@ -2026,7 +2016,9 @@ export async function createPr({
   return result;
 }
 
-async function isMergeQueueEnabled(baseBranch: string): Promise<boolean> {
+export async function isBranchMergeQueueEnabled(
+  baseBranch: string,
+): Promise<boolean> {
   const cachedResult = config.mergeQueueEnabled[baseBranch];
   if (cachedResult !== undefined) {
     return cachedResult;
@@ -2092,7 +2084,7 @@ export async function assertPrNotInMergeQueue(
   branchName: string,
   baseBranch?: string,
 ): Promise<void> {
-  if (!(await isMergeQueueEnabled(baseBranch ?? config.defaultBranch))) {
+  if (!(await isBranchMergeQueueEnabled(baseBranch ?? config.defaultBranch))) {
     return;
   }
 
@@ -2225,18 +2217,11 @@ export async function mergePr({
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${prNo}, ${branchName})`);
 
-  // Only look up the PR when merge queues are enabled, so the direct merge
-  // path stays free of extra requests
-  if (getEnv().RENOVATE_X_GITHUB_MERGE_QUEUE) {
-    const pr = await getPr(prNo);
-    if (
-      pr?.targetBranch &&
-      (await isBranchMergeQueueEnabled(pr.targetBranch))
-    ) {
-      // The PR is not merged directly but through the merge queue, so it must
-      // not be cached as merged nor may its branch be deleted yet
-      return tryEnqueuePr(pr);
-    }
+  const pr = await getPr(prNo);
+  if (pr?.targetBranch && (await isBranchMergeQueueEnabled(pr.targetBranch))) {
+    // The PR is not merged directly but through the merge queue, so it must
+    // not be cached as merged nor may its branch be deleted yet
+    return tryEnqueuePr(pr);
   }
 
   const url = `repos/${

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -105,7 +105,6 @@ import type {
   GhAutomergeResponse,
   GhBranchStatus,
   GhEnqueuePullRequestResponse,
-  GhMergeQueueResponse,
   GhPr,
   GhRepo,
   GhRestPr,
@@ -913,42 +912,7 @@ export async function isBranchMergeQueueEnabled(
     return false;
   }
 
-  config.branchMergeQueueEnabled ??= {};
-
-  const cachedResult = config.branchMergeQueueEnabled[branchName];
-  if (cachedResult !== undefined) {
-    return cachedResult;
-  }
-
-  // Merge queues configured via classic branch protection are only visible
-  // through the GraphQL mergeQueue field, which also covers repository rulesets
-  const [owner, name] = (config.parentRepo ?? config.repository!).split('/');
-  let result = false;
-  try {
-    const res = await githubApi.requestGraphql<GhMergeQueueResponse>(
-      repoMergeQueueQuery,
-      {
-        variables: { owner, name, branch: branchName },
-        readOnly: true,
-        count: 1, // set count to one to bypass graphql check
-      },
-    );
-    if (res?.errors) {
-      // e.g. GitHub Enterprise Server versions without merge queue support
-      logger.once.debug(
-        { errors: res.errors },
-        'Merge queue detection: query failed',
-      );
-    } else {
-      result = isNonEmptyString(res?.data?.repository?.mergeQueue?.id);
-    }
-  } catch (err) {
-    logger.warn({ err }, 'Merge queue detection: request error');
-  }
-
-  logger.debug(`Branch ${branchName} has merge queue enabled: ${result}`);
-  config.branchMergeQueueEnabled[branchName] = result;
-  return result;
+  return isMergeQueueEnabled(branchName);
 }
 
 function handleBranchProtectionError(

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -122,6 +122,7 @@ export interface LocalRepoConfig {
   pushProtection: boolean;
   prReviewsRequired: boolean;
   branchForceRebase?: Record<string, boolean>;
+  branchMergeQueueEnabled?: Record<string, boolean>;
   parentRepo: string | null;
   forkOrg?: string;
   forkToken?: string;
@@ -169,6 +170,18 @@ export interface GhRepo {
 export interface GhAutomergeResponse {
   enablePullRequestAutoMerge: {
     pullRequest: { number: number };
+  };
+}
+
+export interface GhMergeQueueResponse {
+  repository: {
+    mergeQueue: { id: string } | null;
+  };
+}
+
+export interface GhEnqueuePullRequestResponse {
+  enqueuePullRequest: {
+    mergeQueueEntry: { id: string; position: number } | null;
   };
 }
 

--- a/lib/modules/platform/github/types.ts
+++ b/lib/modules/platform/github/types.ts
@@ -122,7 +122,6 @@ export interface LocalRepoConfig {
   pushProtection: boolean;
   prReviewsRequired: boolean;
   branchForceRebase?: Record<string, boolean>;
-  branchMergeQueueEnabled?: Record<string, boolean>;
   parentRepo: string | null;
   forkOrg?: string;
   forkToken?: string;
@@ -170,12 +169,6 @@ export interface GhRepo {
 export interface GhAutomergeResponse {
   enablePullRequestAutoMerge: {
     pullRequest: { number: number };
-  };
-}
-
-export interface GhMergeQueueResponse {
-  repository: {
-    mergeQueue: { id: string } | null;
   };
 }
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -561,8 +561,10 @@ describe('modules/platform/gitlab/index', () => {
       );
       await expect(gitlab.getBranchForceRebase()).resolves.toBeTrue();
     });
+  });
 
-    it('should return false when merge trains are enabled', async () => {
+  describe('isBranchMergeQueueEnabled', () => {
+    it('should return true when merge trains are enabled', async () => {
       await initRepo(
         {
           repository: 'some/repo/project',
@@ -570,11 +572,27 @@ describe('modules/platform/gitlab/index', () => {
         {
           default_branch: 'master',
           http_url_to_repo: null,
-          merge_method: 'ff',
           merge_trains_enabled: true,
         },
       );
-      await expect(gitlab.getBranchForceRebase()).resolves.toBeFalse();
+      await expect(
+        gitlab.isBranchMergeQueueEnabled('master'),
+      ).resolves.toBeTrue();
+    });
+
+    it('should return false when merge trains are disabled', async () => {
+      await initRepo(
+        {
+          repository: 'some/repo/project',
+        },
+        {
+          default_branch: 'master',
+          http_url_to_repo: null,
+        },
+      );
+      await expect(
+        gitlab.isBranchMergeQueueEnabled('master'),
+      ).resolves.toBeFalse();
     });
   });
 
@@ -4031,6 +4049,50 @@ describe('modules/platform/gitlab/index', () => {
           id: 1,
         }),
       ).resolves.toBeTrue();
+    });
+
+    it('adds the MR to the merge train when merge trains are enabled', async () => {
+      const scope = await initRepo(
+        { repository: 'some/repo' },
+        {
+          default_branch: 'master',
+          http_url_to_repo: null,
+          merge_trains_enabled: true,
+        },
+      );
+      scope
+        .post('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(201);
+      await expect(
+        gitlab.mergePr({
+          id: 1,
+          targetBranch: 'master',
+        }),
+      ).resolves.toBeTrue();
+    });
+
+    it('returns false if adding the MR to the merge train fails', async () => {
+      const scope = await initRepo(
+        { repository: 'some/repo' },
+        {
+          default_branch: 'master',
+          http_url_to_repo: null,
+          merge_trains_enabled: true,
+        },
+      );
+      scope
+        .post('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(403);
+      await expect(
+        gitlab.mergePr({
+          id: 1,
+          targetBranch: 'master',
+        }),
+      ).resolves.toBeFalse();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Failed to add MR to the merge train',
+      );
     });
   });
 

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -4038,6 +4038,64 @@ describe('modules/platform/gitlab/index', () => {
     });
   });
 
+  describe('isPrInMergeQueue', () => {
+    async function initRepoWithMergeTrains(): Promise<httpMock.Scope> {
+      return await initRepo(
+        { repository: 'some/repo' },
+        {
+          default_branch: 'master',
+          http_url_to_repo: null,
+          merge_trains_enabled: true,
+        },
+      );
+    }
+
+    it('returns false if merge trains are disabled', async () => {
+      await initRepo();
+      await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeFalse();
+    });
+
+    it('returns true if the MR is waiting on the merge train', async () => {
+      const scope = await initRepoWithMergeTrains();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(200, { status: 'idle' });
+      await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeTrue();
+    });
+
+    it('returns false if the MR was already merged by the merge train', async () => {
+      const scope = await initRepoWithMergeTrains();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(200, { status: 'merged' });
+      await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeFalse();
+    });
+
+    it('returns false if the MR is not on the merge train', async () => {
+      const scope = await initRepoWithMergeTrains();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(404);
+      await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeFalse();
+      expect(logger.logger.debug).not.toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Failed to fetch merge train status',
+      );
+    });
+
+    it('returns false and logs on other errors', async () => {
+      const scope = await initRepoWithMergeTrains();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(500);
+      await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeFalse();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Failed to fetch merge train status',
+      );
+    });
+  });
+
   describe('mergePr(pr)', () => {
     it('merges the PR', async () => {
       httpMock

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -4124,7 +4124,6 @@ describe('modules/platform/gitlab/index', () => {
       await expect(
         gitlab.mergePr({
           id: 1,
-          targetBranch: 'master',
         }),
       ).resolves.toBeTrue();
     });
@@ -4144,7 +4143,6 @@ describe('modules/platform/gitlab/index', () => {
       await expect(
         gitlab.mergePr({
           id: 1,
-          targetBranch: 'master',
         }),
       ).resolves.toBeFalse();
       expect(logger.logger.debug).toHaveBeenCalledWith(

--- a/lib/modules/platform/gitlab/index.spec.ts
+++ b/lib/modules/platform/gitlab/index.spec.ts
@@ -4071,6 +4071,19 @@ describe('modules/platform/gitlab/index', () => {
       await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeFalse();
     });
 
+    it('returns false and logs if the response is malformed', async () => {
+      const scope = await initRepoWithMergeTrains();
+      scope
+        .get('/api/v4/projects/some%2Frepo/merge_trains/merge_requests/1')
+        .reply(200, { status: 'unknown' });
+
+      await expect(gitlab.isPrInMergeQueue(1)).resolves.toBeFalse();
+      expect(logger.logger.debug).toHaveBeenCalledWith(
+        { err: expect.any(Error) },
+        'Failed to fetch merge train status',
+      );
+    });
+
     it('returns false if the MR is not on the merge train', async () => {
       const scope = await initRepoWithMergeTrains();
       scope

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -367,14 +367,24 @@ export async function initRepo({
 }
 
 export function getBranchForceRebase(): Promise<boolean> {
-  const forceRebase =
-    config?.mergeMethod !== 'merge' && !config.mergeTrainsEnabled;
+  const forceRebase = config?.mergeMethod !== 'merge';
   if (forceRebase) {
     logger.once.debug(
       `mergeMethod is ${config.mergeMethod} so PRs will be kept up-to-date with base branch`,
     );
   }
   return Promise.resolve(forceRebase);
+}
+
+/**
+ * Merge trains are GitLab's equivalent of a merge queue. They are enabled per
+ * project, so the branch name is not needed.
+ * https://docs.gitlab.com/ci/pipelines/merge_trains/
+ */
+export function isBranchMergeQueueEnabled(
+  _branchName: string,
+): Promise<boolean> {
+  return Promise.resolve(config.mergeTrainsEnabled);
 }
 
 type BranchState =
@@ -842,7 +852,27 @@ export async function reattemptPlatformAutomerge({
   logger.debug(`PR platform automerge re-attempted...prNo: ${iid}`);
 }
 
+async function tryAddPrToMergeTrain(id: number): Promise<boolean> {
+  try {
+    // Without `auto_merge` the MR is added to the train immediately. The
+    // train merges it and removes the source branch on its own.
+    // https://docs.gitlab.com/api/merge_trains/#add-a-merge-request-to-a-merge-train
+    await gitlabApi.postJson(
+      `projects/${config.repository}/merge_trains/merge_requests/${id}`,
+    );
+    logger.debug(`MR !${id} added to the merge train`);
+    return true;
+  } catch (err) {
+    logger.debug({ err }, 'Failed to add MR to the merge train');
+    return false;
+  }
+}
+
 export async function mergePr({ id }: MergePRConfig): Promise<boolean> {
+  if (config.mergeTrainsEnabled) {
+    return tryAddPrToMergeTrain(id);
+  }
+
   try {
     await gitlabApi.putJson(
       `projects/${config.repository}/merge_requests/${id}/merge`,

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -71,7 +71,7 @@ import { getMR, updateMR } from './merge-request.ts';
 import { GitlabPrCache } from './pr-cache.ts';
 import { getRoleAccessLevel } from './roles.ts';
 import type { GitLabMergeRequest } from './schema.ts';
-import { LastPipelineId } from './schema.ts';
+import { LastPipelineId, MergeTrainCarStatus } from './schema.ts';
 import type {
   GitlabComment,
   GitlabIssue,
@@ -397,11 +397,12 @@ export async function isPrInMergeQueue(id: number): Promise<boolean> {
     return false;
   }
   try {
-    const { body } = await gitlabApi.getJsonUnchecked<{ status?: string }>(
+    const { body: status } = await gitlabApi.getJson(
       `projects/${config.repository}/merge_trains/merge_requests/${id}`,
       { memCache: false },
+      MergeTrainCarStatus,
     );
-    return body.status !== 'merged';
+    return status !== 'merged';
   } catch (err) {
     if (err.statusCode !== 404) {
       logger.debug({ err }, 'Failed to fetch merge train status');

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -387,6 +387,29 @@ export function isBranchMergeQueueEnabled(
   return Promise.resolve(config.mergeTrainsEnabled);
 }
 
+/**
+ * GitLab answers with 404 if the MR is not on a merge train. A car that has
+ * already been merged is not waiting any more.
+ * https://docs.gitlab.com/api/merge_trains/#get-the-status-of-a-merge-request-on-a-merge-train
+ */
+export async function isPrInMergeQueue(id: number): Promise<boolean> {
+  if (!config.mergeTrainsEnabled) {
+    return false;
+  }
+  try {
+    const { body } = await gitlabApi.getJsonUnchecked<{ status?: string }>(
+      `projects/${config.repository}/merge_trains/merge_requests/${id}`,
+      { memCache: false },
+    );
+    return body.status !== 'merged';
+  } catch (err) {
+    if (err.statusCode !== 404) {
+      logger.debug({ err }, 'Failed to fetch merge train status');
+    }
+    return false;
+  }
+}
+
 type BranchState =
   | 'pending'
   | 'created'

--- a/lib/modules/platform/gitlab/readme.md
+++ b/lib/modules/platform/gitlab/readme.md
@@ -97,6 +97,7 @@ By setting the server version yourself, you save a API call that fetches the ser
 - Do not truncate Markdown body to 25K chars since `v13.4.0`
 - Allow configure reviewers since `v13.9.0`
 - Add automerged MRs to merge trains since `v17.11.0` (when [merge trains](https://docs.gitlab.com/ci/pipelines/merge_trains/) are enabled on the project)
+- With `platformAutomerge=false`, Renovate adds MRs to the merge train itself once all checks have passed, see [GitLab Merge Trains](../../../key-concepts/automerge.md#gitlab-merge-trains)
 
 ## Multiple merge request assignees
 

--- a/lib/modules/platform/gitlab/schema.ts
+++ b/lib/modules/platform/gitlab/schema.ts
@@ -10,6 +10,15 @@ export const LastPipelineId = z
   })
   .transform(({ last_pipeline }) => last_pipeline.id);
 
+/**
+ * https://docs.gitlab.com/api/merge_trains/#get-the-status-of-a-merge-request-on-a-merge-train
+ */
+export const MergeTrainCarStatus = z
+  .object({
+    status: z.enum(['idle', 'stale', 'fresh', 'merged', 'merging']),
+  })
+  .transform(({ status }) => status);
+
 const GitlabUser = z.object({
   id: z.number(),
   username: z.string(),

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -180,6 +180,7 @@ export interface MergePRConfig {
   branchName?: string;
   id: number;
   strategy?: MergeStrategy;
+  targetBranch?: string;
 }
 export interface EnsureCommentConfig {
   number: number;
@@ -272,6 +273,11 @@ export interface Platform {
   createPr(prConfig: CreatePRConfig): Promise<Pr | null>;
   getRepos(config?: AutodiscoverConfig): Promise<string[]>;
   getBranchForceRebase?(branchName: string): Promise<boolean>;
+  /**
+   * Returns true if the given branch is protected by a merge queue,
+   * so PRs targeting it must be merged through the queue.
+   */
+  isBranchMergeQueueEnabled?(branchName: string): Promise<boolean>;
   deleteLabel(number: number, label: string): Promise<void>;
   addLabel?(number: number, label: string): Promise<void>;
   setBranchStatus(branchStatusConfig: BranchStatusConfig): Promise<void>;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -274,8 +274,13 @@ export interface Platform {
   getRepos(config?: AutodiscoverConfig): Promise<string[]>;
   getBranchForceRebase?(branchName: string): Promise<boolean>;
   /**
-   * Returns true if the given branch is protected by a merge queue,
-   * so PRs targeting it must be merged through the queue.
+   * Returns true if the given branch is protected by a merge queue (GitHub)
+   * or a merge train (GitLab), so PRs targeting it must be merged through
+   * the queue. `mergePr` is then expected to add the PR to the queue instead
+   * of merging it directly.
+   *
+   * Platforms where the feature is configured per repository rather than
+   * per branch may ignore the branch name.
    */
   isBranchMergeQueueEnabled?(branchName: string): Promise<boolean>;
   deleteLabel(number: number, label: string): Promise<void>;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -278,6 +278,11 @@ export interface Platform {
    * so PRs targeting it must be merged through the queue.
    */
   isBranchMergeQueueEnabled?(branchName: string): Promise<boolean>;
+  /**
+   * Returns true if the PR is currently waiting in a merge queue, so it must
+   * not be enqueued or modified again.
+   */
+  isPrInMergeQueue?(number: number): Promise<boolean>;
   deleteLabel(number: number, label: string): Promise<void>;
   addLabel?(number: number, label: string): Promise<void>;
   setBranchStatus(branchStatusConfig: BranchStatusConfig): Promise<void>;

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -180,7 +180,6 @@ export interface MergePRConfig {
   branchName?: string;
   id: number;
   strategy?: MergeStrategy;
-  targetBranch?: string;
 }
 export interface EnsureCommentConfig {
   number: number;

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -1,4 +1,4 @@
-import { partial, platform, scm } from '~test/util.ts';
+import { logger, partial, platform, scm } from '~test/util.ts';
 import { GlobalConfig } from '../../../../config/global.ts';
 import type { RenovateConfig } from '../../../../config/types.ts';
 import type { Pr } from '../../../../modules/platform/types.ts';
@@ -58,6 +58,22 @@ describe('workers/repository/update/branch/automerge', () => {
       await expect(tryBranchAutomerge(config)).resolves.toBe(
         'automerge aborted - PR exists',
       );
+    });
+
+    it('aborts if the base branch has a merge queue', async () => {
+      config.automerge = true;
+      config.automergeType = 'branch';
+      config.baseBranch = 'test-branch';
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+
+      const res = await tryBranchAutomerge(config);
+
+      expect(res).toBe('automerge aborted - merge queue');
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { baseBranch: 'test-branch' },
+        'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead.',
+      );
+      expect(scm.mergeAndPush).toHaveBeenCalledTimes(0);
     });
 
     it('returns false if automerge fails', async () => {

--- a/lib/workers/repository/update/branch/automerge.ts
+++ b/lib/workers/repository/update/branch/automerge.ts
@@ -8,6 +8,7 @@ import { resolveBranchStatus } from './status-checks.ts';
 
 export type AutomergeResult =
   | 'automerged'
+  | 'automerge aborted - merge queue'
   | 'automerge aborted - PR exists'
   | 'branch status error'
   | 'failed'
@@ -32,6 +33,13 @@ export async function tryBranchAutomerge(
   );
   if (existingPr) {
     return 'automerge aborted - PR exists';
+  }
+  if (await platform.isBranchMergeQueueEnabled?.(config.baseBranch!)) {
+    logger.warn(
+      { baseBranch: config.baseBranch },
+      'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead.',
+    );
+    return 'automerge aborted - merge queue';
   }
   const branchStatus = await resolveBranchStatus(
     config.branchName!,

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -1328,6 +1328,36 @@ describe('workers/repository/update/branch/index', () => {
       });
     });
 
+    it('raises a PR if branch automerge is aborted due to a merge queue', async () => {
+      getUpdated.getUpdatedPackageFiles.mockResolvedValueOnce(
+        partial<PackageFilesResult>({
+          updatedPackageFiles: [partial<FileChange>()],
+        }),
+      );
+      npmPostExtract.getAdditionalFiles.mockResolvedValueOnce({
+        artifactErrors: [],
+        updatedArtifacts: [partial<FileChange>()],
+      });
+      scm.branchExists.mockResolvedValue(true);
+      commit.commitFilesToBranch.mockResolvedValueOnce(null);
+      automerge.tryBranchAutomerge.mockResolvedValueOnce(
+        'automerge aborted - merge queue',
+      );
+      prWorker.ensurePr.mockResolvedValueOnce({
+        type: 'without-pr',
+        prBlockedBy: 'AwaitingTests',
+      });
+
+      await branchWorker.processBranch(config);
+
+      expect(prWorker.ensurePr).toHaveBeenCalledWith(
+        expect.objectContaining({
+          forcePr: true,
+          branchAutomergeFailureMessage: 'automerge aborted - merge queue',
+        }),
+      );
+    });
+
     it('returns if branch automerge is pending', async () => {
       expect.assertions(2);
       const setArtifactErrorStatus = vi.spyOn(

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -913,6 +913,7 @@ export async function processBranch(
         config.branchAutomergeFailureMessage = mergeStatus;
       }
       if (
+        mergeStatus === 'automerge aborted - merge queue' ||
         mergeStatus === 'automerge aborted - PR exists' ||
         mergeStatus === 'branch status error' ||
         mergeStatus === 'failed'

--- a/lib/workers/repository/update/branch/reuse.spec.ts
+++ b/lib/workers/repository/update/branch/reuse.spec.ts
@@ -263,6 +263,44 @@ describe('workers/repository/update/branch/reuse', () => {
       expect(result.rebaseWhen).toBe('conflicted');
     });
 
+    it('converts rebaseWhen=auto to conflicted if the base branch has a merge queue', async () => {
+      config.rebaseWhen = 'auto';
+      config.automerge = true;
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      scm.branchExists.mockResolvedValueOnce(true);
+
+      const result = await shouldReuseExistingBranch(config);
+
+      expect(config.rebaseWhen).toBe('auto');
+      expect(result.rebaseWhen).toBe('conflicted');
+    });
+
+    it('converts rebaseWhen=auto to behind-base-branch if keepUpdatedLabel although the base branch has a merge queue', async () => {
+      config.rebaseWhen = 'auto';
+      config.keepUpdatedLabel = 'keep-updated';
+      platform.isBranchMergeQueueEnabled.mockResolvedValue(true);
+      platform.getBranchPr.mockResolvedValue(pr);
+      scm.branchExists.mockResolvedValueOnce(true);
+      scm.isBranchBehindBase.mockResolvedValueOnce(false);
+
+      const result = await shouldReuseExistingBranch(config);
+
+      expect(config.rebaseWhen).toBe('auto');
+      expect(result.rebaseWhen).toBe('behind-base-branch');
+    });
+
+    it('converts rebaseWhen=automerging to conflicted if the base branch has a merge queue', async () => {
+      config.rebaseWhen = 'automerging';
+      config.automerge = true;
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      scm.branchExists.mockResolvedValueOnce(true);
+
+      const result = await shouldReuseExistingBranch(config);
+
+      expect(config.rebaseWhen).toBe('automerging');
+      expect(result.rebaseWhen).toBe('conflicted');
+    });
+
     it('converts rebaseWhen=automerging to behind-base-branch', async () => {
       config.rebaseWhen = 'automerging';
       config.automerge = true;

--- a/lib/workers/repository/update/branch/reuse.ts
+++ b/lib/workers/repository/update/branch/reuse.ts
@@ -125,10 +125,15 @@ async function determineRebaseWhenValue(
   if (result.rebaseWhen === 'auto' || result.rebaseWhen === 'automerging') {
     let reason;
     let newValue = 'behind-base-branch';
-    if (result.automerge === true) {
-      reason = 'automerge=true';
-    } else if (keepUpdated) {
+    if (keepUpdated) {
       reason = 'keep-updated label is set';
+    } else if (await platform.isBranchMergeQueueEnabled?.(result.baseBranch)) {
+      // The merge queue tests each PR against the base branch head, so
+      // rebasing when behind the base branch is unnecessary
+      newValue = 'conflicted';
+      reason = 'base branch has a merge queue';
+    } else if (result.automerge === true) {
+      reason = 'automerge=true';
     } else if (result.rebaseWhen === 'automerging') {
       newValue = 'never';
       reason = 'no keep-updated label and automerging is set';

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -80,6 +80,22 @@ describe('workers/repository/update/pr/automerge', () => {
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
     });
 
+    it('should skip branch deletion if the PR was added to a merge queue', async () => {
+      config.automerge = true;
+      config.pruneBranchAfterAutomerge = true;
+      platform.getBranchStatus.mockResolvedValueOnce('green');
+      platform.mergePr.mockResolvedValueOnce(true);
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+
+      const res = await prAutomerge.checkAutoMerge(pr, config);
+
+      expect(res).toEqual({ automerged: true, branchRemoved: false });
+      expect(platform.mergePr).toHaveBeenCalledWith(
+        expect.objectContaining({ targetBranch: 'base-branch' }),
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
+    });
+
     it('should skip branch deletion after automerge if prune is disabled', async () => {
       config.automerge = true;
       config.pruneBranchAfterAutomerge = false;

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -94,9 +94,7 @@ describe('workers/repository/update/pr/automerge', () => {
         automerged: false,
         prAutomergeBlockReason: 'InMergeQueue',
       });
-      expect(platform.mergePr).toHaveBeenCalledWith(
-        expect.objectContaining({ targetBranch: 'base-branch' }),
-      );
+      expect(platform.mergePr).toHaveBeenCalledOnce();
       expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
     });
 

--- a/lib/workers/repository/update/pr/automerge.spec.ts
+++ b/lib/workers/repository/update/pr/automerge.spec.ts
@@ -80,20 +80,40 @@ describe('workers/repository/update/pr/automerge', () => {
       expect(platform.ensureComment).toHaveBeenCalledTimes(1);
     });
 
-    it('should skip branch deletion if the PR was added to a merge queue', async () => {
+    it('should not report automerged if the PR was added to a merge queue', async () => {
       config.automerge = true;
       config.pruneBranchAfterAutomerge = true;
       platform.getBranchStatus.mockResolvedValueOnce('green');
       platform.mergePr.mockResolvedValueOnce(true);
       platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      platform.isPrInMergeQueue.mockResolvedValueOnce(false);
 
       const res = await prAutomerge.checkAutoMerge(pr, config);
 
-      expect(res).toEqual({ automerged: true, branchRemoved: false });
+      expect(res).toEqual({
+        automerged: false,
+        prAutomergeBlockReason: 'InMergeQueue',
+      });
       expect(platform.mergePr).toHaveBeenCalledWith(
         expect.objectContaining({ targetBranch: 'base-branch' }),
       );
       expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
+    });
+
+    it('should skip a PR which is already in the merge queue', async () => {
+      config.automerge = true;
+      pr = partial<Pr>({ number: 123 });
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      platform.isPrInMergeQueue.mockResolvedValueOnce(true);
+
+      const res = await prAutomerge.checkAutoMerge(pr, config);
+
+      expect(res).toEqual({
+        automerged: false,
+        prAutomergeBlockReason: 'InMergeQueue',
+      });
+      expect(platform.isPrInMergeQueue).toHaveBeenCalledWith(123);
+      expect(platform.mergePr).toHaveBeenCalledTimes(0);
     });
 
     it('should skip branch deletion after automerge if prune is disabled', async () => {

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -137,8 +137,18 @@ export async function checkAutoMerge(
     branchName,
     id: pr.number,
     strategy: automergeStrategy,
+    targetBranch: baseBranch,
   });
   if (res) {
+    if (await platform.isBranchMergeQueueEnabled?.(baseBranch)) {
+      logger.info(
+        { pr: pr.number, prTitle: pr.title },
+        'PR added to the merge queue',
+      );
+      // The PR is not merged yet - deleting the branch would close the PR
+      // and drop the merge queue entry
+      return { automerged: true, branchRemoved: false };
+    }
     logger.info({ pr: pr.number, prTitle: pr.title }, 'PR automerged');
     if (!pruneBranchAfterAutomerge) {
       logger.info('Skipping pruning of merged branch');

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -147,7 +147,6 @@ export async function checkAutoMerge(
     branchName,
     id: pr.number,
     strategy: automergeStrategy,
-    targetBranch: baseBranch,
   });
   if (res) {
     if (mergeQueueEnabled) {

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -17,6 +17,7 @@ export type PrAutomergeBlockReason =
   | 'BranchNotGreen'
   | 'Conflicted'
   | 'DryRun'
+  | 'InMergeQueue'
   | 'PlatformNotReady'
   | 'PlatformRejection'
   | 'off schedule';
@@ -48,6 +49,15 @@ export async function checkAutoMerge(
     return {
       automerged: false,
       prAutomergeBlockReason: 'off schedule',
+    };
+  }
+  const mergeQueueEnabled =
+    await platform.isBranchMergeQueueEnabled?.(baseBranch);
+  if (mergeQueueEnabled && (await platform.isPrInMergeQueue?.(pr.number))) {
+    logger.debug(`PR #${pr.number} is already in the merge queue`);
+    return {
+      automerged: false,
+      prAutomergeBlockReason: 'InMergeQueue',
     };
   }
   const isConflicted =
@@ -140,14 +150,18 @@ export async function checkAutoMerge(
     targetBranch: baseBranch,
   });
   if (res) {
-    if (await platform.isBranchMergeQueueEnabled?.(baseBranch)) {
+    if (mergeQueueEnabled) {
       logger.info(
         { pr: pr.number, prTitle: pr.title },
         'PR added to the merge queue',
       );
-      // The PR is not merged yet - deleting the branch would close the PR
-      // and drop the merge queue entry
-      return { automerged: true, branchRemoved: false };
+      // The PR is not merged yet and the base branch is unchanged, so this is
+      // not reported as automerged. Deleting the branch would close the PR
+      // and drop the merge queue entry.
+      return {
+        automerged: false,
+        prAutomergeBlockReason: 'InMergeQueue',
+      };
     }
     logger.info({ pr: pr.number, prTitle: pr.title }, 'PR automerged');
     if (!pruneBranchAfterAutomerge) {

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -762,6 +762,32 @@ describe('workers/repository/update/pr/index', () => {
         });
       });
 
+      it('comments on automerge failure due to merge queue', async () => {
+        platform.createPr.mockResolvedValueOnce(pr);
+        checks.resolveBranchStatus.mockResolvedValueOnce('red');
+        platform.massageMarkdown.mockReturnValueOnce('markdown content');
+
+        await ensurePr({
+          ...config,
+          automerge: true,
+          automergeType: 'branch',
+          branchAutomergeFailureMessage: 'automerge aborted - merge queue',
+          suppressNotifications: [],
+        });
+
+        expect(platform.massageMarkdown).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'The base branch has a merge queue, so branch automerge is not possible. Please set `automergeType=pr` instead.',
+          ),
+          undefined,
+        );
+        expect(comment.ensureComment).toHaveBeenCalledExactlyOnceWith({
+          content: 'markdown content',
+          number: 123,
+          topic: 'Branch automerge failure',
+        });
+      });
+
       it('handles ensureComment error', async () => {
         platform.createPr.mockResolvedValueOnce(pr);
         checks.resolveBranchStatus.mockResolvedValueOnce('red');

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -597,6 +597,13 @@ export async function ensurePr(
       if (config.branchAutomergeFailureMessage === 'branch status error') {
         content += '\n___\n * Branch has one or more failed status checks';
       }
+      if (
+        config.branchAutomergeFailureMessage ===
+        'automerge aborted - merge queue'
+      ) {
+        content +=
+          '\n___\n * The base branch has a merge queue, so branch automerge is not possible. Please set `automergeType=pr` instead.';
+      }
       content = platform.massageMarkdown(content, config.rebaseLabel);
       logger.debug('Adding branch automerge failure message to PR');
       if (GlobalConfig.get('dryRun')) {


### PR DESCRIPTION
## Changes

Stacked on #45721. Only the top commit (`feat(gitlab): ...`) is new; the rest is the GitHub merge queue PR below it. Once #45721 merges, this PR's diff shrinks to the GitLab change.

Implements the platform merge queue API from #45721 for GitLab merge trains, so both features share the same abstraction in `lib/modules/platform`:

- `isBranchMergeQueueEnabled` on GitLab returns whether merge trains are enabled on the project. Merge trains are configured per project, so the branch argument is ignored. The API doc comment in `lib/modules/platform/types.ts` now says so.
- `mergePr` on GitLab adds the MR to the merge train (`POST /projects/:id/merge_trains/merge_requests/:iid` without `auto_merge`) instead of merging directly when merge trains are enabled. The train merges the MR and removes the source branch on its own. The worker already handles this case through the shared API: it logs "PR added to the merge queue" and does not delete the branch.
- `isPrInMergeQueue` on GitLab reports whether the MR is still waiting on the merge train (`GET /projects/:id/merge_trains/merge_requests/:iid`, 404 means not on a train), so later runs leave a queued MR alone instead of adding it again. The response is validated with the `MergeTrainCarStatus` Zod schema in `gitlab/schema.ts`; an unexpected body is treated like any other failed lookup.
- `getBranchForceRebase` on GitLab no longer special-cases merge trains. The reuse worker now checks `isBranchMergeQueueEnabled` first and resolves `rebaseWhen=auto` to `conflicted`, so the old clause was redundant.
- Branch automerge (`automergeType=branch`) is skipped with a warning and a MR is created instead, again through the shared worker code.

Like the GitHub side, this is not gated behind a flag: merge train detection is a single field on the project response Renovate already fetches, and platform automerge already uses merge trains.

Docs: new "GitLab Merge Trains" section in `docs/usage/key-concepts/automerge.md`, updates to `automergeType` and `rebaseWhen` in `docs/usage/configuration-options.md`, and a line in the GitLab platform readme.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Fable 5.1) wrote the code, tests and docs in this PR and drafted this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

