### PR TITLE
chore(tools): add a tool to summarise release notes

### DIFF
--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -237,12 +237,10 @@ describe('tools/release-notes/module-changelog', () => {
       expect(group.modules.map((m) => m.label)).toEqual(['Cargo', 'npm']);
     });
 
-    it('groups a bare (non-module) scope with enough commits as its own flat group', () => {
+    it('groups a bare (non-module) scope as its own flat group, however few commits it has', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'workers/repository', subject: 'a' },
-        { type: 'refactor', scope: 'workers/repository', subject: 'b' },
-        { type: 'fix', scope: 'tools', subject: 'c' },
-        { type: 'fix', scope: 'tools', subject: 'd' },
+        { type: 'fix', scope: 'tools', subject: 'b' },
       ];
 
       const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
@@ -255,8 +253,7 @@ describe('tools/release-notes/module-changelog', () => {
     it('sorts category groups ahead of flat groups', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'workers/repository', subject: 'a' },
-        { type: 'refactor', scope: 'workers/repository', subject: 'b' },
-        { type: 'fix', scope: 'versioning/cargo', subject: 'c' },
+        { type: 'fix', scope: 'versioning/cargo', subject: 'b' },
       ];
 
       const groups = groupByModule(
@@ -279,7 +276,6 @@ describe('tools/release-notes/module-changelog', () => {
         { type: 'docs', scope: undefined, subject: 'a' },
         { type: 'chore', scope: 'deps', subject: 'b' },
         { type: 'fix', scope: 'workers/repository', subject: 'c' },
-        { type: 'refactor', scope: 'workers/repository', subject: 'd' },
       ];
 
       const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
@@ -343,54 +339,15 @@ describe('tools/release-notes/module-changelog', () => {
       expect(group.commits).toHaveLength(2);
     });
 
-    describe('pooling small flat groups into "Other"', () => {
-      it('pools a scope below MIN_SCOPE_GROUP_SIZE, keeping the scope inline', () => {
-        const commits: ParsedCommit[] = [
-          { type: 'fix', scope: 'tools', subject: 'a' },
-        ];
+    it('gives a singleton scope its own group rather than folding it into Other', () => {
+      // A scope stays scannable on its own — e.g. searching for "Cargo" —
+      // even if it only has one commit in this range.
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'tools', subject: 'a' },
+      ];
 
-        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
-        expect(groups).toHaveLength(1);
-        expect(groups[0]).toMatchObject({ scope: undefined, label: 'Other' });
-        expect(groups[0].commits[0].subject).toBe('`tools` a');
-      });
-
-      it('keeps a scope at MIN_SCOPE_GROUP_SIZE as its own group', () => {
-        const commits: ParsedCommit[] = [
-          { type: 'fix', scope: 'tools', subject: 'a' },
-          { type: 'fix', scope: 'tools', subject: 'b' },
-        ];
-
-        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
-        expect(groups.map((g) => g.scope)).toEqual(['tools']);
-      });
-
-      it('never pools a COLLAPSED_SCOPES scope, even with a single commit', () => {
-        const commits: ParsedCommit[] = [
-          {
-            type: 'chore',
-            scope: 'deps',
-            subject: 'update dependency foo to v1.0.0',
-          },
-        ];
-
-        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
-        expect(groups.map((g) => g.scope)).toEqual(['deps']);
-      });
-
-      it('merges pooled commits into an existing Other group, sorted by type', () => {
-        const commits: ParsedCommit[] = [
-          { type: 'docs', scope: undefined, subject: 'existing other entry' },
-          { type: 'fix', scope: 'tools', subject: 'pooled fix' },
-        ];
-
-        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
-        expect(groups).toHaveLength(1);
-        expect(groups[0].commits.map((c) => c.subject)).toEqual([
-          '`tools` pooled fix',
-          'existing other entry',
-        ]);
-      });
+      const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+      expect(groups.map((g) => g.scope)).toEqual(['tools']);
     });
 
     describe('breaking changes', () => {
@@ -470,12 +427,10 @@ describe('tools/release-notes/module-changelog', () => {
       const groups = groupByModule(
         [
           { type: 'fix', scope: 'workers/repository', subject: 'a' },
-          { type: 'refactor', scope: 'workers/repository', subject: 'b' },
-          { type: 'docs', scope: undefined, subject: 'c' },
+          { type: 'docs', scope: undefined, subject: 'b' },
         ],
         [
           { type: 'fix', section: 'Bug Fixes' },
-          { type: 'refactor', section: 'Code Refactoring' },
           { type: 'docs', section: 'Documentation' },
         ],
         new Map(),
@@ -486,11 +441,10 @@ describe('tools/release-notes/module-changelog', () => {
           '### workers/repository',
           '',
           '- fix: a',
-          '- refactor: b',
           '',
           '### Other',
           '',
-          '- docs: c',
+          '- docs: b',
         ].join('\n'),
       );
     });

--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -1,9 +1,16 @@
 import type { ParsedCommit } from './module-changelog.ts';
 import {
+  categoryRank,
   groupByModule,
   parseCommitHeader,
   renderModuleChangelog,
 } from './module-changelog.ts';
+
+const types = [
+  { type: 'feat', section: 'Features' },
+  { type: 'fix', section: 'Bug Fixes' },
+  { type: 'refactor', section: 'Code Refactoring' },
+];
 
 describe('tools/release-notes/module-changelog', () => {
   describe('parseCommitHeader', () => {
@@ -48,35 +55,71 @@ describe('tools/release-notes/module-changelog', () => {
     });
   });
 
-  describe('groupByModule', () => {
-    const types = [
-      { type: 'feat', section: 'Features' },
-      { type: 'fix', section: 'Bug Fixes' },
-      { type: 'refactor', section: 'Code Refactoring' },
-    ];
-
-    it('groups commits by scope and sorts groups alphabetically', () => {
-      const commits: ParsedCommit[] = [
-        { type: 'fix', scope: 'workers/repository', subject: 'a' },
-        { type: 'fix', scope: 'manager/gitlab', subject: 'b' },
-      ];
-
-      expect(groupByModule(commits, types).map((g) => g.scope)).toEqual([
-        'manager/gitlab',
-        'workers/repository',
-      ]);
+  describe('categoryRank', () => {
+    it('ranks module scopes ahead of everything else', () => {
+      expect(categoryRank('versioning/cargo')).toBeLessThan(
+        categoryRank('workers/repository'),
+      );
+      expect(categoryRank('manager/npm')).toBeLessThan(
+        categoryRank('workers/repository'),
+      );
     });
 
-    it('sorts the scope-less group last', () => {
+    it('ranks deps last of the named scopes', () => {
+      expect(categoryRank('workers/repository')).toBeLessThan(
+        categoryRank('deps'),
+      );
+    });
+  });
+
+  describe('groupByModule', () => {
+    it('groups commits by scope', () => {
       const commits: ParsedCommit[] = [
-        { type: 'docs', scope: undefined, subject: 'a' },
-        { type: 'fix', scope: 'manager/gitlab', subject: 'b' },
+        { type: 'fix', scope: 'workers/repository', subject: 'a' },
+        { type: 'fix', scope: 'tools', subject: 'b' },
       ];
 
-      expect(groupByModule(commits, types).map((g) => g.scope)).toEqual([
-        'manager/gitlab',
-        undefined,
+      expect(
+        groupByModule(commits, types, new Map()).map((g) => g.scope),
+      ).toEqual(['tools', 'workers/repository']);
+    });
+
+    it('sorts module scopes ahead of non-module scopes', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'workers/repository', subject: 'a' },
+        { type: 'fix', scope: 'versioning/cargo', subject: 'b' },
+      ];
+
+      expect(
+        groupByModule(commits, types, new Map()).map((g) => g.scope),
+      ).toEqual(['versioning/cargo', 'workers/repository']);
+    });
+
+    it('sorts deps after non-module scopes, and Other last', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'docs', scope: undefined, subject: 'a' },
+        { type: 'chore', scope: 'deps', subject: 'b' },
+        { type: 'fix', scope: 'workers/repository', subject: 'c' },
+      ];
+
+      expect(
+        groupByModule(commits, types, new Map()).map((g) => g.scope),
+      ).toEqual(['workers/repository', 'deps', undefined]);
+    });
+
+    it('sorts within a rank by resolved label, falling back to the scope', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'manager/gitlabci', subject: 'a' },
+        { type: 'fix', scope: 'versioning/cargo', subject: 'b' },
+      ];
+      const labels = new Map([
+        ['manager/gitlabci', 'GitLab CI/CD'],
+        ['versioning/cargo', 'Cargo'],
       ]);
+
+      expect(groupByModule(commits, types, labels).map((g) => g.label)).toEqual(
+        ['Cargo', 'GitLab CI/CD'],
+      );
     });
 
     it('sorts commits within a group by type priority', () => {
@@ -89,7 +132,7 @@ describe('tools/release-notes/module-changelog', () => {
         { type: 'fix', scope: 'workers/repository', subject: 'fix it' },
       ];
 
-      expect(groupByModule(commits, types)[0].commits).toEqual([
+      expect(groupByModule(commits, types, new Map())[0].commits).toEqual([
         { type: 'fix', scope: 'workers/repository', subject: 'fix it' },
         {
           type: 'refactor',
@@ -101,46 +144,63 @@ describe('tools/release-notes/module-changelog', () => {
 
     it('ranks unknown types after known types', () => {
       const commits: ParsedCommit[] = [
-        { type: 'chore', scope: 'deps', subject: 'chore it' },
-        { type: 'fix', scope: 'deps', subject: 'fix it' },
+        { type: 'chore', scope: 'tools', subject: 'chore it' },
+        { type: 'fix', scope: 'tools', subject: 'fix it' },
       ];
 
       expect(
-        groupByModule(commits, types)[0].commits.map((c) => c.type),
+        groupByModule(commits, types, new Map())[0].commits.map((c) => c.type),
       ).toEqual(['fix', 'chore']);
     });
   });
 
   describe('renderModuleChangelog', () => {
-    it('renders a nested Markdown list', () => {
+    it('renders a nested Markdown list, using the resolved label', () => {
       const groups = groupByModule(
         [
-          {
-            type: 'fix',
-            scope: 'workers/repository',
-            subject: 'ensure checks',
-          },
-          {
-            type: 'refactor',
-            scope: 'workers/repository',
-            subject: 'add a check',
-          },
+          { type: 'fix', scope: 'versioning/cargo', subject: 'ensure checks' },
           { type: 'docs', scope: undefined, subject: 'add warning' },
         ],
         [
           { type: 'fix', section: 'Bug Fixes' },
-          { type: 'refactor', section: 'Code Refactoring' },
           { type: 'docs', section: 'Documentation' },
         ],
+        new Map([['versioning/cargo', 'Cargo']]),
       );
 
       expect(renderModuleChangelog(groups)).toBe(
         [
-          '- workers/repository',
+          '- Cargo',
           '  - fix: ensure checks',
-          '  - refactor: add a check',
           '- Other',
           '  - docs: add warning',
+        ].join('\n'),
+      );
+    });
+
+    it('collapses a `deps` group behind a <details> block', () => {
+      const groups = groupByModule(
+        [
+          { type: 'chore', scope: 'deps', subject: 'update foo' },
+          { type: 'build', scope: 'deps', subject: 'update bar' },
+        ],
+        [
+          { type: 'chore', section: 'Miscellaneous Chores' },
+          { type: 'build', section: 'Build System' },
+        ],
+        new Map(),
+      );
+
+      expect(renderModuleChangelog(groups)).toBe(
+        [
+          '- deps',
+          '  <details>',
+          '  <summary>2 updates</summary>',
+          '',
+          '  - chore: update foo',
+          '  - build: update bar',
+          '',
+          '  </details>',
         ].join('\n'),
       );
     });

--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -4,6 +4,7 @@ import type {
   ParsedCommit,
 } from './module-changelog.ts';
 import {
+  attributeReleases,
   categoryRank,
   consolidateDependencyBumps,
   dedupeCommits,
@@ -12,6 +13,7 @@ import {
   groupByModule,
   parseCommitHeader,
   renderModuleChangelog,
+  stripPrReference,
 } from './module-changelog.ts';
 
 const types = [
@@ -19,6 +21,8 @@ const types = [
   { type: 'fix', section: 'Bug Fixes' },
   { type: 'refactor', section: 'Code Refactoring' },
 ];
+
+const repo = 'renovatebot/renovate';
 
 describe('tools/release-notes/module-changelog', () => {
   describe('parseCommitHeader', () => {
@@ -399,7 +403,7 @@ describe('tools/release-notes/module-changelog', () => {
         ]),
       );
 
-      expect(renderModuleChangelog(groups)).toBe(
+      expect(renderModuleChangelog(groups, repo)).toBe(
         [
           '### manager',
           '',
@@ -418,7 +422,7 @@ describe('tools/release-notes/module-changelog', () => {
         new Map(),
       );
 
-      expect(renderModuleChangelog(groups)).toBe(
+      expect(renderModuleChangelog(groups, repo)).toBe(
         ['### Other', '', '- docs: add warning'].join('\n'),
       );
     });
@@ -436,7 +440,7 @@ describe('tools/release-notes/module-changelog', () => {
         new Map(),
       );
 
-      expect(renderModuleChangelog(groups)).toBe(
+      expect(renderModuleChangelog(groups, repo)).toBe(
         [
           '### workers/repository',
           '',
@@ -467,7 +471,7 @@ describe('tools/release-notes/module-changelog', () => {
         new Map(),
       );
 
-      expect(renderModuleChangelog(groups)).toBe(
+      expect(renderModuleChangelog(groups, repo)).toBe(
         [
           '### Breaking changes',
           '',
@@ -494,7 +498,7 @@ describe('tools/release-notes/module-changelog', () => {
         new Map(),
       );
 
-      expect(renderModuleChangelog(groups)).toBe(
+      expect(renderModuleChangelog(groups, repo)).toBe(
         [
           '### deps',
           '',
@@ -535,7 +539,7 @@ describe('tools/release-notes/module-changelog', () => {
         new Map(),
       );
 
-      const rendered = renderModuleChangelog(groups);
+      const rendered = renderModuleChangelog(groups, repo);
       expect(rendered).toContain('<summary>3 updates</summary>');
       // Only the final version survives as a displayed entry.
       expect(rendered).toContain(
@@ -685,6 +689,94 @@ describe('tools/release-notes/module-changelog', () => {
     it('leaves code spans and URLs untouched', () => {
       expect(escapeMentions('see `@foo` at https://example.com/@bar')).toBe(
         'see `@foo` at https://example.com/@bar',
+      );
+    });
+  });
+
+  describe('stripPrReference', () => {
+    it('strips a trailing PR reference', () => {
+      expect(stripPrReference('support ~latest component refs (#45234)')).toBe(
+        'support ~latest component refs',
+      );
+    });
+
+    it('strips a channel marker and PR reference together', () => {
+      expect(
+        stripPrReference(
+          'update dependency @biomejs/biome to v2.5.11 (main) (#45676)',
+        ),
+      ).toBe('update dependency @biomejs/biome to v2.5.11');
+    });
+
+    it('leaves a subject with no PR reference untouched', () => {
+      expect(stripPrReference('add warning to `checkedBranches`')).toBe(
+        'add warning to `checkedBranches`',
+      );
+    });
+  });
+
+  describe('attributeReleases', () => {
+    it('attributes each commit to the nearest release at or after it', () => {
+      const releaseTagBySha = new Map([
+        ['c3', '44.61.3'],
+        ['c5', '44.61.4'],
+      ]);
+
+      expect(
+        attributeReleases(['c1', 'c2', 'c3', 'c4', 'c5'], releaseTagBySha),
+      ).toEqual(
+        new Map([
+          ['c1', '44.61.3'],
+          ['c2', '44.61.3'],
+          ['c3', '44.61.3'],
+          ['c4', '44.61.4'],
+          ['c5', '44.61.4'],
+        ]),
+      );
+    });
+
+    it('leaves a trailing commit unattributed if no release follows it', () => {
+      const releaseTagBySha = new Map([['c1', '44.61.3']]);
+
+      const result = attributeReleases(['c1', 'c2'], releaseTagBySha);
+      expect(result.get('c1')).toBe('44.61.3');
+      expect(result.has('c2')).toBe(false);
+    });
+  });
+
+  describe('renderModuleChangelog release links', () => {
+    it('appends a release link when the commit has one', () => {
+      const groups = groupByModule(
+        [
+          {
+            type: 'fix',
+            scope: 'workers/repository',
+            subject: 'a',
+            release: '44.61.3',
+          },
+        ],
+        types,
+        new Map(),
+      );
+
+      expect(renderModuleChangelog(groups, repo)).toBe(
+        [
+          '### workers/repository',
+          '',
+          '- fix: a ([44.61.3](https://github.com/renovatebot/renovate/releases/tag/44.61.3))',
+        ].join('\n'),
+      );
+    });
+
+    it('omits the release link when the commit has none', () => {
+      const groups = groupByModule(
+        [{ type: 'fix', scope: 'workers/repository', subject: 'a' }],
+        types,
+        new Map(),
+      );
+
+      expect(renderModuleChangelog(groups, repo)).toBe(
+        ['### workers/repository', '', '- fix: a'].join('\n'),
       );
     });
   });

--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -1,4 +1,8 @@
-import type { ParsedCommit } from './module-changelog.ts';
+import type {
+  CategoryGroup,
+  FlatGroup,
+  ParsedCommit,
+} from './module-changelog.ts';
 import {
   categoryRank,
   groupByModule,
@@ -73,26 +77,85 @@ describe('tools/release-notes/module-changelog', () => {
   });
 
   describe('groupByModule', () => {
-    it('groups commits by scope', () => {
+    it('nests module scopes under a category group', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'manager/gitlabci', subject: 'a' },
+        { type: 'fix', scope: 'manager/npm', subject: 'b' },
+      ];
+      const labels = new Map([
+        ['manager/gitlabci', 'GitLab CI/CD'],
+        ['manager/npm', 'npm'],
+      ]);
+
+      const groups = groupByModule(commits, types, labels);
+      expect(groups).toEqual([
+        {
+          kind: 'category',
+          category: 'manager',
+          modules: [
+            {
+              scope: 'manager/gitlabci',
+              label: 'GitLab CI/CD',
+              commits: [
+                { type: 'fix', scope: 'manager/gitlabci', subject: 'a' },
+              ],
+            },
+            {
+              scope: 'manager/npm',
+              label: 'npm',
+              commits: [{ type: 'fix', scope: 'manager/npm', subject: 'b' }],
+            },
+          ],
+        },
+      ]);
+    });
+
+    it('sorts modules within a category alphabetically by label', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'versioning/cargo', subject: 'a' },
+        { type: 'fix', scope: 'versioning/npm', subject: 'b' },
+      ];
+      const labels = new Map([
+        ['versioning/cargo', 'Cargo'],
+        ['versioning/npm', 'npm'],
+      ]);
+
+      const [group] = groupByModule(commits, types, labels) as [CategoryGroup];
+      expect(group.modules.map((m) => m.label)).toEqual(['Cargo', 'npm']);
+    });
+
+    it('groups a bare (non-module) scope as a flat group', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'workers/repository', subject: 'a' },
         { type: 'fix', scope: 'tools', subject: 'b' },
       ];
 
-      expect(
-        groupByModule(commits, types, new Map()).map((g) => g.scope),
-      ).toEqual(['tools', 'workers/repository']);
+      const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+      expect(groups.map((g) => g.scope)).toEqual([
+        'tools',
+        'workers/repository',
+      ]);
     });
 
-    it('sorts module scopes ahead of non-module scopes', () => {
+    it('sorts category groups ahead of flat groups', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'workers/repository', subject: 'a' },
         { type: 'fix', scope: 'versioning/cargo', subject: 'b' },
       ];
 
-      expect(
-        groupByModule(commits, types, new Map()).map((g) => g.scope),
-      ).toEqual(['versioning/cargo', 'workers/repository']);
+      const groups = groupByModule(
+        commits,
+        types,
+        new Map([['versioning/cargo', 'Cargo']]),
+      );
+      expect(groups[0]).toMatchObject({
+        kind: 'category',
+        category: 'versioning',
+      });
+      expect(groups[1]).toMatchObject({
+        kind: 'flat',
+        scope: 'workers/repository',
+      });
     });
 
     it('sorts deps after non-module scopes, and Other last', () => {
@@ -102,24 +165,12 @@ describe('tools/release-notes/module-changelog', () => {
         { type: 'fix', scope: 'workers/repository', subject: 'c' },
       ];
 
-      expect(
-        groupByModule(commits, types, new Map()).map((g) => g.scope),
-      ).toEqual(['workers/repository', 'deps', undefined]);
-    });
-
-    it('sorts within a rank by resolved label, falling back to the scope', () => {
-      const commits: ParsedCommit[] = [
-        { type: 'fix', scope: 'manager/gitlabci', subject: 'a' },
-        { type: 'fix', scope: 'versioning/cargo', subject: 'b' },
-      ];
-      const labels = new Map([
-        ['manager/gitlabci', 'GitLab CI/CD'],
-        ['versioning/cargo', 'Cargo'],
+      const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+      expect(groups.map((g) => g.scope)).toEqual([
+        'workers/repository',
+        'deps',
+        undefined,
       ]);
-
-      expect(groupByModule(commits, types, labels).map((g) => g.label)).toEqual(
-        ['Cargo', 'GitLab CI/CD'],
-      );
     });
 
     it('sorts commits within a group by type priority', () => {
@@ -132,7 +183,8 @@ describe('tools/release-notes/module-changelog', () => {
         { type: 'fix', scope: 'workers/repository', subject: 'fix it' },
       ];
 
-      expect(groupByModule(commits, types, new Map())[0].commits).toEqual([
+      const [group] = groupByModule(commits, types, new Map()) as [FlatGroup];
+      expect(group.commits).toEqual([
         { type: 'fix', scope: 'workers/repository', subject: 'fix it' },
         {
           type: 'refactor',
@@ -148,33 +200,45 @@ describe('tools/release-notes/module-changelog', () => {
         { type: 'fix', scope: 'tools', subject: 'fix it' },
       ];
 
-      expect(
-        groupByModule(commits, types, new Map())[0].commits.map((c) => c.type),
-      ).toEqual(['fix', 'chore']);
+      const [group] = groupByModule(commits, types, new Map()) as [FlatGroup];
+      expect(group.commits.map((c) => c.type)).toEqual(['fix', 'chore']);
     });
   });
 
   describe('renderModuleChangelog', () => {
-    it('renders a nested Markdown list, using the resolved label', () => {
+    it('renders category groups nested three levels deep', () => {
       const groups = groupByModule(
         [
-          { type: 'fix', scope: 'versioning/cargo', subject: 'ensure checks' },
-          { type: 'docs', scope: undefined, subject: 'add warning' },
+          { type: 'fix', scope: 'manager/gitlabci', subject: 'support refs' },
+          { type: 'fix', scope: 'manager/npm', subject: 'massage lockstep' },
         ],
-        [
-          { type: 'fix', section: 'Bug Fixes' },
-          { type: 'docs', section: 'Documentation' },
-        ],
-        new Map([['versioning/cargo', 'Cargo']]),
+        [{ type: 'fix', section: 'Bug Fixes' }],
+        new Map([
+          ['manager/gitlabci', 'GitLab CI/CD'],
+          ['manager/npm', 'npm'],
+        ]),
       );
 
       expect(renderModuleChangelog(groups)).toBe(
         [
-          '- Cargo',
-          '  - fix: ensure checks',
-          '- Other',
-          '  - docs: add warning',
+          '- manager',
+          '  - GitLab CI/CD',
+          '    - fix: support refs',
+          '  - npm',
+          '    - fix: massage lockstep',
         ].join('\n'),
+      );
+    });
+
+    it('renders a flat group using its label', () => {
+      const groups = groupByModule(
+        [{ type: 'docs', scope: undefined, subject: 'add warning' }],
+        [{ type: 'docs', section: 'Documentation' }],
+        new Map(),
+      );
+
+      expect(renderModuleChangelog(groups)).toBe(
+        ['- Other', '  - docs: add warning'].join('\n'),
       );
     });
 

--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -1,0 +1,148 @@
+import type { ParsedCommit } from './module-changelog.ts';
+import {
+  groupByModule,
+  parseCommitHeader,
+  renderModuleChangelog,
+} from './module-changelog.ts';
+
+describe('tools/release-notes/module-changelog', () => {
+  describe('parseCommitHeader', () => {
+    it('parses a scoped type', () => {
+      expect(
+        parseCommitHeader('fix(manager/gitlabci): support ~latest refs'),
+      ).toEqual({
+        type: 'fix',
+        scope: 'manager/gitlabci',
+        subject: 'support ~latest refs',
+      });
+    });
+
+    it('parses an unscoped type', () => {
+      expect(parseCommitHeader('docs: add warning')).toEqual({
+        type: 'docs',
+        scope: undefined,
+        subject: 'add warning',
+      });
+    });
+
+    it('parses a breaking-change marker', () => {
+      expect(parseCommitHeader('feat(api)!: drop old option')).toEqual({
+        type: 'feat',
+        scope: 'api',
+        subject: 'drop old option',
+      });
+    });
+
+    it('lowercases the type', () => {
+      expect(parseCommitHeader('Fix: casing')).toMatchObject({ type: 'fix' });
+    });
+
+    it('returns undefined for a merge commit', () => {
+      expect(
+        parseCommitHeader('Merge pull request #1 from foo/bar'),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for a message with no Conventional Commits header', () => {
+      expect(parseCommitHeader('bump version')).toBeUndefined();
+    });
+  });
+
+  describe('groupByModule', () => {
+    const types = [
+      { type: 'feat', section: 'Features' },
+      { type: 'fix', section: 'Bug Fixes' },
+      { type: 'refactor', section: 'Code Refactoring' },
+    ];
+
+    it('groups commits by scope and sorts groups alphabetically', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'workers/repository', subject: 'a' },
+        { type: 'fix', scope: 'manager/gitlab', subject: 'b' },
+      ];
+
+      expect(groupByModule(commits, types).map((g) => g.scope)).toEqual([
+        'manager/gitlab',
+        'workers/repository',
+      ]);
+    });
+
+    it('sorts the scope-less group last', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'docs', scope: undefined, subject: 'a' },
+        { type: 'fix', scope: 'manager/gitlab', subject: 'b' },
+      ];
+
+      expect(groupByModule(commits, types).map((g) => g.scope)).toEqual([
+        'manager/gitlab',
+        undefined,
+      ]);
+    });
+
+    it('sorts commits within a group by type priority', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'refactor',
+          scope: 'workers/repository',
+          subject: 'refactor it',
+        },
+        { type: 'fix', scope: 'workers/repository', subject: 'fix it' },
+      ];
+
+      expect(groupByModule(commits, types)[0].commits).toEqual([
+        { type: 'fix', scope: 'workers/repository', subject: 'fix it' },
+        {
+          type: 'refactor',
+          scope: 'workers/repository',
+          subject: 'refactor it',
+        },
+      ]);
+    });
+
+    it('ranks unknown types after known types', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'chore', scope: 'deps', subject: 'chore it' },
+        { type: 'fix', scope: 'deps', subject: 'fix it' },
+      ];
+
+      expect(
+        groupByModule(commits, types)[0].commits.map((c) => c.type),
+      ).toEqual(['fix', 'chore']);
+    });
+  });
+
+  describe('renderModuleChangelog', () => {
+    it('renders a nested Markdown list', () => {
+      const groups = groupByModule(
+        [
+          {
+            type: 'fix',
+            scope: 'workers/repository',
+            subject: 'ensure checks',
+          },
+          {
+            type: 'refactor',
+            scope: 'workers/repository',
+            subject: 'add a check',
+          },
+          { type: 'docs', scope: undefined, subject: 'add warning' },
+        ],
+        [
+          { type: 'fix', section: 'Bug Fixes' },
+          { type: 'refactor', section: 'Code Refactoring' },
+          { type: 'docs', section: 'Documentation' },
+        ],
+      );
+
+      expect(renderModuleChangelog(groups)).toBe(
+        [
+          '- workers/repository',
+          '  - fix: ensure checks',
+          '  - refactor: add a check',
+          '- Other',
+          '  - docs: add warning',
+        ].join('\n'),
+      );
+    });
+  });
+});

--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -5,6 +5,7 @@ import type {
 } from './module-changelog.ts';
 import {
   categoryRank,
+  consolidateDependencyBumps,
   groupByModule,
   parseCommitHeader,
   renderModuleChangelog,
@@ -206,7 +207,7 @@ describe('tools/release-notes/module-changelog', () => {
   });
 
   describe('renderModuleChangelog', () => {
-    it('renders category groups nested three levels deep', () => {
+    it('renders a category group as an h3 heading, modules as a list', () => {
       const groups = groupByModule(
         [
           { type: 'fix', scope: 'manager/gitlabci', subject: 'support refs' },
@@ -221,16 +222,17 @@ describe('tools/release-notes/module-changelog', () => {
 
       expect(renderModuleChangelog(groups)).toBe(
         [
-          '- manager',
-          '  - GitLab CI/CD',
-          '    - fix: support refs',
-          '  - npm',
-          '    - fix: massage lockstep',
+          '### manager',
+          '',
+          '- GitLab CI/CD',
+          '  - fix: support refs',
+          '- npm',
+          '  - fix: massage lockstep',
         ].join('\n'),
       );
     });
 
-    it('renders a flat group using its label', () => {
+    it('renders a flat group as an h3 heading, commits as a list', () => {
       const groups = groupByModule(
         [{ type: 'docs', scope: undefined, subject: 'add warning' }],
         [{ type: 'docs', section: 'Documentation' }],
@@ -238,7 +240,33 @@ describe('tools/release-notes/module-changelog', () => {
       );
 
       expect(renderModuleChangelog(groups)).toBe(
-        ['- Other', '  - docs: add warning'].join('\n'),
+        ['### Other', '', '- docs: add warning'].join('\n'),
+      );
+    });
+
+    it('joins multiple groups with a blank line between them', () => {
+      const groups = groupByModule(
+        [
+          { type: 'fix', scope: 'workers/repository', subject: 'a' },
+          { type: 'docs', scope: undefined, subject: 'b' },
+        ],
+        [
+          { type: 'fix', section: 'Bug Fixes' },
+          { type: 'docs', section: 'Documentation' },
+        ],
+        new Map(),
+      );
+
+      expect(renderModuleChangelog(groups)).toBe(
+        [
+          '### workers/repository',
+          '',
+          '- fix: a',
+          '',
+          '### Other',
+          '',
+          '- docs: b',
+        ].join('\n'),
       );
     });
 
@@ -257,16 +285,158 @@ describe('tools/release-notes/module-changelog', () => {
 
       expect(renderModuleChangelog(groups)).toBe(
         [
-          '- deps',
-          '  <details>',
-          '  <summary>2 updates</summary>',
+          '### deps',
           '',
-          '  - chore: update foo',
-          '  - build: update bar',
+          '<details>',
+          '<summary>2 updates</summary>',
           '',
-          '  </details>',
+          '- chore: update foo',
+          '- build: update bar',
+          '',
+          '</details>',
         ].join('\n'),
       );
+    });
+
+    it('counts every folded-in commit in the <summary>, not just the displayed entries', () => {
+      const groups = groupByModule(
+        [
+          {
+            type: 'fix',
+            scope: 'deps',
+            subject:
+              'update ghcr.io/renovatebot/base-image docker tag to v13.95.4',
+          },
+          {
+            type: 'fix',
+            scope: 'deps',
+            subject:
+              'update ghcr.io/renovatebot/base-image docker tag to v13.95.5',
+          },
+          {
+            type: 'fix',
+            scope: 'deps',
+            subject:
+              'update ghcr.io/renovatebot/base-image docker tag to v13.95.6',
+          },
+        ],
+        [{ type: 'fix', section: 'Bug Fixes' }],
+        new Map(),
+      );
+
+      const rendered = renderModuleChangelog(groups);
+      expect(rendered).toContain('<summary>3 updates</summary>');
+      // Only the final version survives as a displayed entry.
+      expect(rendered).toContain(
+        '- fix: update ghcr.io/renovatebot/base-image docker tag to v13.95.6 (3 updates)',
+      );
+      expect(rendered).not.toContain('v13.95.4');
+      expect(rendered).not.toContain('v13.95.5');
+    });
+  });
+
+  describe('consolidateDependencyBumps', () => {
+    it('folds repeated bumps of the same dependency into the latest one', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'fix',
+          scope: 'deps',
+          subject:
+            'update ghcr.io/renovatebot/base-image docker tag to v13.95.4 (main) (#45620)',
+        },
+        {
+          type: 'fix',
+          scope: 'deps',
+          subject:
+            'update ghcr.io/renovatebot/base-image docker tag to v13.95.5 (main) (#45625)',
+        },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual([
+        {
+          type: 'fix',
+          scope: 'deps',
+          subject:
+            'update ghcr.io/renovatebot/base-image docker tag to v13.95.5 (2 updates)',
+        },
+      ]);
+    });
+
+    it('keeps a single bump unchanged', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'build',
+          scope: 'deps',
+          subject: 'update dependency p-map to v7.0.7 (main) (#45678)',
+        },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual(commits);
+    });
+
+    it('does not fold bumps of different dependencies together', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'build',
+          scope: 'deps',
+          subject: 'update dependency foo to v1.0.0',
+        },
+        {
+          type: 'build',
+          scope: 'deps',
+          subject: 'update dependency bar to v2.0.0',
+        },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual(commits);
+    });
+
+    it('does not fold bumps of the same dependency across different types', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'build',
+          scope: 'deps',
+          subject: 'update dependency protobufjs to v8.8.0',
+        },
+        {
+          type: 'chore',
+          scope: 'deps',
+          subject: 'update dependency protobufjs@8.0.1 to v8.8.0',
+        },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual(commits);
+    });
+
+    it('leaves non-dependency-update subjects untouched', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'chore', scope: 'deps', subject: 'lock file maintenance' },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual(commits);
+    });
+
+    it('strips a pinned-version suffix from the grouping key', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'chore',
+          scope: 'deps',
+          subject: 'update dependency protobufjs@8.0.1 to v8.8.0',
+        },
+        {
+          type: 'chore',
+          scope: 'deps',
+          subject: 'update dependency protobufjs@8.8.0 to v8.9.0',
+        },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual([
+        {
+          type: 'chore',
+          scope: 'deps',
+          subject: 'update dependency protobufjs@8.8.0 to v8.9.0 (2 updates)',
+        },
+      ]);
     });
   });
 });

--- a/tools/release-notes/module-changelog.spec.ts
+++ b/tools/release-notes/module-changelog.spec.ts
@@ -6,6 +6,9 @@ import type {
 import {
   categoryRank,
   consolidateDependencyBumps,
+  dedupeCommits,
+  escapeMentions,
+  filterHiddenTypes,
   groupByModule,
   parseCommitHeader,
   renderModuleChangelog,
@@ -26,6 +29,7 @@ describe('tools/release-notes/module-changelog', () => {
         type: 'fix',
         scope: 'manager/gitlabci',
         subject: 'support ~latest refs',
+        breaking: false,
       });
     });
 
@@ -34,6 +38,7 @@ describe('tools/release-notes/module-changelog', () => {
         type: 'docs',
         scope: undefined,
         subject: 'add warning',
+        breaking: false,
       });
     });
 
@@ -42,6 +47,7 @@ describe('tools/release-notes/module-changelog', () => {
         type: 'feat',
         scope: 'api',
         subject: 'drop old option',
+        breaking: true,
       });
     });
 
@@ -74,6 +80,72 @@ describe('tools/release-notes/module-changelog', () => {
       expect(categoryRank('workers/repository')).toBeLessThan(
         categoryRank('deps'),
       );
+    });
+  });
+
+  describe('dedupeCommits', () => {
+    it('folds exact repeats (same type, scope, subject) and counts them', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'feat',
+          scope: undefined,
+          subject: 'always set `CI=true` for subprocesses',
+        },
+        {
+          type: 'feat',
+          scope: undefined,
+          subject: 'always set `CI=true` for subprocesses',
+        },
+      ];
+
+      expect(dedupeCommits(commits)).toEqual([
+        {
+          type: 'feat',
+          scope: undefined,
+          subject: 'always set `CI=true` for subprocesses (×2)',
+        },
+      ]);
+    });
+
+    it('does not fold commits that only share a subject', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'a', subject: 'same subject' },
+        { type: 'fix', scope: 'b', subject: 'same subject' },
+      ];
+
+      expect(dedupeCommits(commits)).toEqual(commits);
+    });
+  });
+
+  describe('filterHiddenTypes', () => {
+    it('drops test/style/ci/refactor by default', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'test', scope: 'tools', subject: 'a' },
+        { type: 'fix', scope: 'tools', subject: 'b' },
+      ];
+
+      expect(filterHiddenTypes(commits)).toEqual([commits[1]]);
+    });
+
+    it('keeps a hidden-type commit if it is a breaking change', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'refactor',
+          scope: 'tools',
+          subject: 'a',
+          breaking: true,
+        },
+      ];
+
+      expect(filterHiddenTypes(commits)).toEqual(commits);
+    });
+
+    it('keeps everything when given an empty set', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'test', scope: 'tools', subject: 'a' },
+      ];
+
+      expect(filterHiddenTypes(commits, new Set())).toEqual(commits);
     });
   });
 
@@ -111,6 +183,46 @@ describe('tools/release-notes/module-changelog', () => {
       ]);
     });
 
+    it('normalises a plural category scope into its singular category group', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'fix', scope: 'managers/npm', subject: 'a' },
+      ];
+      const labels = new Map([['managers/npm', 'npm']]);
+
+      const [group] = groupByModule(commits, types, labels) as [CategoryGroup];
+      expect(group).toMatchObject({ kind: 'category', category: 'manager' });
+      expect(group.modules).toEqual([
+        {
+          scope: 'managers/npm',
+          label: 'npm',
+          commits: [{ type: 'fix', scope: 'managers/npm', subject: 'a' }],
+        },
+      ]);
+    });
+
+    it('routes a bare category scope into that category as a "General" entry', () => {
+      const commits: ParsedCommit[] = [
+        { type: 'test', scope: 'datasource', subject: 'replace snapshots' },
+      ];
+
+      const [group] = groupByModule(commits, types, new Map()) as [
+        CategoryGroup,
+      ];
+      expect(group).toMatchObject({
+        kind: 'category',
+        category: 'datasource',
+      });
+      expect(group.modules).toEqual([
+        {
+          scope: 'datasource',
+          label: 'General',
+          commits: [
+            { type: 'test', scope: 'datasource', subject: 'replace snapshots' },
+          ],
+        },
+      ]);
+    });
+
     it('sorts modules within a category alphabetically by label', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'versioning/cargo', subject: 'a' },
@@ -125,10 +237,12 @@ describe('tools/release-notes/module-changelog', () => {
       expect(group.modules.map((m) => m.label)).toEqual(['Cargo', 'npm']);
     });
 
-    it('groups a bare (non-module) scope as a flat group', () => {
+    it('groups a bare (non-module) scope with enough commits as its own flat group', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'workers/repository', subject: 'a' },
-        { type: 'fix', scope: 'tools', subject: 'b' },
+        { type: 'refactor', scope: 'workers/repository', subject: 'b' },
+        { type: 'fix', scope: 'tools', subject: 'c' },
+        { type: 'fix', scope: 'tools', subject: 'd' },
       ];
 
       const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
@@ -141,7 +255,8 @@ describe('tools/release-notes/module-changelog', () => {
     it('sorts category groups ahead of flat groups', () => {
       const commits: ParsedCommit[] = [
         { type: 'fix', scope: 'workers/repository', subject: 'a' },
-        { type: 'fix', scope: 'versioning/cargo', subject: 'b' },
+        { type: 'refactor', scope: 'workers/repository', subject: 'b' },
+        { type: 'fix', scope: 'versioning/cargo', subject: 'c' },
       ];
 
       const groups = groupByModule(
@@ -164,6 +279,7 @@ describe('tools/release-notes/module-changelog', () => {
         { type: 'docs', scope: undefined, subject: 'a' },
         { type: 'chore', scope: 'deps', subject: 'b' },
         { type: 'fix', scope: 'workers/repository', subject: 'c' },
+        { type: 'refactor', scope: 'workers/repository', subject: 'd' },
       ];
 
       const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
@@ -203,6 +319,112 @@ describe('tools/release-notes/module-changelog', () => {
 
       const [group] = groupByModule(commits, types, new Map()) as [FlatGroup];
       expect(group.commits.map((c) => c.type)).toEqual(['fix', 'chore']);
+    });
+
+    it('only folds dependency-shaped commits inside a `deps`-like scope', () => {
+      // Regression: a docs commit like "update references to renovatebot/
+      // github-action to v46.2.5" is dependency-bump *shaped*, but must not
+      // be folded — only COLLAPSED_SCOPES commits go through
+      // `consolidateDependencyBumps` at all.
+      const commits: ParsedCommit[] = [
+        {
+          type: 'docs',
+          scope: undefined,
+          subject: 'update references to renovatebot/github-action to v46.2.5',
+        },
+        {
+          type: 'docs',
+          scope: undefined,
+          subject: 'update references to renovatebot/github-action to v46.2.4',
+        },
+      ];
+
+      const [group] = groupByModule(commits, types, new Map()) as [FlatGroup];
+      expect(group.commits).toHaveLength(2);
+    });
+
+    describe('pooling small flat groups into "Other"', () => {
+      it('pools a scope below MIN_SCOPE_GROUP_SIZE, keeping the scope inline', () => {
+        const commits: ParsedCommit[] = [
+          { type: 'fix', scope: 'tools', subject: 'a' },
+        ];
+
+        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+        expect(groups).toHaveLength(1);
+        expect(groups[0]).toMatchObject({ scope: undefined, label: 'Other' });
+        expect(groups[0].commits[0].subject).toBe('`tools` a');
+      });
+
+      it('keeps a scope at MIN_SCOPE_GROUP_SIZE as its own group', () => {
+        const commits: ParsedCommit[] = [
+          { type: 'fix', scope: 'tools', subject: 'a' },
+          { type: 'fix', scope: 'tools', subject: 'b' },
+        ];
+
+        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+        expect(groups.map((g) => g.scope)).toEqual(['tools']);
+      });
+
+      it('never pools a COLLAPSED_SCOPES scope, even with a single commit', () => {
+        const commits: ParsedCommit[] = [
+          {
+            type: 'chore',
+            scope: 'deps',
+            subject: 'update dependency foo to v1.0.0',
+          },
+        ];
+
+        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+        expect(groups.map((g) => g.scope)).toEqual(['deps']);
+      });
+
+      it('merges pooled commits into an existing Other group, sorted by type', () => {
+        const commits: ParsedCommit[] = [
+          { type: 'docs', scope: undefined, subject: 'existing other entry' },
+          { type: 'fix', scope: 'tools', subject: 'pooled fix' },
+        ];
+
+        const groups = groupByModule(commits, types, new Map()) as FlatGroup[];
+        expect(groups).toHaveLength(1);
+        expect(groups[0].commits.map((c) => c.subject)).toEqual([
+          '`tools` pooled fix',
+          'existing other entry',
+        ]);
+      });
+    });
+
+    describe('breaking changes', () => {
+      it('pulls a breaking commit into a leading group, in addition to its normal group', () => {
+        const commits: ParsedCommit[] = [
+          {
+            type: 'feat',
+            scope: 'config',
+            subject: 'drop old option',
+            breaking: true,
+          },
+          { type: 'fix', scope: 'config', subject: 'other change' },
+        ];
+
+        const groups = groupByModule(commits, types, new Map());
+        expect(groups[0]).toEqual({
+          kind: 'breaking',
+          commits: [commits[0]],
+        });
+
+        const configGroup = groups.find(
+          (g) => g.kind === 'flat' && g.scope === 'config',
+        ) as FlatGroup;
+        expect(configGroup.commits).toHaveLength(2);
+      });
+
+      it('omits the breaking group entirely when nothing is breaking', () => {
+        const commits: ParsedCommit[] = [
+          { type: 'fix', scope: 'config', subject: 'a' },
+        ];
+
+        const groups = groupByModule(commits, types, new Map());
+        expect(groups.some((g) => g.kind === 'breaking')).toBe(false);
+      });
     });
   });
 
@@ -248,10 +470,12 @@ describe('tools/release-notes/module-changelog', () => {
       const groups = groupByModule(
         [
           { type: 'fix', scope: 'workers/repository', subject: 'a' },
-          { type: 'docs', scope: undefined, subject: 'b' },
+          { type: 'refactor', scope: 'workers/repository', subject: 'b' },
+          { type: 'docs', scope: undefined, subject: 'c' },
         ],
         [
           { type: 'fix', section: 'Bug Fixes' },
+          { type: 'refactor', section: 'Code Refactoring' },
           { type: 'docs', section: 'Documentation' },
         ],
         new Map(),
@@ -262,10 +486,43 @@ describe('tools/release-notes/module-changelog', () => {
           '### workers/repository',
           '',
           '- fix: a',
+          '- refactor: b',
           '',
           '### Other',
           '',
-          '- docs: b',
+          '- docs: c',
+        ].join('\n'),
+      );
+    });
+
+    it('renders the breaking group first, with scope and type shown inline', () => {
+      const groups = groupByModule(
+        [
+          {
+            type: 'feat',
+            scope: 'config',
+            subject: 'drop old option',
+            breaking: true,
+          },
+          { type: 'fix', scope: 'config', subject: 'other change' },
+        ],
+        [
+          { type: 'feat', section: 'Features' },
+          { type: 'fix', section: 'Bug Fixes' },
+        ],
+        new Map(),
+      );
+
+      expect(renderModuleChangelog(groups)).toBe(
+        [
+          '### Breaking changes',
+          '',
+          '- `config` feat!: drop old option',
+          '',
+          '### config',
+          '',
+          '- feat: drop old option',
+          '- fix: other change',
         ].join('\n'),
       );
     });
@@ -391,7 +648,7 @@ describe('tools/release-notes/module-changelog', () => {
       expect(consolidateDependencyBumps(commits)).toEqual(commits);
     });
 
-    it('does not fold bumps of the same dependency across different types', () => {
+    it('folds bumps of the same dependency across different commit types', () => {
       const commits: ParsedCommit[] = [
         {
           type: 'build',
@@ -401,16 +658,34 @@ describe('tools/release-notes/module-changelog', () => {
         {
           type: 'chore',
           scope: 'deps',
-          subject: 'update dependency protobufjs@8.0.1 to v8.8.0',
+          subject: 'update dependency protobufjs@8.0.1 to v8.9.0',
         },
       ];
 
-      expect(consolidateDependencyBumps(commits)).toEqual(commits);
+      expect(consolidateDependencyBumps(commits)).toEqual([
+        {
+          type: 'chore',
+          scope: 'deps',
+          subject: 'update dependency protobufjs@8.0.1 to v8.9.0 (2 updates)',
+        },
+      ]);
     });
 
     it('leaves non-dependency-update subjects untouched', () => {
       const commits: ParsedCommit[] = [
         { type: 'chore', scope: 'deps', subject: 'lock file maintenance' },
+      ];
+
+      expect(consolidateDependencyBumps(commits)).toEqual(commits);
+    });
+
+    it('does not treat a non-version "to X" phrase as a dependency bump', () => {
+      const commits: ParsedCommit[] = [
+        {
+          type: 'docs',
+          scope: 'deps',
+          subject: 'update docs to mention the new option',
+        },
       ];
 
       expect(consolidateDependencyBumps(commits)).toEqual(commits);
@@ -437,6 +712,26 @@ describe('tools/release-notes/module-changelog', () => {
           subject: 'update dependency protobufjs@8.8.0 to v8.9.0 (2 updates)',
         },
       ]);
+    });
+  });
+
+  describe('escapeMentions', () => {
+    it('neutralises an npm scoped package name so it cannot be read as a mention', () => {
+      expect(escapeMentions('update dependency @types/luxon to v3.7.5')).toBe(
+        'update dependency @\u200Btypes/luxon to v3.7.5',
+      );
+    });
+
+    it('leaves an email-like name@host untouched', () => {
+      expect(escapeMentions('contact jane@example.com')).toBe(
+        'contact jane@example.com',
+      );
+    });
+
+    it('leaves code spans and URLs untouched', () => {
+      expect(escapeMentions('see `@foo` at https://example.com/@bar')).toBe(
+        'see `@foo` at https://example.com/@bar',
+      );
     });
   });
 });

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -12,6 +12,7 @@ export interface ParsedCommit {
 
 export interface ModuleGroup {
   scope: string | undefined;
+  label: string;
   commits: ParsedCommit[];
 }
 
@@ -42,19 +43,110 @@ function typeRank(types: CommitTypeConfig[], type: string): number {
   return rank === -1 ? types.length : rank;
 }
 
+interface CategoryRank {
+  pattern: RegExp;
+  rank: number;
+}
+
+/**
+ * Where a commit's scope sorts, lower first. A scope matching no pattern
+ * falls back to `DEFAULT_CATEGORY_RANK`. Commits with no scope always
+ * render in a trailing "Other" group, regardless of rank.
+ *
+ * Edit this list to change what counts as "user-facing" for prioritising
+ * the changelog.
+ */
+export const CATEGORY_RANKS: CategoryRank[] = [
+  // Ecosystem-specific modules (managers, datasources, versionings,
+  // platforms) matter most to a reader unfamiliar with Renovate's own
+  // internals, so they lead the changelog.
+  { pattern: /^(?:manager|datasource|versioning|platform)\//, rank: 0 },
+  // High-volume, low-signal dependency bumps: still worth listing, but
+  // shouldn't crowd out everything else.
+  { pattern: /^deps$/, rank: 2 },
+];
+const DEFAULT_CATEGORY_RANK = 1;
+
+export function categoryRank(scope: string): number {
+  for (const { pattern, rank } of CATEGORY_RANKS) {
+    if (pattern.test(scope)) {
+      return rank;
+    }
+  }
+  return DEFAULT_CATEGORY_RANK;
+}
+
+/** Scopes rendered as a collapsed `<details>` block, for verbosity. */
+export const COLLAPSED_SCOPES = new Set(['deps']);
+
+const MODULE_CATEGORIES = new Set([
+  'manager',
+  'datasource',
+  'versioning',
+  'platform',
+]);
+
+function formatName(input: string): string {
+  return input
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
+ * Resolve a commit scope to a display label. For a module scope (for
+ * example `versioning/cargo`), this imports `lib/modules/versioning/cargo/
+ * index.ts` and uses its `displayName` export, matching what our own docs
+ * generation (`tools/docs/`) already does. Falls back to a humanized module
+ * name, or the raw scope, when there is no `displayName` to find.
+ */
+async function resolveModuleLabel(scope: string): Promise<string> {
+  const [category, name] = scope.split('/');
+  if (!name || !MODULE_CATEGORIES.has(category)) {
+    return scope;
+  }
+
+  try {
+    const definition = (await import(
+      `../../lib/modules/${category}/${name}/index.ts`
+    )) as { displayName?: string };
+    return definition.displayName ?? formatName(name);
+  } catch {
+    return scope;
+  }
+}
+
+/**
+ * Resolve display labels for a set of commit scopes. See
+ * `resolveModuleLabel` for how each scope is resolved.
+ */
+export async function resolveModuleLabels(
+  scopes: Iterable<string>,
+): Promise<Map<string, string>> {
+  const labels = new Map<string, string>();
+  await Promise.all(
+    Array.from(new Set(scopes)).map(async (scope) => {
+      labels.set(scope, await resolveModuleLabel(scope));
+    }),
+  );
+  return labels;
+}
+
 /**
  * Group commits by their Conventional Commits scope (Renovate's modules,
  * for example `manager/gitlab`) instead of by type. Commits with no scope
  * are collected under `scope: undefined` ("Other").
  *
- * Groups are sorted alphabetically by scope, with the scope-less group
- * last. Commits inside each group are sorted by their type's position in
- * `types`, i.e. the same priority order `.releaserc.json` already assigns
- * each Conventional Commit type.
+ * Groups are sorted by `categoryRank`, then alphabetically by `label`
+ * within a rank; the scope-less group is always last. Commits inside each
+ * group are sorted by their type's position in `types`, i.e. the same
+ * priority order `.releaserc.json` already assigns each Conventional
+ * Commit type.
  */
 export function groupByModule(
   commits: ParsedCommit[],
   types: CommitTypeConfig[],
+  labels: ReadonlyMap<string, string>,
 ): ModuleGroup[] {
   const groups = new Map<string | undefined, ParsedCommit[]>();
   for (const commit of commits) {
@@ -71,7 +163,11 @@ export function groupByModule(
     groupCommits.sort(
       (a, b) => typeRank(types, a.type) - typeRank(types, b.type),
     );
-    result.push({ scope, commits: groupCommits });
+    result.push({
+      scope,
+      label: scope ? (labels.get(scope) ?? scope) : 'Other',
+      commits: groupCommits,
+    });
   }
 
   result.sort((a, b) => {
@@ -84,7 +180,11 @@ export function groupByModule(
     if (!b.scope) {
       return -1;
     }
-    return a.scope.localeCompare(b.scope);
+    const rankDiff = categoryRank(a.scope) - categoryRank(b.scope);
+    if (rankDiff !== 0) {
+      return rankDiff;
+    }
+    return a.label.localeCompare(b.label);
   });
 
   return result;
@@ -93,17 +193,39 @@ export function groupByModule(
 /**
  * Render module groups as a nested Markdown list, for example:
  *
- * - manager/gitlab
+ * - Cargo
  *   - fix: support ~latest component refs
+ * - deps
+ *   <details>
+ *   <summary>2 updates</summary>
+ *
+ *   - chore: update dependency foo to v1.2.3
+ *   - build: update dependency bar to v4.5.6
+ *
+ *   </details>
  * - Other
  *   - docs: add warning to `checkedBranches`
  */
 export function renderModuleChangelog(groups: ModuleGroup[]): string {
   const lines: string[] = [];
   for (const group of groups) {
-    lines.push(`- ${group.scope ?? 'Other'}`);
+    lines.push(`- ${group.label}`);
+    const collapse =
+      group.scope !== undefined && COLLAPSED_SCOPES.has(group.scope);
+
+    if (collapse) {
+      lines.push('  <details>');
+      lines.push(`  <summary>${group.commits.length} updates</summary>`);
+      lines.push('');
+    }
+
     for (const commit of group.commits) {
       lines.push(`  - ${commit.type}: ${commit.subject}`);
+    }
+
+    if (collapse) {
+      lines.push('');
+      lines.push('  </details>');
     }
   }
   return lines.join('\n');

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -10,11 +10,30 @@ export interface ParsedCommit {
   subject: string;
 }
 
-export interface ModuleGroup {
+export interface ModuleEntry {
+  scope: string;
+  label: string;
+  commits: ParsedCommit[];
+}
+
+/** A `manager`/`datasource`/`versioning`/`platform` scope, split into its
+ * category and per-module entries, e.g. `manager` -> [`npm`, `cargo`, ...]. */
+export interface CategoryGroup {
+  kind: 'category';
+  category: string;
+  modules: ModuleEntry[];
+}
+
+/** Anything that isn't a module scope: a bare named scope (`workers/
+ * repository`, `deps`), or no scope at all (`label: 'Other'`). */
+export interface FlatGroup {
+  kind: 'flat';
   scope: string | undefined;
   label: string;
   commits: ParsedCommit[];
 }
+
+export type ModuleGroup = CategoryGroup | FlatGroup;
 
 const COMMIT_HEADER_RE =
   /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?!?:\s*(?<subject>.+)$/i;
@@ -86,6 +105,10 @@ const MODULE_CATEGORIES = new Set([
   'platform',
 ]);
 
+const MODULE_SCOPE_RE = new RegExp(
+  `^(?<category>${Array.from(MODULE_CATEGORIES).join('|')})/(?<name>.+)$`,
+);
+
 function formatName(input: string): string {
   return input
     .split('-')
@@ -134,43 +157,75 @@ export async function resolveModuleLabels(
 
 /**
  * Group commits by their Conventional Commits scope (Renovate's modules,
- * for example `manager/gitlab`) instead of by type. Commits with no scope
- * are collected under `scope: undefined` ("Other").
+ * for example `manager/gitlab`) instead of by type. A module scope (one of
+ * `manager/`, `datasource/`, `versioning/`, `platform/`) becomes a module
+ * entry nested under a category group (`manager`, ...); everything else
+ * (a bare named scope, or no scope at all) becomes its own flat group,
+ * with the scope-less group labelled "Other".
  *
- * Groups are sorted by `categoryRank`, then alphabetically by `label`
- * within a rank; the scope-less group is always last. Commits inside each
- * group are sorted by their type's position in `types`, i.e. the same
- * priority order `.releaserc.json` already assigns each Conventional
- * Commit type.
+ * Category groups always lead, sorted alphabetically by category name; the
+ * modules inside a category are sorted alphabetically by `label`. Flat
+ * groups follow, sorted by `categoryRank` then alphabetically by `label`,
+ * with the scope-less group last. Commits inside a group are sorted by
+ * their type's position in `types`, i.e. the same priority order
+ * `.releaserc.json` already assigns each Conventional Commit type.
  */
 export function groupByModule(
   commits: ParsedCommit[],
   types: CommitTypeConfig[],
   labels: ReadonlyMap<string, string>,
 ): ModuleGroup[] {
-  const groups = new Map<string | undefined, ParsedCommit[]>();
+  const byScope = new Map<string | undefined, ParsedCommit[]>();
   for (const commit of commits) {
-    const existing = groups.get(commit.scope);
+    const existing = byScope.get(commit.scope);
     if (existing) {
       existing.push(commit);
     } else {
-      groups.set(commit.scope, [commit]);
+      byScope.set(commit.scope, [commit]);
     }
   }
 
-  const result: ModuleGroup[] = [];
-  for (const [scope, groupCommits] of groups) {
+  const modulesByCategory = new Map<string, ModuleEntry[]>();
+  const flat: FlatGroup[] = [];
+
+  for (const [scope, groupCommits] of byScope) {
     groupCommits.sort(
       (a, b) => typeRank(types, a.type) - typeRank(types, b.type),
     );
-    result.push({
+
+    const match = scope ? MODULE_SCOPE_RE.exec(scope) : null;
+    if (scope && match?.groups) {
+      const { category } = match.groups;
+      const entry: ModuleEntry = {
+        scope,
+        label: labels.get(scope) ?? scope,
+        commits: groupCommits,
+      };
+      const existing = modulesByCategory.get(category);
+      if (existing) {
+        existing.push(entry);
+      } else {
+        modulesByCategory.set(category, [entry]);
+      }
+      continue;
+    }
+
+    flat.push({
+      kind: 'flat',
       scope,
-      label: scope ? (labels.get(scope) ?? scope) : 'Other',
+      label: scope ?? 'Other',
       commits: groupCommits,
     });
   }
 
-  result.sort((a, b) => {
+  const categoryGroups: CategoryGroup[] = [];
+  for (const [category, modules] of modulesByCategory) {
+    modules.sort((a, b) => a.label.localeCompare(b.label));
+    categoryGroups.push({ kind: 'category', category, modules });
+  }
+  categoryGroups.sort((a, b) => a.category.localeCompare(b.category));
+
+  flat.sort((a, b) => {
     if (!a.scope && !b.scope) {
       return 0;
     }
@@ -187,14 +242,15 @@ export function groupByModule(
     return a.label.localeCompare(b.label);
   });
 
-  return result;
+  return [...categoryGroups, ...flat];
 }
 
 /**
  * Render module groups as a nested Markdown list, for example:
  *
- * - Cargo
- *   - fix: support ~latest component refs
+ * - manager
+ *   - Cargo
+ *     - fix: support ~latest component refs
  * - deps
  *   <details>
  *   <summary>2 updates</summary>
@@ -209,6 +265,17 @@ export function groupByModule(
 export function renderModuleChangelog(groups: ModuleGroup[]): string {
   const lines: string[] = [];
   for (const group of groups) {
+    if (group.kind === 'category') {
+      lines.push(`- ${group.category}`);
+      for (const module of group.modules) {
+        lines.push(`  - ${module.label}`);
+        for (const commit of module.commits) {
+          lines.push(`    - ${commit.type}: ${commit.subject}`);
+        }
+      }
+      continue;
+    }
+
     lines.push(`- ${group.label}`);
     const collapse =
       group.scope !== undefined && COLLAPSED_SCOPES.has(group.scope);

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -1,0 +1,110 @@
+export interface CommitTypeConfig {
+  type: string;
+  section?: string;
+  hidden?: boolean;
+}
+
+export interface ParsedCommit {
+  type: string;
+  scope: string | undefined;
+  subject: string;
+}
+
+export interface ModuleGroup {
+  scope: string | undefined;
+  commits: ParsedCommit[];
+}
+
+const COMMIT_HEADER_RE =
+  /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?!?:\s*(?<subject>.+)$/i;
+
+/**
+ * Parse a single-line Conventional Commits header (`type(scope): subject`)
+ * into its parts. Returns `undefined` for anything that isn't a
+ * Conventional Commit, for example a merge commit.
+ */
+export function parseCommitHeader(header: string): ParsedCommit | undefined {
+  const match = COMMIT_HEADER_RE.exec(header.trim());
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  const { type, scope, subject } = match.groups;
+  return {
+    type: type.toLowerCase(),
+    scope,
+    subject,
+  };
+}
+
+function typeRank(types: CommitTypeConfig[], type: string): number {
+  const rank = types.findIndex((entry) => entry.type === type);
+  return rank === -1 ? types.length : rank;
+}
+
+/**
+ * Group commits by their Conventional Commits scope (Renovate's modules,
+ * for example `manager/gitlab`) instead of by type. Commits with no scope
+ * are collected under `scope: undefined` ("Other").
+ *
+ * Groups are sorted alphabetically by scope, with the scope-less group
+ * last. Commits inside each group are sorted by their type's position in
+ * `types`, i.e. the same priority order `.releaserc.json` already assigns
+ * each Conventional Commit type.
+ */
+export function groupByModule(
+  commits: ParsedCommit[],
+  types: CommitTypeConfig[],
+): ModuleGroup[] {
+  const groups = new Map<string | undefined, ParsedCommit[]>();
+  for (const commit of commits) {
+    const existing = groups.get(commit.scope);
+    if (existing) {
+      existing.push(commit);
+    } else {
+      groups.set(commit.scope, [commit]);
+    }
+  }
+
+  const result: ModuleGroup[] = [];
+  for (const [scope, groupCommits] of groups) {
+    groupCommits.sort(
+      (a, b) => typeRank(types, a.type) - typeRank(types, b.type),
+    );
+    result.push({ scope, commits: groupCommits });
+  }
+
+  result.sort((a, b) => {
+    if (!a.scope && !b.scope) {
+      return 0;
+    }
+    if (!a.scope) {
+      return 1;
+    }
+    if (!b.scope) {
+      return -1;
+    }
+    return a.scope.localeCompare(b.scope);
+  });
+
+  return result;
+}
+
+/**
+ * Render module groups as a nested Markdown list, for example:
+ *
+ * - manager/gitlab
+ *   - fix: support ~latest component refs
+ * - Other
+ *   - docs: add warning to `checkedBranches`
+ */
+export function renderModuleChangelog(groups: ModuleGroup[]): string {
+  const lines: string[] = [];
+  for (const group of groups) {
+    lines.push(`- ${group.scope ?? 'Other'}`);
+    for (const commit of group.commits) {
+      lines.push(`  - ${commit.type}: ${commit.subject}`);
+    }
+  }
+  return lines.join('\n');
+}

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -31,6 +31,9 @@ export interface FlatGroup {
   scope: string | undefined;
   label: string;
   commits: ParsedCommit[];
+  /** Commits in this group before `consolidateDependencyBumps` folded
+   * repeated dependency bumps together; `>= commits.length`. */
+  totalCommits: number;
 }
 
 export type ModuleGroup = CategoryGroup | FlatGroup;
@@ -60,6 +63,83 @@ export function parseCommitHeader(header: string): ParsedCommit | undefined {
 function typeRank(types: CommitTypeConfig[], type: string): number {
   const rank = types.findIndex((entry) => entry.type === type);
   return rank === -1 ? types.length : rank;
+}
+
+// Matches Renovate's own "update dependency X to Y", "update X docker tag
+// to Y", "update X action to Y", "update X monorepo to Y" commit subjects.
+// This only ever looks at a single commit's own header/title. A commit's
+// body can carry a much richer `| datasource | package | from | to |`
+// table (see `getCommitHeaders` in summarize.ts), but parsing that means
+// fetching full commit history, which is only affordable for this
+// standalone tool, not for something that would run on every changelog
+// fetch in the real product — so this stays title-only on purpose.
+const DEPENDENCY_UPDATE_RE =
+  /^update (?:dependency )?(?<name>.+?)(?: (?:docker tag|action|monorepo))? to (?<version>v?[^\s(]+)/i;
+
+interface DependencyUpdate {
+  name: string;
+  version: string;
+  text: string;
+}
+
+function stripPinnedVersionSuffix(name: string): string {
+  const at = name.lastIndexOf('@');
+  // Keep a leading `@` (a scoped package name like `@biomejs/biome`); only
+  // strip a trailing `@<version>` pin, e.g. `protobufjs@8.0.1` -> `protobufjs`.
+  return at > 0 ? name.slice(0, at) : name;
+}
+
+function parseDependencyUpdate(subject: string): DependencyUpdate | undefined {
+  const match = DEPENDENCY_UPDATE_RE.exec(subject);
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  return {
+    name: stripPinnedVersionSuffix(match.groups.name),
+    version: match.groups.version,
+    text: match[0],
+  };
+}
+
+/**
+ * Collapse repeated "update X to Y" commits for the same dependency (and
+ * commit type) into a single entry showing only the version it ended up
+ * at, plus how many commits were folded in. Commits that aren't a
+ * recognised dependency-update subject pass through unchanged.
+ */
+export function consolidateDependencyBumps(
+  commits: ParsedCommit[],
+): ParsedCommit[] {
+  const result: ParsedCommit[] = [];
+  const indexByKey = new Map<string, number>();
+  const countByKey = new Map<string, number>();
+
+  for (const commit of commits) {
+    const update = parseDependencyUpdate(commit.subject);
+    if (!update) {
+      result.push(commit);
+      continue;
+    }
+
+    const key = `${commit.type}::${update.name.toLowerCase()}`;
+    const existingIndex = indexByKey.get(key);
+    if (existingIndex === undefined) {
+      indexByKey.set(key, result.length);
+      countByKey.set(key, 1);
+      result.push(commit);
+      continue;
+    }
+
+    const count = (countByKey.get(key) ?? 1) + 1;
+    countByKey.set(key, count);
+    result[existingIndex] = {
+      ...commit,
+      subject: `${update.text} (${count} updates)`,
+    };
+  }
+
+  return result;
 }
 
 interface CategoryRank {
@@ -188,7 +268,8 @@ export function groupByModule(
   const modulesByCategory = new Map<string, ModuleEntry[]>();
   const flat: FlatGroup[] = [];
 
-  for (const [scope, groupCommits] of byScope) {
+  for (const [scope, rawCommits] of byScope) {
+    const groupCommits = consolidateDependencyBumps(rawCommits);
     groupCommits.sort(
       (a, b) => typeRank(types, a.type) - typeRank(types, b.type),
     );
@@ -215,6 +296,7 @@ export function groupByModule(
       scope,
       label: scope ?? 'Other',
       commits: groupCommits,
+      totalCommits: rawCommits.length,
     });
   }
 
@@ -246,54 +328,65 @@ export function groupByModule(
 }
 
 /**
- * Render module groups as a nested Markdown list, for example:
+ * Render module groups as `###` headings over a Markdown list, for example:
  *
- * - manager
- *   - Cargo
- *     - fix: support ~latest component refs
- * - deps
- *   <details>
- *   <summary>2 updates</summary>
+ * ### manager
  *
- *   - chore: update dependency foo to v1.2.3
- *   - build: update dependency bar to v4.5.6
+ * - Cargo
+ *   - fix: support ~latest component refs
  *
- *   </details>
- * - Other
- *   - docs: add warning to `checkedBranches`
+ * ### deps
+ *
+ * <details>
+ * <summary>2 updates</summary>
+ *
+ * - chore: update dependency foo to v1.2.3
+ * - build: update dependency bar to v4.5.6
+ *
+ * </details>
+ *
+ * ### Other
+ *
+ * - docs: add warning to `checkedBranches`
  */
 export function renderModuleChangelog(groups: ModuleGroup[]): string {
-  const lines: string[] = [];
+  const sections: string[] = [];
   for (const group of groups) {
+    const lines: string[] = [];
+
     if (group.kind === 'category') {
-      lines.push(`- ${group.category}`);
+      lines.push(`### ${group.category}`, '');
       for (const module of group.modules) {
-        lines.push(`  - ${module.label}`);
+        lines.push(`- ${module.label}`);
         for (const commit of module.commits) {
-          lines.push(`    - ${commit.type}: ${commit.subject}`);
+          lines.push(`  - ${commit.type}: ${commit.subject}`);
         }
       }
+      sections.push(lines.join('\n'));
       continue;
     }
 
-    lines.push(`- ${group.label}`);
+    lines.push(`### ${group.label}`, '');
     const collapse =
       group.scope !== undefined && COLLAPSED_SCOPES.has(group.scope);
 
     if (collapse) {
-      lines.push('  <details>');
-      lines.push(`  <summary>${group.commits.length} updates</summary>`);
-      lines.push('');
+      lines.push(
+        '<details>',
+        `<summary>${group.totalCommits} updates</summary>`,
+        '',
+      );
     }
 
     for (const commit of group.commits) {
-      lines.push(`  - ${commit.type}: ${commit.subject}`);
+      lines.push(`- ${commit.type}: ${commit.subject}`);
     }
 
     if (collapse) {
-      lines.push('');
-      lines.push('  </details>');
+      lines.push('', '</details>');
     }
+
+    sections.push(lines.join('\n'));
   }
-  return lines.join('\n');
+  return sections.join('\n\n');
 }

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -265,11 +265,6 @@ export function categoryRank(scope: string): number {
 /** Scopes rendered as a collapsed `<details>` block, for verbosity. */
 export const COLLAPSED_SCOPES = new Set(['deps']);
 
-/** Flat (non-module, non-`COLLAPSED_SCOPES`) groups smaller than this get
- * pooled into "Other" instead of getting their own heading, to avoid a
- * changelog that's mostly one-line sections. */
-export const MIN_SCOPE_GROUP_SIZE = 2;
-
 // A commit scope's category can be written singular or plural
 // (`manager/npm`, `managers/npm`) — both are normalised to the singular
 // form, which is also the real `lib/modules/<category>` directory name.
@@ -371,9 +366,8 @@ export async function resolveModuleLabels(
  *   module name (`datasource` on its own) becomes a "General" entry in
  *   that same category, rather than a second, colliding group.
  * - Everything else becomes its own `FlatGroup`, with the scope-less group
- *   labelled "Other". A flat group smaller than `MIN_SCOPE_GROUP_SIZE`
- *   (and not one of `COLLAPSED_SCOPES`) is folded into "Other" instead of
- *   getting its own heading, with its scope kept inline on each commit.
+ *   labelled "Other" — however few commits it has, so a scope stays
+ *   scannable as its own heading.
  *
  * Category groups are sorted alphabetically by category name, and the
  * modules inside a category alphabetically by `label`. Flat groups are
@@ -460,44 +454,7 @@ export function groupByModule(
     return a.label.localeCompare(b.label);
   });
 
-  const pooled: ParsedCommit[] = [];
-  const kept: FlatGroup[] = [];
-  let other: FlatGroup | undefined;
-
-  for (const group of flat) {
-    if (group.scope === undefined) {
-      other = group;
-      continue;
-    }
-    if (
-      !COLLAPSED_SCOPES.has(group.scope) &&
-      group.totalCommits < MIN_SCOPE_GROUP_SIZE
-    ) {
-      for (const commit of group.commits) {
-        pooled.push({
-          ...commit,
-          subject: `\`${group.scope}\` ${commit.subject}`,
-        });
-      }
-      continue;
-    }
-    kept.push(group);
-  }
-
-  if (pooled.length > 0) {
-    const combined = [...(other?.commits ?? []), ...pooled];
-    combined.sort((a, b) => typeRank(types, a.type) - typeRank(types, b.type));
-    other = {
-      kind: 'flat',
-      scope: undefined,
-      label: 'Other',
-      commits: combined,
-      totalCommits: (other?.totalCommits ?? 0) + pooled.length,
-    };
-  }
-
-  const finalFlat = other ? [...kept, other] : kept;
-  const groups: ModuleGroup[] = [...categoryGroups, ...finalFlat];
+  const groups: ModuleGroup[] = [...categoryGroups, ...flat];
   if (breaking.length > 0) {
     groups.unshift({ kind: 'breaking', commits: breaking });
   }

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -8,6 +8,10 @@ export interface ParsedCommit {
   scope: string | undefined;
   subject: string;
   breaking?: boolean;
+  /** The release (tag) this commit was first shipped in, if known. Set by
+   * `attributeReleases`, not `parseCommitHeader` — a single commit header
+   * carries no information about which release it landed in. */
+  release?: string;
 }
 
 export interface ModuleEntry {
@@ -72,6 +76,58 @@ export function parseCommitHeader(header: string): ParsedCommit | undefined {
 function typeRank(types: CommitTypeConfig[], type: string): number {
   const rank = types.findIndex((entry) => entry.type === type);
   return rank === -1 ? types.length : rank;
+}
+
+// Matches GitHub's own trailing PR reference on a squash-merge commit
+// subject, e.g. " (#45678)" or " (main) (#45678)" (the "(main)" part is
+// semantic-release's channel marker, which Renovate's own bump commits
+// carry). We replace this with which release the commit shipped in
+// instead — more useful for tracing when something changed than a link to
+// the PR that merged it.
+const TRAILING_PR_REFERENCE_RE = /\s*(?:\([\w-]+\)\s*)?\(#\d+\)\s*$/;
+
+/**
+ * Strip a trailing GitHub PR reference (and any channel marker before it)
+ * from a commit subject.
+ */
+export function stripPrReference(subject: string): string {
+  return subject.replace(TRAILING_PR_REFERENCE_RE, '');
+}
+
+/**
+ * Attribute each commit to the release it first shipped in.
+ *
+ * `orderedShas` must be oldest-to-newest, covering every commit in the
+ * range up to (and including) the release being summarized. `releaseTagBySha`
+ * maps a commit SHA to the release tag pointing directly at it, for every
+ * commit in the repository that happens to be a release boundary (most
+ * commits won't be in this map at all).
+ *
+ * A commit is attributed to the nearest release tag at or after it in
+ * `orderedShas` — i.e. whichever release actually shipped it. A commit
+ * with no release at or after it in the given range (for example, because
+ * `orderedShas` doesn't reach all the way to a tagged commit) is left
+ * unattributed.
+ */
+export function attributeReleases(
+  orderedShas: string[],
+  releaseTagBySha: ReadonlyMap<string, string>,
+): Map<string, string> {
+  const releaseBySha = new Map<string, string>();
+  const pending: string[] = [];
+
+  for (const sha of orderedShas) {
+    pending.push(sha);
+    const release = releaseTagBySha.get(sha);
+    if (release) {
+      for (const pendingSha of pending) {
+        releaseBySha.set(pendingSha, release);
+      }
+      pending.length = 0;
+    }
+  }
+
+  return releaseBySha;
 }
 
 /**
@@ -462,25 +518,37 @@ export function groupByModule(
   return groups;
 }
 
+function renderReleaseLink(commit: ParsedCommit, repo: string): string {
+  if (!commit.release) {
+    return '';
+  }
+  return ` ([${commit.release}](https://github.com/${repo}/releases/tag/${commit.release}))`;
+}
+
+function renderCommitLine(commit: ParsedCommit, repo: string): string {
+  return `- ${commit.type}: ${commit.subject}${renderReleaseLink(commit, repo)}`;
+}
+
 /**
- * Render module groups as `###` headings over a Markdown list, for example:
+ * Render module groups as `###` headings over a Markdown list, linking each
+ * commit to the release it shipped in (when known), for example:
  *
  * ### Breaking changes
  *
- * - `manager/npm` fix!: drop support for npm 6
+ * - `manager/npm` fix!: drop support for npm 6 ([44.61.4](...))
  *
  * ### manager
  *
  * - Cargo
- *   - fix: support ~latest component refs
+ *   - fix: support ~latest component refs ([44.61.3](...))
  *
  * ### deps
  *
  * <details>
  * <summary>2 updates</summary>
  *
- * - chore: update dependency foo to v1.2.3
- * - build: update dependency bar to v4.5.6
+ * - chore: update dependency foo to v1.2.3 ([44.61.3](...))
+ * - build: update dependency bar to v4.5.6 ([44.61.4](...))
  *
  * </details>
  *
@@ -488,7 +556,10 @@ export function groupByModule(
  *
  * - docs: add warning to `checkedBranches`
  */
-export function renderModuleChangelog(groups: ModuleGroup[]): string {
+export function renderModuleChangelog(
+  groups: ModuleGroup[],
+  repo: string,
+): string {
   const sections: string[] = [];
   for (const group of groups) {
     const lines: string[] = [];
@@ -497,7 +568,9 @@ export function renderModuleChangelog(groups: ModuleGroup[]): string {
       lines.push('### Breaking changes', '');
       for (const commit of group.commits) {
         const scopePrefix = commit.scope ? `\`${commit.scope}\` ` : '';
-        lines.push(`- ${scopePrefix}${commit.type}!: ${commit.subject}`);
+        lines.push(
+          `- ${scopePrefix}${commit.type}!: ${commit.subject}${renderReleaseLink(commit, repo)}`,
+        );
       }
       sections.push(lines.join('\n'));
       continue;
@@ -508,7 +581,7 @@ export function renderModuleChangelog(groups: ModuleGroup[]): string {
       for (const module of group.modules) {
         lines.push(`- ${module.label}`);
         for (const commit of module.commits) {
-          lines.push(`  - ${commit.type}: ${commit.subject}`);
+          lines.push(`  ${renderCommitLine(commit, repo)}`);
         }
       }
       sections.push(lines.join('\n'));
@@ -528,7 +601,7 @@ export function renderModuleChangelog(groups: ModuleGroup[]): string {
     }
 
     for (const commit of group.commits) {
-      lines.push(`- ${commit.type}: ${commit.subject}`);
+      lines.push(renderCommitLine(commit, repo));
     }
 
     if (collapse) {

--- a/tools/release-notes/module-changelog.ts
+++ b/tools/release-notes/module-changelog.ts
@@ -1,13 +1,13 @@
 export interface CommitTypeConfig {
   type: string;
   section?: string;
-  hidden?: boolean;
 }
 
 export interface ParsedCommit {
   type: string;
   scope: string | undefined;
   subject: string;
+  breaking?: boolean;
 }
 
 export interface ModuleEntry {
@@ -36,10 +36,18 @@ export interface FlatGroup {
   totalCommits: number;
 }
 
-export type ModuleGroup = CategoryGroup | FlatGroup;
+/** Commits carrying a Conventional Commits `!` breaking-change marker,
+ * pulled out into a leading section. These also still appear in their
+ * normal category/flat group — this is a highlight, not a move. */
+export interface BreakingGroup {
+  kind: 'breaking';
+  commits: ParsedCommit[];
+}
+
+export type ModuleGroup = CategoryGroup | FlatGroup | BreakingGroup;
 
 const COMMIT_HEADER_RE =
-  /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?!?:\s*(?<subject>.+)$/i;
+  /^(?<type>[a-z]+)(?:\((?<scope>[^)]+)\))?(?<breaking>!)?:\s*(?<subject>.+)$/i;
 
 /**
  * Parse a single-line Conventional Commits header (`type(scope): subject`)
@@ -52,17 +60,79 @@ export function parseCommitHeader(header: string): ParsedCommit | undefined {
     return undefined;
   }
 
-  const { type, scope, subject } = match.groups;
+  const { type, scope, subject, breaking } = match.groups;
   return {
     type: type.toLowerCase(),
     scope,
     subject,
+    breaking: breaking === '!',
   };
 }
 
 function typeRank(types: CommitTypeConfig[], type: string): number {
   const rank = types.findIndex((entry) => entry.type === type);
   return rank === -1 ? types.length : rank;
+}
+
+/**
+ * Drop commits that are exact repeats of an earlier one in the same range
+ * (same type, scope and subject) — for example a change that landed, got
+ * reverted, and was reapplied verbatim. Keeps a running count on the
+ * surviving entry rather than silently dropping the repeat.
+ */
+export function dedupeCommits(commits: ParsedCommit[]): ParsedCommit[] {
+  const result: ParsedCommit[] = [];
+  const indexByKey = new Map<string, number>();
+  const countByKey = new Map<string, number>();
+
+  for (const commit of commits) {
+    const key = `${commit.type}::${commit.scope ?? ''}::${commit.subject}`;
+    const existingIndex = indexByKey.get(key);
+    if (existingIndex === undefined) {
+      indexByKey.set(key, result.length);
+      countByKey.set(key, 1);
+      result.push(commit);
+      continue;
+    }
+
+    const count = (countByKey.get(key) ?? 1) + 1;
+    countByKey.set(key, count);
+    result[existingIndex] = {
+      ...commit,
+      subject: `${commit.subject} (×${count})`,
+    };
+  }
+
+  return result;
+}
+
+/**
+ * Commit types hidden by default: implementation detail that rarely
+ * matters to someone skimming what changed, as opposed to a behaviour
+ * change. `docs`/`chore` stay visible by default — a docs fix can matter
+ * to the reader, and `chore` is how Renovate's own dependency bumps are
+ * typed (already deprioritised and collapsed via `CATEGORY_RANKS`/
+ * `COLLAPSED_SCOPES`, rather than hidden outright).
+ *
+ * A commit with a breaking-change marker is always shown, regardless of
+ * its type.
+ */
+export const HIDDEN_TYPES = new Set(['test', 'style', 'ci', 'refactor']);
+
+/**
+ * Drop commits whose type is in `hiddenTypes`, unless they're a breaking
+ * change. Pass `new Set()` to disable filtering.
+ */
+export function filterHiddenTypes(
+  commits: ParsedCommit[],
+  hiddenTypes: ReadonlySet<string> = HIDDEN_TYPES,
+): ParsedCommit[] {
+  return commits.filter((commit) => {
+    if (commit.breaking) {
+      return true;
+    }
+    return !hiddenTypes.has(commit.type);
+  });
 }
 
 // Matches Renovate's own "update dependency X to Y", "update X docker tag
@@ -76,9 +146,16 @@ function typeRank(types: CommitTypeConfig[], type: string): number {
 const DEPENDENCY_UPDATE_RE =
   /^update (?:dependency )?(?<name>.+?)(?: (?:docker tag|action|monorepo))? to (?<version>v?[^\s(]+)/i;
 
+// A parsed "version" only counts if it actually looks like one (or a git
+// SHA/digest) — otherwise ordinary prose like "update docs to mention the
+// new option" gets misread as a dependency bump. This is on top of only
+// running `consolidateDependencyBumps` for `COLLAPSED_SCOPES` scopes
+// (below) — belt and braces, since those scopes are bot-authored and
+// unlikely to contain non-dependency subjects in the first place.
+const VERSION_LIKE_RE = /^(?:v?\d[\w.+-]*|[0-9a-f]{7,40})$/i;
+
 interface DependencyUpdate {
   name: string;
-  version: string;
   text: string;
 }
 
@@ -91,22 +168,27 @@ function stripPinnedVersionSuffix(name: string): string {
 
 function parseDependencyUpdate(subject: string): DependencyUpdate | undefined {
   const match = DEPENDENCY_UPDATE_RE.exec(subject);
-  if (!match?.groups) {
+  if (!match?.groups || !VERSION_LIKE_RE.test(match.groups.version)) {
     return undefined;
   }
 
   return {
     name: stripPinnedVersionSuffix(match.groups.name),
-    version: match.groups.version,
     text: match[0],
   };
 }
 
 /**
- * Collapse repeated "update X to Y" commits for the same dependency (and
- * commit type) into a single entry showing only the version it ended up
- * at, plus how many commits were folded in. Commits that aren't a
- * recognised dependency-update subject pass through unchanged.
+ * Collapse repeated "update X to Y" commits for the same dependency into a
+ * single entry showing only the version it ended up at, plus how many
+ * commits were folded in. Commits that aren't a recognised
+ * dependency-update subject pass through unchanged.
+ *
+ * Only call this on a scope's commits when that scope is one of
+ * `COLLAPSED_SCOPES` — dependency-bump phrasing ("update X to Y") isn't
+ * unique to actual dependency bumps (e.g. "update docs to mention ..."),
+ * so this is only safe to run where every commit is already known to be a
+ * Renovate self-update.
  */
 export function consolidateDependencyBumps(
   commits: ParsedCommit[],
@@ -122,7 +204,12 @@ export function consolidateDependencyBumps(
       continue;
     }
 
-    const key = `${commit.type}::${update.name.toLowerCase()}`;
+    // Keyed on the dependency name alone, not the commit type — the same
+    // dependency can be classified `feat`/`fix`/`chore` across different
+    // bumps, and folding by type would leave stale, contradictory entries
+    // (e.g. a `feat:` bump "stuck" at an old version once later bumps were
+    // reclassified as `fix:`).
+    const key = update.name.toLowerCase();
     const existingIndex = indexByKey.get(key);
     if (existingIndex === undefined) {
       indexByKey.set(key, result.length);
@@ -178,16 +265,52 @@ export function categoryRank(scope: string): number {
 /** Scopes rendered as a collapsed `<details>` block, for verbosity. */
 export const COLLAPSED_SCOPES = new Set(['deps']);
 
-const MODULE_CATEGORIES = new Set([
-  'manager',
-  'datasource',
-  'versioning',
-  'platform',
-]);
+/** Flat (non-module, non-`COLLAPSED_SCOPES`) groups smaller than this get
+ * pooled into "Other" instead of getting their own heading, to avoid a
+ * changelog that's mostly one-line sections. */
+export const MIN_SCOPE_GROUP_SIZE = 2;
+
+// A commit scope's category can be written singular or plural
+// (`manager/npm`, `managers/npm`) — both are normalised to the singular
+// form, which is also the real `lib/modules/<category>` directory name.
+const CATEGORY_ALIASES: Record<string, string> = {
+  manager: 'manager',
+  managers: 'manager',
+  datasource: 'datasource',
+  datasources: 'datasource',
+  versioning: 'versioning',
+  versionings: 'versioning',
+  platform: 'platform',
+  platforms: 'platform',
+};
 
 const MODULE_SCOPE_RE = new RegExp(
-  `^(?<category>${Array.from(MODULE_CATEGORIES).join('|')})/(?<name>.+)$`,
+  `^(?<category>${Object.keys(CATEGORY_ALIASES).join('|')})(?:/(?<name>.+))?$`,
+  'i',
 );
+
+interface ModuleScope {
+  category: string;
+  name: string | undefined;
+}
+
+/**
+ * Parse a commit scope into a module category and name, accepting both
+ * `manager/npm` and the plural `managers/npm`, and a bare category with no
+ * specific module (`datasource` on its own). Returns `undefined` for
+ * anything that isn't a module scope at all.
+ */
+function parseModuleScope(scope: string): ModuleScope | undefined {
+  const match = MODULE_SCOPE_RE.exec(scope);
+  if (!match?.groups) {
+    return undefined;
+  }
+
+  return {
+    category: CATEGORY_ALIASES[match.groups.category.toLowerCase()],
+    name: match.groups.name,
+  };
+}
 
 function formatName(input: string): string {
   return input
@@ -204,16 +327,16 @@ function formatName(input: string): string {
  * name, or the raw scope, when there is no `displayName` to find.
  */
 async function resolveModuleLabel(scope: string): Promise<string> {
-  const [category, name] = scope.split('/');
-  if (!name || !MODULE_CATEGORIES.has(category)) {
+  const parsed = parseModuleScope(scope);
+  if (!parsed?.name) {
     return scope;
   }
 
   try {
     const definition = (await import(
-      `../../lib/modules/${category}/${name}/index.ts`
+      `../../lib/modules/${parsed.category}/${parsed.name}/index.ts`
     )) as { displayName?: string };
-    return definition.displayName ?? formatName(name);
+    return definition.displayName ?? formatName(parsed.name);
   } catch {
     return scope;
   }
@@ -237,24 +360,35 @@ export async function resolveModuleLabels(
 
 /**
  * Group commits by their Conventional Commits scope (Renovate's modules,
- * for example `manager/gitlab`) instead of by type. A module scope (one of
- * `manager/`, `datasource/`, `versioning/`, `platform/`) becomes a module
- * entry nested under a category group (`manager`, ...); everything else
- * (a bare named scope, or no scope at all) becomes its own flat group,
- * with the scope-less group labelled "Other".
+ * for example `manager/gitlab`) instead of by type.
  *
- * Category groups always lead, sorted alphabetically by category name; the
- * modules inside a category are sorted alphabetically by `label`. Flat
- * groups follow, sorted by `categoryRank` then alphabetically by `label`,
- * with the scope-less group last. Commits inside a group are sorted by
- * their type's position in `types`, i.e. the same priority order
- * `.releaserc.json` already assigns each Conventional Commit type.
+ * - A commit with a breaking-change marker (`!`) is always pulled into a
+ *   leading `BreakingGroup`, in addition to (not instead of) its normal
+ *   group below.
+ * - A module scope (`manager/`, `datasource/`, `versioning/`, `platform/`,
+ *   singular or plural, with or without a specific module name) becomes a
+ *   module entry nested under a `CategoryGroup`; a bare category with no
+ *   module name (`datasource` on its own) becomes a "General" entry in
+ *   that same category, rather than a second, colliding group.
+ * - Everything else becomes its own `FlatGroup`, with the scope-less group
+ *   labelled "Other". A flat group smaller than `MIN_SCOPE_GROUP_SIZE`
+ *   (and not one of `COLLAPSED_SCOPES`) is folded into "Other" instead of
+ *   getting its own heading, with its scope kept inline on each commit.
+ *
+ * Category groups are sorted alphabetically by category name, and the
+ * modules inside a category alphabetically by `label`. Flat groups are
+ * sorted by `categoryRank` then alphabetically by `label`, with "Other"
+ * last. Commits inside a group are sorted by their type's position in
+ * `types`, i.e. the same priority order `.releaserc.json` already assigns
+ * each Conventional Commit type.
  */
 export function groupByModule(
   commits: ParsedCommit[],
   types: CommitTypeConfig[],
   labels: ReadonlyMap<string, string>,
 ): ModuleGroup[] {
+  const breaking = commits.filter((commit) => commit.breaking);
+
   const byScope = new Map<string | undefined, ParsedCommit[]>();
   for (const commit of commits) {
     const existing = byScope.get(commit.scope);
@@ -269,24 +403,26 @@ export function groupByModule(
   const flat: FlatGroup[] = [];
 
   for (const [scope, rawCommits] of byScope) {
-    const groupCommits = consolidateDependencyBumps(rawCommits);
+    const groupCommits =
+      scope && COLLAPSED_SCOPES.has(scope)
+        ? consolidateDependencyBumps(rawCommits)
+        : rawCommits;
     groupCommits.sort(
       (a, b) => typeRank(types, a.type) - typeRank(types, b.type),
     );
 
-    const match = scope ? MODULE_SCOPE_RE.exec(scope) : null;
-    if (scope && match?.groups) {
-      const { category } = match.groups;
+    const parsed = scope ? parseModuleScope(scope) : undefined;
+    if (scope && parsed) {
       const entry: ModuleEntry = {
         scope,
-        label: labels.get(scope) ?? scope,
+        label: parsed.name ? (labels.get(scope) ?? scope) : 'General',
         commits: groupCommits,
       };
-      const existing = modulesByCategory.get(category);
+      const existing = modulesByCategory.get(parsed.category);
       if (existing) {
         existing.push(entry);
       } else {
-        modulesByCategory.set(category, [entry]);
+        modulesByCategory.set(parsed.category, [entry]);
       }
       continue;
     }
@@ -324,11 +460,57 @@ export function groupByModule(
     return a.label.localeCompare(b.label);
   });
 
-  return [...categoryGroups, ...flat];
+  const pooled: ParsedCommit[] = [];
+  const kept: FlatGroup[] = [];
+  let other: FlatGroup | undefined;
+
+  for (const group of flat) {
+    if (group.scope === undefined) {
+      other = group;
+      continue;
+    }
+    if (
+      !COLLAPSED_SCOPES.has(group.scope) &&
+      group.totalCommits < MIN_SCOPE_GROUP_SIZE
+    ) {
+      for (const commit of group.commits) {
+        pooled.push({
+          ...commit,
+          subject: `\`${group.scope}\` ${commit.subject}`,
+        });
+      }
+      continue;
+    }
+    kept.push(group);
+  }
+
+  if (pooled.length > 0) {
+    const combined = [...(other?.commits ?? []), ...pooled];
+    combined.sort((a, b) => typeRank(types, a.type) - typeRank(types, b.type));
+    other = {
+      kind: 'flat',
+      scope: undefined,
+      label: 'Other',
+      commits: combined,
+      totalCommits: (other?.totalCommits ?? 0) + pooled.length,
+    };
+  }
+
+  const finalFlat = other ? [...kept, other] : kept;
+  const groups: ModuleGroup[] = [...categoryGroups, ...finalFlat];
+  if (breaking.length > 0) {
+    groups.unshift({ kind: 'breaking', commits: breaking });
+  }
+
+  return groups;
 }
 
 /**
  * Render module groups as `###` headings over a Markdown list, for example:
+ *
+ * ### Breaking changes
+ *
+ * - `manager/npm` fix!: drop support for npm 6
  *
  * ### manager
  *
@@ -353,6 +535,16 @@ export function renderModuleChangelog(groups: ModuleGroup[]): string {
   const sections: string[] = [];
   for (const group of groups) {
     const lines: string[] = [];
+
+    if (group.kind === 'breaking') {
+      lines.push('### Breaking changes', '');
+      for (const commit of group.commits) {
+        const scopePrefix = commit.scope ? `\`${commit.scope}\` ` : '';
+        lines.push(`- ${scopePrefix}${commit.type}!: ${commit.subject}`);
+      }
+      sections.push(lines.join('\n'));
+      continue;
+    }
 
     if (group.kind === 'category') {
       lines.push(`### ${group.category}`, '');
@@ -389,4 +581,32 @@ export function renderModuleChangelog(groups: ModuleGroup[]): string {
     sections.push(lines.join('\n'));
   }
   return sections.join('\n\n');
+}
+
+/**
+ * Neutralise `@name` sequences (`@biomejs/biome`, `@types/luxon`, ...) so
+ * `linkify()` (remark-github) doesn't misread an npm-scoped package name as
+ * a GitHub `@mention` and turn it into a broken profile link, e.g.
+ * `@types/luxon` -> a fabricated link to `github.com/types/luxon`. Skips
+ * code spans and URLs, and leaves an email-like `name@host` alone — same
+ * approach as `sanitizeMarkdown` in `lib/util/markdown.ts`, but narrower:
+ * that helper also neutralises bare `#1234` references, which would stop
+ * `linkify()` from turning them into real links, so it can't be reused
+ * as-is here (`linkify()` runs after this, not before).
+ */
+const ZERO_WIDTH_SPACE = '\u200B';
+
+export function escapeMentions(markdown: string): string {
+  const escaped = markdown
+    .split(/(?<skip>```[\s\S]*?```|`[^`\n]*?`|https?:\/\/[^\s<]+)/g)
+    .map((part) =>
+      part.startsWith('`') || /^https?:\/\//i.test(part)
+        ? part
+        : part.replace(/@/g, `@${ZERO_WIDTH_SPACE}`),
+    )
+    .join('');
+  return escaped.replace(
+    new RegExp(`([a-z])@${ZERO_WIDTH_SPACE}`, 'gi'),
+    '$1@',
+  );
 }

--- a/tools/release-notes/summarize.ts
+++ b/tools/release-notes/summarize.ts
@@ -1,0 +1,90 @@
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { Command } from 'commander';
+import { init, logger } from '../../lib/logger/index.ts';
+import { linkify } from '../../lib/util/markdown.ts';
+import { exec } from '../utils/exec.ts';
+import type { CommitTypeConfig } from './module-changelog.ts';
+import {
+  groupByModule,
+  parseCommitHeader,
+  renderModuleChangelog,
+} from './module-changelog.ts';
+
+interface CliOptions {
+  repo: string;
+}
+
+const defaultRepo = 'renovatebot/renovate';
+
+async function loadCommitTypes(): Promise<CommitTypeConfig[]> {
+  const releasercPath = fileURLToPath(
+    new URL('../../.releaserc.json', import.meta.url),
+  );
+  const releaserc = JSON.parse(await readFile(releasercPath, 'utf8'));
+  return releaserc.presetConfig.types as CommitTypeConfig[];
+}
+
+interface CompareCommit {
+  commit: { message: string };
+}
+
+async function getCommitHeaders(
+  repo: string,
+  from: string,
+  to: string,
+): Promise<string[]> {
+  const result = await exec('gh', [
+    'api',
+    `repos/${repo}/compare/${from}...${to}`,
+  ]);
+
+  const response = JSON.parse(result.stdout) as { commits: CompareCommit[] };
+  return response.commits.map(
+    (compareCommit) => compareCommit.commit.message.split('\n')[0],
+  );
+}
+
+async function summarize(
+  repo: string,
+  from: string,
+  to: string,
+): Promise<string> {
+  const [headers, types] = await Promise.all([
+    getCommitHeaders(repo, from, to),
+    loadCommitTypes(),
+  ]);
+
+  const commits = [];
+  for (const header of headers) {
+    const commit = parseCommitHeader(header);
+    if (commit) {
+      commits.push(commit);
+    }
+  }
+
+  const groups = groupByModule(commits, types);
+  const changelog = renderModuleChangelog(groups);
+  return await linkify(changelog, { repository: repo });
+}
+
+await init();
+
+process.on('unhandledRejection', (err) => {
+  // Will print "unhandledRejection err is not defined"
+  logger.error({ err }, 'unhandledRejection');
+  process.exit(-1);
+});
+
+const program = new Command('node tools/release-notes/summarize.ts')
+  .description(
+    'Summarize the commits between two tags, grouped by module instead of by Conventional Commit type.',
+  )
+  .option('--repo <owner/name>', 'Repository to query', defaultRepo)
+  .argument('<from>', 'tag/ref to compare from, for example 44.61.2')
+  .argument('<to>', 'tag/ref to compare to, for example 44.61.3')
+  .action(async (from: string, to: string, options: CliOptions) => {
+    console.log(await summarize(options.repo, from, to));
+  });
+
+await program.parseAsync();

--- a/tools/release-notes/summarize.ts
+++ b/tools/release-notes/summarize.ts
@@ -6,6 +6,7 @@ import { linkify } from '../../lib/util/markdown.ts';
 import { exec } from '../utils/exec.ts';
 import type { CommitTypeConfig, ParsedCommit } from './module-changelog.ts';
 import {
+  attributeReleases,
   dedupeCommits,
   escapeMentions,
   filterHiddenTypes,
@@ -13,6 +14,7 @@ import {
   parseCommitHeader,
   renderModuleChangelog,
   resolveModuleLabels,
+  stripPrReference,
 } from './module-changelog.ts';
 
 interface CliOptions {
@@ -30,24 +32,53 @@ async function loadCommitTypes(): Promise<CommitTypeConfig[]> {
   return releaserc.presetConfig.types as CommitTypeConfig[];
 }
 
-interface CompareCommit {
-  commit: { message: string };
+interface RawCommit {
+  sha: string;
+  header: string;
 }
 
-async function getCommitHeaders(
-  repo: string,
-  from: string,
-  to: string,
-): Promise<string[]> {
-  const result = await exec('gh', [
-    'api',
-    `repos/${repo}/compare/${from}...${to}`,
+/**
+ * Commits between two refs, oldest to newest, read from this checkout's
+ * local git history rather than the GitHub API — this repo is exactly
+ * where this tool runs from, so the full history and every release tag
+ * are already right here, with no API round trip or pagination limit.
+ */
+async function getCommits(from: string, to: string): Promise<RawCommit[]> {
+  const result = await exec('git', [
+    'log',
+    '--reverse',
+    '--ancestry-path',
+    '--pretty=format:%H\t%s',
+    `${from}..${to}`,
   ]);
 
-  const response = JSON.parse(result.stdout) as { commits: CompareCommit[] };
-  return response.commits.map(
-    (compareCommit) => compareCommit.commit.message.split('\n')[0],
-  );
+  return result.stdout
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const tab = line.indexOf('\t');
+      return { sha: line.slice(0, tab), header: line.slice(tab + 1) };
+    });
+}
+
+const RELEASE_TAG_RE = /^\d+\.\d+\.\d+$/;
+
+/** Every release tag in this checkout, keyed by the commit it points at. */
+async function getReleaseTagsByCommit(): Promise<Map<string, string>> {
+  const result = await exec('git', [
+    'for-each-ref',
+    '--format=%(objectname) %(refname:short)',
+    'refs/tags',
+  ]);
+
+  const bySha = new Map<string, string>();
+  for (const line of result.stdout.split('\n')) {
+    const [sha, tag] = line.split(' ');
+    if (tag && RELEASE_TAG_RE.test(tag)) {
+      bySha.set(sha, tag);
+    }
+  }
+  return bySha;
 }
 
 async function summarize(
@@ -56,16 +87,26 @@ async function summarize(
   to: string,
   all: boolean,
 ): Promise<string> {
-  const [headers, types] = await Promise.all([
-    getCommitHeaders(repo, from, to),
+  const [rawCommits, types, releaseTagsByCommit] = await Promise.all([
+    getCommits(from, to),
     loadCommitTypes(),
+    getReleaseTagsByCommit(),
   ]);
 
+  const releaseBySha = attributeReleases(
+    rawCommits.map((commit) => commit.sha),
+    releaseTagsByCommit,
+  );
+
   const parsed: ParsedCommit[] = [];
-  for (const header of headers) {
-    const commit = parseCommitHeader(header);
+  for (const rawCommit of rawCommits) {
+    const commit = parseCommitHeader(rawCommit.header);
     if (commit) {
-      parsed.push(commit);
+      parsed.push({
+        ...commit,
+        subject: stripPrReference(commit.subject),
+        release: releaseBySha.get(rawCommit.sha),
+      });
     }
   }
 
@@ -84,7 +125,7 @@ async function summarize(
   const labels = await resolveModuleLabels(scopes);
 
   const groups = groupByModule(commits, types, labels);
-  const changelog = renderModuleChangelog(groups);
+  const changelog = renderModuleChangelog(groups, repo);
   return await linkify(escapeMentions(changelog), { repository: repo });
 }
 
@@ -100,7 +141,11 @@ const program = new Command('node tools/release-notes/summarize.ts')
   .description(
     'Summarize the commits between two tags, grouped by module instead of by Conventional Commit type.',
   )
-  .option('--repo <owner/name>', 'Repository to query', defaultRepo)
+  .option(
+    '--repo <owner/name>',
+    'Repository to build GitHub links against (commits are always read from this local checkout)',
+    defaultRepo,
+  )
   .option(
     '--all',
     'Include test/style/ci/refactor commits, hidden by default',

--- a/tools/release-notes/summarize.ts
+++ b/tools/release-notes/summarize.ts
@@ -4,11 +4,12 @@ import { Command } from 'commander';
 import { init, logger } from '../../lib/logger/index.ts';
 import { linkify } from '../../lib/util/markdown.ts';
 import { exec } from '../utils/exec.ts';
-import type { CommitTypeConfig } from './module-changelog.ts';
+import type { CommitTypeConfig, ParsedCommit } from './module-changelog.ts';
 import {
   groupByModule,
   parseCommitHeader,
   renderModuleChangelog,
+  resolveModuleLabels,
 } from './module-changelog.ts';
 
 interface CliOptions {
@@ -55,7 +56,7 @@ async function summarize(
     loadCommitTypes(),
   ]);
 
-  const commits = [];
+  const commits: ParsedCommit[] = [];
   for (const header of headers) {
     const commit = parseCommitHeader(header);
     if (commit) {
@@ -63,7 +64,12 @@ async function summarize(
     }
   }
 
-  const groups = groupByModule(commits, types);
+  const scopes = commits
+    .map((commit) => commit.scope)
+    .filter((scope) => scope !== undefined);
+  const labels = await resolveModuleLabels(scopes);
+
+  const groups = groupByModule(commits, types, labels);
   const changelog = renderModuleChangelog(groups);
   return await linkify(changelog, { repository: repo });
 }

--- a/tools/release-notes/summarize.ts
+++ b/tools/release-notes/summarize.ts
@@ -6,6 +6,9 @@ import { linkify } from '../../lib/util/markdown.ts';
 import { exec } from '../utils/exec.ts';
 import type { CommitTypeConfig, ParsedCommit } from './module-changelog.ts';
 import {
+  dedupeCommits,
+  escapeMentions,
+  filterHiddenTypes,
   groupByModule,
   parseCommitHeader,
   renderModuleChangelog,
@@ -14,6 +17,7 @@ import {
 
 interface CliOptions {
   repo: string;
+  all: boolean;
 }
 
 const defaultRepo = 'renovatebot/renovate';
@@ -50,18 +54,28 @@ async function summarize(
   repo: string,
   from: string,
   to: string,
+  all: boolean,
 ): Promise<string> {
   const [headers, types] = await Promise.all([
     getCommitHeaders(repo, from, to),
     loadCommitTypes(),
   ]);
 
-  const commits: ParsedCommit[] = [];
+  const parsed: ParsedCommit[] = [];
   for (const header of headers) {
     const commit = parseCommitHeader(header);
     if (commit) {
-      commits.push(commit);
+      parsed.push(commit);
     }
+  }
+
+  const deduped = dedupeCommits(parsed);
+  const commits = all ? deduped : filterHiddenTypes(deduped);
+  const hiddenCount = deduped.length - commits.length;
+  if (hiddenCount > 0) {
+    logger.info(
+      `Hid ${hiddenCount} test/style/ci/refactor commit(s); pass --all to include them.`,
+    );
   }
 
   const scopes = commits
@@ -71,7 +85,7 @@ async function summarize(
 
   const groups = groupByModule(commits, types, labels);
   const changelog = renderModuleChangelog(groups);
-  return await linkify(changelog, { repository: repo });
+  return await linkify(escapeMentions(changelog), { repository: repo });
 }
 
 await init();
@@ -87,10 +101,15 @@ const program = new Command('node tools/release-notes/summarize.ts')
     'Summarize the commits between two tags, grouped by module instead of by Conventional Commit type.',
   )
   .option('--repo <owner/name>', 'Repository to query', defaultRepo)
+  .option(
+    '--all',
+    'Include test/style/ci/refactor commits, hidden by default',
+    false,
+  )
   .argument('<from>', 'tag/ref to compare from, for example 44.61.2')
   .argument('<to>', 'tag/ref to compare to, for example 44.61.3')
   .action(async (from: string, to: string, options: CliOptions) => {
-    console.log(await summarize(options.repo, from, to));
+    console.log(await summarize(options.repo, from, to, options.all));
   });
 
 await program.parseAsync();


### PR DESCRIPTION
- **feat(tools/release-notes): add a tool to summarize release commits by module**
- **feat(tools/release-notes): prioritise modules and collapse `deps`**
- **feat(tools/release-notes): nest module scopes under their category**
- **feat(tools/release-notes): headings, and fold repeated dependency bumps**
- **fix(tools/release-notes): fix real bugs found by an independent review**
- **revert(tools/release-notes): give every scope its own heading again**
- **feat(tools/release-notes): show the release a change shipped in**

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
