### PR TITLE
feat(manager/pep621): add configurable PDM lock update strategy

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4055,6 +4055,14 @@ In the example above, a package name like `hashicorp/aws` will be transformed to
 
 Add to this object if you wish to define rules that apply only to patch updates.
 
+## `pdmUpdateStrategy`
+
+For PDM lock-file maintenance, Renovate uses PDM's `--update-eager` strategy by default.
+Set `pdmUpdateStrategy` to `"all"` to use `pdm update --no-sync --update-all` instead, which re-resolves all dependencies and sub-dependencies.
+
+This option only affects PDM lock-file maintenance.
+Targeted dependency updates continue to use `--update-eager`.
+
 ## `pin`
 
 Add to this object if you wish to define rules that apply only to PRs that pin dependencies.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -724,6 +724,14 @@ const options: Readonly<RenovateOptions>[] = [
     default: ['./...'],
     supportedManagers: ['gomod'],
   },
+  {
+    name: 'pdmUpdateStrategy',
+    description: 'Update strategy to use for PDM lock file maintenance.',
+    type: 'string',
+    allowedValues: ['eager', 'all'],
+    default: 'eager',
+    supportedManagers: ['pep621'],
+  },
   // Log options
   {
     name: 'logContext',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -128,6 +128,7 @@ export interface RenovateSharedConfig {
   npmrc?: string;
   npmrcMerge?: boolean;
   npmToken?: string;
+  pdmUpdateStrategy?: PdmUpdateStrategy;
 
   pinDigests?: boolean;
   platformAutomerge?: boolean;
@@ -574,6 +575,8 @@ export type UpdateTypeOptions = (typeof UpdateTypesOptions)[number];
 export type FetchChangeLogsOptions = 'off' | 'branch' | 'pr';
 
 export type MatchStringsStrategy = 'any' | 'recursive' | 'combination';
+
+export type PdmUpdateStrategy = 'eager' | 'all';
 
 export type MergeStrategy =
   | 'auto'

--- a/lib/modules/manager/pep621/processors/pdm.spec.ts
+++ b/lib/modules/manager/pep621/processors/pdm.spec.ts
@@ -137,7 +137,7 @@ describe('modules/manager/pep621/processors/pdm', () => {
       expect(execSnapshots).toEqual([]);
     });
 
-    it('return update dep update', async () => {
+    it('keeps dependency updates eager when update-all is configured', async () => {
       const execSnapshots = mockExecAll();
       GlobalConfig.set(adminConfig);
       fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
@@ -199,7 +199,9 @@ describe('modules/manager/pep621/processors/pdm', () => {
         {
           packageFileName: 'pyproject.toml',
           newPackageFileContent: '',
-          config: {},
+          config: {
+            pdmUpdateStrategy: 'all',
+          },
           updatedDeps,
         },
         parsePyProject('')!,
@@ -313,6 +315,52 @@ describe('modules/manager/pep621/processors/pdm', () => {
       expect(execSnapshots).toMatchObject([
         {
           cmd: 'pdm update --no-sync --update-eager',
+          options: {
+            cwd: '/tmp/github/some/repo/folder',
+          },
+        },
+      ]);
+    });
+
+    it('uses update-all when configured for lockfileMaintenance', async () => {
+      const execSnapshots = mockExecAll();
+      GlobalConfig.set(adminConfig);
+      fs.getSiblingFileName.mockReturnValueOnce('pdm.lock');
+      fs.readLocalFile.mockResolvedValueOnce('test content');
+      fs.readLocalFile.mockResolvedValueOnce('changed test content');
+      // python
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: '3.11.1' }, { version: '3.11.2' }],
+      });
+      // pdm
+      getPkgReleases.mockResolvedValueOnce({
+        releases: [{ version: 'v2.6.1' }, { version: 'v2.5.0' }],
+      });
+
+      const result = await processor.updateArtifacts(
+        {
+          packageFileName: 'folder/pyproject.toml',
+          newPackageFileContent: '',
+          config: {
+            isLockFileMaintenance: true,
+            pdmUpdateStrategy: 'all',
+          },
+          updatedDeps: [],
+        },
+        parsePyProject('')!,
+      );
+      expect(result).toEqual([
+        {
+          file: {
+            contents: 'changed test content',
+            path: 'pdm.lock',
+            type: 'addition',
+          },
+        },
+      ]);
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'pdm update --no-sync --update-all',
           options: {
             cwd: '/tmp/github/some/repo/folder',
           },

--- a/lib/modules/manager/pep621/processors/pdm.ts
+++ b/lib/modules/manager/pep621/processors/pdm.ts
@@ -23,7 +23,8 @@ import type { Pep621ManagerData } from '../types.ts';
 import { depTypes } from '../utils.ts';
 import { BasePyProjectProcessor } from './abstract.ts';
 
-const pdmUpdateCMD = 'pdm update --no-sync --update-eager';
+const pdmUpdateEagerCMD = 'pdm update --no-sync --update-eager';
+const pdmUpdateAllCMD = 'pdm update --no-sync --update-all';
 const gitExec = withGitEnvironment(['pep621']);
 
 export class PdmProcessor extends BasePyProjectProcessor {
@@ -118,7 +119,11 @@ export class PdmProcessor extends BasePyProjectProcessor {
       // else only update specific packages
       const cmds: string[] = [];
       if (isLockFileMaintenance) {
-        cmds.push(pdmUpdateCMD);
+        cmds.push(
+          config.pdmUpdateStrategy === 'all'
+            ? pdmUpdateAllCMD
+            : pdmUpdateEagerCMD,
+        );
       } else {
         cmds.push(...generateCMDs(updatedDeps));
       }
@@ -173,7 +178,7 @@ function generateCMDs(updatedDeps: Upgrade<Pep621ManagerData>[]): string[] {
         }
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -G ${quote(dep.managerData.depGroup)}`,
+          `${pdmUpdateEagerCMD} -G ${quote(dep.managerData.depGroup)}`,
           dep.packageName!,
         );
         break;
@@ -189,7 +194,7 @@ function generateCMDs(updatedDeps: Upgrade<Pep621ManagerData>[]): string[] {
         }
         addPackageToCMDRecord(
           packagesByCMD,
-          `${pdmUpdateCMD} -dG ${quote(dep.managerData.depGroup)}`,
+          `${pdmUpdateEagerCMD} -dG ${quote(dep.managerData.depGroup)}`,
           dep.packageName!,
         );
         break;
@@ -199,7 +204,11 @@ function generateCMDs(updatedDeps: Upgrade<Pep621ManagerData>[]): string[] {
         // Reference: https://github.com/pdm-project/pdm/discussions/2869
         break;
       default: {
-        addPackageToCMDRecord(packagesByCMD, pdmUpdateCMD, dep.packageName!);
+        addPackageToCMDRecord(
+          packagesByCMD,
+          pdmUpdateEagerCMD,
+          dep.packageName!,
+        );
       }
     }
   }

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -1,6 +1,7 @@
 import type { ReleaseType } from 'semver';
 import type {
   MatchStringsStrategy,
+  PdmUpdateStrategy,
   RepoToolSettingsOptions,
   UpdateType,
   ValidationMessage,
@@ -43,6 +44,7 @@ export interface UpdateArtifactsConfig {
   constraints?: Partial<Record<ConstraintName, string>>;
   composerIgnorePlatformReqs?: string[];
   goGetDirs?: string[];
+  pdmUpdateStrategy?: PdmUpdateStrategy;
   currentValue?: string;
   postUpdateOptions?: string[];
   ignorePlugins?: boolean;


### PR DESCRIPTION
## Changes

- Add the opt-in `pdmUpdateStrategy` configuration for the `pep621` manager.
- Preserve the existing `--update-eager` behavior by default.
- Use `pdm update --no-sync --update-all` only for PDM lock-file maintenance when `pdmUpdateStrategy: "all"` is configured.
- Keep targeted dependency and dependency-group updates on `--update-eager`.
- Add regression tests and user-facing documentation.

This PR supersedes #45818; the implementation is unchanged, but the commit uses the GitHub-linked author identity `astein-mam-dev <astein@1und1.de>`.

## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

Related discussion: https://github.com/renovatebot/renovate/discussions/42711

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

AI assistance was provided by GitHub Copilot CLI, powered by GPT-5.6 Luna, for code, tests, documentation, repository investigation, and PR preparation.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @astein-mam-dev will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @astein-mam-dev will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: https://github.com/renovatebot/renovate