### PR TITLE
fix(http): improve warning message for ignored cross origin requests

### DIFF
--- a/lib/util/http/github.spec.ts
+++ b/lib/util/http/github.spec.ts
@@ -204,10 +204,34 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a', 'b', 'c', 'd']);
       expect(logger.logger.once.warn).toHaveBeenCalledWith(
         {
-          requestHost: 'api.github.com',
-          paginationHost: 'attacker.example.com',
+          requestOrigin: 'https://api.github.com',
+          paginationOrigin: 'https://attacker.example.com',
         },
-        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different origin in pagination links.',
+      );
+    });
+
+    it('does not follow cursor pagination links to a different protocol on the same host', async () => {
+      // Same host, but a different scheme still counts as a different origin
+      const url = '/some-url?per_page=2';
+      httpMock
+        .scope(githubApiHost)
+        .get(url)
+        .reply(200, ['a', 'b'], {
+          link: `<${url}&after=cursor-1>; rel="next"`,
+        })
+        .get(`${url}&after=cursor-1`)
+        .reply(200, ['c', 'd'], {
+          link: '<http://api.github.com/some-url?after=cursor-2>; rel="next"',
+        });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: true });
+      expect(res.body).toEqual(['a', 'b', 'c', 'd']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          requestOrigin: 'https://api.github.com',
+          paginationOrigin: 'http://api.github.com',
+        },
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different origin in pagination links.',
       );
     });
 
@@ -418,10 +442,27 @@ describe('util/http/github', () => {
       expect(res.body).toEqual(['a', 'b']);
       expect(logger.logger.once.warn).toHaveBeenCalledWith(
         {
-          requestHost: 'api.github.com',
-          paginationHost: 'attacker.example.com',
+          requestOrigin: 'https://api.github.com',
+          paginationOrigin: 'https://attacker.example.com',
         },
-        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different origin in pagination links.',
+      );
+    });
+
+    it('does not follow pagination links to a different protocol on the same host', async () => {
+      // Same host, but a different scheme still counts as a different origin
+      const url = '/some-url?per_page=2';
+      httpMock.scope(githubApiHost).get(url).reply(200, ['a', 'b'], {
+        link: `<http://api.github.com/some-url?per_page=2&page=2>; rel="next", <http://api.github.com/some-url?per_page=2&page=3>; rel="last"`,
+      });
+      const res = await githubApi.getJsonUnchecked(url, { paginate: true });
+      expect(res.body).toEqual(['a', 'b']);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        {
+          requestOrigin: 'https://api.github.com',
+          paginationOrigin: 'http://api.github.com',
+        },
+        'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different origin in pagination links.',
       );
     });
 

--- a/lib/util/http/github.ts
+++ b/lib/util/http/github.ts
@@ -497,10 +497,10 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
               if (nextUrl.origin !== resolvedUrl.origin) {
                 logger.once.warn(
                   {
-                    requestHost: resolvedUrl.host,
-                    paginationHost: nextUrl.host,
+                    requestOrigin: resolvedUrl.origin,
+                    paginationOrigin: nextUrl.origin,
                   },
-                  'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+                  'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different origin in pagination links.',
                 );
                 break;
               }
@@ -555,10 +555,10 @@ export class GithubHttp extends HttpBase<GithubHttpOptions> {
           // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
           logger.once.warn(
             {
-              requestHost: resolvedUrl.host,
-              paginationHost: firstPageUrl.host,
+              requestOrigin: resolvedUrl.origin,
+              paginationOrigin: firstPageUrl.origin,
             },
-            'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different host in pagination links.',
+            'Ignoring cross-origin GitHub pagination link. Set RENOVATE_X_REBASE_PAGINATION_LINKS if this is a self-hosted instance that returns a different origin in pagination links.',
           );
         }
       }

--- a/lib/util/http/gitlab.spec.ts
+++ b/lib/util/http/gitlab.spec.ts
@@ -94,10 +94,28 @@ describe('util/http/gitlab', () => {
     expect(res.body).toHaveLength(1);
     expect(logger.logger.once.warn).toHaveBeenCalledWith(
       {
-        requestHost: 'gitlab.com',
-        paginationHost: 'other.host.com',
+        requestOrigin: 'https://gitlab.com',
+        paginationOrigin: 'https://other.host.com',
       },
-      'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different host in pagination links.',
+      'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different origin in pagination links.',
+    );
+  });
+
+  it('does not follow pagination links to a different protocol on the same host', async () => {
+    // Same host, but a different scheme still counts as a different origin
+    httpMock.scope(gitlabApiHost).get('/api/v4/some-url').reply(200, ['a'], {
+      link: '<http://gitlab.com/api/v4/some-url&page=2>; rel="next", <http://gitlab.com/api/v4/some-url&page=3>; rel="last"',
+    });
+    const res = await gitlabApi.getJsonUnchecked('some-url', {
+      paginate: true,
+    });
+    expect(res.body).toHaveLength(1);
+    expect(logger.logger.once.warn).toHaveBeenCalledWith(
+      {
+        requestOrigin: 'https://gitlab.com',
+        paginationOrigin: 'http://gitlab.com',
+      },
+      'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different origin in pagination links.',
     );
   });
 

--- a/lib/util/http/gitlab.ts
+++ b/lib/util/http/gitlab.ts
@@ -72,8 +72,11 @@ export class GitlabHttp extends HttpBase<GitlabHttpOptions> {
           } else {
             // make sure that users are aware if there are any (potentially malicious, or misconfigured) pagination links being returned
             logger.once.warn(
-              { requestHost: resolvedUrl.host, paginationHost: nextUrl.host },
-              'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different host in pagination links.',
+              {
+                requestOrigin: resolvedUrl.origin,
+                paginationOrigin: nextUrl.origin,
+              },
+              'Ignoring cross-origin GitLab pagination link. Set GITLAB_IGNORE_REPO_URL if this is a self-hosted instance that returns a different origin in pagination links.',
             );
           }
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Follow up of the discussion https://github.com/renovatebot/renovate/discussions/45793.

The goal is to improve the warning message so that it gives an helpful information in all cases, using the "origin" rather than only the "host".

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @gaeljw  will read and reply directly. 
- [ ] An agent will draft replies and @username will read them before they are posted. 
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
