### PR TITLE
fix(manager/npm): keep workspace entries when massaging lockstep siblings

### DIFF
--- a/lib/modules/manager/npm/post-update/index.spec.ts
+++ b/lib/modules/manager/npm/post-update/index.spec.ts
@@ -249,6 +249,17 @@ describe('modules/manager/npm/post-update/index', () => {
               dev: true,
               peerDependencies: { vue: '3.x' },
             },
+            // workspace pinning vue exactly, must stay: it is the link target
+            // of node_modules/@vue-repro/app
+            'packages/app': {
+              name: '@vue-repro/app',
+              version: '1.0.0',
+              dependencies: { vue: '3.5.39' },
+            },
+            'node_modules/@vue-repro/app': {
+              resolved: 'packages/app',
+              link: true,
+            },
           },
         }),
       );
@@ -292,6 +303,10 @@ describe('modules/manager/npm/post-update/index', () => {
       // packages without an exact pin on the updated dep stay
       expect(written.packages['node_modules/@vue/test-utils']).toBeDefined();
       expect(written.packages['node_modules/@vue/shared']).toBeDefined();
+      // workspaces stay even when they pin exactly, else npm fails with
+      // EMISSINGTARGET on the link entry referencing them
+      expect(written.packages['packages/app']).toBeDefined();
+      expect(written.packages['node_modules/@vue-repro/app']).toBeDefined();
     });
 
     it('writes .npmrc files', async () => {

--- a/lib/modules/manager/npm/post-update/index.ts
+++ b/lib/modules/manager/npm/post-update/index.ts
@@ -210,7 +210,14 @@ export async function writeExistingFiles(
                 delete npmLockParsed.packages[packageName];
                 continue;
               }
-              if (!depName || !oldVersion) {
+              if (
+                !depName ||
+                !oldVersion ||
+                // Workspace entries (e.g. `packages/app`) and the root entry
+                // are link targets: `node_modules/<name>` points at them with
+                // `link: true`, so deleting one breaks npm with EMISSINGTARGET.
+                !packageName.startsWith('node_modules/')
+              ) {
                 continue;
               }
               // Lockstep monorepo siblings (e.g. vue -> @vue/server-renderer)


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

Restrict the lockstep-sibling massage added in #45085 to `node_modules/` entries in `package-lock.json`.

The massage deletes any `packages` entry that pins the updated dep at its old exact version. In an npm workspaces repo that also matches workspace entries, whose keys are paths like `packages/app`. Deleting one leaves the `node_modules/<name>` entry that points at it with `link: true` dangling, and npm then fails:

```
npm error code EMISSINGTARGET
npm error Missing target in lock file: "packages/app" is referenced by "node_modules/@repro/app" but does not exist.
```

The guard also protects the root `""` entry, which is a link target too. The pre-existing loop above only ever deletes `node_modules/...` keys, so this brings the new check in line with it.

Reported in https://github.com/renovatebot/renovate/discussions/45681 with a reproducer.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Opus 5) wrote the code change and the test case.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @RahulGautamSingh will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/RahulGautamSingh/renovate-repro-45681

Same repo state, two runs, only the Renovate build differs:

| PR | Renovate build | Outcome |
| --- | --- | --- |
| [renovate-repro-45681#1](https://github.com/RahulGautamSingh/renovate-repro-45681/pull/1) | `main` | `EMISSINGTARGET`, only `packages/app/package.json` updated, lockfile left stale |
| [renovate-repro-45681#3](https://github.com/RahulGautamSingh/renovate-repro-45681/pull/3) | this branch | lockfile updated to lodash 4.18.1, `packages/app` entry intact |

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
