### PR TITLE
feat(automerge): attempt branch automerge before falling back to a PR on merge queue rejection

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -338,7 +338,8 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 - Automerge the branch commit if it's: (a) up-to-date with the base branch, and (b) passing all tests
 - As a backup, raise a PR only if either: (a) tests fail, or (b) tests remain pending for too long (default: 25 hours, see [`prNotPendingHours`](#prnotpendinghours))
 
-Note that `"automergeType": "branch"` is not compatible with GitHub merge queues or GitLab merge trains, because the merge queue does not allow pushing directly to the base branch.
+Note that `"automergeType": "branch"` only works with GitHub merge queues or GitLab merge trains if Renovate is on the merge queue's bypass list, because the merge queue does not allow pushing directly to the base branch otherwise.
+If the push is rejected, Renovate falls back to creating a PR.
 
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.

--- a/docs/usage/key-concepts/automerge.md
+++ b/docs/usage/key-concepts/automerge.md
@@ -142,9 +142,9 @@ We recommend enabling the "Automatically delete head branches" repository settin
 
 <!-- prettier-ignore -->
 !!! warning
-  Branch automerge (`automergeType=branch`) cannot work if the base branch has a merge queue, because pushing directly to the base branch is not possible.
-  With `RENOVATE_X_GITHUB_MERGE_QUEUE` set, Renovate detects this misconfiguration, logs a warning, and creates a PR instead.
-  Configure `automergeType=pr` in such repositories.
+  Branch automerge (`automergeType=branch`) only works if the base branch has a merge queue when Renovate is on the merge queue's bypass list, because pushing directly to the base branch is not possible otherwise.
+  With `RENOVATE_X_GITHUB_MERGE_QUEUE` set, Renovate logs a warning and creates a PR instead if the merge queue rejects the push.
+  Configure `automergeType=pr` in such repositories, or add Renovate to the bypass list.
 
 !!! tip "GitHub Merge Queue overview page"
   GitHub has a page that shows all the PRs in the Merge Queue.
@@ -205,9 +205,9 @@ Renovate detects whether merge trains are enabled on the project and then:
 
 <!-- prettier-ignore -->
 !!! warning
-  Branch automerge (`automergeType=branch`) cannot work if merge trains are enabled, because pushing directly to the target branch is not possible.
-  Renovate detects this misconfiguration, logs a warning, and creates a MR instead.
-  Configure `automergeType=pr` in such projects.
+  Branch automerge (`automergeType=branch`) only works with merge trains if Renovate is allowed to push to the protected target branch.
+  If the push is rejected, Renovate logs a warning and creates a MR instead.
+  Configure `automergeType=pr` in such projects, or allow Renovate to push to the target branch.
 
 ## Automerging and scheduling
 

--- a/docs/usage/self-hosted-experimental.md
+++ b/docs/usage/self-hosted-experimental.md
@@ -63,7 +63,7 @@ If set to any value, Renovate will detect if a GitHub merge queue is required fo
 If a merge queue is detected, then:
 
 - Renovate-native PR automerge (`platformAutomerge=false`) adds the PR to the merge queue instead of merging it directly, even if Renovate is on the merge queue's bypass list
-- branch automerge (`automergeType=branch`) is skipped with a warning, and a PR is created instead
+- branch automerge (`automergeType=branch`) falls back to creating a PR if the merge queue rejects the direct push. If Renovate is on the merge queue's bypass list, branch automerge keeps working
 - `rebaseWhen=auto` resolves to `conflicted` instead of `behind-base-branch`, because the merge queue already tests PRs against the head of the base branch
 
 ## `RENOVATE_X_GITLAB_AUTO_APPROVE_TOKEN`

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -60,20 +60,57 @@ describe('workers/repository/update/branch/automerge', () => {
       );
     });
 
-    it('aborts if the base branch has a merge queue', async () => {
+    it('aborts if the push is rejected by a merge queue', async () => {
       config.automerge = true;
       config.automergeType = 'branch';
       config.baseBranch = 'test-branch';
-      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      platform.getBranchStatus.mockResolvedValueOnce('green');
+      const err = new Error(
+        'GH013: Repository rule violations found for refs/heads/test-branch.\n- Changes must be made through the merge queue.',
+      );
+      scm.mergeAndPush.mockRejectedValueOnce(err);
 
       const res = await tryBranchAutomerge(config);
 
       expect(res).toBe('automerge aborted - merge queue');
       expect(logger.logger.warn).toHaveBeenCalledWith(
-        { baseBranch: 'test-branch' },
-        'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead.',
+        { baseBranch: 'test-branch', err },
+        'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead, or add Renovate to the merge queue bypass list.',
       );
-      expect(scm.mergeAndPush).toHaveBeenCalledTimes(0);
+      expect(platform.isBranchMergeQueueEnabled).not.toHaveBeenCalled();
+    });
+
+    it('aborts if a protected branch rejects the push and the platform reports a merge queue', async () => {
+      config.automerge = true;
+      config.automergeType = 'branch';
+      config.baseBranch = 'test-branch';
+      platform.getBranchStatus.mockResolvedValueOnce('green');
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+      scm.mergeAndPush.mockRejectedValueOnce(
+        new Error('Protected branch update failed'),
+      );
+
+      const res = await tryBranchAutomerge(config);
+
+      expect(res).toBe('automerge aborted - merge queue');
+      expect(platform.isBranchMergeQueueEnabled).toHaveBeenCalledWith(
+        'test-branch',
+      );
+    });
+
+    it('automerges if the base branch has a merge queue but the push is accepted', async () => {
+      config.automerge = true;
+      config.automergeType = 'branch';
+      config.baseBranch = 'test-branch';
+      platform.getBranchStatus.mockResolvedValueOnce('green');
+      platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
+
+      const res = await tryBranchAutomerge(config);
+
+      expect(res).toBe('automerged');
+      expect(scm.mergeAndPush).toHaveBeenCalledExactlyOnceWith(
+        config.branchName,
+      );
     });
 
     it('returns false if automerge fails', async () => {

--- a/lib/workers/repository/update/branch/automerge.spec.ts
+++ b/lib/workers/repository/update/branch/automerge.spec.ts
@@ -60,41 +60,24 @@ describe('workers/repository/update/branch/automerge', () => {
       );
     });
 
-    it('aborts if the push is rejected by a merge queue', async () => {
-      config.automerge = true;
-      config.automergeType = 'branch';
-      config.baseBranch = 'test-branch';
-      platform.getBranchStatus.mockResolvedValueOnce('green');
-      const err = new Error(
-        'GH013: Repository rule violations found for refs/heads/test-branch.\n- Changes must be made through the merge queue.',
-      );
-      scm.mergeAndPush.mockRejectedValueOnce(err);
-
-      const res = await tryBranchAutomerge(config);
-
-      expect(res).toBe('automerge aborted - merge queue');
-      expect(logger.logger.warn).toHaveBeenCalledWith(
-        { baseBranch: 'test-branch', err },
-        'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead, or add Renovate to the merge queue bypass list.',
-      );
-      expect(platform.isBranchMergeQueueEnabled).not.toHaveBeenCalled();
-    });
-
-    it('aborts if a protected branch rejects the push and the platform reports a merge queue', async () => {
+    it('aborts if the push is rejected and the base branch has a merge queue', async () => {
       config.automerge = true;
       config.automergeType = 'branch';
       config.baseBranch = 'test-branch';
       platform.getBranchStatus.mockResolvedValueOnce('green');
       platform.isBranchMergeQueueEnabled.mockResolvedValueOnce(true);
-      scm.mergeAndPush.mockRejectedValueOnce(
-        new Error('Protected branch update failed'),
-      );
+      const err = new Error('Protected branch update failed');
+      scm.mergeAndPush.mockRejectedValueOnce(err);
 
       const res = await tryBranchAutomerge(config);
 
       expect(res).toBe('automerge aborted - merge queue');
       expect(platform.isBranchMergeQueueEnabled).toHaveBeenCalledWith(
         'test-branch',
+      );
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { baseBranch: 'test-branch', err },
+        'automergeType=branch is not possible because the base branch only accepts changes through its merge queue - falling back to creating a PR. Set automergeType=pr instead, or allow Renovate to bypass the merge queue.',
       );
     });
 

--- a/lib/workers/repository/update/branch/automerge.ts
+++ b/lib/workers/repository/update/branch/automerge.ts
@@ -3,7 +3,6 @@ import type { RenovateConfig } from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import { platform } from '../../../../modules/platform/index.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
-import { regEx } from '../../../../util/regex.ts';
 import { isScheduledNow } from './schedule.ts';
 import { resolveBranchStatus } from './status-checks.ts';
 
@@ -70,20 +69,14 @@ export async function tryBranchAutomerge(
         logger.info('Branch is not up to date - cannot automerge');
         return 'stale';
       }
-      // A merge queue rejects direct pushes unless Renovate is on its bypass
-      // list, so the push is attempted first and a PR is created only if it
-      // was refused. GitHub reports this as "Changes must be made through the
-      // merge queue"; other platforms are covered by asking the platform.
-      if (
-        regEx(/merge queue/i).test(err.message) ||
-        (regEx(/Protected branch|Repository rule violations/).test(
-          err.message,
-        ) &&
-          (await platform.isBranchMergeQueueEnabled?.(config.baseBranch!)))
-      ) {
+      // A merge queue (or merge train) rejects direct pushes unless Renovate
+      // is allowed to bypass it, so the push is attempted first and a PR is
+      // created only if it was refused. The rejection message is platform
+      // specific, so the platform is asked instead of parsing it.
+      if (await platform.isBranchMergeQueueEnabled?.(config.baseBranch!)) {
         logger.warn(
           { baseBranch: config.baseBranch, err },
-          'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead, or add Renovate to the merge queue bypass list.',
+          'automergeType=branch is not possible because the base branch only accepts changes through its merge queue - falling back to creating a PR. Set automergeType=pr instead, or allow Renovate to bypass the merge queue.',
         );
         return 'automerge aborted - merge queue';
       }

--- a/lib/workers/repository/update/branch/automerge.ts
+++ b/lib/workers/repository/update/branch/automerge.ts
@@ -3,6 +3,7 @@ import type { RenovateConfig } from '../../../../config/types.ts';
 import { logger } from '../../../../logger/index.ts';
 import { platform } from '../../../../modules/platform/index.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
+import { regEx } from '../../../../util/regex.ts';
 import { isScheduledNow } from './schedule.ts';
 import { resolveBranchStatus } from './status-checks.ts';
 
@@ -33,13 +34,6 @@ export async function tryBranchAutomerge(
   );
   if (existingPr) {
     return 'automerge aborted - PR exists';
-  }
-  if (await platform.isBranchMergeQueueEnabled?.(config.baseBranch!)) {
-    logger.warn(
-      { baseBranch: config.baseBranch },
-      'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead.',
-    );
-    return 'automerge aborted - merge queue';
   }
   const branchStatus = await resolveBranchStatus(
     config.branchName!,
@@ -75,6 +69,23 @@ export async function tryBranchAutomerge(
         logger.debug({ err }, 'Branch automerge error');
         logger.info('Branch is not up to date - cannot automerge');
         return 'stale';
+      }
+      // A merge queue rejects direct pushes unless Renovate is on its bypass
+      // list, so the push is attempted first and a PR is created only if it
+      // was refused. GitHub reports this as "Changes must be made through the
+      // merge queue"; other platforms are covered by asking the platform.
+      if (
+        regEx(/merge queue/i).test(err.message) ||
+        (regEx(/Protected branch|Repository rule violations/).test(
+          err.message,
+        ) &&
+          (await platform.isBranchMergeQueueEnabled?.(config.baseBranch!)))
+      ) {
+        logger.warn(
+          { baseBranch: config.baseBranch, err },
+          'automergeType=branch is not possible because the base branch has a merge queue - falling back to creating a PR. Set automergeType=pr instead, or add Renovate to the merge queue bypass list.',
+        );
+        return 'automerge aborted - merge queue';
       }
       /* v8 ignore if -- TODO: needs test */
       if (err.message.includes('Protected branch')) {

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -777,7 +777,7 @@ describe('workers/repository/update/pr/index', () => {
 
         expect(platform.massageMarkdown).toHaveBeenCalledWith(
           expect.stringContaining(
-            'The base branch has a merge queue which rejected the direct push, so branch automerge is not possible. Please set `automergeType=pr` instead, or add Renovate to the merge queue bypass list.',
+            'The base branch only accepts changes through its merge queue and rejected the direct push, so branch automerge is not possible. Please set `automergeType=pr` instead, or allow Renovate to bypass the merge queue.',
           ),
           undefined,
         );

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -777,7 +777,7 @@ describe('workers/repository/update/pr/index', () => {
 
         expect(platform.massageMarkdown).toHaveBeenCalledWith(
           expect.stringContaining(
-            'The base branch has a merge queue, so branch automerge is not possible. Please set `automergeType=pr` instead.',
+            'The base branch has a merge queue which rejected the direct push, so branch automerge is not possible. Please set `automergeType=pr` instead, or add Renovate to the merge queue bypass list.',
           ),
           undefined,
         );

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -602,7 +602,7 @@ export async function ensurePr(
         'automerge aborted - merge queue'
       ) {
         content +=
-          '\n___\n * The base branch has a merge queue which rejected the direct push, so branch automerge is not possible. Please set `automergeType=pr` instead, or add Renovate to the merge queue bypass list.';
+          '\n___\n * The base branch only accepts changes through its merge queue and rejected the direct push, so branch automerge is not possible. Please set `automergeType=pr` instead, or allow Renovate to bypass the merge queue.';
       }
       content = platform.massageMarkdown(content, config.rebaseLabel);
       logger.debug('Adding branch automerge failure message to PR');

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -602,7 +602,7 @@ export async function ensurePr(
         'automerge aborted - merge queue'
       ) {
         content +=
-          '\n___\n * The base branch has a merge queue, so branch automerge is not possible. Please set `automergeType=pr` instead.';
+          '\n___\n * The base branch has a merge queue which rejected the direct push, so branch automerge is not possible. Please set `automergeType=pr` instead, or add Renovate to the merge queue bypass list.';
       }
       content = platform.massageMarkdown(content, config.rebaseLabel);
       logger.debug('Adding branch automerge failure message to PR');


### PR DESCRIPTION
## Changes

Stacked on #45722 (which is stacked on #45721). Only the top commit is new.

#45721 made branch automerge (`automergeType=branch`) abort up front whenever the base branch has a merge queue. That blocks a valid setup: if Renovate is on the merge queue's bypass list, a direct push to the base branch is allowed and branch automerge works fine.

This PR removes the up-front check and attempts the merge and push first. Only when the push is refused does Renovate fall back to creating a PR:

- After a refused push (other than the existing "not ready" and "stale" cases), the worker asks the platform via `isBranchMergeQueueEnabled`. If the base branch has a merge queue or merge train, Renovate logs a warning and creates a PR instead.
- The worker does not parse the rejection message. Wording like "merge queue", "protected branch" or "repository rule violations" is GitHub specific and other platforms (GitLab merge trains, for example) phrase it differently, so classification stays behind the platform API.
- Repositories without a queue keep the existing "branch protection" and "required status checks" handling unchanged.
- The warning log and the PR body hint now mention bypassing the queue as an alternative to `automergeType=pr`.

Cost: one refused push per branch on repositories with a queue and no bypass. Benefit: no bypass detection logic, no platform specific message parsing in the worker, and no new config option.

Docs updated in `docs/usage/key-concepts/automerge.md` and `docs/usage/configuration-options.md`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Fable 5.1) wrote the code, tests and docs in this PR and drafted this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
