### PR TITLE
ci: add pr size labeler

### DIFF
--- a/.github/pull-request-size.yml
+++ b/.github/pull-request-size.yml
@@ -1,0 +1,41 @@
+# Configuration for PR Size Labeler
+
+# List of files to exclude from size calculation
+# Files matching these patterns will not be considered when calculating PR size
+#exclude_files:
+#  - "foo.bar"  # Example: Exclude 'foo.bar' file
+#  - "*.xyz"
+# fixtures can't be easily excluded https://pkg.go.dev/path/filepath#Match
+
+# Configuration for labeling based on the size of the Pull Request
+# Each entry defines a size label, along with thresholds for diff and file count
+label_configs:
+  # Configuration for 'extra small' PRs
+  - size: xs
+    diff: 25 # Threshold for the total lines of code changed (additions + deletions)
+    files: 1 # Threshold for the total number of files changed
+    labels: ['size/xs'] # Labels to be applied for this size
+
+  # Configuration for 'small' PRs
+  - size: s
+    diff: 150
+    files: 10
+    labels: ['size/s']
+
+  # Configuration for 'medium' PRs
+  - size: m
+    diff: 600
+    files: 25
+    labels: ['size/m']
+
+  # Configuration for 'large' PRs
+  - size: l
+    diff: 2500
+    files: 50
+    labels: ['size/l']
+
+  # Configuration for 'extra large' PRs
+  - size: xl
+    diff: 5000
+    files: 100
+    labels: ['size/xl']

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   auto-label-pr:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,0 +1,23 @@
+name: PR Size Labeler
+
+on:
+  pull_request: # Trigger the workflow when a pull request is opened or synchronized
+
+jobs:
+  auto-label-pr:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          filter: blob:none # we don't need all blobs
+          show-progress: false
+
+      - name: Label PR based on size
+        uses: cbrgm/pr-size-labeler-action@6b70abfe1f75f6f35ca24731f6d25fb7251b6127 # v1.3.13
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }} # Pass the GitHub token for authentication
+          github_repository: ${{ github.repository }} # Pass the repository name
+          github_pr_number: ${{ github.event.number }} # Pass the pull request number
+          config_file_path: '.github/pull-request-size.yml' # Specify the path to the configuration file

--- a/.github/workflows/pr-size-labeler.yml
+++ b/.github/workflows/pr-size-labeler.yml
@@ -1,10 +1,17 @@
 name: PR Size Labeler
 
 on:
-  pull_request: # Trigger the workflow when a pull request is opened or synchronized
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 jobs:
   auto-label-pr:
+    if: github.event.pull_request.draft != true
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

<!-- Describe what behavior is changed by this PR. -->

add pr size labeler.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @viceice will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
