### PR TITLE
feat(presets): vale package versions custom manager

### DIFF
--- a/lib/config/presets/internal/custom-managers.preset.ts
+++ b/lib/config/presets/internal/custom-managers.preset.ts
@@ -166,4 +166,18 @@ export const presets: Record<string, Preset> = {
     description:
       'Update `@tsconfig/node` extends  in `tsconfig.json` and `jsconfig.json` files.',
   },
+  valeVersions: {
+    customManagers: [
+      {
+        customType: 'regex',
+        datasourceTemplate: 'github-releases',
+        managerFilePatterns: ['(^|/)\\.vale\\.ini$'],
+        matchStrings: [
+          'https://github\\.com/(?<packageName>[^/]+/[^/]+)/releases/download/(?<currentValue>[^/]+)/',
+        ],
+      },
+    ],
+    description:
+      'Update Vale package versions in `.vale.ini` configuration files.',
+  },
 };

--- a/lib/config/presets/internal/custom-managers.preset.ts
+++ b/lib/config/presets/internal/custom-managers.preset.ts
@@ -171,7 +171,7 @@ export const presets: Record<string, Preset> = {
       {
         customType: 'regex',
         datasourceTemplate: 'github-releases',
-        managerFilePatterns: ['(^|/)\\.vale\\.ini$'],
+        managerFilePatterns: ['/(^|/)\\.vale\\.ini$/'],
         matchStrings: [
           'https://github\\.com/(?<packageName>[^/]+/[^/]+)/releases/download/(?<currentValue>[^/]+)/',
         ],

--- a/lib/config/presets/internal/custom-managers.spec.ts
+++ b/lib/config/presets/internal/custom-managers.spec.ts
@@ -768,6 +768,67 @@ describe('config/presets/internal/custom-managers', () => {
     });
   });
 
+  describe('Update Vale package versions in .vale.ini', () => {
+    const customManager = presets.valeVersions.customManagers?.[0];
+
+    it('finds dependencies in file', async () => {
+      const fileContent = codeBlock`
+        StylesPath = styles
+
+        MinAlertLevel = suggestion
+
+        [*.{md,txt}]
+        BasedOnStyles = Vale
+
+        Packages = https://github.com/errata-ai/Google/releases/download/v1.0.0/Google.zip
+        Packages = https://github.com/errata-ai/Microsoft/releases/download/v0.1.0/Microsoft.zip, https://github.com/errata-ai/write-good/releases/download/v0.4.0/write-good.zip
+      `;
+
+      const res = await extractPackageFile(
+        fileContent,
+        '.vale.ini',
+        customManager!,
+      );
+
+      expect(res?.deps).toMatchObject([
+        {
+          currentValue: 'v1.0.0',
+          datasource: 'github-releases',
+          packageName: 'errata-ai/Google',
+          replaceString:
+            'https://github.com/errata-ai/Google/releases/download/v1.0.0/',
+        },
+        {
+          currentValue: 'v0.1.0',
+          datasource: 'github-releases',
+          packageName: 'errata-ai/Microsoft',
+          replaceString:
+            'https://github.com/errata-ai/Microsoft/releases/download/v0.1.0/',
+        },
+        {
+          currentValue: 'v0.4.0',
+          datasource: 'github-releases',
+          packageName: 'errata-ai/write-good',
+          replaceString:
+            'https://github.com/errata-ai/write-good/releases/download/v0.4.0/',
+        },
+      ]);
+    });
+
+    describe('matches regex patterns', () => {
+      it.each`
+        path                    | expected
+        ${'.vale.ini'}          | ${true}
+        ${'foo/.vale.ini'}      | ${true}
+        ${'foo/bar/.vale.ini'}  | ${true}
+        ${'vale.ini'}           | ${false}
+        ${'.vale.ini.bak'}      | ${false}
+      `('$path', ({ path, expected }) => {
+        expect(regexMatches(path, customManager!.managerFilePatterns)).toBe(expected);
+      });
+    });
+  });
+
   describe('finds dependencies in pom.xml properties', () => {
     const customManager = presets.mavenPropertyVersions.customManagers?.[0];
 

--- a/lib/config/presets/internal/custom-managers.spec.ts
+++ b/lib/config/presets/internal/custom-managers.spec.ts
@@ -785,6 +785,7 @@ describe('config/presets/internal/custom-managers', () => {
       `;
 
       const res = await extractPackageFile(
+        'regex',
         fileContent,
         '.vale.ini',
         customManager!,
@@ -817,14 +818,16 @@ describe('config/presets/internal/custom-managers', () => {
 
     describe('matches regex patterns', () => {
       it.each`
-        path                    | expected
-        ${'.vale.ini'}          | ${true}
-        ${'foo/.vale.ini'}      | ${true}
-        ${'foo/bar/.vale.ini'}  | ${true}
-        ${'vale.ini'}           | ${false}
-        ${'.vale.ini.bak'}      | ${false}
+        path                   | expected
+        ${'.vale.ini'}         | ${true}
+        ${'foo/.vale.ini'}     | ${true}
+        ${'foo/bar/.vale.ini'} | ${true}
+        ${'vale.ini'}          | ${false}
+        ${'.vale.ini.bak'}     | ${false}
       `('$path', ({ path, expected }) => {
-        expect(regexMatches(path, customManager!.managerFilePatterns)).toBe(expected);
+        expect(
+          matchRegexOrGlobList(path, customManager!.managerFilePatterns),
+        ).toBe(expected);
       });
     });
   });

--- a/lib/config/presets/internal/custom-managers.spec.ts
+++ b/lib/config/presets/internal/custom-managers.spec.ts
@@ -780,8 +780,9 @@ describe('config/presets/internal/custom-managers', () => {
         [*.{md,txt}]
         BasedOnStyles = Vale
 
-        Packages = https://github.com/errata-ai/Google/releases/download/v1.0.0/Google.zip
-        Packages = https://github.com/errata-ai/Microsoft/releases/download/v0.1.0/Microsoft.zip, https://github.com/errata-ai/write-good/releases/download/v0.4.0/write-good.zip
+        Packages = https://github.com/vale-cli/Google/releases/download/v1.0.0/Google.zip
+        Packages = https://github.com/vale-cli/Microsoft/releases/download/v0.1.0/Microsoft.zip, https://github.com/vale-cli/write-good/releases/download/v0.4.0/write-good.zip
+        Packages = proselint
       `;
 
       const res = await extractPackageFile(
@@ -795,23 +796,23 @@ describe('config/presets/internal/custom-managers', () => {
         {
           currentValue: 'v1.0.0',
           datasource: 'github-releases',
-          packageName: 'errata-ai/Google',
+          packageName: 'vale-cli/Google',
           replaceString:
-            'https://github.com/errata-ai/Google/releases/download/v1.0.0/',
+            'https://github.com/vale-cli/Google/releases/download/v1.0.0/',
         },
         {
           currentValue: 'v0.1.0',
           datasource: 'github-releases',
-          packageName: 'errata-ai/Microsoft',
+          packageName: 'vale-cli/Microsoft',
           replaceString:
-            'https://github.com/errata-ai/Microsoft/releases/download/v0.1.0/',
+            'https://github.com/vale-cli/Microsoft/releases/download/v0.1.0/',
         },
         {
           currentValue: 'v0.4.0',
           datasource: 'github-releases',
-          packageName: 'errata-ai/write-good',
+          packageName: 'vale-cli/write-good',
           replaceString:
-            'https://github.com/errata-ai/write-good/releases/download/v0.4.0/',
+            'https://github.com/vale-cli/write-good/releases/download/v0.4.0/',
         },
       ]);
     });


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Add a `customManagers:valeVersions` preset for updating [Vale](https://vale.sh/) package versions in `.vale.ini` configuration files. Vale packages are pinned via GitHub release download URLs, and this preset extracts the `packageName` and `currentValue` from those URLs using the `github-releases` datasource.

Projects using Vale for prose linting can pin packages to specific GitHub release versions in `.vale.ini`. Having Renovate update these pinned versions is already achievable via a custom manager config, but having a built-in preset removes that boilerplate for users.

## Context

Please select one of the following:

- [x] This closes an existing Issue, Closes: https://github.com/renovatebot/renovate/discussions/45782 (this is a discussion)
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @wrslatz will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
