### PR TITLE
fix(manager/npm): prevent updates to unrelated Yarn v1 entries

### DIFF
--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.spec.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/index.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import { partial } from '~test/util.ts';
 import type { UpdateLockedConfig } from '../../../../types.ts';
@@ -58,5 +59,58 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/index', () => {
       config.newVersion = '0.3.1';
       expect(updateLockedDependency(config).status).toBe('updated');
     });
+
+    it.each`
+      otherSelector            | targetSelector
+      ${'other-foo@^1.0.0'}    | ${'foo@^1.0.0'}
+      ${'"@scope/foo@^1.0.0"'} | ${'"foo@^1.0.0"'}
+      ${'other-foo@^1.0.0'}    | ${'foo@~1.0.0, foo@^1.0.0'}
+    `(
+      'updates $targetSelector without changing $otherSelector',
+      ({ otherSelector, targetSelector }) => {
+        const lockFileContent = codeBlock`
+          # yarn lockfile v1
+
+          ${otherSelector}:
+            version "1.0.0"
+            resolved "https://registry.yarnpkg.com/other/-/other-1.0.0.tgz"
+
+          ${targetSelector}:
+            version "1.0.0"
+            resolved "https://registry.yarnpkg.com/foo/-/foo-1.0.0.tgz"
+
+          zzz@^1.0.0:
+            version "1.0.0"
+        `;
+
+        const result = updateLockedDependency({
+          ...config,
+          lockFile: 'yarn.lock',
+          lockFileContent,
+          depName: 'foo',
+          currentVersion: '1.0.0',
+          newVersion: '1.0.1',
+        });
+
+        expect(result).toEqual({
+          status: 'updated',
+          files: {
+            'yarn.lock': codeBlock`
+              # yarn lockfile v1
+
+              ${otherSelector}:
+                version "1.0.0"
+                resolved "https://registry.yarnpkg.com/other/-/other-1.0.0.tgz"
+
+              ${targetSelector}:
+                version "1.0.1"
+
+              zzz@^1.0.0:
+                version "1.0.0"
+            `,
+          },
+        });
+      },
+    );
   });
 });

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.spec.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.spec.ts
@@ -121,6 +121,19 @@ describe('modules/manager/npm/update/locked-dependency/yarn-lock/replace', () =>
       `);
     });
 
+    it('replaces a non-leading selector', () => {
+      const res = replaceConstraintVersion(
+        yarnLock2,
+        'string-width',
+        '^2.0.0',
+        '2.2.0',
+      );
+
+      expect(res).toContain(
+        '"string-width@^1.0.1 || ^2.0.0", string-width@^2.0.0:\n  version "2.2.0"\n  dependencies:',
+      );
+    });
+
     it('handles quoted', () => {
       const res = replaceConstraintVersion(
         yarnLock2,

--- a/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.ts
+++ b/lib/modules/manager/npm/update/locked-dependency/yarn-lock/replace.ts
@@ -17,7 +17,7 @@ export function replaceConstraintVersion(
     regEx(/(?<special>@|\^|\.|\\|\|)/g),
     '\\$<special>',
   );
-  const matchString = `(${escaped}(("|",|,)[^\n:]*)?:\n)(.*\n)*?(\\s+dependencies|\n[@a-z])`;
+  const matchString = `((?:^|\n|, )"?${escaped}(("|",|,)[^\n:]*)?:\n)(.*\n)*?(\\s+dependencies|\n[@a-z])`;
   // yarn will fill in the details later
   const matchResult = regEx(matchString).exec(lockFileContent);
   /* v8 ignore next -- needs test */


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Yarn v1 lockfile updates can change an unrelated package when its name ends with the requested package's name. For example, an update to `foo@^1.0.0` can match the suffix of an earlier `other-foo@^1.0.0` or `@scope/foo@^1.0.0` selector. Renovate then reports success while leaving `foo` at its old version.

Require the replacement match to start at a selector boundary. This confines the update to the requested package while still allowing quoted selectors and entries shared by multiple constraints.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GPT-6 Astra was used to identify the bug, implement the fix and regression tests, and draft this description.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
