### PR TITLE
feat(config): add experimental `exitCodeForErrors` option

### DIFF
--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -720,6 +720,29 @@ If set to a string value, Renovate will log warnings with the `encryptedWarning`
 Default execution timeout in minutes for child processes Renovate creates.
 If this option is not set, Renovate will fallback to 15 minutes.
 
+## `exitCodeForErrors`
+
+By default Renovate exits with code `1` if anything was logged at error level, and `0` otherwise.
+Set `exitCodeForErrors` to `true` to instead exit with a code that says _which_ kind of error ended the repository run:
+
+| Exit code | Meaning                                                                                        |
+| --------- | ---------------------------------------------------------------------------------------------- |
+| `0`       | Success                                                                                        |
+| `1`       | Renovate logged an error                                                                       |
+| `2`       | Renovate could not parse its own configuration                                                 |
+| `3`       | System error, see `SystemErrors` in `lib/constants/error-messages.ts`                          |
+| `4`       | Platform error, see `PlatformErrors`                                                           |
+| `5`       | Configuration error, see `ConfigErrors`                                                        |
+| `6`       | Temporary error, see `TemporaryErrors`                                                         |
+| `7`       | Other error: external host error, lockfile error, missing API credentials, or an unknown error |
+
+The results in `RepositoryErrors` are _not_ mapped to an exit code, because they mean the repository is disabled, archived, empty and so on, and not that the run failed.
+
+When Renovate runs against multiple repositories, the exit code comes from the first repository that ended in an error state.
+Renovate still processes the remaining repositories.
+
+The exit code a repository maps to is always logged in the `Repository finished` message, even when this option is disabled.
+
 ## `exposeAllEnv`
 
 To keep you safe, Renovate only passes a limited set of environment variables to package managers.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -722,21 +722,23 @@ If this option is not set, Renovate will fallback to 15 minutes.
 
 ## `exitCodeForErrors`
 
-By default Renovate exits with code `1` if anything was logged at error level, and `0` otherwise.
-Set `exitCodeForErrors` to `true` to instead exit with a code that says _which_ kind of error ended the repository run:
+Set `exitCodeForErrors` to `true` to exit with a code that says _which_ kind of error ended the repository run.
+The groups are the exported error constants in [`lib/constants/error-messages.ts`](https://github.com/renovatebot/renovate/blob/HEAD/lib/constants/error-messages.ts):
 
-| Exit code | Meaning                                                                                        |
-| --------- | ---------------------------------------------------------------------------------------------- |
-| `0`       | Success                                                                                        |
-| `1`       | Renovate logged an error                                                                       |
-| `2`       | Renovate could not parse its own configuration                                                 |
-| `3`       | System error, see `SystemErrors` in `lib/constants/error-messages.ts`                          |
-| `4`       | Platform error, see `PlatformErrors`                                                           |
-| `5`       | Configuration error, see `ConfigErrors`                                                        |
-| `6`       | Temporary error, see `TemporaryErrors`                                                         |
-| `7`       | Other error: external host error, lockfile error, missing API credentials, or an unknown error |
+| Exit code | Repository result                                               |
+| --------- | --------------------------------------------------------------- |
+| `0`       | Success, or a `RepositoryErrors` result                         |
+| `3`       | `SystemErrors`                                                  |
+| `4`       | `PlatformErrors`                                                |
+| `5`       | `ConfigErrors`                                                  |
+| `6`       | `TemporaryErrors`                                               |
+| `7`       | External host error, lockfile error, or missing API credentials |
+| `8`       | Unknown error                                                   |
 
-The results in `RepositoryErrors` are _not_ mapped to an exit code, because they mean the repository is disabled, archived, empty and so on, and not that the run failed.
+The results in `RepositoryErrors` map to `0`, because they mean the repository is disabled, archived, empty and so on, and not that the run failed.
+
+This option only adds the codes above.
+Renovate's existing exit codes are unchanged: `1` when something was logged at error level, and `2` when Renovate could not parse its own configuration.
 
 When Renovate runs against multiple repositories, the exit code comes from the first repository that ended in an error state.
 Renovate still processes the remaining repositories.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -725,20 +725,22 @@ If this option is not set, Renovate will fallback to 15 minutes.
 Set `exitCodeForErrors` to `true` to exit with a code that says _which_ kind of error ended the repository run.
 The groups are the exported error constants in [`lib/constants/error-messages.ts`](https://github.com/renovatebot/renovate/blob/HEAD/lib/constants/error-messages.ts):
 
-| Exit code | Repository result                                               |
-| --------- | --------------------------------------------------------------- |
-| `0`       | Success, or a `RepositoryErrors` result                         |
-| `3`       | `SystemErrors`                                                  |
-| `4`       | `PlatformErrors`                                                |
-| `5`       | `ConfigErrors`                                                  |
-| `6`       | `TemporaryErrors`                                               |
-| `7`       | External host error, lockfile error, or missing API credentials |
-| `8`       | Unknown error                                                   |
+| Exit code | Repository result                                                            |
+| --------- | ---------------------------------------------------------------------------- |
+| `0`       | Success, or a `RepositoryErrors` result                                      |
+| `1`       | Renovate logged an error, but no repository ended in one of the states below |
+| `2`       | Renovate could not parse its own configuration                               |
+| `3`       | `SystemErrors`                                                               |
+| `4`       | `PlatformErrors`                                                             |
+| `5`       | `ConfigErrors`                                                               |
+| `6`       | `TemporaryErrors`                                                            |
+| `7`       | External host error, lockfile error, or missing API credentials              |
+| `8`       | Unknown error                                                                |
+
+Codes `3` to `8` take precedence over `1`, so a repository that ends in one of those states sets the exit code even if errors were logged as well.
+Renovate still exits `1` when no repository ended in an error state but something was logged at error level, such as a failed changelog fetch during an otherwise successful run.
 
 The results in `RepositoryErrors` map to `0`, because they mean the repository is disabled, archived, empty and so on, and not that the run failed.
-
-This option only adds the codes above.
-Renovate's existing exit codes are unchanged: `1` when something was logged at error level, and `2` when Renovate could not parse its own configuration.
 
 When Renovate runs against multiple repositories, the exit code comes from the first repository that ended in an error state.
 Renovate still processes the remaining repositories.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1348,6 +1348,15 @@ const options: Readonly<RenovateOptions>[] = [
     globalOnly: true,
   },
   {
+    name: 'exitCodeForErrors',
+    description:
+      'Exit with an error-specific exit code when a repository run ends in a known error state.',
+    type: 'boolean',
+    default: false,
+    experimental: true,
+    globalOnly: true,
+  },
+  {
     name: 'registryAliases',
     description: 'Aliases for registries.',
     mergeable: true,

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -204,6 +204,7 @@ export interface GlobalOnlyConfigLegacy {
   detectHostRulesFromEnv?: boolean;
   dockerCliOptions?: string;
   endpoint?: string;
+  exitCodeForErrors?: boolean;
   forceCli?: boolean;
   gitNoVerify?: GitNoVerifyOption[];
   gitPrivateKey?: string;

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -1,13 +1,14 @@
 import { ERROR, WARN } from 'bunyan';
 import fs from 'fs-extra';
 import type { RenovateConfig } from '~test/util.ts';
-import { logger } from '~test/util.ts';
+import { logger, partial } from '~test/util.ts';
 import { GlobalConfig } from '../../config/global.ts';
 import { DockerDatasource } from '../../modules/datasource/docker/index.ts';
 import * as platform from '../../modules/platform/index.ts';
 import * as hostRules from '../../util/host-rules.ts';
 import * as secrets from '../../util/sanitize.ts';
 import * as repositoryWorker from '../repository/index.ts';
+import type { ProcessResult } from '../repository/result.ts';
 import * as configParser from './config/parse/index.ts';
 import * as globalWorker from './index.ts';
 import * as limits from './limits.ts';
@@ -198,6 +199,33 @@ describe('workers/global/index', () => {
     await expect(globalWorker.start()).resolves.toBe(0);
     expect(parseConfigs).toHaveBeenCalledTimes(1);
     expect(repositoryWorker.renovateRepository).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the exit code of the first errored repository when exitCodeForErrors is enabled', async () => {
+    parseConfigs.mockResolvedValueOnce({
+      enabled: true,
+      exitCodeForErrors: true,
+      repositories: ['a', 'b', 'c'],
+    });
+    vi.mocked(repositoryWorker.renovateRepository)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(partial<ProcessResult>({ exitCode: 5 }))
+      .mockResolvedValueOnce(partial<ProcessResult>({ exitCode: 6 }));
+
+    await expect(globalWorker.start()).resolves.toBe(5);
+    expect(repositoryWorker.renovateRepository).toHaveBeenCalledTimes(3);
+  });
+
+  it('ignores repository exit codes when exitCodeForErrors is disabled', async () => {
+    parseConfigs.mockResolvedValueOnce({
+      enabled: true,
+      repositories: ['a'],
+    });
+    vi.mocked(repositoryWorker.renovateRepository).mockResolvedValueOnce(
+      partial<ProcessResult>({ exitCode: 5 }),
+    );
+
+    await expect(globalWorker.start()).resolves.toBe(0);
   });
 
   it("filters the self-hosted admin's own hostRules headers against allowedHeaders", async () => {

--- a/lib/workers/global/index.ts
+++ b/lib/workers/global/index.ts
@@ -158,6 +158,7 @@ export async function start(): Promise<number> {
   }
 
   let config: AllConfig;
+  let repoExitCode = 0;
   const env = getEnv();
   try {
     if (isNonEmptyStringAndNotWhitespace(env.AWS_SECRET_ACCESS_KEY)) {
@@ -269,7 +270,11 @@ export async function start(): Promise<number> {
           queue.clear();
           throttle.clear();
 
-          await repositoryWorker.renovateRepository(repoConfig);
+          const repoResult =
+            await repositoryWorker.renovateRepository(repoConfig);
+          if (config.exitCodeForErrors && !repoExitCode) {
+            repoExitCode = repoResult?.exitCode ?? 0;
+          }
           setMeta({});
         },
         {
@@ -309,6 +314,13 @@ export async function start(): Promise<number> {
         `Renovate was run at log level "${logLevel()}". Set LOG_LEVEL=debug in environment variables to see extended debug logs.`,
       );
     }
+  }
+  if (repoExitCode) {
+    logger.info(
+      { exitCode: repoExitCode },
+      'Renovate is exiting with an error-specific code due to a repository error',
+    );
+    return repoExitCode;
   }
   const loggerErrors = getProblems().filter((p) => p.level >= ERROR);
   if (loggerErrors.length) {

--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -231,6 +231,7 @@ export async function renovateRepository(
       status: repoResult?.status,
       enabled: repoResult?.enabled,
       onboarded: repoResult?.onboarded,
+      exitCode: repoResult?.exitCode,
     },
     'Repository finished',
   );

--- a/lib/workers/repository/result.spec.ts
+++ b/lib/workers/repository/result.spec.ts
@@ -42,7 +42,7 @@ describe('workers/repository/result', () => {
       ${'config-validation'}   | ${5}
       ${'temporary-error'}     | ${6}
       ${'external-host-error'} | ${7}
-      ${'unknown-error'}       | ${7}
+      ${'unknown-error'}       | ${8}
     `('maps $res to exit code $exitCode', ({ res, exitCode }) => {
       expect(processResult(config, res).exitCode).toBe(exitCode);
     });

--- a/lib/workers/repository/result.spec.ts
+++ b/lib/workers/repository/result.spec.ts
@@ -29,7 +29,22 @@ describe('workers/repository/result', () => {
         status: 'onboarding',
         enabled: true,
         onboarded: false,
+        exitCode: 0,
       });
+    });
+
+    it.each`
+      res                      | exitCode
+      ${'done'}                | ${0}
+      ${'disabled-by-config'}  | ${0}
+      ${'out-of-memory'}       | ${3}
+      ${'bad-credentials'}     | ${4}
+      ${'config-validation'}   | ${5}
+      ${'temporary-error'}     | ${6}
+      ${'external-host-error'} | ${7}
+      ${'unknown-error'}       | ${7}
+    `('maps $res to exit code $exitCode', ({ res, exitCode }) => {
+      expect(processResult(config, res).exitCode).toBe(exitCode);
     });
   });
 });

--- a/lib/workers/repository/result.ts
+++ b/lib/workers/repository/result.ts
@@ -80,15 +80,8 @@ const exitCodes: [readonly string[], number][] = [
   [PlatformErrors, 4],
   [ConfigErrors, 5],
   [TemporaryErrors, 6],
-  [
-    [
-      EXTERNAL_HOST_ERROR,
-      MANAGER_LOCKFILE_ERROR,
-      MISSING_API_CREDENTIALS,
-      UNKNOWN_ERROR,
-    ],
-    7,
-  ],
+  [[EXTERNAL_HOST_ERROR, MANAGER_LOCKFILE_ERROR, MISSING_API_CREDENTIALS], 7],
+  [[UNKNOWN_ERROR], 8],
 ];
 
 function getExitCode(res: RepositoryResult): number {

--- a/lib/workers/repository/result.ts
+++ b/lib/workers/repository/result.ts
@@ -1,19 +1,17 @@
 import type { RenovateConfig } from '../../config/types.ts';
 
-import type {
-  ConfigErrors,
-  EXTERNAL_HOST_ERROR,
-  MANAGER_LOCKFILE_ERROR,
-  PlatformErrors,
-  SystemErrors,
-  TemporaryErrors,
-  UNKNOWN_ERROR,
-} from '../../constants/error-messages.ts';
 import {
   CONFIG_SECRETS_EXPOSED,
   CONFIG_VALIDATION,
+  ConfigErrors,
+  EXTERNAL_HOST_ERROR,
+  MANAGER_LOCKFILE_ERROR,
   MISSING_API_CREDENTIALS,
+  PlatformErrors,
   RepositoryErrors,
+  SystemErrors,
+  TemporaryErrors,
+  UNKNOWN_ERROR,
 } from '../../constants/error-messages.ts';
 
 import { logger } from '../../logger/index.ts';
@@ -48,6 +46,8 @@ export interface ProcessResult {
   status: ProcessStatus;
   enabled: boolean | undefined;
   onboarded: boolean | undefined;
+  /** the process exit code this result maps to, used when `exitCodeForErrors` is enabled */
+  exitCode: number;
 }
 
 /** a strong type for any repository result status that Renovate may report */
@@ -69,6 +69,31 @@ export type RepositoryResult =
   | typeof MISSING_API_CREDENTIALS
   | typeof MANAGER_LOCKFILE_ERROR
   | typeof UNKNOWN_ERROR;
+
+/**
+ * Exit code per known error group, used when `exitCodeForErrors` is enabled.
+ *
+ * `RepositoryErrors` are deliberately absent: they mean the repository is disabled, not that the run failed.
+ */
+const exitCodes: [readonly string[], number][] = [
+  [SystemErrors, 3],
+  [PlatformErrors, 4],
+  [ConfigErrors, 5],
+  [TemporaryErrors, 6],
+  [
+    [
+      EXTERNAL_HOST_ERROR,
+      MANAGER_LOCKFILE_ERROR,
+      MISSING_API_CREDENTIALS,
+      UNKNOWN_ERROR,
+    ],
+    7,
+  ],
+];
+
+function getExitCode(res: RepositoryResult): number {
+  return exitCodes.find(([errors]) => errors.includes(res))?.[1] ?? 0;
+}
 
 export function processResult(
   config: RenovateConfig,
@@ -106,5 +131,5 @@ export function processResult(
     // TODO: types (#22198)
     `Repository result: ${res}, status: ${status}, enabled: ${enabled!}, onboarded: ${onboarded!}`,
   );
-  return { res, status, enabled, onboarded };
+  return { res, status, enabled, onboarded, exitCode: getExitCode(res) };
 }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Adds an experimental self-hosted `exitCodeForErrors` option. When enabled, Renovate exits with an error-group-specific code (`3` system, `4` platform, `5` config, `6` temporary, `7` other) instead of the generic `1`. `RepositoryErrors` map to `0`, since they mean the repository is disabled rather than that the run failed.

With multiple repositories the code comes from the first repository that errored, and the run continues. The mapped exit code is now always logged in `Repository finished`.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: #45475 <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation). Claude Code (Opus 5) generated the code, unit tests and documentation.
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @RahulGautamSingh will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/RahulGautamSingh/renovate-exit-code-repro

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
