### PR TITLE
fix(merge-confidence): don't require auth in `platform=local`

### DIFF
--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -15,6 +15,10 @@ type TestConfig = PackageRuleInputConfig & {
 };
 
 describe('util/package-rules/index', () => {
+  afterEach(() => {
+    GlobalConfig.reset();
+  });
+
   const config1: TestConfig = {
     foo: 'bar',
 
@@ -949,6 +953,42 @@ describe('util/package-rules/index', () => {
       expect(error.validationMessage).toBe(
         'The `matchConfidence` matcher in `packageRules` requires authentication. Please refer to the [documentation](https://docs.renovatebot.com/configuration-options/#packagerulesmatchconfidence) and add the required host rule.',
       );
+    });
+
+    it('does not throw when unauthenticated on platform=local', async () => {
+      GlobalConfig.set({
+        platform: 'local',
+      });
+
+      const config: TestConfig = {
+        packageRules: [
+          {
+            matchUpdateTypes: ['major'],
+            matchConfidence: ['high'],
+          },
+        ],
+      };
+      hostRules.clear();
+
+      await expect(applyPackageRules(config)).resolves.not.toThrow();
+    });
+
+    it('returns null on platform=local', async () => {
+      GlobalConfig.set({
+        platform: 'local',
+      });
+
+      const config: TestConfig = {
+        packageRules: [
+          {
+            matchUpdateTypes: ['major'],
+            matchConfidence: ['high'],
+          },
+        ],
+      };
+      hostRules.clear();
+
+      await expect(applyPackageRules(config)).resolves.toBeNull();
     });
 
     it('uses productLinks.documentation in error message URL', async () => {

--- a/lib/util/package-rules/index.spec.ts
+++ b/lib/util/package-rules/index.spec.ts
@@ -973,7 +973,7 @@ describe('util/package-rules/index', () => {
       await expect(applyPackageRules(config)).resolves.not.toThrow();
     });
 
-    it('returns null on platform=local', async () => {
+    it('does not apply the packageRule on platform=local', async () => {
       GlobalConfig.set({
         platform: 'local',
       });
@@ -983,12 +983,15 @@ describe('util/package-rules/index', () => {
           {
             matchUpdateTypes: ['major'],
             matchConfidence: ['high'],
+            // @ts-expect-error -- testing
+            x: 1,
           },
         ],
       };
       hostRules.clear();
 
-      await expect(applyPackageRules(config)).resolves.toBeNull();
+      const res = await applyPackageRules(config);
+      expect(res.x).toBeUndefined();
     });
 
     it('uses productLinks.documentation in error message URL', async () => {

--- a/lib/util/package-rules/merge-confidence.ts
+++ b/lib/util/package-rules/merge-confidence.ts
@@ -10,6 +10,7 @@ import type {
   PackageRuleInputConfig,
 } from '../../config/types.ts';
 import { MISSING_API_CREDENTIALS } from '../../constants/error-messages.ts';
+import { logger } from '../../logger/index.ts';
 import { getApiToken } from '../merge-confidence/index.ts';
 import { Matcher } from './base.ts';
 
@@ -19,6 +20,14 @@ export class MergeConfidenceMatcher extends Matcher {
     { matchConfidence }: PackageRule,
   ): boolean | null {
     if (isNullOrUndefined(matchConfidence)) {
+      return null;
+    }
+
+    // if we're on `local` platform - for instance to test against a repo - don't error, but don't allow the packageRule either
+    if (GlobalConfig.get('platform') === 'local') {
+      logger.once.debug(
+        "Skipping packageRule(s) with `matchConfidence`, as we're running in platform=local",
+      );
       return null;
     }
 


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

When dry-running Renovate against a repository to validate it[0], if a
repository is using `matchConfidence`, the whole Renovate run is aborted
due to missing API credentials.

This can be frustrating, and the workaround available is to temporarily
remove all package rules use `matchConfidence`, which isn't the best
experience.

Instead, we should follow the existing pattern to return `null` when
loading a Package Rule with `matchConfidence`, as well as DEBUG logging
to inform the user why this is happening.

[0]: https://www.jvt.me/posts/2026/03/08/renovate-test-config/
<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
