### PR TITLE
fix(datasource): isolate release lookups by registry configuration

### DIFF
--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -7,6 +7,7 @@ import {
   HOST_DISABLED,
 } from '../../constants/error-messages.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
+import * as memCache from '../../util/cache/memory/index.ts';
 import * as _packageCache from '../../util/cache/package/index.ts';
 import { loadModules } from '../../util/modules.ts';
 import datasources from './api.ts';
@@ -22,6 +23,7 @@ import {
 import type {
   DatasourceApi,
   DigestConfig,
+  GetPkgReleasesConfig,
   GetReleasesConfig,
   ReleaseResult,
 } from './types.ts';
@@ -316,6 +318,58 @@ describe('modules/datasource/index', () => {
   });
 
   describe('Packages', () => {
+    describe('registry caching', () => {
+      beforeEach(() => memCache.init());
+      afterEach(() => memCache.reset());
+
+      it.each(['defaultRegistryUrls', 'additionalRegistryUrls'])(
+        'keeps releases separate for different %s',
+        async (registryOption) => {
+          const firstRegistry = vi.fn(() => ({
+            releases: [{ version: '1.0.0' }],
+          }));
+          const secondRegistry = vi.fn(() => ({
+            releases: [{ version: '2.0.0' }],
+          }));
+          datasources.set(
+            datasource,
+            new DummyDatasource({
+              'https://reg2.com': firstRegistry,
+              'https://reg3.com': secondRegistry,
+            }),
+          );
+          const firstConfig = {
+            datasource,
+            packageName,
+            registryStrategy: 'merge',
+            [registryOption]: ['https://reg2.com'],
+          } satisfies GetPkgReleasesConfig;
+          const secondConfig = {
+            ...firstConfig,
+            [registryOption]: ['https://reg3.com'],
+          };
+
+          const [first, second, repeated] = await Promise.all([
+            getPkgReleases(firstConfig),
+            getPkgReleases(secondConfig),
+            getPkgReleases(secondConfig),
+          ]);
+
+          expect(first).toMatchObject({
+            releases: [{ version: '1.0.0' }],
+            registryUrl: 'https://reg2.com',
+          });
+          expect(second).toMatchObject({
+            releases: [{ version: '2.0.0' }],
+            registryUrl: 'https://reg3.com',
+          });
+          expect(repeated).toEqual(second);
+          expect(firstRegistry).toHaveBeenCalledTimes(1);
+          expect(secondRegistry).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+
     it('supports defaultRegistryUrls parameter', async () => {
       const registries: RegistriesMock = {
         'https://foo.bar': { releases: [{ version: '0.0.1' }] },

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -444,8 +444,8 @@ function fetchCachedReleases(
   config: GetReleasesInternalConfig,
 ): Promise<ReleaseResult | null> {
   const { datasource, packageName, registryUrls } = config;
-  const cacheKey = `datasource-mem:releases:${datasource}:${packageName}:${config.registryStrategy}:${String(
-    registryUrls,
+  const cacheKey = `datasource-mem:releases:${datasource}:${packageName}:${config.registryStrategy}:${JSON.stringify(
+    [registryUrls, config.defaultRegistryUrls, config.additionalRegistryUrls],
   )}`;
   // By returning a Promise and reusing it, we should only fetch each package at most once
   const cachedResult = memCache.get<Promise<ReleaseResult | null>>(cacheKey);

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -24,6 +24,7 @@ import { clone } from '../../util/clone.ts';
 import { filterMap } from '../../util/filter-map.ts';
 import { AsyncResult, Result } from '../../util/result.ts';
 import { DatasourceCacheStats } from '../../util/stats.ts';
+import { safeStringify } from '../../util/stringify.ts';
 import { trimTrailingSlash } from '../../util/url.ts';
 import * as versioning from '../versioning/index.ts';
 import datasources from './api.ts';
@@ -202,7 +203,10 @@ async function mergeRegistries(
   const releaseVersioning = versioning.get(config.versioning);
   for (const registryUrl of registryUrls) {
     try {
-      const res = await getRegistryReleases(datasource, config, registryUrl);
+      // Merging must not mutate responses shared by the package cache.
+      const res = clone(
+        await getRegistryReleases(datasource, config, registryUrl),
+      );
       if (!res) {
         continue;
       }
@@ -444,7 +448,7 @@ function fetchCachedReleases(
   config: GetReleasesInternalConfig,
 ): Promise<ReleaseResult | null> {
   const { datasource, packageName, registryUrls } = config;
-  const cacheKey = `datasource-mem:releases:${datasource}:${packageName}:${config.registryStrategy}:${JSON.stringify(
+  const cacheKey = `datasource-mem:releases:${datasource}:${packageName}:${config.registryStrategy}:${safeStringify(
     [registryUrls, config.defaultRegistryUrls, config.additionalRegistryUrls],
   )}`;
   // By returning a Promise and reusing it, we should only fetch each package at most once

--- a/lib/modules/datasource/pypi/index.spec.ts
+++ b/lib/modules/datasource/pypi/index.spec.ts
@@ -1,10 +1,14 @@
 import { codeBlock } from 'common-tags';
 import { GoogleAuth as _googleAuth } from 'google-auth-library';
+import { dir as tmpDir } from 'tmp-promise';
 import { Fixtures } from '~test/fixtures.ts';
 import * as httpMock from '~test/http-mock.ts';
 import { partial } from '~test/util.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
+import * as memCache from '../../../util/cache/memory/index.ts';
+import * as packageCache from '../../../util/cache/package/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
+import { extractPackageFile } from '../../manager/pip_requirements/extract.ts';
 import { getPkgReleases } from '../index.ts';
 import { PypiDatasource } from './index.ts';
 
@@ -79,6 +83,65 @@ const baseUrl = 'https://pypi.org/pypi';
 const datasource = PypiDatasource.id;
 
 describe('modules/datasource/pypi/index', () => {
+  describe('registry caching', () => {
+    let cacheDir: Awaited<ReturnType<typeof tmpDir>>;
+
+    beforeEach(async () => {
+      memCache.init();
+      cacheDir = await tmpDir({ unsafeCleanup: true });
+      await packageCache.init({ cacheDir: cacheDir.path });
+    });
+
+    afterEach(async () => {
+      await packageCache.cleanup({});
+      memCache.reset();
+      await cacheDir.cleanup();
+    });
+
+    it('keeps merged PyPI releases within each requirements file registry set', async () => {
+      httpMock
+        .scope(PypiDatasource.defaultURL)
+        .get('/foo/json')
+        .reply(200, { releases: { '1.0.0': [{}] } });
+      httpMock
+        .scope('https://index-a.example/pypi')
+        .get('/foo/json')
+        .reply(200, { releases: { '2.0.0': [{}] } });
+      httpMock
+        .scope('https://index-b.example/pypi')
+        .get('/foo/json')
+        .reply(200, { releases: { '3.0.0': [{}] } });
+
+      const fileA = extractPackageFile(
+        '--extra-index-url https://index-a.example/pypi\nfoo==1.0.0\n',
+      )!;
+      const fileB = extractPackageFile(
+        '--extra-index-url https://index-b.example/pypi\nfoo==1.0.0\n',
+      )!;
+      const firstConfig = {
+        ...fileA,
+        datasource: 'pypi',
+        packageName: fileA.deps[0].packageName!,
+      };
+      const first = await getPkgReleases(firstConfig);
+      const second = await getPkgReleases({
+        ...fileB,
+        datasource: 'pypi',
+        packageName: fileB.deps[0].packageName!,
+      });
+
+      expect(first?.releases.map(({ version }) => version)).toEqual([
+        '1.0.0',
+        '2.0.0',
+      ]);
+      expect(second?.releases.map(({ version }) => version)).toEqual([
+        '1.0.0',
+        '3.0.0',
+      ]);
+      await expect(getPkgReleases(firstConfig)).resolves.toEqual(first);
+    });
+  });
+
   describe('getReleases', () => {
     beforeEach(() => {
       vi.stubEnv('PIP_INDEX_URL', undefined);


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Keep release lookups separate when the same package uses different default or additional registries. This prevents one dependency's registry settings from hiding available updates or supplying versions unavailable from another dependency's registries.

For example, suppose a repository contains these two files:

`service-a/requirements.txt`:

```text
--extra-index-url https://index-a.example/simple
foo==1.0.0
```

`service-b/requirements.txt`:

```text
--extra-index-url https://index-b.example/simple
foo==1.0.0
```

Assume PyPI has `foo` version `1.0.0`, index A has `2.0.0`, and index B has `3.0.0`. Each file should see PyPI plus its own extra index:

| Lookup | Expected versions | Before this fix, if A is looked up first |
| --- | --- | --- |
| Service A | `1.0.0`, `2.0.0` | `1.0.0`, `2.0.0` |
| Service B | `1.0.0`, `3.0.0` | `1.0.0`, `2.0.0` |

Two cache behaviors need to change:

1. **Separate the complete lookups.** The in-memory cache key omits `additionalRegistryUrls`, where the requirements manager stores `--extra-index-url`. Service B therefore reuses service A's result and never sees `3.0.0`. Include both `additionalRegistryUrls` and `defaultRegistryUrls` in the key. The latter has the same problem when lookups select different fallback registries.
2. **Keep individual registry responses unchanged.** Merging A's releases currently appends `2.0.0` to the cached PyPI response itself. Even with separate lookup keys, a later lookup of PyPI plus B can then return `1.0.0`, `2.0.0`, and `3.0.0`. Clone each registry response before merging so B receives only `1.0.0` and `3.0.0`.

The cache key preserves the order and boundaries of all three registry lists. Identical lookup settings continue to share the same fetch.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

GPT-6 Astra was used to identify the bug, implement the fix and regression tests, and draft this description.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable.

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->

