### PR TITLE
feat(manager): share OCI Helm chart resolution across managers

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4649,6 +4649,7 @@ The aliases support variables with default values (using the `:-` syntax) which 
 This feature works with the following managers:
 
 - [`ansible`](modules/manager/ansible/index.md)
+- [`argocd`](modules/manager/argocd/index.md)
 - [`bazel-module`](modules/manager/bazel-module/index.md)
 - [`bitbucket-pipelines`](modules/manager/bitbucket-pipelines/index.md)
 - [`circleci`](modules/manager/circleci/index.md)
@@ -4663,6 +4664,7 @@ This feature works with the following managers:
 - [`helm-requirements`](modules/manager/helm-requirements/index.md)
 - [`helm-values`](modules/manager/helm-values/index.md)
 - [`helmfile`](modules/manager/helmfile/index.md)
+- [`helmsman`](modules/manager/helmsman/index.md)
 - [`helmv3`](modules/manager/helmv3/index.md)
 - [`kubernetes`](modules/manager/kubernetes/index.md)
 - [`terraform`](modules/manager/terraform/index.md)

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1358,6 +1358,7 @@ const options: Readonly<RenovateOptions>[] = [
     },
     supportedManagers: [
       'ansible',
+      'argocd',
       'bitbucket-pipelines',
       'buildpacks',
       'crossplane',
@@ -1369,6 +1370,7 @@ const options: Readonly<RenovateOptions>[] = [
       'gitlabci',
       'helm-requirements',
       'helmfile',
+      'helmsman',
       'helmv3',
       'kubernetes',
       'kustomize',

--- a/lib/modules/manager/argocd/extract.spec.ts
+++ b/lib/modules/manager/argocd/extract.spec.ts
@@ -1,3 +1,4 @@
+import { codeBlock } from 'common-tags';
 import { Fixtures } from '~test/fixtures.ts';
 import { extractPackageFile } from './index.ts';
 
@@ -85,6 +86,49 @@ spec:
       });
     });
 
+    it('resolves registryAliases for OCI charts', () => {
+      const result = extractPackageFile(
+        codeBlock`
+          apiVersion: argoproj.io/v1alpha1
+          kind: Application
+          metadata:
+            name: test
+          spec:
+            source:
+              chart: some/chart
+              repoURL: oci://registry.example.com/charts
+              targetRevision: 1.0.0
+            sources:
+              - repoURL: oci://registry.example.com/charts/other
+                targetRevision: 2.0.0
+        `,
+        'applications.yml',
+        {
+          registryAliases: {
+            'registry.example.com': 'registry-1.docker.io',
+          },
+        },
+      );
+      expect(result).toEqual({
+        deps: [
+          {
+            currentValue: '1.0.0',
+            datasource: 'docker',
+            depName: 'registry.example.com/charts/some/chart',
+            packageName: 'registry-1.docker.io/charts/some/chart',
+            pinDigests: false,
+          },
+          {
+            currentValue: '2.0.0',
+            datasource: 'docker',
+            depName: 'registry.example.com/charts/other',
+            packageName: 'registry-1.docker.io/charts/other',
+            pinDigests: false,
+          },
+        ],
+      });
+    });
+
     it('full test', () => {
       const result = extractPackageFile(validApplication, 'applications.yml');
       expect(result).toEqual({
@@ -132,26 +176,36 @@ spec:
             currentValue: '1.2.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io/some/image',
+            packageName: 'somecontainer.registry.io/some/image',
+            pinDigests: false,
           },
           {
             currentValue: '1.3.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io/some/image2',
+            packageName: 'somecontainer.registry.io/some/image2',
+            pinDigests: false,
           },
           {
             currentValue: '1.3.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io:443/some/image2',
+            packageName: 'somecontainer.registry.io:443/some/image2',
+            pinDigests: false,
           },
           {
             currentValue: '1.0.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io:443/some/image3',
+            packageName: 'somecontainer.registry.io:443/some/image3',
+            pinDigests: false,
           },
           {
             currentValue: '1.0.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io:443/some/image3',
+            packageName: 'somecontainer.registry.io:443/some/image3',
+            pinDigests: false,
           },
           {
             currentValue: 'v1.2.0',
@@ -162,6 +216,8 @@ spec:
             currentValue: '1.0.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io:443/some/image3',
+            packageName: 'somecontainer.registry.io:443/some/image3',
+            pinDigests: false,
           },
           {
             currentValue: 'v1.2.0',
@@ -195,6 +251,8 @@ spec:
             currentValue: '0.4.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io/org/chart',
+            packageName: 'somecontainer.registry.io/org/chart',
+            pinDigests: false,
           },
         ],
       });
@@ -236,6 +294,8 @@ spec:
             currentValue: '1.0.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io:443/some/image3',
+            packageName: 'somecontainer.registry.io:443/some/image3',
+            pinDigests: false,
           },
           {
             currentValue: 'v1.2.0',
@@ -246,6 +306,8 @@ spec:
             currentValue: '1.0.0',
             datasource: 'docker',
             depName: 'somecontainer.registry.io:443/some/image3',
+            packageName: 'somecontainer.registry.io:443/some/image3',
+            pinDigests: false,
           },
           {
             currentValue: 'v1.2.0',

--- a/lib/modules/manager/argocd/extract.ts
+++ b/lib/modules/manager/argocd/extract.ts
@@ -4,11 +4,14 @@ import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 import { withDebugMessage } from '../../../util/schema-utils/index.ts';
 import { trimTrailingSlash } from '../../../util/url.ts';
-import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 import { getDep } from '../dockerfile/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import {
+  getOciChartDep,
+  isOCIRegistry,
+  removeOCIPrefix,
+} from '../helmv3/oci.ts';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -27,7 +30,7 @@ const kustomizeImageRe = regEx(/=(?<image>.+)$/);
 export function extractPackageFile(
   content: string,
   packageFile: string,
-  _config?: ExtractConfig,
+  config?: ExtractConfig,
 ): PackageFileContent | null {
   // check for argo reference. API version for the kind attribute is used
   if (fileTestRegex.test(content) === false) {
@@ -41,12 +44,17 @@ export function extractPackageFile(
     withDebugMessage([], `${packageFile} does not match schema`),
   ).parse(content);
 
-  const deps = definitions.flatMap(processAppSpec);
+  const deps = definitions.flatMap((definition) =>
+    processAppSpec(definition, config?.registryAliases),
+  );
 
   return deps.length ? { deps } : null;
 }
 
-function processSource(source: ApplicationSource): PackageDependency[] {
+function processSource(
+  source: ApplicationSource,
+  registryAliases: Record<string, string> | undefined,
+): PackageDependency[] {
   // a chart variable is defined this is helm declaration
   if (source.chart) {
     // assume OCI helm chart if repoURL doesn't contain explicit protocol
@@ -55,9 +63,9 @@ function processSource(source: ApplicationSource): PackageDependency[] {
 
       return [
         {
+          ...getOciChartDep(source.repoURL, source.chart, registryAliases),
           depName: `${registryURL}/${source.chart}`,
           currentValue: source.targetRevision,
-          datasource: DockerDatasource.id,
         },
       ];
     }
@@ -74,13 +82,11 @@ function processSource(source: ApplicationSource): PackageDependency[] {
 
   // Handle OCI Helm chart without explicit chart field
   if (isOCIRegistry(source.repoURL)) {
-    const registryURL = trimTrailingSlash(removeOCIPrefix(source.repoURL));
-
     return [
       {
-        depName: registryURL,
+        ...getOciChartDep(source.repoURL, undefined, registryAliases),
+        depName: trimTrailingSlash(removeOCIPrefix(source.repoURL)),
         currentValue: source.targetRevision,
-        datasource: DockerDatasource.id,
       },
     ];
   }
@@ -105,6 +111,7 @@ function processSource(source: ApplicationSource): PackageDependency[] {
 
 function processAppSpec(
   definition: ApplicationDefinition,
+  registryAliases: Record<string, string> | undefined,
 ): PackageDependency[] {
   const spec: ApplicationSpec =
     definition.kind === 'Application'
@@ -114,11 +121,11 @@ function processAppSpec(
   const deps: PackageDependency[] = [];
 
   if (isNonEmptyObject(spec.source)) {
-    deps.push(...processSource(spec.source));
+    deps.push(...processSource(spec.source, registryAliases));
   }
 
   for (const source of coerceArray(spec.sources)) {
-    deps.push(...processSource(source));
+    deps.push(...processSource(source, registryAliases));
   }
 
   return deps;

--- a/lib/modules/manager/argocd/readme.md
+++ b/lib/modules/manager/argocd/readme.md
@@ -29,3 +29,8 @@ Some configuration examples:
   }
 }
 ```
+
+### OCI Helm charts
+
+Renovate looks up Helm charts stored in OCI registries with the `docker` datasource.
+Use [`registryAliases`](../../../configuration-options.md#registryaliases) to map a registry host, for example a pull-through cache, to the registry Renovate should query instead.

--- a/lib/modules/manager/fleet/extract.spec.ts
+++ b/lib/modules/manager/fleet/extract.spec.ts
@@ -126,6 +126,29 @@ kind: Fleet
           },
         ]);
       });
+      it('should skip OCI charts without version', () => {
+        const result = extractPackageFile(
+          codeBlock`
+            defaultNamespace: external-dns
+            helm:
+              chart: oci://registry-1.docker.io/bitnamicharts/external-dns
+          `,
+          'fleet.yaml',
+          {},
+        );
+
+        expect(result?.deps).toEqual([
+          {
+            datasource: 'docker',
+            depName: 'registry-1.docker.io/bitnamicharts/external-dns',
+            depType: 'fleet',
+            packageName: 'registry-1.docker.io/bitnamicharts/external-dns',
+            pinDigests: false,
+            skipReason: 'unspecified-version',
+          },
+        ]);
+      });
+
       it('should parse valid configuration with target customization', () => {
         const validFleetYamlWithCustom = codeBlock`
           # This should generate two dependencies with different versions

--- a/lib/modules/manager/fleet/extract.ts
+++ b/lib/modules/manager/fleet/extract.ts
@@ -3,8 +3,11 @@ import { regEx } from '../../../util/regex.ts';
 import { parseYaml } from '../../../util/yaml.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
-import { getDep } from '../dockerfile/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import {
+  getOciChartDep,
+  isOCIRegistry,
+  removeOCIPrefix,
+} from '../helmv3/oci.ts';
 import { checkIfStringIsPath } from '../terraform/util.ts';
 import type {
   ExtractConfig,
@@ -60,18 +63,20 @@ function extractFleetHelmBlock(
   }
 
   if (isOCIRegistry(doc.chart)) {
-    const dockerDep = getDep(
-      `${removeOCIPrefix(doc.chart)}:${doc.version}`,
-      false,
-      config.registryAliases,
-    );
-
+    const ociDep: PackageDependency = {
+      ...dep,
+      ...getOciChartDep(doc.chart, undefined, config.registryAliases),
+      depName: removeOCIPrefix(doc.chart),
+    };
+    if (!doc.version) {
+      return {
+        ...ociDep,
+        skipReason: 'unspecified-version',
+      };
+    }
     return {
-      ...dockerDep,
-      depType: 'fleet',
-      // https://github.com/helm/helm/issues/10312
-      // https://github.com/helm/helm/issues/10678
-      pinDigests: false,
+      ...ociDep,
+      currentValue: doc.version,
     };
   }
 

--- a/lib/modules/manager/flux/extract.spec.ts
+++ b/lib/modules/manager/flux/extract.spec.ts
@@ -263,6 +263,7 @@ describe('modules/manager/flux/extract', () => {
             datasource: DockerDatasource.id,
             depName: 'sealed-secrets',
             packageName: 'ghcr.io/charts/sealed-secrets',
+            pinDigests: false,
           },
         ],
       });
@@ -1757,6 +1758,7 @@ describe('modules/manager/flux/extract', () => {
               depName: 'actions-runner-controller-charts/gha-runner-scale-set',
               packageName:
                 'ghcr.proxy.test/some/path/actions/actions-runner-controller-charts/gha-runner-scale-set',
+              pinDigests: false,
             },
           ],
           packageFile:
@@ -1778,6 +1780,7 @@ describe('modules/manager/flux/extract', () => {
               datasource: DockerDatasource.id,
               depName: 'kyverno',
               packageName: 'ghcr.io/kyverno/charts/kyverno',
+              pinDigests: false,
             },
           ],
           packageFile:

--- a/lib/modules/manager/flux/extract.ts
+++ b/lib/modules/manager/flux/extract.ts
@@ -15,7 +15,6 @@ import { regEx } from '../../../util/regex.ts';
 import { isHttpUrl } from '../../../util/url.ts';
 import { parseYaml } from '../../../util/yaml.ts';
 import { BitbucketTagsDatasource } from '../../datasource/bitbucket-tags/index.ts';
-import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { GitRefsDatasource } from '../../datasource/git-refs/index.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
@@ -24,7 +23,11 @@ import { GitlabTagsDatasource } from '../../datasource/gitlab-tags/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 import { getDep } from '../dockerfile/extract.ts';
 import { findDependencies } from '../helm-values/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import {
+  getOciChartDep,
+  isOCIRegistry,
+  removeOCIPrefix,
+} from '../helmv3/oci.ts';
 import { extractImage } from '../kustomize/extract.ts';
 import type {
   ExtractConfig,
@@ -130,14 +133,10 @@ function resolveHelmRepository(
     dep.registryUrls = matchingRepositories
       .map((repo) => {
         if (repo.spec.type === 'oci' || isOCIRegistry(repo.spec.url)) {
-          // Change datasource to Docker
-          dep.datasource = DockerDatasource.id;
-          // Ensure the URL is a valid OCI path
-          dep.packageName = getDep(
-            `${removeOCIPrefix(repo.spec.url)}/${dep.depName}`,
-            false,
-            registryAliases,
-          ).packageName;
+          Object.assign(
+            dep,
+            getOciChartDep(repo.spec.url, dep.depName, registryAliases),
+          );
           return null;
         }
         return repo.spec.url;
@@ -156,12 +155,10 @@ function resolveHelmRepository(
     if (aliasUrl) {
       if (isOCIRegistry(aliasUrl)) {
         // Treat alias value as an OCI registry URL
-        dep.datasource = DockerDatasource.id;
-        dep.packageName = getDep(
-          `${removeOCIPrefix(aliasUrl)}/${dep.depName}`,
-          false,
-          registryAliases,
-        ).packageName;
+        Object.assign(
+          dep,
+          getOciChartDep(aliasUrl, dep.depName, registryAliases),
+        );
       } else {
         dep.registryUrls = [aliasUrl];
       }

--- a/lib/modules/manager/helmfile/extract.spec.ts
+++ b/lib/modules/manager/helmfile/extract.spec.ts
@@ -351,6 +351,7 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/example',
+            pinDigests: false,
           },
           {
             currentValue: '3.3.0',
@@ -362,6 +363,48 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'ghcr.io/example/oci-repo/url-example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/url-example',
+            pinDigests: false,
+          },
+        ],
+      });
+    });
+
+    it('resolves registryAliases for OCI charts', async () => {
+      const content = codeBlock`
+        repositories:
+          - name: oci-repo
+            url: ghcr.io/example/oci-repo
+            oci: true
+        releases:
+          - name: example
+            version: 0.1.0
+            chart: oci-repo/example
+          - name: oci-url
+            version: 0.4.2
+            chart: oci://ghcr.io/example/oci-repo/url-example
+      `;
+      const fileName = 'helmfile.yaml';
+      const result = await extractPackageFile(content, fileName, {
+        registryAliases: {
+          'ghcr.io': 'ghcr.proxy.test',
+        },
+      });
+      expect(result).toMatchObject({
+        datasource: 'helm',
+        deps: [
+          {
+            currentValue: '0.1.0',
+            depName: 'example',
+            datasource: 'docker',
+            packageName: 'ghcr.proxy.test/example/oci-repo/example',
+            pinDigests: false,
+          },
+          {
+            currentValue: '0.4.2',
+            depName: 'ghcr.io/example/oci-repo/url-example',
+            datasource: 'docker',
+            packageName: 'ghcr.proxy.test/example/oci-repo/url-example',
+            pinDigests: false,
           },
         ],
       });
@@ -388,6 +431,7 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'nested/path/chart',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/nested/path/chart',
+            pinDigests: false,
           },
         ],
       });
@@ -419,6 +463,7 @@ describe('modules/manager/helmfile/extract', () => {
             depName: 'example',
             datasource: 'docker',
             packageName: 'ghcr.io/example/oci-repo/example',
+            pinDigests: false,
           },
         ],
       });
@@ -535,6 +580,7 @@ describe('modules/manager/helmfile/extract', () => {
             datasource: 'docker',
             depName: 'gitlab.example.com:5000/group/subgroup',
             packageName: 'gitlab.example.com:5000/group/subgroup',
+            pinDigests: false,
           },
         ],
       });

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -105,15 +105,13 @@ export async function extractPackageFile(
         } else {
           repoName = dep.chart;
         }
-        if (registryData[repoName]?.oci) {
-          const registryUrl = registryData[repoName]?.url;
-          if (registryUrl) {
-            ociDep = getOciChartDep(
-              registryUrl,
-              depName,
-              config.registryAliases,
-            );
-          }
+        const registry = registryData[repoName];
+        if (registry?.oci) {
+          ociDep = getOciChartDep(
+            registry.url,
+            depName,
+            config.registryAliases,
+          );
           repoName = null;
         }
       }

--- a/lib/modules/manager/helmfile/extract.ts
+++ b/lib/modules/manager/helmfile/extract.ts
@@ -6,7 +6,11 @@ import { regEx } from '../../../util/regex.ts';
 import { parseYaml } from '../../../util/yaml.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import {
+  getOciChartDep,
+  isOCIRegistry,
+  removeOCIPrefix,
+} from '../helmv3/oci.ts';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -72,7 +76,7 @@ export async function extractPackageFile(
       ...Object.values(coerceObject(doc.templates)),
     ]) {
       let depName = dep.chart;
-      let packageName: string | null = null;
+      let ociDep: PackageDependency | null = null;
       let repoName: string | null = null;
 
       // If it starts with ./ ../ or / then it's a local path
@@ -91,7 +95,8 @@ export async function extractPackageFile(
       }
 
       if (isOCIRegistry(dep.chart)) {
-        packageName = depName = removeOCIPrefix(dep.chart);
+        depName = removeOCIPrefix(dep.chart);
+        ociDep = getOciChartDep(dep.chart, undefined, config.registryAliases);
       } else {
         if (dep.chart.includes('/')) {
           const v = dep.chart.split('/');
@@ -101,9 +106,13 @@ export async function extractPackageFile(
           repoName = dep.chart;
         }
         if (registryData[repoName]?.oci) {
-          const alias = registryData[repoName]?.url;
-          if (alias) {
-            packageName = `${alias}/${depName}`;
+          const registryUrl = registryData[repoName]?.url;
+          if (registryUrl) {
+            ociDep = getOciChartDep(
+              registryUrl,
+              depName,
+              config.registryAliases,
+            );
           }
           repoName = null;
         }
@@ -124,9 +133,8 @@ export async function extractPackageFile(
       if (kustomizationsKeysUsed(dep)) {
         needKustomize = true;
       }
-      if (packageName) {
-        res.datasource = DockerDatasource.id;
-        res.packageName = packageName;
+      if (ociDep) {
+        Object.assign(res, ociDep);
       } else if (repoName) {
         res.registryUrls = [registryData[repoName]?.url]
           .concat([config.registryAliases?.[repoName]] as string[])
@@ -140,7 +148,7 @@ export async function extractPackageFile(
           isOCIRegistry(dep.chart)
             ? depName.slice(depName.lastIndexOf('/') + 1)
             : depName,
-          !!packageName,
+          !!ociDep,
         )
       ) {
         res.skipReason = 'unsupported-chart-type';

--- a/lib/modules/manager/helmsman/extract.spec.ts
+++ b/lib/modules/manager/helmsman/extract.spec.ts
@@ -26,6 +26,19 @@ describe('modules/manager/helmsman/extract', () => {
       expect(result).toBeNull();
     });
 
+    it('resolves registryAliases for OCI charts', () => {
+      const result = extractPackageFile(multiDepFile, 'helmsman.yaml', {
+        registryAliases: { 'ghcr.io': 'ghcr.proxy.test' },
+      });
+      expect(result?.deps).toContainEqual({
+        currentValue: '6.4.0',
+        datasource: 'docker',
+        depName: 'podinfo',
+        packageName: 'ghcr.proxy.test/stefanprodan/charts/podinfo',
+        pinDigests: false,
+      });
+    });
+
     it('extract deps', () => {
       const fileName = 'helmsman.yaml';
       const result = extractPackageFile(multiDepFile, fileName, {});
@@ -75,6 +88,7 @@ describe('modules/manager/helmsman/extract', () => {
             datasource: 'docker',
             depName: 'podinfo',
             packageName: 'ghcr.io/stefanprodan/charts/podinfo',
+            pinDigests: false,
           },
           {
             datasource: 'helm',

--- a/lib/modules/manager/helmsman/extract.ts
+++ b/lib/modules/manager/helmsman/extract.ts
@@ -2,9 +2,8 @@ import { isNonEmptyString, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { parseSingleYaml } from '../../../util/yaml.ts';
-import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import { getOciChartDep, isOCIRegistry } from '../helmv3/oci.ts';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -17,6 +16,7 @@ const chartRegex = regEx('^(?<registryRef>[^/]*)/(?<packageName>[^/]*)$');
 function createDep(
   key: string,
   doc: HelmsmanDocument,
+  registryAliases: Record<string, string> | undefined,
 ): PackageDependency | null {
   const dep: PackageDependency = {
     depName: key,
@@ -34,10 +34,11 @@ function createDep(
   dep.currentValue = anApp.version;
 
   // in case of OCI repository, we need a PackageDependency with a DockerDatasource and a packageName
-  if (isOCIRegistry(anApp.chart)) {
-    dep.datasource = DockerDatasource.id;
-    dep.packageName = removeOCIPrefix(anApp.chart!);
-    return dep;
+  if (anApp.chart && isOCIRegistry(anApp.chart)) {
+    return {
+      ...dep,
+      ...getOciChartDep(anApp.chart, undefined, registryAliases),
+    };
   }
 
   const regexResult = anApp.chart ? chartRegex.exec(anApp.chart) : null;
@@ -65,7 +66,7 @@ function createDep(
 export function extractPackageFile(
   content: string,
   packageFile: string,
-  _config: ExtractConfig,
+  config: ExtractConfig,
 ): PackageFileContent | null {
   try {
     // TODO: use schema (#9610)
@@ -76,7 +77,7 @@ export function extractPackageFile(
     }
 
     const deps = Object.keys(doc.apps)
-      .map((key) => createDep(key, doc))
+      .map((key) => createDep(key, doc, config.registryAliases))
       .filter(isTruthy); // filter null values
 
     if (deps.length === 0) {

--- a/lib/modules/manager/helmsman/readme.md
+++ b/lib/modules/manager/helmsman/readme.md
@@ -19,3 +19,8 @@ To enable the `helmsman` manager, provide a valid `managerFilePatterns` yourself
 
 Currently, state files must be in the `.yaml` format.
 The `.toml` format is not supported.
+
+### OCI Helm charts
+
+Renovate looks up Helm charts stored in OCI registries with the `docker` datasource.
+Use [`registryAliases`](../../../configuration-options.md#registryaliases) to map a registry host, for example a pull-through cache, to the registry Renovate should query instead.

--- a/lib/modules/manager/helmv3/oci.spec.ts
+++ b/lib/modules/manager/helmv3/oci.spec.ts
@@ -1,0 +1,54 @@
+import { getOciChartDep } from './oci.ts';
+
+describe('modules/manager/helmv3/oci', () => {
+  describe('getOciChartDep()', () => {
+    it('resolves a chart in an OCI repository', () => {
+      expect(getOciChartDep('oci://ghcr.io/charts', 'foo')).toEqual({
+        datasource: 'docker',
+        packageName: 'ghcr.io/charts/foo',
+        pinDigests: false,
+      });
+    });
+
+    it('resolves a repository which already contains the chart', () => {
+      expect(getOciChartDep('oci://ghcr.io/charts/foo')).toEqual({
+        datasource: 'docker',
+        packageName: 'ghcr.io/charts/foo',
+        pinDigests: false,
+      });
+    });
+
+    it('ignores a trailing slash and a missing oci prefix', () => {
+      expect(getOciChartDep('ghcr.io/charts/', 'foo')).toMatchObject({
+        packageName: 'ghcr.io/charts/foo',
+      });
+    });
+
+    it('keeps the registry port', () => {
+      expect(
+        getOciChartDep('oci://registry.example.com:5000/charts', 'foo'),
+      ).toMatchObject({
+        packageName: 'registry.example.com:5000/charts/foo',
+      });
+    });
+
+    it('applies registryAliases', () => {
+      expect(
+        getOciChartDep('oci://registry.example.com/charts', 'foo', {
+          'registry.example.com': 'registry-1.docker.io',
+        }),
+      ).toMatchObject({
+        packageName: 'registry-1.docker.io/charts/foo',
+      });
+    });
+
+    it('skips references containing variables', () => {
+      expect(getOciChartDep('oci://$REGISTRY/charts', 'foo')).toEqual({
+        datasource: 'docker',
+        packageName: undefined,
+        skipReason: 'contains-variable',
+        pinDigests: false,
+      });
+    });
+  });
+});

--- a/lib/modules/manager/helmv3/oci.ts
+++ b/lib/modules/manager/helmv3/oci.ts
@@ -45,9 +45,10 @@ export function getOciChartDep(
     datasource: DockerDatasource.id,
     packageName,
     ...(skipReason && { skipReason }),
-    // Helm cannot pull OCI charts by digest:
-    // https://github.com/helm/helm/issues/10312
-    // https://github.com/helm/helm/issues/10678
+    // The version fields these managers update cannot carry a digest: Helm only
+    // accepts one inside the OCI reference (`chart@sha256:...`, helm/helm#12690)
+    // and Flux HelmCharts take semver only. A pin would fail in auto-replace
+    // with "Digest is not updated".
     pinDigests: false,
   };
 }

--- a/lib/modules/manager/helmv3/oci.ts
+++ b/lib/modules/manager/helmv3/oci.ts
@@ -1,4 +1,8 @@
 import { isNullOrUndefined, isString } from '@sindresorhus/is';
+import { trimTrailingSlash } from '../../../util/url.ts';
+import { DockerDatasource } from '../../datasource/docker/index.ts';
+import { getDep } from '../dockerfile/extract.ts';
+import type { PackageDependency } from '../types.ts';
 import type { Repository } from './types.ts';
 
 export function isOCIRegistry(
@@ -16,4 +20,34 @@ export function removeOCIPrefix(repository: string): string {
     return repository.replace('oci://', '');
   }
   return repository;
+}
+
+/**
+ * Resolves a Helm chart stored in an OCI registry to the `docker` datasource.
+ *
+ * @param repository OCI registry or repository URL, with or without the `oci://` prefix
+ * @param chart chart name appended to `repository`, omit when `repository` already points to the chart
+ * @param registryAliases resolved the same way as for container image references
+ * @returns `datasource`, `packageName` and `pinDigests`. Callers set `depName`, `currentValue` and `depType`.
+ */
+export function getOciChartDep(
+  repository: string,
+  chart?: string,
+  registryAliases?: Record<string, string>,
+): PackageDependency {
+  const image = trimTrailingSlash(removeOCIPrefix(repository));
+  const { packageName, skipReason } = getDep(
+    chart ? `${image}/${chart}` : image,
+    false,
+    registryAliases,
+  );
+  return {
+    datasource: DockerDatasource.id,
+    packageName,
+    ...(skipReason && { skipReason }),
+    // Helm cannot pull OCI charts by digest:
+    // https://github.com/helm/helm/issues/10312
+    // https://github.com/helm/helm/issues/10678
+    pinDigests: false,
+  };
 }

--- a/lib/modules/manager/helmv3/utils.ts
+++ b/lib/modules/manager/helmv3/utils.ts
@@ -2,9 +2,8 @@ import upath from 'upath';
 import { logger } from '../../../logger/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { parseUrl } from '../../../util/url.ts';
-import { DockerDatasource } from '../../datasource/docker/index.ts';
 import type { PackageDependency } from '../types.ts';
-import { removeOCIPrefix } from './oci.ts';
+import { getOciChartDep } from './oci.ts';
 import type { ChartDefinition, Repository } from './types.ts';
 
 export function parseRepository(
@@ -21,12 +20,7 @@ export function parseRepository(
   }
   switch (url.protocol) {
     case 'oci:':
-      res.datasource = DockerDatasource.id;
-      res.packageName = `${removeOCIPrefix(repositoryURL)}/${depName}`;
-      // https://github.com/helm/helm/issues/10312
-      // https://github.com/helm/helm/issues/10678
-      res.pinDigests = false;
-      break;
+      return getOciChartDep(repositoryURL, depName);
     case 'file:':
       res.skipReason = 'local-dependency';
       break;

--- a/lib/modules/manager/kustomize/extract.ts
+++ b/lib/modules/manager/kustomize/extract.ts
@@ -8,7 +8,7 @@ import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../../datasource/github-tags/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 import { getDep } from '../dockerfile/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import { getOciChartDep, isOCIRegistry } from '../helmv3/oci.ts';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -159,18 +159,10 @@ export function extractHelmChart(
   }
 
   if (isOCIRegistry(helmChart.repo)) {
-    const dep = getDep(
-      `${removeOCIPrefix(helmChart.repo)}/${helmChart.name}:${helmChart.version}`,
-      false,
-      aliases,
-    );
-    delete dep.replaceString;
     return {
-      ...dep,
+      ...getOciChartDep(helmChart.repo, helmChart.name, aliases),
       depName: helmChart.name,
-      // https://github.com/helm/helm/issues/10312
-      // https://github.com/helm/helm/issues/10678
-      pinDigests: false,
+      currentValue: helmChart.version,
     };
   }
 

--- a/lib/modules/manager/sveltos/extract.spec.ts
+++ b/lib/modules/manager/sveltos/extract.spec.ts
@@ -284,6 +284,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'Profile',
             depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
+            pinDigests: false,
           },
           {
             currentValue: '0.5.0',
@@ -291,6 +292,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'Profile',
             depName: 'vault-sidecar',
             packageName: 'custom-registry:443/charts/vault-sidecar',
+            pinDigests: false,
           },
         ],
       });
@@ -385,6 +387,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'ClusterProfile',
             depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
+            pinDigests: false,
           },
           {
             currentValue: '0.5.0',
@@ -392,6 +395,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'ClusterProfile',
             depName: 'vault-sidecar',
             packageName: 'custom-registry:443/charts/vault-sidecar',
+            pinDigests: false,
           },
         ],
       });
@@ -429,6 +433,7 @@ describe('modules/manager/sveltos/extract', () => {
             packageName: 'docker.proxy.test/some/path/bitnamicharts/vault',
             datasource: 'docker',
             depType: 'ClusterProfile',
+            pinDigests: false,
           },
         ],
       });
@@ -495,6 +500,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'ClusterPromotion',
             depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
+            pinDigests: false,
           },
         ],
       });
@@ -586,6 +592,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'EventTrigger',
             depName: 'vault',
             packageName: 'registry-1.docker.io/bitnamicharts/vault',
+            pinDigests: false,
           },
           {
             currentValue: '0.5.0',
@@ -593,6 +600,7 @@ describe('modules/manager/sveltos/extract', () => {
             depType: 'EventTrigger',
             depName: 'vault-sidecar',
             packageName: 'custom-registry:443/charts/vault-sidecar',
+            pinDigests: false,
           },
         ],
       });

--- a/lib/modules/manager/sveltos/extract.ts
+++ b/lib/modules/manager/sveltos/extract.ts
@@ -1,10 +1,7 @@
 import { coerceArray } from '../../../util/array.ts';
-import { trimTrailingSlash } from '../../../util/url.ts';
 import { parseYaml } from '../../../util/yaml.ts';
-import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
-import { getDep } from '../dockerfile/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import { getOciChartDep, isOCIRegistry } from '../helmv3/oci.ts';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -43,32 +40,29 @@ export function extractDefinition(
 function processHelmCharts(
   source: SveltosHelmSource,
   registryAliases: Record<string, string> | undefined,
-): PackageDependency | null {
+): PackageDependency {
   const dep: PackageDependency = {
     depName: source.chartName,
     currentValue: source.chartVersion,
-    datasource: HelmDatasource.id,
   };
 
   if (isOCIRegistry(source.repositoryURL)) {
-    const image = trimTrailingSlash(removeOCIPrefix(source.repositoryURL));
-
-    dep.datasource = DockerDatasource.id;
-    dep.packageName = getDep(
-      `${image}/${source.chartName}`,
-      false,
-      registryAliases,
-    ).packageName;
-  } else {
-    dep.packageName = removeRepositoryName(
-      source.repositoryName,
-      source.chartName,
-    );
-    dep.registryUrls = [source.repositoryURL];
-    dep.datasource = HelmDatasource.id;
+    return {
+      ...dep,
+      ...getOciChartDep(
+        source.repositoryURL,
+        source.chartName,
+        registryAliases,
+      ),
+    };
   }
 
-  return dep;
+  return {
+    ...dep,
+    packageName: removeRepositoryName(source.repositoryName, source.chartName),
+    registryUrls: [source.repositoryURL],
+    datasource: HelmDatasource.id,
+  };
 }
 
 function processAppSpec(
@@ -86,10 +80,8 @@ function processAppSpec(
 
   for (const source of coerceArray(helmCharts)) {
     const dep = processHelmCharts(source, config?.registryAliases);
-    if (dep) {
-      dep.depType = depType;
-      deps.push(dep);
-    }
+    dep.depType = depType;
+    deps.push(dep);
   }
 
   return deps;

--- a/lib/modules/manager/terraform/extract.spec.ts
+++ b/lib/modules/manager/terraform/extract.spec.ts
@@ -810,6 +810,7 @@ describe('modules/manager/terraform/extract', () => {
           datasource: 'docker',
           depName: 'public.ecr.aws/karpenter/karpenter',
           depType: 'helm_release',
+          pinDigests: false,
         },
         {
           currentValue: 'v0.22.1',
@@ -817,6 +818,7 @@ describe('modules/manager/terraform/extract', () => {
           depName: 'karpenter',
           depType: 'helm_release',
           packageName: 'public.ecr.aws/karpenter/karpenter',
+          pinDigests: false,
         },
         {
           datasource: 'helm',
@@ -830,6 +832,7 @@ describe('modules/manager/terraform/extract', () => {
           depName: 'kube-prometheus',
           depType: 'helm_release',
           packageName: 'index.docker.io/bitnamicharts/kube-prometheus',
+          pinDigests: false,
         },
         {
           currentValue: '1.0.1',
@@ -843,6 +846,28 @@ describe('modules/manager/terraform/extract', () => {
           depName: 'redis',
           depType: 'helm_release',
           registryUrls: ['https://charts.helm.sh/stable'],
+        },
+      ]);
+    });
+
+    it('extracts helm releases from OCI registries with a port', async () => {
+      const src = codeBlock`
+        resource "helm_release" "redis" {
+          name       = "redis"
+          repository = "oci://registry.example.com:5000/charts"
+          chart      = "redis"
+          version    = "1.0.1"
+        }
+      `;
+      const res = await extractPackageFile(src, 'helm.tf', {});
+      expect(res?.deps).toEqual([
+        {
+          currentValue: '1.0.1',
+          datasource: 'docker',
+          depName: 'redis',
+          depType: 'helm_release',
+          packageName: 'registry.example.com:5000/charts/redis',
+          pinDigests: false,
         },
       ]);
     });

--- a/lib/modules/manager/terraform/extractors/resources/helm-release.ts
+++ b/lib/modules/manager/terraform/extractors/resources/helm-release.ts
@@ -4,10 +4,12 @@ import {
   isPlainObject,
 } from '@sindresorhus/is';
 import { logger } from '../../../../../logger/index.ts';
-import { joinUrlParts } from '../../../../../util/url.ts';
 import { HelmDatasource } from '../../../../datasource/helm/index.ts';
-import { getDep } from '../../../dockerfile/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../../../helmv3/oci.ts';
+import {
+  getOciChartDep,
+  isOCIRegistry,
+  removeOCIPrefix,
+} from '../../../helmv3/oci.ts';
 import type { ExtractConfig, PackageDependency } from '../../../types.ts';
 import { DependencyExtractor } from '../../base.ts';
 import type { TerraformDefinitionFile } from '../../hcl/types.ts';
@@ -55,19 +57,22 @@ export class HelmReleaseExtractor extends DependencyExtractor {
       } else if (isOCIRegistry(helmRelease.chart)) {
         // For oci charts, we remove the oci:// and use the docker datasource
         dep.depName = removeOCIPrefix(helmRelease.chart);
-        this.processOCI(dep.depName, config, dep);
+        Object.assign(
+          dep,
+          getOciChartDep(helmRelease.chart, undefined, config.registryAliases),
+        );
       } else if (checkIfStringIsPath(helmRelease.chart)) {
         dep.skipReason = 'local-chart';
       } else if (isNonEmptyString(helmRelease.repository)) {
         if (isOCIRegistry(helmRelease.repository)) {
           // For oci charts, we remove the oci:// and use the docker datasource
-          this.processOCI(
-            joinUrlParts(
-              removeOCIPrefix(helmRelease.repository),
-              helmRelease.chart,
-            ),
-            config,
+          Object.assign(
             dep,
+            getOciChartDep(
+              helmRelease.repository,
+              helmRelease.chart,
+              config.registryAliases,
+            ),
           );
         } else {
           dep.registryUrls = [helmRelease.repository];
@@ -76,19 +81,5 @@ export class HelmReleaseExtractor extends DependencyExtractor {
     }
 
     return dependencies;
-  }
-
-  private processOCI(
-    depName: string,
-    config: ExtractConfig,
-    dep: PackageDependency,
-  ): void {
-    const { packageName, datasource } = getDep(
-      depName,
-      false,
-      config.registryAliases,
-    );
-    dep.packageName = packageName;
-    dep.datasource = datasource;
   }
 }

--- a/lib/modules/manager/vendir/extract.spec.ts
+++ b/lib/modules/manager/vendir/extract.spec.ts
@@ -55,7 +55,6 @@ describe('modules/manager/vendir/extract', () => {
             registryUrls: ['https://charts.bitnami.com/bitnami'],
           },
           {
-            currentDigest: undefined,
             currentValue: '7.10.1',
             depName: 'oci-chart',
             datasource: 'docker',
@@ -64,7 +63,6 @@ describe('modules/manager/vendir/extract', () => {
             pinDigests: false,
           },
           {
-            currentDigest: undefined,
             currentValue: '7.10.1',
             depName: 'aliased-oci-chart',
             datasource: 'docker',

--- a/lib/modules/manager/vendir/extract.ts
+++ b/lib/modules/manager/vendir/extract.ts
@@ -4,8 +4,7 @@ import { parseSingleYaml } from '../../../util/yaml.ts';
 import { GitRefsDatasource } from '../../datasource/git-refs/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
-import { getDep } from '../dockerfile/extract.ts';
-import { isOCIRegistry, removeOCIPrefix } from '../helmv3/oci.ts';
+import { getOciChartDep, isOCIRegistry } from '../helmv3/oci.ts';
 import type {
   ExtractConfig,
   PackageDependency,
@@ -24,18 +23,11 @@ export function extractHelmChart(
   aliases?: Record<string, string>,
 ): PackageDependency {
   if (isOCIRegistry(helmChart.repository.url)) {
-    const dep = getDep(
-      `${removeOCIPrefix(helmChart.repository.url)}/${helmChart.name}:${helmChart.version}`,
-      false,
-      aliases,
-    );
     return {
-      ...dep,
+      ...getOciChartDep(helmChart.repository.url, helmChart.name, aliases),
       depName: helmChart.name,
       depType: 'HelmChart',
-      // https://github.com/helm/helm/issues/10312
-      // https://github.com/helm/helm/issues/10678
-      pinDigests: false,
+      currentValue: helmChart.version,
     };
   }
   return {


### PR DESCRIPTION
## Changes

Adds `getOciChartDep()` to `lib/modules/manager/helmv3/oci.ts` and uses it in every manager that resolves Helm charts stored in OCI registries: `argocd`, `fleet`, `flux`, `helmfile`, `helmsman`, `helmv3`, `kustomize`, `sveltos`, `terraform` (`helm_release`) and `vendir`.

The helper strips the `oci://` prefix and a trailing slash, resolves `registryAliases` through the `dockerfile` manager's `getDep()`, and returns the `docker` datasource, the `packageName` and `pinDigests: false`. The version fields these managers update cannot carry a digest: Helm only accepts one inside the OCI reference (`chart@sha256:...`, helm/helm#12690) and Flux HelmCharts take semver only, so a pin attempt failed in auto-replace with "Digest is not updated". Each manager keeps its own `depName` convention.

Until now every manager carried its own copy of this logic and the copies disagreed, so this PR also changes behaviour:

- `pinDigests: false` was only set by `fleet`, `helmv3`, `kustomize` and `vendir`. `argocd`, `flux`, `helmfile`, `helmsman`, `sveltos` and `terraform` now set it as well, so `pinDigests: true` no longer produces failing pin attempts. For `argocd` (already excluded by the `docker:pinDigests` preset) and `terraform` (manager default `pinDigests: false`) the dep-level flag only matters when `pinDigests: true` is set explicitly.
- `registryAliases` were ignored for OCI charts in `argocd`, `helmfile` (`oci://` charts and `oci: true` repositories) and `helmsman`. They now apply the same way as for container images. The `registryAliases` docs and the `argocd` and `helmsman` readmes mention this.
- `helmfile`: the `url` guard for `oci: true` repositories is gone. The repository schema already requires `url` to be a string, so the guard only left an unreachable branch.
- `terraform` joined `repository` and `chart` with `url-join`, which turns `oci://registry.example.com:5000/charts` into `registry.example.com://5000/charts/<chart>`. The port is kept now.
- `fleet` produced `currentValue: 'undefined'` for OCI charts without a `version`. Such charts are now skipped with `unspecified-version`, like charts from classic repositories.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Fable 5.1) wrote the code, tests and documentation changes, starting from an audit of the duplicated OCI chart handling across managers.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
