### PR TITLE
test(util): cover remaining lib/util coverage gaps

### DIFF
--- a/lib/util/fs/index.spec.ts
+++ b/lib/util/fs/index.spec.ts
@@ -596,6 +596,18 @@ describe('util/fs/index', () => {
   });
 
   describe('cachePathIsFile', () => {
+    it('returns true for file', async () => {
+      await fs.outputFile(`${cacheDir}/foo/bar/file.txt`, 'foobar');
+
+      await expect(cachePathIsFile(`foo/bar/file.txt`)).resolves.toBeTrue();
+    });
+
+    it('returns false for directory', async () => {
+      await fs.ensureDir(`${cacheDir}/foo/bar`);
+
+      await expect(cachePathIsFile(`foo/bar`)).resolves.toBeFalse();
+    });
+
     it('returns false if does not exist', async () => {
       await expect(cachePathIsFile(`a/a/file.txt`)).resolves.toBe(false);
     });

--- a/lib/util/minimatch.spec.ts
+++ b/lib/util/minimatch.spec.ts
@@ -39,5 +39,17 @@ describe('util/minimatch', () => {
       expect(filterFunc('test.js')).toBe(true);
       expect(filterFunc('test.txt')).toBe(false);
     });
+
+    it('should correctly match filenames when uncached', () => {
+      const filterFunc = minimatchFilter('*.ts', undefined, false);
+      expect(filterFunc('test.ts')).toBe(true);
+      expect(filterFunc('test.txt')).toBe(false);
+    });
+
+    it('should respect options', () => {
+      const filterFunc = minimatchFilter('*.js', { dot: true });
+      expect(filterFunc('.test.js')).toBe(true);
+      expect(minimatchFilter('*.js')('.test.js')).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## Changes

Closes the last two coverage gaps in `lib/util`, bringing the directory to 100% statements, branches and functions.

`lib/util/minimatch.ts`:

- The closure returned from `minimatchFilter` on the **uncached** path (line 45) was created but never invoked — the existing test called `minimatchFilter('*.js')` a second time, which returns the *cached* closure on line 37 instead. Added a test that calls a filter built with `useCache = false`.
- The `options ? ... : pattern` cache-key branch (line 32) never took its truthy side, because every `minimatchFilter` test passed `undefined` options. Added a test with `{ dot: true }` that also asserts the option changes matching behaviour.

`lib/util/fs/index.ts`:

- `cachePathIsFile` only had a "does not exist" test, so the `stat().isFile()` return (line 316) never ran. Added true-for-file and false-for-directory cases.

No production code is touched — tests only.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Opus 5) analysed the v8 coverage report to locate the uncovered lines, wrote the new test cases, and drafted this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @viceice will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Full suite run locally with coverage: 1005 test files, 26755 tests passing. Function coverage goes from 99.98% to 100% and `lib/util` reports no uncovered statements, branches or functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
