### PR TITLE
feat(manager/gradle): support rich version constraints in the Groovy/Kotlin DSL

### DIFF
--- a/lib/modules/manager/gradle/extract.spec.ts
+++ b/lib/modules/manager/gradle/extract.spec.ts
@@ -407,6 +407,65 @@ describe('modules/manager/gradle/extract', () => {
     ]);
   });
 
+  it('extracts rich version constraints', async () => {
+    const fsMock = {
+      'build.gradle': codeBlock`
+        dependencies {
+          implementation('org.slf4j:slf4j-api') {
+            version {
+              strictly '[1.7, 1.8['
+            }
+          }
+          implementation('com.google.guava:guava') {
+            version {
+              require '30.1-jre'
+              prefer '31.0-jre'
+            }
+          }
+          implementation('com.google.gson:gson') {
+            version {
+              strictly '2.8.9'
+              reject '2.8.8'
+            }
+          }
+        }
+      `,
+    };
+    mockFs(fsMock);
+
+    const res = await extractAllPackageFiles(
+      partial<ExtractConfig>(),
+      Object.keys(fsMock),
+    );
+
+    expect(res).toMatchObject([
+      {
+        packageFile: 'build.gradle',
+        deps: [
+          {
+            depName: 'org.slf4j:slf4j-api',
+            currentValue: '[1.7, 1.8[',
+            depType: 'dependencies',
+            enabled: false,
+            managerData: { versionConstraint: 'strictly' },
+          },
+          {
+            depName: 'com.google.guava:guava',
+            currentValue: '30.1-jre',
+            depType: 'dependencies',
+            managerData: { versionConstraint: 'require' },
+          },
+          {
+            depName: 'com.google.gson:gson',
+            depType: 'dependencies',
+            skipReason: 'unsupported-version',
+          },
+        ],
+      },
+    ]);
+    expect(res![0].deps[1].enabled).toBeUndefined();
+  });
+
   describe('registry URLs', () => {
     it('deduplicates registry urls', async () => {
       const fsMock = {

--- a/lib/modules/manager/gradle/parser.spec.ts
+++ b/lib/modules/manager/gradle/parser.spec.ts
@@ -613,6 +613,39 @@ describe('modules/manager/gradle/parser', () => {
       });
     });
 
+    describe('rich version constraints', () => {
+      it.each`
+        def                   | str                                                                                   | output
+        ${''}                 | ${"implementation('foo:bar') { version { strictly '1.2.3' } }"}                       | ${{ depName: 'foo:bar', currentValue: '1.2.3', enabled: false, managerData: { versionConstraint: 'strictly', fileReplacePosition: 48 } }}
+        ${''}                 | ${'implementation("foo:bar") { version { strictly("1.2.3") } }'}                      | ${{ depName: 'foo:bar', currentValue: '1.2.3', enabled: false, managerData: { versionConstraint: 'strictly', fileReplacePosition: 48 } }}
+        ${''}                 | ${"implementation('foo:bar') { version { strictly '[1.7, 1.8[' } }"}                  | ${{ depName: 'foo:bar', currentValue: '[1.7, 1.8[', enabled: false, managerData: { versionConstraint: 'strictly' } }}
+        ${''}                 | ${"implementation('foo:bar') { version { require '1.2.3' } }"}                        | ${{ depName: 'foo:bar', currentValue: '1.2.3', managerData: { versionConstraint: 'require', fileReplacePosition: 47 } }}
+        ${''}                 | ${"implementation('foo:bar') { version { prefer '1.2.3' } }"}                         | ${{ depName: 'foo:bar', currentValue: '1.2.3', enabled: false, managerData: { versionConstraint: 'prefer' } }}
+        ${''}                 | ${"implementation('foo:bar') { version { require '[1.0, 2.0['; prefer '1.5' } }"}     | ${{ depName: 'foo:bar', currentValue: '[1.0, 2.0[', managerData: { versionConstraint: 'require' } }}
+        ${''}                 | ${"implementation('foo:bar') { version { strictly '1.2.3'; prefer '1.2.0' } }"}       | ${{ depName: 'foo:bar', currentValue: '1.2.3', enabled: false, managerData: { versionConstraint: 'strictly' } }}
+        ${''}                 | ${"implementation('foo:bar') { version { strictly '[1.7, 1.8['; prefer '1.7.25' } }"} | ${{ depName: 'foo:bar', skipReason: 'multiple-constraint-dep' }}
+        ${''}                 | ${"implementation('foo:bar') { version { require '1.2.3'; strictly '1.2.4' } }"}      | ${{ depName: 'foo:bar', skipReason: 'multiple-constraint-dep' }}
+        ${''}                 | ${"implementation('foo:bar') { version { require '1.2.3'; reject '1.2.4' } }"}        | ${{ depName: 'foo:bar', skipReason: 'unsupported-version' }}
+        ${''}                 | ${"implementation('foo:bar') { version { require '1.2.3'; rejectAll() } }"}           | ${{ depName: 'foo:bar', skipReason: 'unsupported-version' }}
+        ${''}                 | ${"implementation('foo:bar') { exclude group: 'baz'; version { strictly '1.2.3' } }"} | ${{ depName: 'foo:bar', currentValue: '1.2.3', managerData: { versionConstraint: 'strictly' } }}
+        ${''}                 | ${"implementation(group: 'foo', name: 'bar') { version { strictly '1.2.3' } }"}       | ${{ depName: 'foo:bar', currentValue: '1.2.3', managerData: { versionConstraint: 'strictly' } }}
+        ${''}                 | ${'implementation(group = "foo", name = "bar") { version { strictly("1.2.3") } }'}    | ${{ depName: 'foo:bar', currentValue: '1.2.3', managerData: { versionConstraint: 'strictly' } }}
+        ${'baz = "1.2.3"'}    | ${"implementation('foo:bar') { version { strictly baz } }"}                           | ${{ depName: 'foo:bar', currentValue: '1.2.3', sharedVariableName: 'baz', managerData: { fileReplacePosition: 7 } }}
+        ${'baz = "1.2.3"'}    | ${'implementation("foo:bar") { version { strictly("${baz}") } }'}                     | ${{ depName: 'foo:bar', currentValue: '1.2.3', sharedVariableName: 'baz', managerData: { fileReplacePosition: 7 } }}
+        ${'a = "1"; b = "2"'} | ${'implementation("foo:bar") { version { strictly("$a.$b.3") } }'}                    | ${{ depName: 'foo:bar', currentValue: '1.2.3', skipReason: 'unspecified-version' }}
+        ${''}                 | ${"implementation('foo:bar') { version { strictly baz } }"}                           | ${null}
+        ${''}                 | ${'implementation("${baz}") { version { strictly("1.2.3") } }'}                       | ${null}
+        ${''}                 | ${"implementation(group: 'foo', name: baz) { version { strictly '1.2.3' } }"}         | ${null}
+        ${''}                 | ${"implementation('foo:bar:baz:qux') { version { strictly '1.2.3' } }"}               | ${null}
+        ${''}                 | ${'implementation(libs.foo) { version { strictly "1.2.3" } }'}                        | ${null}
+        ${''}                 | ${"implementation('foo:bar') { version { } }"}                                        | ${null}
+        ${''}                 | ${"implementation('foo:bar:1.2.3') { version { strictly '1.2.4' } }"}                 | ${{ depName: 'foo:bar', currentValue: '1.2.3' }}
+      `('$def | $str', ({ def, str, output }) => {
+        const { deps } = parseGradle([def, str].filter(isTruthy).join('\n'));
+        expect(deps).toMatchObject([output].filter(isTruthy));
+      });
+    });
+
     describe('dependencySubstitution constructs', () => {
       it.each`
         input                                                                   | output

--- a/lib/modules/manager/gradle/parser/dependencies.ts
+++ b/lib/modules/manager/gradle/parser/dependencies.ts
@@ -1,3 +1,4 @@
+import type { parser } from '@renovatebot/good-enough-parser';
 import { query as q } from '@renovatebot/good-enough-parser';
 import { regEx } from '../../../../util/regex.ts';
 import type { Ctx } from '../types.ts';
@@ -19,6 +20,7 @@ import {
   handleImplicitDep,
   handleKotlinShortNotationDep,
   handleLongFormDep,
+  handleRichVersionDep,
 } from './handlers.ts';
 
 // "foo:bar:1.2.3"
@@ -153,6 +155,86 @@ export const qLongFormDep = q
   .handler(handleLongFormDep)
   .handler(cleanupTempVars);
 
+// strictly '1.2.3'
+// strictly("1.2.3")
+function qRichVersionValue(
+  tokenMapKey: string,
+): q.QueryBuilder<Ctx, parser.Node> {
+  return q
+    .alt<Ctx>(
+      q.tree({
+        type: 'wrapped-tree',
+        maxDepth: 1,
+        maxMatches: 1,
+        startsWith: '(',
+        endsWith: ')',
+        search: q.begin<Ctx>().join(qValueMatcher).end(),
+      }),
+      qValueMatcher,
+    )
+    .handler((ctx) => storeInTokenMap(ctx, tokenMapKey));
+}
+
+// version { strictly '[1.7, 1.8['; prefer '1.7.25' }
+// version { strictly("[1.7, 1.8["); prefer("1.7.25") }
+const qRichVersion = q.sym<Ctx>('version').tree({
+  type: 'wrapped-tree',
+  maxDepth: 1,
+  startsWith: '{',
+  endsWith: '}',
+  search: q.alt<Ctx>(
+    q.sym<Ctx>('strictly').join(qRichVersionValue('strictly')),
+    q.sym<Ctx>('require').join(qRichVersionValue('require')),
+    q.sym<Ctx>('prefer').join(qRichVersionValue('prefer')),
+    // the rejected versions themselves are irrelevant: their mere presence
+    // means Renovate cannot reason about the constraint
+    q
+      .sym<Ctx>(regEx(/^reject(?:All)?$/), storeVarToken)
+      .handler((ctx) => storeInTokenMap(ctx, 'reject')),
+  ),
+});
+
+// implementation('foo:bar') { version { strictly '1.2.3' } }
+// implementation("foo:bar") { version { strictly("1.2.3") } }
+// implementation(group: 'foo', name: 'bar') { version { strictly '1.2.3' } }
+const qRichVersionDep = q
+  .opt<Ctx>(
+    q.sym(storeVarToken).handler((ctx) => storeInTokenMap(ctx, 'methodName')),
+  )
+  .tree({
+    type: 'wrapped-tree',
+    maxDepth: 1,
+    maxMatches: 1,
+    startsWith: '(',
+    endsWith: ')',
+    search: q
+      .begin<Ctx>()
+      .alt(
+        qTemplateString.handler((ctx) =>
+          storeInTokenMap(ctx, 'templateStringTokens'),
+        ),
+        q
+          .sym<Ctx>('group')
+          .alt(q.op(':'), q.op('='))
+          .join(qGroupId)
+          .op(',')
+          .sym('name')
+          .alt(q.op(':'), q.op('='))
+          .join(qArtifactId),
+      )
+      .end(),
+  })
+  .tree({
+    type: 'wrapped-tree',
+    maxDepth: 1,
+    maxMatches: 1,
+    startsWith: '{',
+    endsWith: '}',
+    search: qRichVersion,
+  })
+  .handler(handleRichVersionDep)
+  .handler(cleanupTempVars);
+
 // pmd { toolVersion = "1.2.3" }
 const qImplicitGradlePlugin = q
   .alt(
@@ -262,6 +344,7 @@ const qIgnoreAndroidBuildValues = q.alt(
 export const qDependencies = q.alt(
   qDependencyStrings,
   qDependencySet,
+  qRichVersionDep,
   qGroovyMapNotationDependencies,
   qKotlinShortNotationDependencies,
   qKotlinMapNotationDependencies,

--- a/lib/modules/manager/gradle/parser/handlers.ts
+++ b/lib/modules/manager/gradle/parser/handlers.ts
@@ -3,6 +3,7 @@ import { logger } from '../../../../logger/index.ts';
 import { getSiblingFileName } from '../../../../util/fs/index.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { parseUrl } from '../../../../util/url.ts';
+import { api as gradleVersioning } from '../../../versioning/gradle/index.ts';
 import type { PackageDependency } from '../../types.ts';
 import type { parseGradle as parseGradleCallback } from '../parser.ts';
 import type {
@@ -10,8 +11,13 @@ import type {
   ContentDescriptorSpec,
   Ctx,
   GradleManagerData,
+  RichVersionConstraint,
 } from '../types.ts';
-import { isDependencyString, parseDependencyString } from '../utils.ts';
+import {
+  isDependencyString,
+  isGroupArtifactString,
+  parseDependencyString,
+} from '../utils.ts';
 import {
   GRADLE_PLUGINS,
   GRADLE_TEST_SUITES,
@@ -217,6 +223,138 @@ export function handleLongFormDep(ctx: Ctx): Ctx {
       fileReplacePosition: versionTokens[0].offset,
       packageFile: ctx.packageFile,
     };
+  }
+
+  ctx.deps.push(dep);
+
+  return ctx;
+}
+
+function resolveRichVersionDepName(ctx: Ctx): string | null {
+  if (ctx.tokenMap.templateStringTokens) {
+    return interpolateString(
+      loadFromTokenMap(ctx, 'templateStringTokens'),
+      ctx,
+    );
+  }
+
+  const groupId = interpolateString(loadFromTokenMap(ctx, 'groupId'), ctx);
+  const artifactId = interpolateString(
+    loadFromTokenMap(ctx, 'artifactId'),
+    ctx,
+  );
+  if (!groupId || !artifactId) {
+    return null;
+  }
+
+  return `${groupId}:${artifactId}`;
+}
+
+function pushSkippedRichVersionDep(
+  ctx: Ctx,
+  depName: string,
+  skipReason: 'multiple-constraint-dep' | 'unsupported-version',
+): Ctx {
+  ctx.deps.push({
+    depName,
+    skipReason,
+    managerData: { packageFile: ctx.packageFile },
+  });
+
+  return ctx;
+}
+
+/**
+ * Extracts a dependency whose version comes from a rich version constraint,
+ * e.g. `implementation('foo:bar') { version { strictly '1.2.3' } }`.
+ *
+ * Renovate can only rewrite a single version literal per dependency, so any
+ * combination of constraints whose parts would have to move together is
+ * skipped instead of updated.
+ *
+ * @see https://docs.gradle.org/current/userguide/dependency_versions.html#sec:rich-version-constraints
+ */
+export function handleRichVersionDep(ctx: Ctx): Ctx {
+  const depName = resolveRichVersionDepName(ctx);
+  if (!depName) {
+    return ctx;
+  }
+
+  // A version block alongside a fully qualified dependency string is invalid
+  // Gradle, so keep extracting the dependency string as we always have
+  if (ctx.tokenMap.templateStringTokens && isDependencyString(depName)) {
+    return handleDepString(ctx);
+  }
+
+  if (!isGroupArtifactString(depName)) {
+    return ctx;
+  }
+
+  // Renovate cannot tell which versions an arbitrary rejection leaves available
+  if (ctx.tokenMap.reject) {
+    return pushSkippedRichVersionDep(ctx, depName, 'unsupported-version');
+  }
+
+  const hasStrictly = !!ctx.tokenMap.strictly;
+  const hasRequire = !!ctx.tokenMap.require;
+  const hasPrefer = !!ctx.tokenMap.prefer;
+
+  // Gradle applies `require()` before `strictly()`, so bumping only `strictly`
+  // would leave the `require` literal behind as stale text
+  if (hasStrictly && hasRequire) {
+    return pushSkippedRichVersionDep(ctx, depName, 'multiple-constraint-dep');
+  }
+
+  // `prefer` is only a hint, so `require` is the constraint worth bumping
+  let versionConstraint: RichVersionConstraint = 'prefer';
+  if (hasStrictly) {
+    versionConstraint = 'strictly';
+  } else if (hasRequire) {
+    versionConstraint = 'require';
+  }
+
+  const versionTokens = loadFromTokenMap(ctx, versionConstraint);
+  const currentValue = interpolateString(versionTokens, ctx);
+  if (!currentValue) {
+    return ctx;
+  }
+
+  // A strict single version makes `prefer` inert, so it can stay untouched.
+  // A strict range does not: `prefer` has to keep pointing inside it.
+  if (
+    hasStrictly &&
+    hasPrefer &&
+    !gradleVersioning.isSingleVersion(currentValue)
+  ) {
+    return pushSkippedRichVersionDep(ctx, depName, 'multiple-constraint-dep');
+  }
+
+  const managerData: GradleManagerData = {
+    packageFile: ctx.packageFile,
+    versionConstraint,
+  };
+  const dep: PackageDependency<GradleManagerData> = {
+    depName,
+    currentValue,
+    managerData,
+  };
+
+  // `strictly` and `prefer` pin a version on purpose, so updating them is opt-in
+  if (versionConstraint !== 'require') {
+    dep.enabled = false;
+  }
+
+  if (versionTokens.length > 1) {
+    // = template string with multiple variables
+    dep.skipReason = 'unspecified-version';
+  } else if (versionTokens[0].type === 'symbol') {
+    // interpolateString above already proved this variable resolves
+    const varData = findVariable(versionTokens[0].value, ctx)!;
+    dep.sharedVariableName = varData.key;
+    managerData.fileReplacePosition = varData.fileReplacePosition;
+    managerData.packageFile = varData.packageFile;
+  } else {
+    managerData.fileReplacePosition = versionTokens[0].offset;
   }
 
   ctx.deps.push(dep);

--- a/lib/modules/manager/gradle/readme.md
+++ b/lib/modules/manager/gradle/readme.md
@@ -28,3 +28,56 @@ Renovate will check the file for existing hash types (like `sha256`) and use the
   Gradle allows verification metadata to use the `md5` and `sha1` algorithms.
   Because those algorithms are prone to collision attacks, Renovate ignores them.
   If Renovate encounters hashes that are generated with `md5` or `sha1` algorithms, Renovate uses `sha256` instead.
+
+### Rich version constraints
+
+Renovate extracts dependencies whose version comes from a Gradle [rich version constraint](https://docs.gradle.org/current/userguide/dependency_versions.html#sec:rich-version-constraints) declared in a `version { ... }` block, in both the Groovy and the Kotlin DSL:
+
+```groovy
+dependencies {
+    implementation('org.slf4j:slf4j-api') {
+        version {
+            strictly '[1.7, 1.8['
+        }
+    }
+}
+```
+
+Renovate can only rewrite one version literal per dependency, so it picks a single constraint to update and records which one in `managerData.versionConstraint`:
+
+| Declared constraints               | What Renovate updates                         |
+| ---------------------------------- | --------------------------------------------- |
+| `strictly`                         | `strictly`                                    |
+| `strictly` + `prefer`              | `strictly`, if `strictly` is a single version |
+| `require`                          | `require`                                     |
+| `require` + `prefer`               | `require`, because `prefer` is only a hint    |
+| `prefer`                           | `prefer`                                      |
+| `require` + `strictly`             | nothing, skipped as `multiple-constraint-dep` |
+| `strictly` range + `prefer`        | nothing, skipped as `multiple-constraint-dep` |
+| anything + `reject` or `rejectAll` | nothing, skipped as `unsupported-version`     |
+
+`strictly` and `prefer` pin a version on purpose, so Renovate disables those dependencies by default and only updates them for [vulnerability alerts](../../../configuration-options.md#vulnerabilityalerts).
+A `require` constraint means the same thing as a plain version declaration, so it is updated like any other dependency.
+
+To also receive regular updates for `strictly` and `prefer` constraints, opt in with a package rule:
+
+```json
+{
+  "packageRules": [
+    {
+      "matchManagers": ["gradle"],
+      "matchJsonata": [
+        "managerData.versionConstraint in ['strictly', 'prefer']"
+      ],
+      "enabled": true
+    }
+  ]
+}
+```
+
+!!! note
+  Rich versions in [version catalogs](https://docs.gradle.org/current/userguide/platforms.html) are extracted by the TOML parser instead, which updates a single `require`, `prefer` or `strictly` constraint without disabling it.
+
+!!! note
+  A `version { ... }` block on a dependency that already spells out its version, such as `implementation('org.slf4j:slf4j-api:1.7.25') { version { strictly '1.7.30' } }`, is not valid Gradle.
+  Renovate updates the version in the dependency string and ignores the block.

--- a/lib/modules/manager/gradle/types.ts
+++ b/lib/modules/manager/gradle/types.ts
@@ -1,9 +1,17 @@
 import type { lexer } from '@renovatebot/good-enough-parser';
 import type { PackageDependency } from '../types.ts';
 
+/**
+ * The rich version constraint a dependency's `currentValue` was extracted from.
+ *
+ * @see https://docs.gradle.org/current/userguide/dependency_versions.html#sec:rich-version-constraints
+ */
+export type RichVersionConstraint = 'strictly' | 'require' | 'prefer';
+
 export interface GradleManagerData {
   fileReplacePosition?: number;
   packageFile?: string;
+  versionConstraint?: RichVersionConstraint;
 }
 
 export interface VariableData extends GradleManagerData {

--- a/lib/modules/manager/gradle/update.spec.ts
+++ b/lib/modules/manager/gradle/update.spec.ts
@@ -1,4 +1,6 @@
+import { codeBlock } from 'common-tags';
 import { updateDependency } from './index.ts';
+import { parseGradle } from './parser.ts';
 
 describe('modules/manager/gradle/update', () => {
   it('replaces', () => {
@@ -80,6 +82,40 @@ describe('modules/manager/gradle/update', () => {
       }),
     ).toBeNull();
   });
+
+  it.each`
+    constraint    | currentValue    | newValue
+    ${'strictly'} | ${'1.2.3'}      | ${'1.2.4'}
+    ${'strictly'} | ${'[1.7, 1.8['} | ${'[1.8, 1.9['}
+    ${'require'}  | ${'1.2.3'}      | ${'1.2.4'}
+    ${'prefer'}   | ${'1.2.3'}      | ${'1.2.4'}
+  `(
+    'replaces a $constraint rich version constraint',
+    ({ constraint, currentValue, newValue }) => {
+      const fileContent = codeBlock`
+        dependencies {
+          implementation('foo:bar') {
+            version {
+              ${constraint} '${currentValue}'
+            }
+          }
+        }
+      `;
+      const [dep] = parseGradle(fileContent, {}, 'build.gradle').deps;
+      expect(dep).toMatchObject({
+        currentValue,
+        managerData: { versionConstraint: constraint },
+      });
+
+      expect(
+        updateDependency({
+          fileContent,
+          packageFile: 'build.gradle',
+          upgrade: { ...dep, newValue },
+        }),
+      ).toBe(fileContent.replace(currentValue, newValue));
+    },
+  );
 
   it('should return null for replacement', () => {
     const res = updateDependency({

--- a/lib/modules/manager/gradle/utils.spec.ts
+++ b/lib/modules/manager/gradle/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   isGradleScriptFile,
   isGradleSettingsFile,
   isGradleVersionsFile,
+  isGroupArtifactString,
   isKotlinSourceFile,
   isPropsFile,
   isTOMLFile,
@@ -78,6 +79,22 @@ describe('modules/manager/gradle/utils', () => {
       ${'foo:bar:1.2.3@zip@foo'}               | ${false}
     `('$input', ({ input, output }) => {
       expect(isDependencyString(input)).toBe(output);
+    });
+  });
+
+  describe('isGroupArtifactString', () => {
+    it.each`
+      input                | output
+      ${'foo:bar'}         | ${true}
+      ${'foo.foo:bar.bar'} | ${true}
+      ${'foo'}             | ${false}
+      ${'foo:bar:1.2.3'}   | ${false}
+      ${':bar'}            | ${false}
+      ${'foo:'}            | ${false}
+      ${'foo$foo:bar'}     | ${false}
+      ${'foo:bar$bar'}     | ${false}
+    `('$input', ({ input, output }) => {
+      expect(isGroupArtifactString(input)).toBe(output);
     });
   });
 

--- a/lib/modules/manager/gradle/utils.ts
+++ b/lib/modules/manager/gradle/utils.ts
@@ -60,6 +60,24 @@ export function isDependencyString(input: string): boolean {
   );
 }
 
+// Matches the `group:artifact` notation used by dependencies whose version is
+// declared separately, e.g. inside a rich version constraint block
+export function isGroupArtifactString(input: string): boolean {
+  const parts = input.split(':');
+  if (parts.length !== 2) {
+    return false;
+  }
+
+  const [groupId, artifactId] = parts;
+
+  return !!(
+    groupId &&
+    artifactId &&
+    artifactRegex.test(groupId) &&
+    artifactRegex.test(artifactId)
+  );
+}
+
 export function parseDependencyString(
   input: string,
 ): PackageDependency<GradleManagerData> | null {


### PR DESCRIPTION
## Changes

Extracts dependencies whose version comes from a Gradle [rich version constraint](https://docs.gradle.org/current/userguide/dependency_versions.html#sec:rich-version-constraints) declared in a `version { ... }` block, in both the Groovy and the Kotlin DSL:

```groovy
dependencies {
    implementation('org.slf4j:slf4j-api') {
        version {
            strictly '[1.7, 1.8['
        }
    }
}
```

Previously these were not extracted at all, so a `strictly` pin never received updates — not even for a security fix.

Renovate can only rewrite a single version literal per dependency, so we pick one constraint to update and record which one in `managerData.versionConstraint`:

| Declared constraints               | What Renovate updates                         |
| ---------------------------------- | --------------------------------------------- |
| `strictly`                         | `strictly`                                    |
| `strictly` single + `prefer`       | `strictly`, as `prefer` is inert              |
| `require`, optionally + `prefer`   | `require`, as `prefer` is only a hint         |
| `prefer`                           | `prefer`                                      |
| `require` + `strictly`             | nothing, skipped as `multiple-constraint-dep` |
| `strictly` range + `prefer`        | nothing, skipped as `multiple-constraint-dep` |
| anything + `reject` or `rejectAll` | nothing, skipped as `unsupported-version`     |

`strictly` and `prefer` pin a version on purpose, so updating them by default would be surprising. Those deps are extracted with `enabled: false`, meaning they only receive updates for vulnerability alerts (which force through). Users who want regular updates opt in with a package rule, similar to how `manager/gomod` handles `depType: indirect`:

```json
{
  "packageRules": [
    {
      "matchManagers": ["gradle"],
      "matchJsonata": [
        "managerData.versionConstraint in ['strictly', 'prefer']"
      ],
      "enabled": true
    }
  ]
}
```

A `require` constraint means the same thing as a plain version declaration, so it is updated like any other dependency.

Also supported: the `group:`/`name:` and `group =`/`name =` map notations, version blocks alongside other config such as `exclude`, blocks inside `constraints { }`, and versions coming from variables (which keep `sharedVariableName` and the variable's `fileReplacePosition`).

### Design notes

This follows @Churro's [suggestion in the discussion](https://github.com/renovatebot/renovate/discussions/45481#discussioncomment-18185564) to use `managerData.versionConstraint` rather than `depType`, since `depType` describes _how_ a dep is used rather than what its version looks like.

Two deviations worth calling out:

- For **`strictly` range + `prefer`**, the discussion suggested bumping the range and moving `prefer` if it sat on a boundary. Renovate writes a single `fileReplacePosition` per dependency, so moving two literals isn't expressible today. Skipping is safer than leaving a `prefer` that now points outside the range.
- **Version catalogs are left alone.** The TOML extractor already extracts a single `require`/`prefer`/`strictly` and updates it enabled-by-default, without setting `versionConstraint`. Aligning it would take away updates users get today, so that felt like a separate decision — happy to fold it in if maintainers would prefer consistency.

### Not included

- The `!!` shorthand (`foo:bar:1.7.25!!`) is untouched — it already extracts as an opaque version string.
- Rich versions declared in the Groovy/Kotlin `versionCatalogs { }` builder (as opposed to TOML) are still dropped silently.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Discussed in https://github.com/renovatebot/renovate/discussions/45481.

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5, via Claude Code, wrote the parser matchers, the handler, the tests and the documentation.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Parser tests cover each constraint combination, both DSLs, map notation, variables and the skip reasons. `update.spec.ts` round-trips parse → `updateDependency` for `strictly`, `require` and `prefer`, including the `[1.7, 1.8[` range case, and `extract.spec.ts` checks `enabled`/`depType`/`skipReason` survive into the extracted `PackageDependency`.
