### PR TITLE
feat(bun): add support for bunfig.toml registry config

### DIFF
--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -31,17 +31,14 @@ registry = "https://registry.example.com"
       });
     });
 
-    it('parses registry object with url', () => {
+    it('parses registry object with url and extracts url', () => {
       const toml = `
 [install]
 registry = { url = "https://registry.example.com", token = "abc123" }
 `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
-          registry: {
-            url: 'https://registry.example.com',
-            token: 'abc123',
-          },
+          registry: 'https://registry.example.com',
         },
       });
     });
@@ -74,10 +71,7 @@ otherorg = { url = "https://registry.other.com", token = "secret" }
           registry: 'https://registry.example.com',
           scopes: {
             myorg: 'https://registry.myorg.com',
-            otherorg: {
-              url: 'https://registry.other.com',
-              token: 'secret',
-            },
+            otherorg: 'https://registry.other.com',
           },
         },
       });
@@ -119,13 +113,11 @@ registry = "https://registry.example.com"
       );
     });
 
-    it('returns default registry object url for unscoped package', () => {
+    it('returns default registry for unscoped package with object config', () => {
+      // After schema transform, registry is always a string URL
       const config = {
         install: {
-          registry: {
-            url: 'https://registry.example.com',
-            token: 'abc',
-          },
+          registry: 'https://registry.example.com',
         },
       };
       expect(resolveRegistryUrl('lodash', config)).toBe(
@@ -147,14 +139,12 @@ registry = "https://registry.example.com"
       );
     });
 
-    it('returns scoped registry object url for scoped package', () => {
+    it('returns scoped registry for scoped package with object config', () => {
+      // After schema transform, scoped registries are always string URLs
       const config = {
         install: {
           scopes: {
-            myorg: {
-              url: 'https://registry.myorg.com',
-              token: 'secret',
-            },
+            myorg: 'https://registry.myorg.com',
           },
         },
       };

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,0 +1,195 @@
+import { parseBunfigToml, resolveRegistryUrl } from './bunfig';
+
+describe('modules/manager/bun/bunfig', () => {
+  describe('parseBunfigToml', () => {
+    it('returns null for invalid TOML', () => {
+      expect(parseBunfigToml('invalid toml {')).toBeNull();
+    });
+
+    it('returns empty config for empty TOML', () => {
+      expect(parseBunfigToml('')).toEqual({});
+    });
+
+    it('parses simple string registry', () => {
+      const toml = `
+[install]
+registry = "https://registry.example.com"
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: 'https://registry.example.com',
+        },
+      });
+    });
+
+    it('parses registry object with url', () => {
+      const toml = `
+[install]
+registry = { url = "https://registry.example.com", token = "abc123" }
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: {
+            url: 'https://registry.example.com',
+            token: 'abc123',
+          },
+        },
+      });
+    });
+
+    it('parses scoped registries', () => {
+      const toml = `
+[install.scopes]
+myorg = "https://registry.myorg.com"
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      });
+    });
+
+    it('parses mixed default and scoped registries', () => {
+      const toml = `
+[install]
+registry = "https://registry.example.com"
+
+[install.scopes]
+myorg = "https://registry.myorg.com"
+otherorg = { url = "https://registry.other.com", token = "secret" }
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: 'https://registry.example.com',
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+            otherorg: {
+              url: 'https://registry.other.com',
+              token: 'secret',
+            },
+          },
+        },
+      });
+    });
+
+    it('ignores unrelated TOML sections', () => {
+      const toml = `
+[run]
+shell = "zsh"
+
+[install]
+registry = "https://registry.example.com"
+`;
+      expect(parseBunfigToml(toml)).toEqual({
+        install: {
+          registry: 'https://registry.example.com',
+        },
+      });
+    });
+  });
+
+  describe('resolveRegistryUrl', () => {
+    it('returns null when no install config', () => {
+      expect(resolveRegistryUrl('dep', {})).toBeNull();
+    });
+
+    it('returns null when no registry configured', () => {
+      expect(resolveRegistryUrl('dep', { install: {} })).toBeNull();
+    });
+
+    it('returns default registry for unscoped package', () => {
+      const config = {
+        install: {
+          registry: 'https://registry.example.com',
+        },
+      };
+      expect(resolveRegistryUrl('lodash', config)).toBe(
+        'https://registry.example.com',
+      );
+    });
+
+    it('returns default registry object url for unscoped package', () => {
+      const config = {
+        install: {
+          registry: {
+            url: 'https://registry.example.com',
+            token: 'abc',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('lodash', config)).toBe(
+        'https://registry.example.com',
+      );
+    });
+
+    it('returns scoped registry for scoped package', () => {
+      const config = {
+        install: {
+          registry: 'https://registry.example.com',
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
+        'https://registry.myorg.com',
+      );
+    });
+
+    it('returns scoped registry object url for scoped package', () => {
+      const config = {
+        install: {
+          scopes: {
+            myorg: {
+              url: 'https://registry.myorg.com',
+              token: 'secret',
+            },
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
+        'https://registry.myorg.com',
+      );
+    });
+
+    it('falls back to default registry for unmatched scope', () => {
+      const config = {
+        install: {
+          registry: 'https://registry.example.com',
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@other/pkg', config)).toBe(
+        'https://registry.example.com',
+      );
+    });
+
+    it('returns null for unmatched scope with no default', () => {
+      const config = {
+        install: {
+          scopes: {
+            myorg: 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@other/pkg', config)).toBeNull();
+    });
+
+    it('handles scope with @ prefix in config', () => {
+      const config = {
+        install: {
+          scopes: {
+            '@myorg': 'https://registry.myorg.com',
+          },
+        },
+      };
+      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
+        'https://registry.myorg.com',
+      );
+    });
+  });
+});

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -10,6 +10,15 @@ describe('modules/manager/bun/bunfig', () => {
       expect(parseBunfigToml('')).toEqual({});
     });
 
+    it('returns null for valid TOML with invalid schema', () => {
+      // Valid TOML but registry is not a string or valid object
+      const toml = `
+[install]
+registry = 123
+`;
+      expect(parseBunfigToml(toml)).toBeNull();
+    });
+
     it('parses simple string registry', () => {
       const toml = `
 [install]

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,5 +1,5 @@
 import { codeBlock } from 'common-tags';
-import { parseBunfigToml, resolveRegistryUrl } from './bunfig';
+import { parseBunfigToml, resolveRegistryUrl } from './bunfig.ts';
 
 describe('modules/manager/bun/bunfig', () => {
   describe('parseBunfigToml', () => {

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { parseBunfigToml, resolveRegistryUrl } from './bunfig';
 
 describe('modules/manager/bun/bunfig', () => {
@@ -12,18 +13,18 @@ describe('modules/manager/bun/bunfig', () => {
 
     it('returns null for valid TOML with invalid schema', () => {
       // Valid TOML but registry is not a string or valid object
-      const toml = `
-[install]
-registry = 123
-`;
+      const toml = codeBlock`
+        [install]
+        registry = 123
+      `;
       expect(parseBunfigToml(toml)).toBeNull();
     });
 
     it('parses simple string registry', () => {
-      const toml = `
-[install]
-registry = "https://registry.example.com"
-`;
+      const toml = codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',
@@ -32,10 +33,10 @@ registry = "https://registry.example.com"
     });
 
     it('parses registry object with url and extracts url', () => {
-      const toml = `
-[install]
-registry = { url = "https://registry.example.com", token = "abc123" }
-`;
+      const toml = codeBlock`
+        [install]
+        registry = { url = "https://registry.example.com", token = "abc123" }
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',
@@ -44,10 +45,10 @@ registry = { url = "https://registry.example.com", token = "abc123" }
     });
 
     it('parses scoped registries', () => {
-      const toml = `
-[install.scopes]
-myorg = "https://registry.myorg.com"
-`;
+      const toml = codeBlock`
+        [install.scopes]
+        myorg = "https://registry.myorg.com"
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           scopes: {
@@ -58,14 +59,14 @@ myorg = "https://registry.myorg.com"
     });
 
     it('parses mixed default and scoped registries', () => {
-      const toml = `
-[install]
-registry = "https://registry.example.com"
+      const toml = codeBlock`
+        [install]
+        registry = "https://registry.example.com"
 
-[install.scopes]
-myorg = "https://registry.myorg.com"
-otherorg = { url = "https://registry.other.com", token = "secret" }
-`;
+        [install.scopes]
+        myorg = "https://registry.myorg.com"
+        otherorg = { url = "https://registry.other.com", token = "secret" }
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',
@@ -78,13 +79,13 @@ otherorg = { url = "https://registry.other.com", token = "secret" }
     });
 
     it('ignores unrelated TOML sections', () => {
-      const toml = `
-[run]
-shell = "zsh"
+      const toml = codeBlock`
+        [run]
+        shell = "zsh"
 
-[install]
-registry = "https://registry.example.com"
-`;
+        [install]
+        registry = "https://registry.example.com"
+      `;
       expect(parseBunfigToml(toml)).toEqual({
         install: {
           registry: 'https://registry.example.com',

--- a/lib/modules/manager/bun/bunfig.spec.ts
+++ b/lib/modules/manager/bun/bunfig.spec.ts
@@ -1,73 +1,62 @@
 import { codeBlock } from 'common-tags';
-import { parseBunfigToml, resolveRegistryUrl } from './bunfig.ts';
+import { fs } from '~test/util.ts';
+import { NpmDatasource } from '../../datasource/npm/index.ts';
+import type { PackageDependency } from '../types.ts';
+import { applyBunfigRegistries, loadBunfigToml } from './bunfig.ts';
+import type { BunfigConfig } from './schema.ts';
+
+vi.mock('../../../util/fs/index.ts');
+
+function npmDeps(...packageNames: string[]): PackageDependency[] {
+  return packageNames.map((depName) => ({
+    depName,
+    datasource: NpmDatasource.id,
+  }));
+}
 
 describe('modules/manager/bun/bunfig', () => {
-  describe('parseBunfigToml', () => {
-    it('returns null for invalid TOML', () => {
-      expect(parseBunfigToml('invalid toml {')).toBeNull();
+  describe('loadBunfigToml()', () => {
+    it('returns null for a missing file', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(null);
+
+      await expect(loadBunfigToml('bunfig.toml')).resolves.toBeNull();
     });
 
-    it('returns empty config for empty TOML', () => {
-      expect(parseBunfigToml('')).toEqual({});
+    it('returns null for invalid TOML', async () => {
+      fs.readLocalFile.mockResolvedValueOnce('invalid toml {');
+
+      await expect(loadBunfigToml('bunfig.toml')).resolves.toBeNull();
     });
 
-    it('returns null for valid TOML with invalid schema', () => {
-      // Valid TOML but registry is not a string or valid object
-      const toml = codeBlock`
+    it('returns null for valid TOML with invalid schema', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
         [install]
         registry = 123
-      `;
-      expect(parseBunfigToml(toml)).toBeNull();
+      `);
+
+      await expect(loadBunfigToml('bunfig.toml')).resolves.toBeNull();
     });
 
-    it('parses simple string registry', () => {
-      const toml = codeBlock`
-        [install]
-        registry = "https://registry.example.com"
-      `;
-      expect(parseBunfigToml(toml)).toEqual({
-        install: {
-          registry: 'https://registry.example.com',
-        },
-      });
+    it('parses a bunfig without install section', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+        [run]
+        shell = "zsh"
+      `);
+
+      await expect(loadBunfigToml('bunfig.toml')).resolves.toEqual({});
     });
 
-    it('parses registry object with url and extracts url', () => {
-      const toml = codeBlock`
-        [install]
-        registry = { url = "https://registry.example.com", token = "abc123" }
-      `;
-      expect(parseBunfigToml(toml)).toEqual({
-        install: {
-          registry: 'https://registry.example.com',
-        },
-      });
-    });
-
-    it('parses scoped registries', () => {
-      const toml = codeBlock`
-        [install.scopes]
-        myorg = "https://registry.myorg.com"
-      `;
-      expect(parseBunfigToml(toml)).toEqual({
-        install: {
-          scopes: {
-            myorg: 'https://registry.myorg.com',
-          },
-        },
-      });
-    });
-
-    it('parses mixed default and scoped registries', () => {
-      const toml = codeBlock`
+    it('parses default and scoped registries', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
         [install]
         registry = "https://registry.example.com"
 
         [install.scopes]
         myorg = "https://registry.myorg.com"
         otherorg = { url = "https://registry.other.com", token = "secret" }
-      `;
-      expect(parseBunfigToml(toml)).toEqual({
+      `);
+
+      await expect(loadBunfigToml('bunfig.toml')).resolves.toEqual({
         install: {
           registry: 'https://registry.example.com',
           scopes: {
@@ -78,118 +67,216 @@ describe('modules/manager/bun/bunfig', () => {
       });
     });
 
-    it('ignores unrelated TOML sections', () => {
-      const toml = codeBlock`
-        [run]
-        shell = "zsh"
-
+    it('parses the default registry object form', async () => {
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
         [install]
-        registry = "https://registry.example.com"
-      `;
-      expect(parseBunfigToml(toml)).toEqual({
-        install: {
-          registry: 'https://registry.example.com',
-        },
+        registry = { url = "https://registry.example.com", token = "abc123" }
+      `);
+
+      await expect(loadBunfigToml('bunfig.toml')).resolves.toEqual({
+        install: { registry: 'https://registry.example.com' },
       });
     });
   });
 
-  describe('resolveRegistryUrl', () => {
-    it('returns null when no install config', () => {
-      expect(resolveRegistryUrl('dep', {})).toBeNull();
+  describe('applyBunfigRegistries()', () => {
+    it('does nothing without a bunfig', () => {
+      const deps = npmDeps('lodash');
+
+      applyBunfigRegistries(deps, null);
+
+      expect(deps[0].registryUrls).toBeUndefined();
     });
 
-    it('returns null when no registry configured', () => {
-      expect(resolveRegistryUrl('dep', { install: {} })).toBeNull();
+    it('does nothing without an install section', () => {
+      const deps = npmDeps('lodash');
+
+      applyBunfigRegistries(deps, {});
+
+      expect(deps[0].registryUrls).toBeUndefined();
     });
 
-    it('returns default registry for unscoped package', () => {
-      const config = {
+    it('does nothing without a configured registry', () => {
+      const deps = npmDeps('lodash');
+
+      applyBunfigRegistries(deps, { install: {} });
+
+      expect(deps[0].registryUrls).toBeUndefined();
+    });
+
+    it('skips dependencies of other datasources', () => {
+      const deps: PackageDependency[] = [
+        { depName: 'lodash', datasource: 'github-tags' },
+      ];
+
+      applyBunfigRegistries(deps, {
+        install: { registry: 'https://registry.example.com' },
+      });
+
+      expect(deps[0].registryUrls).toBeUndefined();
+    });
+
+    it('skips dependencies without a name', () => {
+      const deps: PackageDependency[] = [{ datasource: NpmDatasource.id }];
+
+      applyBunfigRegistries(deps, {
+        install: { registry: 'https://registry.example.com' },
+      });
+
+      expect(deps[0].registryUrls).toBeUndefined();
+    });
+
+    it('applies the default registry', () => {
+      const deps = npmDeps('lodash', '@myorg/utils');
+
+      applyBunfigRegistries(deps, {
+        install: { registry: 'https://registry.example.com' },
+      });
+
+      expect(deps).toMatchObject([
+        { registryUrls: ['https://registry.example.com'] },
+        { registryUrls: ['https://registry.example.com'] },
+      ]);
+    });
+
+    it('prefers a scoped registry over the default registry', () => {
+      const deps = npmDeps('lodash', '@myorg/utils', '@other/pkg');
+
+      applyBunfigRegistries(deps, {
         install: {
           registry: 'https://registry.example.com',
+          scopes: { myorg: 'https://registry.myorg.com' },
         },
-      };
-      expect(resolveRegistryUrl('lodash', config)).toBe(
-        'https://registry.example.com',
-      );
+      });
+
+      expect(deps).toMatchObject([
+        { registryUrls: ['https://registry.example.com'] },
+        { registryUrls: ['https://registry.myorg.com'] },
+        { registryUrls: ['https://registry.example.com'] },
+      ]);
     });
 
-    it('returns default registry for unscoped package with object config', () => {
-      // After schema transform, registry is always a string URL
-      const config = {
-        install: {
-          registry: 'https://registry.example.com',
-        },
-      };
-      expect(resolveRegistryUrl('lodash', config)).toBe(
-        'https://registry.example.com',
-      );
+    it('matches scopes which keep the leading @', () => {
+      const deps = npmDeps('@myorg/utils');
+
+      applyBunfigRegistries(deps, {
+        install: { scopes: { '@myorg': 'https://registry.myorg.com' } },
+      });
+
+      expect(deps[0].registryUrls).toEqual(['https://registry.myorg.com']);
     });
 
-    it('returns scoped registry for scoped package', () => {
-      const config = {
+    it('leaves unmatched scopes alone when there is no default registry', () => {
+      const deps = npmDeps('@other/pkg');
+
+      applyBunfigRegistries(deps, {
+        install: { scopes: { myorg: 'https://registry.myorg.com' } },
+      });
+
+      expect(deps[0].registryUrls).toBeUndefined();
+    });
+
+    it('resolves the registry by package name', () => {
+      const deps: PackageDependency[] = [
+        {
+          depName: 'utils',
+          packageName: '@myorg/utils',
+          datasource: NpmDatasource.id,
+        },
+      ];
+
+      applyBunfigRegistries(deps, {
+        install: { scopes: { myorg: 'https://registry.myorg.com' } },
+      });
+
+      expect(deps[0].registryUrls).toEqual(['https://registry.myorg.com']);
+    });
+
+    it('ignores registries which are not HTTP URLs', () => {
+      const deps = npmDeps('lodash', '@myorg/utils');
+
+      applyBunfigRegistries(deps, {
         install: {
-          registry: 'https://registry.example.com',
-          scopes: {
-            myorg: 'https://registry.myorg.com',
+          registry: '$NPM_REGISTRY',
+          scopes: { myorg: 'ftp://registry.myorg.com' },
+        },
+      });
+
+      expect(deps[0].registryUrls).toBeUndefined();
+      expect(deps[1].registryUrls).toBeUndefined();
+    });
+
+    it('removes credentials from registry URLs', () => {
+      const deps = npmDeps('lodash', '@myorg/utils');
+
+      applyBunfigRegistries(deps, {
+        install: {
+          registry: 'https://user:pass@registry.example.com/',
+          scopes: { myorg: 'https://$NPM_TOKEN@registry.myorg.com/' },
+        },
+      });
+
+      expect(deps).toMatchObject([
+        { registryUrls: ['https://registry.example.com/'] },
+        { registryUrls: ['https://registry.myorg.com/'] },
+      ]);
+    });
+
+    describe('with an .npmrc file', () => {
+      const bunfig: BunfigConfig = {
+        install: { registry: 'https://registry.example.com' },
+      };
+
+      it('keeps a scoped registry from the .npmrc file', () => {
+        const deps = npmDeps('lodash', '@myorg/utils');
+
+        applyBunfigRegistries(
+          deps,
+          bunfig,
+          '@myorg:registry=https://registry.myorg.com\n',
+        );
+
+        expect(deps[0].registryUrls).toEqual(['https://registry.example.com']);
+        expect(deps[1].registryUrls).toBeUndefined();
+      });
+
+      it('overrides a scoped registry from the .npmrc file', () => {
+        const deps = npmDeps('@myorg/utils');
+
+        applyBunfigRegistries(
+          deps,
+          {
+            install: { scopes: { myorg: 'https://registry.bunfig.com' } },
           },
-        },
-      };
-      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
-        'https://registry.myorg.com',
-      );
-    });
+          '@myorg:registry=https://registry.myorg.com\n',
+        );
 
-    it('returns scoped registry for scoped package with object config', () => {
-      // After schema transform, scoped registries are always string URLs
-      const config = {
-        install: {
-          scopes: {
-            myorg: 'https://registry.myorg.com',
-          },
-        },
-      };
-      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
-        'https://registry.myorg.com',
-      );
-    });
+        expect(deps[0].registryUrls).toEqual(['https://registry.bunfig.com']);
+      });
 
-    it('falls back to default registry for unmatched scope', () => {
-      const config = {
-        install: {
-          registry: 'https://registry.example.com',
-          scopes: {
-            myorg: 'https://registry.myorg.com',
-          },
-        },
-      };
-      expect(resolveRegistryUrl('@other/pkg', config)).toBe(
-        'https://registry.example.com',
-      );
-    });
+      it('overrides the default registry from the .npmrc file', () => {
+        const deps = npmDeps('lodash');
 
-    it('returns null for unmatched scope with no default', () => {
-      const config = {
-        install: {
-          scopes: {
-            myorg: 'https://registry.myorg.com',
-          },
-        },
-      };
-      expect(resolveRegistryUrl('@other/pkg', config)).toBeNull();
-    });
+        applyBunfigRegistries(
+          deps,
+          bunfig,
+          'registry=https://registry.myorg.com\n',
+        );
 
-    it('handles scope with @ prefix in config', () => {
-      const config = {
-        install: {
-          scopes: {
-            '@myorg': 'https://registry.myorg.com',
-          },
-        },
-      };
-      expect(resolveRegistryUrl('@myorg/utils', config)).toBe(
-        'https://registry.myorg.com',
-      );
+        expect(deps[0].registryUrls).toEqual(['https://registry.example.com']);
+      });
+
+      it('ignores empty and unscoped .npmrc registry keys', () => {
+        const deps = npmDeps('@myorg/utils');
+
+        applyBunfigRegistries(
+          deps,
+          bunfig,
+          '@myorg:registry=\n//registry.myorg.com/:_authToken=abc\n',
+        );
+
+        expect(deps[0].registryUrls).toEqual(['https://registry.example.com']);
+      });
     });
   });
 });

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,4 +1,3 @@
-import { isString } from '@sindresorhus/is';
 import { z } from 'zod';
 import { logger } from '../../../logger';
 import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
@@ -7,21 +6,14 @@ import { parse as parseToml } from '../../../util/toml';
 
 /**
  * Schema for bunfig.toml registry configuration.
- * Supports both string URLs and object with url/token/username/password.
+ * Supports both string URLs and object with url.
  * Transforms to extract just the URL string.
  * See: https://bun.sh/docs/runtime/bunfig#install-registry
  */
-const BunfigRegistrySchema = z
-  .union([
-    z.string(),
-    z.object({
-      url: z.string(),
-      token: z.string().optional(),
-      username: z.string().optional(),
-      password: z.string().optional(),
-    }),
-  ])
-  .transform((val) => (isString(val) ? val : val.url));
+const BunfigRegistrySchema = z.union([
+  z.string(),
+  z.object({ url: z.string() }).transform((val) => val.url),
+]);
 
 const BunfigInstallSchema = z.object({
   registry: BunfigRegistrySchema.optional(),

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+import { logger } from '../../../logger';
+import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
+import { Result } from '../../../util/result';
+import { parse as parseToml } from '../../../util/toml';
+
+/**
+ * Schema for bunfig.toml registry configuration.
+ * Supports both string URLs and object with url/token/username/password.
+ * See: https://bun.sh/docs/runtime/bunfig#install-registry
+ */
+const BunfigRegistrySchema = z.union([
+  z.string(),
+  z.object({
+    url: z.string(),
+    token: z.string().optional(),
+    username: z.string().optional(),
+    password: z.string().optional(),
+  }),
+]);
+
+const BunfigInstallSchema = z.object({
+  registry: BunfigRegistrySchema.optional(),
+  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
+});
+
+const BunfigSchema = z.object({
+  install: BunfigInstallSchema.optional(),
+});
+
+export type BunfigConfig = z.infer<typeof BunfigSchema>;
+export type BunfigRegistryConfig = z.infer<typeof BunfigRegistrySchema>;
+
+/**
+ * Extracts the URL from a registry config (string or object).
+ */
+function getRegistryUrl(config: BunfigRegistryConfig): string {
+  return typeof config === 'string' ? config : config.url;
+}
+
+/**
+ * Resolves the registry URL for a given package name based on bunfig.toml config.
+ * Scoped packages (@org/pkg) are matched against scoped registries first.
+ */
+export function resolveRegistryUrl(
+  packageName: string,
+  bunfigConfig: BunfigConfig,
+): string | null {
+  const install = bunfigConfig.install;
+  if (!install) {
+    return null;
+  }
+
+  // Check scoped registries first
+  if (install.scopes) {
+    for (const scope in install.scopes) {
+      // Bun scopes in bunfig.toml don't include the @ prefix
+      const scopePrefix = scope.startsWith('@') ? scope : `@${scope}`;
+      if (packageName.startsWith(`${scopePrefix}/`)) {
+        return getRegistryUrl(install.scopes[scope]);
+      }
+    }
+  }
+
+  // Fall back to default registry
+  if (install.registry) {
+    return getRegistryUrl(install.registry);
+  }
+
+  return null;
+}
+
+/**
+ * Loads and parses bunfig.toml from the filesystem.
+ * Returns null if file not found or parsing fails.
+ */
+export async function loadBunfigToml(
+  packageFile: string,
+): Promise<BunfigConfig | null> {
+  const bunfigFileName = await findLocalSiblingOrParent(
+    packageFile,
+    'bunfig.toml',
+  );
+
+  if (!bunfigFileName) {
+    return null;
+  }
+
+  const content = await readLocalFile(bunfigFileName, 'utf8');
+  if (!content) {
+    return null;
+  }
+
+  return parseBunfigToml(content);
+}
+
+/**
+ * Parses bunfig.toml content string into a typed config object.
+ */
+export function parseBunfigToml(content: string): BunfigConfig | null {
+  try {
+    const parsed = parseToml(content);
+    return Result.parse(parsed, BunfigSchema)
+      .onError((err) => {
+        logger.debug({ err }, 'Failed to parse bunfig.toml');
+      })
+      .unwrapOrNull();
+  } catch (err) {
+    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
+    return null;
+  }
+}

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -20,7 +20,7 @@ const BunfigRegistrySchema = z
       password: z.string().optional(),
     }),
   ])
-  .transform((val) => (typeof val === 'string' ? val : val.url));
+  .transform((val) => (isString(val) ? val : val.url));
 
 const BunfigInstallSchema = z.object({
   registry: BunfigRegistrySchema.optional(),

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,3 +1,4 @@
+import { isString } from '@sindresorhus/is';
 import { z } from 'zod';
 import { logger } from '../../../logger';
 import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,6 +1,40 @@
-import { logger } from '../../../logger';
-import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
-import { BunfigConfig } from './schema';
+import { logger } from '../../../logger/index.ts';
+import {
+  findLocalSiblingOrParent,
+  readLocalFile,
+} from '../../../util/fs/index.ts';
+import { parse as parseToml } from '../../../util/toml.ts';
+import {
+  type BunfigConfig,
+  type BunfigRegistryConfig,
+  BunfigSchema,
+  type RawBunfigConfig,
+} from './schema.ts';
+
+function getRegistryUrl(config: BunfigRegistryConfig): string {
+  return typeof config === 'string' ? config : config.url;
+}
+
+function normalizeBunfigConfig(config: RawBunfigConfig): BunfigConfig {
+  const install = config.install;
+  if (!install) {
+    return {};
+  }
+
+  return {
+    install: {
+      registry: install.registry ? getRegistryUrl(install.registry) : undefined,
+      scopes: install.scopes
+        ? Object.fromEntries(
+            Object.entries(install.scopes).map(([scope, registryConfig]) => [
+              scope,
+              getRegistryUrl(registryConfig),
+            ]),
+          )
+        : undefined,
+    },
+  };
+}
 
 /**
  * Resolves the registry URL for a given package name based on bunfig.toml config.
@@ -62,11 +96,17 @@ export async function loadBunfigToml(
  * Parses bunfig.toml content string into a typed config object.
  */
 export function parseBunfigToml(content: string): BunfigConfig | null {
-  const res = BunfigConfig.safeParse(content);
-  if (res.success) {
-    return res.data;
-  }
+  try {
+    const parsed = parseToml(content);
+    const res = BunfigSchema.safeParse(parsed);
+    if (res.success) {
+      return normalizeBunfigConfig(res.data);
+    }
 
-  logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
-  return null;
+    logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
+    return null;
+  } catch (err) {
+    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
+    return null;
+  }
 }

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,30 +1,6 @@
-import { z } from 'zod';
 import { logger } from '../../../logger';
 import { findLocalSiblingOrParent, readLocalFile } from '../../../util/fs';
-import { Result } from '../../../util/result';
-import { parse as parseToml } from '../../../util/toml';
-
-/**
- * Schema for bunfig.toml registry configuration.
- * Supports both string URLs and object with url.
- * Transforms to extract just the URL string.
- * See: https://bun.sh/docs/runtime/bunfig#install-registry
- */
-const BunfigRegistrySchema = z.union([
-  z.string(),
-  z.object({ url: z.string() }).transform((val) => val.url),
-]);
-
-const BunfigInstallSchema = z.object({
-  registry: BunfigRegistrySchema.optional(),
-  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
-});
-
-const BunfigSchema = z.object({
-  install: BunfigInstallSchema.optional(),
-});
-
-export type BunfigConfig = z.infer<typeof BunfigSchema>;
+import { BunfigConfig } from './schema';
 
 /**
  * Resolves the registry URL for a given package name based on bunfig.toml config.
@@ -86,15 +62,11 @@ export async function loadBunfigToml(
  * Parses bunfig.toml content string into a typed config object.
  */
 export function parseBunfigToml(content: string): BunfigConfig | null {
-  try {
-    const parsed = parseToml(content);
-    return Result.parse(parsed, BunfigSchema)
-      .onError((err) => {
-        logger.debug({ err }, 'Failed to parse bunfig.toml');
-      })
-      .unwrapOrNull();
-  } catch (err) {
-    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
-    return null;
+  const res = BunfigConfig.safeParse(content);
+  if (res.success) {
+    return res.data;
   }
+
+  logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
+  return null;
 }

--- a/lib/modules/manager/bun/bunfig.ts
+++ b/lib/modules/manager/bun/bunfig.ts
@@ -1,112 +1,125 @@
+import { isNonEmptyString } from '@sindresorhus/is';
+import ini from 'ini';
 import { logger } from '../../../logger/index.ts';
-import {
-  findLocalSiblingOrParent,
-  readLocalFile,
-} from '../../../util/fs/index.ts';
-import { parse as parseToml } from '../../../util/toml.ts';
-import {
-  type BunfigConfig,
-  type BunfigRegistryConfig,
-  BunfigSchema,
-  type RawBunfigConfig,
-} from './schema.ts';
+import { readLocalFile } from '../../../util/fs/index.ts';
+import { coerceObject } from '../../../util/object.ts';
+import { regEx } from '../../../util/regex.ts';
+import { Result } from '../../../util/result.ts';
+import { isHttpUrl, parseUrl } from '../../../util/url.ts';
+import { NpmDatasource } from '../../datasource/npm/index.ts';
+import type { PackageDependency } from '../types.ts';
+import { BunfigConfig } from './schema.ts';
 
-function getRegistryUrl(config: BunfigRegistryConfig): string {
-  return typeof config === 'string' ? config : config.url;
-}
-
-function normalizeBunfigConfig(config: RawBunfigConfig): BunfigConfig {
-  const install = config.install;
-  if (!install) {
-    return {};
-  }
-
-  return {
-    install: {
-      registry: install.registry ? getRegistryUrl(install.registry) : undefined,
-      scopes: install.scopes
-        ? Object.fromEntries(
-            Object.entries(install.scopes).map(([scope, registryConfig]) => [
-              scope,
-              getRegistryUrl(registryConfig),
-            ]),
-          )
-        : undefined,
-    },
-  };
-}
-
-/**
- * Resolves the registry URL for a given package name based on bunfig.toml config.
- * Scoped packages (@org/pkg) are matched against scoped registries first.
- */
-export function resolveRegistryUrl(
-  packageName: string,
-  bunfigConfig: BunfigConfig,
-): string | null {
-  const install = bunfigConfig.install;
-  if (!install) {
+export async function loadBunfigToml(
+  bunfigFile: string,
+): Promise<BunfigConfig | null> {
+  const content = await readLocalFile(bunfigFile, 'utf8');
+  if (!content) {
     return null;
   }
 
-  // Check scoped registries first
-  if (install.scopes) {
-    for (const [scope, registryUrl] of Object.entries(install.scopes)) {
-      // Bun scopes in bunfig.toml don't include the @ prefix
-      const scopePrefix = scope.startsWith('@') ? scope : `@${scope}`;
-      if (packageName.startsWith(`${scopePrefix}/`)) {
-        return registryUrl;
-      }
+  return Result.parse(content, BunfigConfig)
+    .onError((err) => {
+      logger.debug({ bunfigFile, err }, 'Failed to parse bunfig.toml');
+    })
+    .unwrapOrNull();
+}
+
+/**
+ * Bun accepts credentials inside the registry URL, but Renovate resolves
+ * credentials through host rules instead, so they are dropped here to keep them
+ * out of logs and pull request bodies.
+ */
+function sanitizeRegistryUrl(registryUrl: string): string | null {
+  const parsedUrl = parseUrl(registryUrl);
+  if (!parsedUrl || !isHttpUrl(parsedUrl)) {
+    logger.debug({ registryUrl }, 'Invalid bunfig.toml registry URL');
+    return null;
+  }
+
+  if (!parsedUrl.username && !parsedUrl.password) {
+    return registryUrl;
+  }
+
+  logger.debug('Removing credentials from bunfig.toml registry URL');
+  parsedUrl.username = '';
+  parsedUrl.password = '';
+  return parsedUrl.href;
+}
+
+/**
+ * Returns the scopes which the `.npmrc` file configures a registry for, like
+ * `@myorg` for `@myorg:registry=https://registry.myorg.com`.
+ */
+function getNpmrcScopes(npmrc: string | undefined): string[] {
+  if (!npmrc) {
+    return [];
+  }
+
+  const scopes: string[] = [];
+  for (const [key, value] of Object.entries(ini.parse(npmrc))) {
+    const scope = key.replace(regEx(/:registry$/), '');
+    if (scope !== key && scope.startsWith('@') && isNonEmptyString(value)) {
+      scopes.push(scope);
+    }
+  }
+  return scopes;
+}
+
+/**
+ * Resolves the registry URL for a package name, following Bun's precedence: a
+ * matching scoped registry first, then the default registry.
+ *
+ * Bun merges `bunfig.toml` over `.npmrc` key by key, so a scoped registry from
+ * `.npmrc` still wins over the default registry from `bunfig.toml`.
+ */
+function resolveRegistryUrl(
+  packageName: string,
+  install: NonNullable<BunfigConfig['install']>,
+  npmrcScopes: string[],
+): string | null {
+  for (const [scope, registryUrl] of Object.entries(
+    coerceObject(install.scopes),
+  )) {
+    // Bun accepts scopes with and without the leading `@`
+    const scopePrefix = scope.startsWith('@') ? scope : `@${scope}`;
+    if (packageName.startsWith(`${scopePrefix}/`)) {
+      return sanitizeRegistryUrl(registryUrl);
     }
   }
 
-  // Fall back to default registry
+  if (npmrcScopes.some((scope) => packageName.startsWith(`${scope}/`))) {
+    return null;
+  }
+
   if (install.registry) {
-    return install.registry;
+    return sanitizeRegistryUrl(install.registry);
   }
 
   return null;
 }
 
-/**
- * Loads and parses bunfig.toml from the filesystem.
- * Returns null if file not found or parsing fails.
- */
-export async function loadBunfigToml(
-  packageFile: string,
-): Promise<BunfigConfig | null> {
-  const bunfigFileName = await findLocalSiblingOrParent(
-    packageFile,
-    'bunfig.toml',
-  );
-
-  if (!bunfigFileName) {
-    return null;
+export function applyBunfigRegistries(
+  deps: PackageDependency[],
+  bunfig: BunfigConfig | null,
+  npmrc?: string,
+): void {
+  const install = bunfig?.install;
+  if (!install) {
+    return;
   }
 
-  const content = await readLocalFile(bunfigFileName, 'utf8');
-  if (!content) {
-    return null;
-  }
+  const npmrcScopes = getNpmrcScopes(npmrc);
 
-  return parseBunfigToml(content);
-}
-
-/**
- * Parses bunfig.toml content string into a typed config object.
- */
-export function parseBunfigToml(content: string): BunfigConfig | null {
-  try {
-    const parsed = parseToml(content);
-    const res = BunfigSchema.safeParse(parsed);
-    if (res.success) {
-      return normalizeBunfigConfig(res.data);
+  for (const dep of deps) {
+    const lookupName = dep.packageName ?? dep.depName;
+    if (!lookupName || dep.datasource !== NpmDatasource.id) {
+      continue;
     }
 
-    logger.debug({ err: res.error }, 'Failed to parse bunfig.toml');
-    return null;
-  } catch (err) {
-    logger.debug({ err }, 'Failed to parse bunfig.toml TOML syntax');
-    return null;
+    const registryUrl = resolveRegistryUrl(lookupName, install, npmrcScopes);
+    if (registryUrl) {
+      dep.registryUrls = [registryUrl];
+    }
   }
 }

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { fs } from '~test/util.ts';
 import { extractAllPackageFiles } from './extract.ts';
 
@@ -309,5 +310,137 @@ describe('modules/manager/bun/extract', () => {
     expect(packageFiles[0].npmrc).toBe(
       'registry=https://custom.registry.com\n',
     );
+  });
+
+  describe('bunfig.toml registry support', () => {
+    it('applies default registry from bunfig.toml', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+      `);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toEqual([
+        'https://registry.example.com',
+      ]);
+    });
+
+    it('applies scoped registry from bunfig.toml', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: {
+            lodash: '1.0.0',
+            '@myorg/utils': '2.0.0',
+          },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+
+        [install.scopes]
+        myorg = "https://registry.myorg.com"
+      `);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      const lodashDep = packageFiles[0].deps.find(
+        (d) => d.depName === 'lodash',
+      );
+      const myorgDep = packageFiles[0].deps.find(
+        (d) => d.depName === '@myorg/utils',
+      );
+
+      expect(lodashDep?.registryUrls).toEqual(['https://registry.example.com']);
+      expect(myorgDep?.registryUrls).toEqual(['https://registry.myorg.com']);
+    });
+
+    it('handles missing bunfig.toml gracefully', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(null);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
+    });
+
+    it('applies bunfig.toml registry to workspace packages', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile)
+        // Root package.json with workspaces
+        .mockResolvedValueOnce(
+          JSON.stringify({
+            name: 'root',
+            version: '1.0.0',
+            workspaces: ['packages/*'],
+            dependencies: { lodash: '1.0.0' },
+          }),
+        );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = "https://registry.example.com"
+      `);
+      vi.mocked(fs.getParentDir).mockReturnValueOnce('');
+      // Workspace package.json
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'pkg1',
+          version: '1.0.0',
+          dependencies: { axios: '2.0.0' },
+        }),
+      );
+
+      const matchedFiles = [
+        'bun.lock',
+        'package.json',
+        'packages/pkg1/package.json',
+      ];
+
+      const packageFiles = await extractAllPackageFiles({}, matchedFiles);
+
+      // Root package should have registry applied
+      const rootPkg = packageFiles.find(
+        (p) => p.packageFile === 'package.json',
+      );
+      expect(rootPkg?.deps[0].registryUrls).toEqual([
+        'https://registry.example.com',
+      ]);
+
+      // Workspace package should also have registry applied
+      const workspacePkg = packageFiles.find(
+        (p) => p.packageFile === 'packages/pkg1/package.json',
+      );
+      expect(workspacePkg?.deps[0].registryUrls).toEqual([
+        'https://registry.example.com',
+      ]);
+    });
   });
 });

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -322,8 +322,13 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
         [install]
@@ -349,8 +354,13 @@ describe('modules/manager/bun/extract', () => {
           },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
         [install]
@@ -382,7 +392,9 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(null);
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(() =>
+        Promise.resolve(null),
+      );
 
       const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
 
@@ -398,8 +410,13 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       // bunfig.toml exists but is empty/null
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(null);
@@ -421,8 +438,13 @@ describe('modules/manager/bun/extract', () => {
             dependencies: { lodash: '1.0.0' },
           }),
         );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
         [install]
@@ -472,8 +494,13 @@ describe('modules/manager/bun/extract', () => {
           dependencies: { lodash: '1.0.0' },
         }),
       );
-      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
-        'bunfig.toml',
+      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
+        (_packageFile, configFile): Promise<string | null> => {
+          if (configFile === 'bunfig.toml') {
+            return Promise.resolve('bunfig.toml');
+          }
+          return Promise.resolve(null);
+        },
       );
       // Valid TOML but invalid schema (registry should be string or object with url)
       vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -476,10 +476,10 @@ describe('modules/manager/bun/extract', () => {
         'bunfig.toml',
       );
       // Valid TOML but invalid schema (registry should be string or object with url)
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(`
-[install]
-registry = 123
-`);
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = 123
+      `);
 
       const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
 

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -389,6 +389,26 @@ describe('modules/manager/bun/extract', () => {
       expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
     });
 
+    it('handles empty bunfig.toml file gracefully', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      // bunfig.toml exists but is empty/null
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(null);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
+    });
+
     it('applies bunfig.toml registry to workspace packages', async () => {
       vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
       vi.mocked(fs.readLocalFile)
@@ -441,6 +461,29 @@ describe('modules/manager/bun/extract', () => {
       expect(workspacePkg?.deps[0].registryUrls).toEqual([
         'https://registry.example.com',
       ]);
+    });
+
+    it('handles invalid bunfig.toml schema gracefully', async () => {
+      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'test',
+          version: '0.0.1',
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      vi.mocked(fs.findLocalSiblingOrParent).mockResolvedValueOnce(
+        'bunfig.toml',
+      );
+      // Valid TOML but invalid schema (registry should be string or object with url)
+      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(`
+[install]
+registry = 123
+`);
+
+      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+
+      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
     });
   });
 });

--- a/lib/modules/manager/bun/extract.spec.ts
+++ b/lib/modules/manager/bun/extract.spec.ts
@@ -313,146 +313,117 @@ describe('modules/manager/bun/extract', () => {
   });
 
   describe('bunfig.toml registry support', () => {
-    it('applies default registry from bunfig.toml', async () => {
-      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
-        JSON.stringify({
-          name: 'test',
-          version: '0.0.1',
-          dependencies: { lodash: '1.0.0' },
-        }),
-      );
-      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
-        (_packageFile, configFile): Promise<string | null> => {
-          if (configFile === 'bunfig.toml') {
-            return Promise.resolve('bunfig.toml');
-          }
-          return Promise.resolve(null);
-        },
-      );
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+    const packageJson = JSON.stringify({
+      name: 'test',
+      version: '0.0.1',
+      dependencies: { lodash: '1.0.0', '@myorg/utils': '2.0.0' },
+    });
+
+    it('applies the default registry', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('package.json');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
         [install]
         registry = "https://registry.example.com"
       `);
+      fs.readLocalFile.mockResolvedValueOnce(packageJson);
 
-      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+      const packageFiles = await extractAllPackageFiles({}, [
+        'bun.lock',
+        'bunfig.toml',
+      ]);
 
-      expect(packageFiles[0].deps[0].registryUrls).toEqual([
-        'https://registry.example.com',
+      expect(packageFiles).toMatchObject([
+        {
+          deps: [
+            {
+              depName: 'lodash',
+              registryUrls: ['https://registry.example.com'],
+            },
+            {
+              depName: '@myorg/utils',
+              registryUrls: ['https://registry.example.com'],
+            },
+          ],
+        },
       ]);
     });
 
-    it('applies scoped registry from bunfig.toml', async () => {
-      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
-        JSON.stringify({
-          name: 'test',
-          version: '0.0.1',
-          dependencies: {
-            lodash: '1.0.0',
-            '@myorg/utils': '2.0.0',
-          },
-        }),
-      );
-      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
-        (_packageFile, configFile): Promise<string | null> => {
-          if (configFile === 'bunfig.toml') {
-            return Promise.resolve('bunfig.toml');
-          }
-          return Promise.resolve(null);
-        },
-      );
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+    it('applies scoped registries', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('package.json');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
         [install]
         registry = "https://registry.example.com"
 
         [install.scopes]
         myorg = "https://registry.myorg.com"
       `);
+      fs.readLocalFile.mockResolvedValueOnce(packageJson);
 
-      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+      const packageFiles = await extractAllPackageFiles({}, [
+        'bun.lock',
+        'bunfig.toml',
+      ]);
 
-      const lodashDep = packageFiles[0].deps.find(
-        (d) => d.depName === 'lodash',
-      );
-      const myorgDep = packageFiles[0].deps.find(
-        (d) => d.depName === '@myorg/utils',
-      );
-
-      expect(lodashDep?.registryUrls).toEqual(['https://registry.example.com']);
-      expect(myorgDep?.registryUrls).toEqual(['https://registry.myorg.com']);
+      expect(packageFiles).toMatchObject([
+        {
+          deps: [
+            {
+              depName: 'lodash',
+              registryUrls: ['https://registry.example.com'],
+            },
+            {
+              depName: '@myorg/utils',
+              registryUrls: ['https://registry.myorg.com'],
+            },
+          ],
+        },
+      ]);
     });
 
-    it('handles missing bunfig.toml gracefully', async () => {
-      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
-        JSON.stringify({
-          name: 'test',
-          version: '0.0.1',
-          dependencies: { lodash: '1.0.0' },
-        }),
-      );
-      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(() =>
-        Promise.resolve(null),
-      );
+    it('ignores an invalid bunfig.toml file', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('package.json');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+        [install]
+        registry = 123
+      `);
+      fs.readLocalFile.mockResolvedValueOnce(packageJson);
 
-      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+      const packageFiles = await extractAllPackageFiles({}, [
+        'bun.lock',
+        'bunfig.toml',
+      ]);
 
       expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
     });
 
-    it('handles empty bunfig.toml file gracefully', async () => {
-      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
-        JSON.stringify({
-          name: 'test',
-          version: '0.0.1',
-          dependencies: { lodash: '1.0.0' },
-        }),
-      );
-      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
-        (_packageFile, configFile): Promise<string | null> => {
-          if (configFile === 'bunfig.toml') {
-            return Promise.resolve('bunfig.toml');
-          }
-          return Promise.resolve(null);
-        },
-      );
-      // bunfig.toml exists but is empty/null
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(null);
+    it('ignores a bunfig.toml file which is not next to the lock file', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('package.json');
+      fs.readLocalFile.mockResolvedValueOnce(packageJson);
 
-      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
+      const packageFiles = await extractAllPackageFiles({}, [
+        'bun.lock',
+        'packages/pkg1/bunfig.toml',
+      ]);
 
       expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
     });
 
-    it('applies bunfig.toml registry to workspace packages', async () => {
-      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
-      vi.mocked(fs.readLocalFile)
-        // Root package.json with workspaces
-        .mockResolvedValueOnce(
-          JSON.stringify({
-            name: 'root',
-            version: '1.0.0',
-            workspaces: ['packages/*'],
-            dependencies: { lodash: '1.0.0' },
-          }),
-        );
-      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
-        (_packageFile, configFile): Promise<string | null> => {
-          if (configFile === 'bunfig.toml') {
-            return Promise.resolve('bunfig.toml');
-          }
-          return Promise.resolve(null);
-        },
-      );
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
+    it('applies the workspace root registries to workspace packages', async () => {
+      fs.getSiblingFileName.mockReturnValueOnce('package.json');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
         [install]
         registry = "https://registry.example.com"
       `);
-      vi.mocked(fs.getParentDir).mockReturnValueOnce('');
-      // Workspace package.json
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
+      fs.readLocalFile.mockResolvedValueOnce(
+        JSON.stringify({
+          name: 'root',
+          version: '1.0.0',
+          workspaces: ['packages/*'],
+          dependencies: { lodash: '1.0.0' },
+        }),
+      );
+      fs.getParentDir.mockReturnValueOnce('');
+      fs.readLocalFile.mockResolvedValueOnce(
         JSON.stringify({
           name: 'pkg1',
           version: '1.0.0',
@@ -460,57 +431,33 @@ describe('modules/manager/bun/extract', () => {
         }),
       );
 
-      const matchedFiles = [
+      const packageFiles = await extractAllPackageFiles({}, [
         'bun.lock',
+        'bunfig.toml',
         'package.json',
         'packages/pkg1/package.json',
-      ];
-
-      const packageFiles = await extractAllPackageFiles({}, matchedFiles);
-
-      // Root package should have registry applied
-      const rootPkg = packageFiles.find(
-        (p) => p.packageFile === 'package.json',
-      );
-      expect(rootPkg?.deps[0].registryUrls).toEqual([
-        'https://registry.example.com',
       ]);
 
-      // Workspace package should also have registry applied
-      const workspacePkg = packageFiles.find(
-        (p) => p.packageFile === 'packages/pkg1/package.json',
-      );
-      expect(workspacePkg?.deps[0].registryUrls).toEqual([
-        'https://registry.example.com',
-      ]);
-    });
-
-    it('handles invalid bunfig.toml schema gracefully', async () => {
-      vi.mocked(fs.getSiblingFileName).mockReturnValue('package.json');
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(
-        JSON.stringify({
-          name: 'test',
-          version: '0.0.1',
-          dependencies: { lodash: '1.0.0' },
-        }),
-      );
-      vi.mocked(fs.findLocalSiblingOrParent).mockImplementation(
-        (_packageFile, configFile): Promise<string | null> => {
-          if (configFile === 'bunfig.toml') {
-            return Promise.resolve('bunfig.toml');
-          }
-          return Promise.resolve(null);
+      expect(packageFiles).toMatchObject([
+        {
+          packageFile: 'package.json',
+          deps: [
+            {
+              depName: 'lodash',
+              registryUrls: ['https://registry.example.com'],
+            },
+          ],
         },
-      );
-      // Valid TOML but invalid schema (registry should be string or object with url)
-      vi.mocked(fs.readLocalFile).mockResolvedValueOnce(codeBlock`
-        [install]
-        registry = 123
-      `);
-
-      const packageFiles = await extractAllPackageFiles({}, ['bun.lock']);
-
-      expect(packageFiles[0].deps[0].registryUrls).toBeUndefined();
+        {
+          packageFile: 'packages/pkg1/package.json',
+          deps: [
+            {
+              depName: 'axios',
+              registryUrls: ['https://registry.example.com'],
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -5,7 +5,6 @@ import {
   getSiblingFileName,
   readLocalFile,
 } from '../../../util/fs/index.ts';
-} from '../../../util/fs/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 import { extractPackageJson } from '../npm/extract/common/package-file.ts';

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -12,11 +12,8 @@ import type { NpmPackage } from '../npm/extract/types.ts';
 import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
 import type { ExtractConfig, PackageFile } from '../types.ts';
-import {
-  type BunfigConfig,
-  loadBunfigToml,
-  resolveRegistryUrl,
-} from './bunfig.ts';
+import { loadBunfigToml, resolveRegistryUrl } from './bunfig.ts';
+import type { BunfigConfig } from './schema.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -5,18 +5,45 @@ import {
   getSiblingFileName,
   readLocalFile,
 } from '../../../util/fs/index.ts';
+} from '../../../util/fs/index.ts';
+import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 import { extractPackageJson } from '../npm/extract/common/package-file.ts';
 import type { NpmPackage } from '../npm/extract/types.ts';
 import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
 import type { ExtractConfig, PackageFile } from '../types.ts';
+import {
+  type BunfigConfig,
+  loadBunfigToml,
+  resolveRegistryUrl,
+} from './bunfig.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {
   return (
     fileNameWithPath === fileName || fileNameWithPath.endsWith(`/${fileName}`)
   );
+}
+
+/**
+ * Applies registry URLs from bunfig.toml to dependencies.
+ */
+function applyRegistryUrls(
+  packageFile: PackageFile,
+  bunfigConfig: BunfigConfig,
+): void {
+  for (const dep of packageFile.deps) {
+    if (dep.depName && dep.datasource === NpmDatasource.id) {
+      const registryUrl = resolveRegistryUrl(
+        dep.packageName ?? dep.depName,
+        bunfigConfig,
+      );
+      if (registryUrl) {
+        dep.registryUrls = [registryUrl];
+      }
+    }
+  }
 }
 
 export async function processPackageFile(
@@ -71,6 +98,15 @@ export async function extractAllPackageFiles(
     if (res) {
       packageFiles.push({ ...res, lockFiles: [lockFile] });
     }
+
+    // Load bunfig.toml for registry configuration
+    const bunfigConfig = await loadBunfigToml(packageFile);
+
+    // Apply registry URLs from bunfig.toml if present
+    if (bunfigConfig && res) {
+      applyRegistryUrls(res, bunfigConfig);
+    }
+
     // Check if package.json contains workspaces
     let workspaces = res?.managerData?.workspaces;
 
@@ -95,6 +131,10 @@ export async function extractAllPackageFiles(
       for (const workspaceFile of workspacePackageFiles) {
         const res = await processPackageFile(workspaceFile, config);
         if (res) {
+          // Apply registry URLs from root bunfig.toml to workspace packages
+          if (bunfigConfig) {
+            applyRegistryUrls(res, bunfigConfig);
+          }
           packageFiles.push({ ...res, lockFiles: [lockFile] });
         }
       }

--- a/lib/modules/manager/bun/extract.ts
+++ b/lib/modules/manager/bun/extract.ts
@@ -1,45 +1,24 @@
 import { isArray, isObject, isString } from '@sindresorhus/is';
+import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
 import {
   getParentDir,
   getSiblingFileName,
   readLocalFile,
 } from '../../../util/fs/index.ts';
-import { NpmDatasource } from '../../datasource/npm/index.ts';
 
 import { extractPackageJson } from '../npm/extract/common/package-file.ts';
 import type { NpmPackage } from '../npm/extract/types.ts';
 import { resolveNpmrc } from '../npm/npmrc.ts';
 import type { NpmManagerData } from '../npm/types.ts';
 import type { ExtractConfig, PackageFile } from '../types.ts';
-import { loadBunfigToml, resolveRegistryUrl } from './bunfig.ts';
-import type { BunfigConfig } from './schema.ts';
+import { applyBunfigRegistries, loadBunfigToml } from './bunfig.ts';
 import { filesMatchingWorkspaces } from './utils.ts';
 
 function matchesFileName(fileNameWithPath: string, fileName: string): boolean {
   return (
     fileNameWithPath === fileName || fileNameWithPath.endsWith(`/${fileName}`)
   );
-}
-
-/**
- * Applies registry URLs from bunfig.toml to dependencies.
- */
-function applyRegistryUrls(
-  packageFile: PackageFile,
-  bunfigConfig: BunfigConfig,
-): void {
-  for (const dep of packageFile.deps) {
-    if (dep.depName && dep.datasource === NpmDatasource.id) {
-      const registryUrl = resolveRegistryUrl(
-        dep.packageName ?? dep.depName,
-        bunfigConfig,
-      );
-      if (registryUrl) {
-        dep.registryUrls = [registryUrl];
-      }
-    }
-  }
 }
 
 export async function processPackageFile(
@@ -88,19 +67,23 @@ export async function extractAllPackageFiles(
   const allPackageJson = matchedFiles.filter((file) =>
     matchesFileName(file, 'package.json'),
   );
+  const allBunfigToml = matchedFiles.filter((file) =>
+    matchesFileName(file, 'bunfig.toml'),
+  );
   for (const lockFile of allLockFiles) {
     const packageFile = getSiblingFileName(lockFile, 'package.json');
+    // Bun reads `bunfig.toml` from the directory it runs in only, so a single
+    // file next to the lock file applies to the whole workspace
+    const lockFileDir = upath.dirname(lockFile);
+    const bunfigFile = allBunfigToml.find(
+      (file) => upath.dirname(file) === lockFileDir,
+    );
+    const bunfig = bunfigFile ? await loadBunfigToml(bunfigFile) : null;
+
     const res = await processPackageFile(packageFile, config);
     if (res) {
+      applyBunfigRegistries(res.deps, bunfig, res.npmrc);
       packageFiles.push({ ...res, lockFiles: [lockFile] });
-    }
-
-    // Load bunfig.toml for registry configuration
-    const bunfigConfig = await loadBunfigToml(packageFile);
-
-    // Apply registry URLs from bunfig.toml if present
-    if (bunfigConfig && res) {
-      applyRegistryUrls(res, bunfigConfig);
     }
 
     // Check if package.json contains workspaces
@@ -127,10 +110,7 @@ export async function extractAllPackageFiles(
       for (const workspaceFile of workspacePackageFiles) {
         const res = await processPackageFile(workspaceFile, config);
         if (res) {
-          // Apply registry URLs from root bunfig.toml to workspace packages
-          if (bunfigConfig) {
-            applyRegistryUrls(res, bunfigConfig);
-          }
+          applyBunfigRegistries(res.deps, bunfig, res.npmrc);
           packageFiles.push({ ...res, lockFiles: [lockFile] });
         }
       }

--- a/lib/modules/manager/bun/index.ts
+++ b/lib/modules/manager/bun/index.ts
@@ -15,7 +15,11 @@ export const lockFileNames = ['bun.lockb', 'bun.lock'];
 export const lockFileMaintenanceIsDelegatedToPackageManager = true;
 
 export const defaultConfig = {
-  managerFilePatterns: ['/(^|/)bun\\.lockb?$/', '/(^|/)package\\.json$/'],
+  managerFilePatterns: [
+    '/(^|/)bun\\.lockb?$/',
+    '/(^|/)package\\.json$/',
+    '/(^|/)bunfig\\.toml$/',
+  ],
   digest: {
     prBodyDefinitions: {
       Change:

--- a/lib/modules/manager/bun/readme.md
+++ b/lib/modules/manager/bun/readme.md
@@ -2,3 +2,22 @@ Used for updating bun projects.
 Bun is a tool for JavaScript projects and therefore an alternative to managers like npm, pnpm and Yarn.
 
 If a `package.json` is found to be part of `bun` manager results then the same file will be excluded from the `npm` manager results unless an npm/pnpm/Yarn lock file is also found.
+
+### `bunfig.toml` registry configuration
+
+Renovate reads the [`[install]` registry configuration](https://bun.com/docs/pm/scopes-registries) from the `bunfig.toml` file next to the Bun lock file:
+
+```toml
+[install]
+registry = "https://registry.example.com"
+
+[install.scopes]
+myorg = "https://registry.myorg.com"
+```
+
+Renovate looks up scoped packages like `@myorg/utils` in the matching scoped registry, and all other packages in the default `registry`.
+Like Bun, Renovate reads the `bunfig.toml` file next to the lock file only, so workspace packages use the registries of the workspace root.
+Also like Bun, a scoped registry from a `.npmrc` file still wins over the default `registry` from the `bunfig.toml` file.
+
+Renovate ignores any credentials in the `bunfig.toml` file, including credentials in a registry URL.
+Configure [`hostRules`](../../../configuration-options.md#hostrules) to let Renovate authenticate to a private registry.

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { Toml } from '../../../util/schema-utils';
+
+const BunfigRegistrySchema = z.union([
+  z.string(),
+  z.object({ url: z.string() }).transform((val) => val.url),
+]);
+
+const BunfigInstallSchema = z.object({
+  registry: BunfigRegistrySchema.optional(),
+  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
+});
+
+export const BunfigSchema = z.object({
+  install: BunfigInstallSchema.optional(),
+});
+
+export const BunfigConfig = Toml.pipe(BunfigSchema);
+export type BunfigConfig = z.infer<typeof BunfigSchema>;

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -1,19 +1,28 @@
 import { z } from 'zod';
-import { Toml } from '../../../util/schema-utils';
 
-const BunfigRegistrySchema = z.union([
+const BunfigRegistryConfigSchema = z.union([
   z.string(),
-  z.object({ url: z.string() }).transform((val) => val.url),
+  z.object({ url: z.string() }),
 ]);
 
 const BunfigInstallSchema = z.object({
-  registry: BunfigRegistrySchema.optional(),
-  scopes: z.record(z.string(), BunfigRegistrySchema).optional(),
+  registry: BunfigRegistryConfigSchema.optional(),
+  scopes: z.record(z.string(), BunfigRegistryConfigSchema).optional(),
 });
 
 export const BunfigSchema = z.object({
   install: BunfigInstallSchema.optional(),
 });
 
-export const BunfigConfig = Toml.pipe(BunfigSchema);
-export type BunfigConfig = z.infer<typeof BunfigConfig>;
+const ResolvedBunfigInstallSchema = z.object({
+  registry: z.string().optional(),
+  scopes: z.record(z.string(), z.string()).optional(),
+});
+
+export const ResolvedBunfigSchema = z.object({
+  install: ResolvedBunfigInstallSchema.optional(),
+});
+
+export type BunfigConfig = z.infer<typeof ResolvedBunfigSchema>;
+export type BunfigRegistryConfig = z.infer<typeof BunfigRegistryConfigSchema>;
+export type RawBunfigConfig = z.infer<typeof BunfigSchema>;

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -16,4 +16,4 @@ export const BunfigSchema = z.object({
 });
 
 export const BunfigConfig = Toml.pipe(BunfigSchema);
-export type BunfigConfig = z.infer<typeof BunfigSchema>;
+export type BunfigConfig = z.infer<typeof BunfigConfig>;

--- a/lib/modules/manager/bun/schema.ts
+++ b/lib/modules/manager/bun/schema.ts
@@ -1,28 +1,25 @@
-import { z } from 'zod';
+import { isString } from '@sindresorhus/is';
+import { z } from 'zod/v4';
+import { Toml } from '../../../util/schema-utils/index.ts';
 
-const BunfigRegistryConfigSchema = z.union([
-  z.string(),
-  z.object({ url: z.string() }),
-]);
+/**
+ * A registry is either the URL as a string, or an object which pairs the URL
+ * with credentials. Only the URL is of interest to us.
+ *
+ * @see https://bun.com/docs/pm/scopes-registries
+ */
+const BunfigRegistry = z
+  .union([z.string(), z.object({ url: z.string() })])
+  .transform((val) => (isString(val) ? val : val.url));
 
-const BunfigInstallSchema = z.object({
-  registry: BunfigRegistryConfigSchema.optional(),
-  scopes: z.record(z.string(), BunfigRegistryConfigSchema).optional(),
-});
-
-export const BunfigSchema = z.object({
-  install: BunfigInstallSchema.optional(),
-});
-
-const ResolvedBunfigInstallSchema = z.object({
-  registry: z.string().optional(),
-  scopes: z.record(z.string(), z.string()).optional(),
-});
-
-export const ResolvedBunfigSchema = z.object({
-  install: ResolvedBunfigInstallSchema.optional(),
-});
-
-export type BunfigConfig = z.infer<typeof ResolvedBunfigSchema>;
-export type BunfigRegistryConfig = z.infer<typeof BunfigRegistryConfigSchema>;
-export type RawBunfigConfig = z.infer<typeof BunfigSchema>;
+export const BunfigConfig = Toml.pipe(
+  z.object({
+    install: z
+      .object({
+        registry: BunfigRegistry.optional(),
+        scopes: z.record(z.string(), BunfigRegistry).optional(),
+      })
+      .optional(),
+  }),
+);
+export type BunfigConfig = z.infer<typeof BunfigConfig>;


### PR DESCRIPTION
## Changes

Renovate now reads the `[install]` registry configuration from `bunfig.toml` when it detects a Bun lock file, and applies the resolved registry to the npm dependencies of that lock file's package files.

This continues #39830 by @sebdanielsson, with their commits preserved, rebased onto `main` and finished off against Bun 1.4.2.

Review feedback from #39830 that is addressed here:

- The schema moved into `schema.ts` and is parsed with `Toml.pipe()`; the `string | { url }` union is normalized to a URL string by a schema transform instead of a hand-written `normalizeBunfigConfig()` function
- The registries are applied before the package file is pushed onto the result, so the changes cannot get lost through the object spread
- `codeBlock` and `toMatchObject` are used in the tests
- @RahulGautamSingh asked whether workspace packages with their own `bunfig.toml` are handled. They are not, because Bun does not handle them either: I verified against Bun 1.4.2 that `bun install` reads only the `bunfig.toml` next to the lock file, both when run from the workspace root and when run from inside a workspace member. Renovate now does the same, and no longer searches parent directories for the file.

Finalized on top of that:

- `bunfig.toml` is matched through `managerFilePatterns`, so the extract cache stays correct when only that file changes
- A scoped registry from `.npmrc` keeps precedence over the default `registry` from `bunfig.toml`. Bun [merges the two files key by key](https://bun.com/docs/pm/npmrc), so without this a repository which sets a default registry in `bunfig.toml` and a scoped registry in `.npmrc` would have its scoped packages looked up in the wrong registry, which is a regression compared to today
- Registry values which are not HTTP(S) URLs (for example an unexpanded `$NPM_REGISTRY`) are ignored
- Credentials are stripped from the registry URL, so they do not end up in `registryUrls`, logs or pull request bodies. Registry authentication stays with `hostRules`, and Bun's own `.npmrc` auth still works during lock file updates because Renovate writes the host rules into `.npmrc` before running `bun install`

## Context

- [x] This closes an existing Issue, Closes: #24460

## AI assistance disclosure

- [x] Yes: substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).

The original commits by @sebdanielsson were created with GitHub Copilot (Claude Opus 4.5). The rebase, the review fixes and the follow-up commits were made with Claude Code (Claude Opus 5), reviewed by @dennisameling before pushing.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @dennisameling will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation

Added a `bunfig.toml` section to the bun manager readme.

## How I've tested my work (please select one)

- [x] Both unit tests + ran on a real repository

Besides the unit tests, I ran Renovate (`RENOVATE_PLATFORM=local`) against a Bun workspace whose `bunfig.toml` and `.npmrc` point at local registries, and compared the requests Renovate makes with the requests `bun install` (1.4.2) makes for the same repository. Both send the same package to the same registry in every case: default registry, scoped registry, workspace member, `bunfig.toml` over `.npmrc` default, and `.npmrc` scope over `bunfig.toml` default.
