### PR TITLE
ci: raise coverage thresholds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -542,10 +542,10 @@ jobs:
       - name: Check coverage threshold
         run: |
           pnpm nyc check-coverage -t ./coverage/nyc \
-            --statements 99.88 \
-            --branches 97.84 \
-            --functions 99.96 \
-            --lines 99.87 \
+            --statements 99.97 \
+            --branches 98.68 \
+            --functions 99.97 \
+            --lines 99.98 \
 
   # Catch-all required check for test matrix and coverage
   test-success:


### PR DESCRIPTION
## Changes

Raises the `nyc check-coverage` thresholds in the `coverage` job to match current coverage levels:

| Metric | Before | After |
| --- | --- | --- |
| statements | 99.88 | 99.97 |
| branches | 97.84 | 98.68 |
| functions | 99.96 | 99.97 |
| lines | 99.87 | 99.98 |

Coverage has drifted well above the previously pinned floors, so the check no longer catches regressions. Bumping the thresholds restores the ratchet.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Opus 5) was used to commit the change and draft this pull request description. The threshold values themselves were authored by @viceice.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @viceice will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The `coverage` job in this PR's own CI run verifies the new thresholds hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
