### PR TITLE
feat(platform/azure): allow bypassing specified policies

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -341,6 +341,43 @@ If you prefer that Renovate more silently automerge _without_ Pull Requests at a
 The final value for `automergeType` is `"pr-comment"`, intended only for users who already have a "merge bot" such as [bors-ng](https://github.com/bors-ng/bors-ng) and want Renovate to _not_ actually automerge by itself and instead tell `bors-ng` to merge for it, by using a comment in the PR.
 If you're not already using `bors-ng` or similar, don't worry about this option.
 
+## `azureBypassPolicyReason`
+
+Define a custom reason when policies are being bypassed to perform auto-merge.
+
+By default, the reason for bypassing policies is set to "Auto-merge by Renovate".
+
+## `azureBypassPolicyTypeIds`
+
+Define a list of policy UUIDs which are allowed to be bypassed when merging the PR.
+
+!!! note
+  For this to work, the account used by Renovate must have the "Bypass policies when completing pull requests" permission enabled in Azure DevOps.
+
+!!! tip
+  You can acquire list of the policy UUIDs by using the [Azure DevOps REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/policy/types/list) to list the policies for a repository.
+
+Specific API request to acquire the policy UUIDs configured within given organization and project:
+```http request
+GET https://dev.azure.com/{organization}/{project}/_apis/policy/types?api-version=7.1
+```
+
+Example:
+
+```json5
+{
+  "azureBypassPolicyTypeIds": [
+    "fa4e907d-c16b-4a4c-9dfa-4906e5d171dd", // Approval count policy
+    "0609b952-1397-4640-95ec-e00a01b2c241", // Build policy
+    "fd2167ab-b0be-447a-8ec8-39368250530e", // Required reviewers policy
+    "7ed39669-655c-494e-b4a0-a08b4da0fcce", // Git case enforcement policy
+    "2e26e725-8201-4edd-8bf5-978563c34a80", // Git maximum blob size policy
+    "fa4e907d-c16b-4a4c-9dfa-4916e5d171ab", // Merge strategy policy
+    "40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e", // Work item linking policy
+  ]
+}
+```
+
 ## `azureWorkItemId`
 
 When creating a PR in Azure DevOps, some branches can be protected with branch policies to [check for linked work items](https://learn.microsoft.com/azure/devops/repos/git/branch-policies#check-for-linked-work-items).

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -358,6 +358,7 @@ Define a list of policy UUIDs which are allowed to be bypassed when merging the 
   You can acquire list of the policy UUIDs by using the [Azure DevOps REST API](https://learn.microsoft.com/en-us/rest/api/azure/devops/policy/types/list) to list the policies for a repository.
 
 Specific API request to acquire the policy UUIDs configured within given organization and project:
+
 ```http request
 GET https://dev.azure.com/{organization}/{project}/_apis/policy/types?api-version=7.1
 ```
@@ -366,7 +367,7 @@ Example:
 
 ```json5
 {
-  "azureBypassPolicyTypeIds": [
+  azureBypassPolicyTypeIds: [
     "fa4e907d-c16b-4a4c-9dfa-4906e5d171dd", // Approval count policy
     "0609b952-1397-4640-95ec-e00a01b2c241", // Build policy
     "fd2167ab-b0be-447a-8ec8-39368250530e", // Required reviewers policy

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -368,14 +368,14 @@ Example:
 ```json5
 {
   azureBypassPolicyTypeIds: [
-    "fa4e907d-c16b-4a4c-9dfa-4906e5d171dd", // Approval count policy
-    "0609b952-1397-4640-95ec-e00a01b2c241", // Build policy
-    "fd2167ab-b0be-447a-8ec8-39368250530e", // Required reviewers policy
-    "7ed39669-655c-494e-b4a0-a08b4da0fcce", // Git case enforcement policy
-    "2e26e725-8201-4edd-8bf5-978563c34a80", // Git maximum blob size policy
-    "fa4e907d-c16b-4a4c-9dfa-4916e5d171ab", // Merge strategy policy
-    "40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e", // Work item linking policy
-  ]
+    'fa4e907d-c16b-4a4c-9dfa-4906e5d171dd', // Approval count policy
+    '0609b952-1397-4640-95ec-e00a01b2c241', // Build policy
+    'fd2167ab-b0be-447a-8ec8-39368250530e', // Required reviewers policy
+    '7ed39669-655c-494e-b4a0-a08b4da0fcce', // Git case enforcement policy
+    '2e26e725-8201-4edd-8bf5-978563c34a80', // Git maximum blob size policy
+    'fa4e907d-c16b-4a4c-9dfa-4916e5d171ab', // Merge strategy policy
+    '40e92b44-2fe1-4dd6-b3d8-74a9c21d0c6e', // Work item linking policy
+  ],
 }
 ```
 

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1454,6 +1454,22 @@ const options: Readonly<RenovateOptions>[] = [
     supportedPlatforms: ['azure'],
   },
   {
+    name: 'azureBypassPolicyTypeIds',
+    description: 'A list of policy type IDs (UUID) allowed to be bypassed',
+    type: 'array',
+    subType: 'string',
+    allowString: true,
+    default: [],
+    supportedPlatforms: ['azure'],
+  },
+  {
+    name: 'azureBypassPolicyReason',
+    description: 'The `reason` to use when bypassing policies on Azure DevOps.',
+    type: 'string',
+    default: "Auto-merge by Renovate",
+    supportedPlatforms: ['azure'],
+  },
+  {
     name: 'autoApprove',
     description: 'Set to `true` to automatically approve PRs.',
     type: 'boolean',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -1466,7 +1466,7 @@ const options: Readonly<RenovateOptions>[] = [
     name: 'azureBypassPolicyReason',
     description: 'The `reason` to use when bypassing policies on Azure DevOps.',
     type: 'string',
-    default: "Auto-merge by Renovate",
+    default: 'Auto-merge by Renovate',
     supportedPlatforms: ['azure'],
   },
   {

--- a/lib/modules/platform/azure/index.spec.ts
+++ b/lib/modules/platform/azure/index.spec.ts
@@ -2096,6 +2096,67 @@ describe('modules/platform/azure/index', () => {
       expect(res).toBeFalse();
     });
 
+    it('should complete the PR by bypassing configured pending policies', async () => {
+      await initRepo({ repository: 'some/repo' });
+      const pullRequestIdMock = 12345;
+      const lastMergeSourceCommitMock = { commitId: 'abcd1234' };
+      const updatePullRequestMock = vi.fn().mockResolvedValue({
+        status: PullRequestStatus.Completed,
+      });
+      azureApi.gitApi.mockResolvedValueOnce(
+        partial<IGitApi>({
+          getPullRequestById: vi.fn().mockResolvedValue({
+            lastMergeSourceCommit: lastMergeSourceCommitMock,
+            targetRefName: 'refs/heads/ding',
+            title: 'title',
+          }),
+          updatePullRequest: updatePullRequestMock,
+        }),
+      );
+      azureHelper.getMergeMethod = vi
+        .fn()
+        .mockReturnValue(GitPullRequestMergeStrategy.Squash);
+      azureHelper.getPolicyEvaluations.mockResolvedValueOnce([
+        partial<PolicyEvaluationRecord>({
+          configuration: partial<PolicyConfiguration>({
+            isBlocking: true,
+            type: partial<PolicyTypeRef>({
+              id: 'minimum-reviewers',
+              displayName: 'Minimum number of reviewers',
+            }),
+          }),
+          status: PolicyEvaluationStatus.Running,
+        }),
+      ]);
+
+      const res = await azure.mergePr({
+        branchName: 'test',
+        id: pullRequestIdMock,
+        strategy: 'auto',
+        platformOptions: {
+          azureBypassPolicyTypeIds: ['minimum-reviewers'],
+          azureBypassPolicyReason: 'Renovate automerge',
+        },
+      });
+
+      expect(updatePullRequestMock).toHaveBeenCalledExactlyOnceWith(
+        {
+          status: PullRequestStatus.Completed,
+          lastMergeSourceCommit: lastMergeSourceCommitMock,
+          completionOptions: {
+            mergeStrategy: GitPullRequestMergeStrategy.Squash,
+            deleteSourceBranch: true,
+            mergeCommitMessage: 'title',
+            bypassPolicy: true,
+            bypassReason: 'Renovate automerge',
+          },
+        },
+        '1',
+        pullRequestIdMock,
+      );
+      expect(res).toBeTrue();
+    });
+
     it('should complete the PR if blocking policies have been approved or are not applicable', async () => {
       await initRepo({ repository: 'some/repo' });
       const pullRequestIdMock = 12345;

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -4,6 +4,7 @@ import type {
   GitItem,
   GitPullRequest,
   GitPullRequestCommentThread,
+  GitPullRequestCompletionOptions,
   GitStatus,
   GitVersionDescriptor,
 } from 'azure-devops-node-api/interfaces/GitInterfaces.js';
@@ -511,7 +512,7 @@ async function getMergeStrategy(
   );
 }
 
-async function getPendingBlockingPolicyEvaluations(
+async function getPrPendingBlockingPolicyEvaluations(
   pullRequestId: number,
 ): Promise<PolicyEvaluationRecord[]> {
   const artifactId = `vstfs:///CodeReview/CodeReviewId/${config.projectId}/${pullRequestId}`;
@@ -864,23 +865,59 @@ export async function mergePr({
   branchName,
   id: pullRequestId,
   strategy,
+  platformOptions,
 }: MergePRConfig): Promise<boolean> {
   logger.debug(`mergePr(${pullRequestId}, ${branchName!})`);
 
   const pendingPolicyEvaluations =
-    await getPendingBlockingPolicyEvaluations(pullRequestId);
+    await getPrPendingBlockingPolicyEvaluations(pullRequestId);
+
+  let extraCompletionOptions: GitPullRequestCompletionOptions = {};
   if (pendingPolicyEvaluations.length) {
-    logger.debug(
-      {
-        pullRequestId,
-        pendingPolicies: pendingPolicyEvaluations.map((evaluation) => ({
-          name: evaluation.configuration?.type?.displayName,
-          status: PolicyEvaluationStatus[evaluation.status!],
-        })),
-      },
-      'Not completing PR because branch policies have not been satisfied yet',
+    const bypassedPolicyTypeIds = new Set(
+      platformOptions?.azureBypassPolicyTypeIds,
     );
-    return false;
+    const bypassedEvaluations: PolicyEvaluationRecord[] = [];
+    const enforcedEvaluations: PolicyEvaluationRecord[] = [];
+
+    for (const evaluation of pendingPolicyEvaluations) {
+      const policyTypeId = evaluation.configuration?.type?.id;
+      if (policyTypeId && bypassedPolicyTypeIds.has(policyTypeId)) {
+        bypassedEvaluations.push(evaluation);
+      } else {
+        enforcedEvaluations.push(evaluation);
+      }
+    }
+
+    if (bypassedEvaluations.length) {
+      logger.debug(
+        {
+          pullRequestId,
+          bypassedPolicies: bypassedEvaluations.map((evaluation) => ({
+            name: evaluation.configuration?.type?.displayName,
+            status: PolicyEvaluationStatus[evaluation.status!],
+          })),
+        },
+        'The listed branch policies have been bypassed as per configuration',
+      );
+      extraCompletionOptions = {
+        bypassPolicy: true,
+        bypassReason: platformOptions?.azureBypassPolicyReason
+      };
+    }
+    if (enforcedEvaluations.length) {
+      logger.debug(
+        {
+          pullRequestId,
+          pendingPolicies: enforcedEvaluations.map((evaluation) => ({
+            name: evaluation.configuration?.type?.displayName,
+            status: PolicyEvaluationStatus[evaluation.status!],
+          })),
+        },
+        'Not completing PR because branch policies have not been satisfied yet',
+      );
+      return false;
+    }
   }
 
   const azureApiGit = await azureApi.gitApi();
@@ -898,6 +935,7 @@ export async function mergePr({
       mergeStrategy,
       deleteSourceBranch: true,
       mergeCommitMessage: pr.title,
+      ...extraCompletionOptions,
     },
   };
 

--- a/lib/modules/platform/azure/index.ts
+++ b/lib/modules/platform/azure/index.ts
@@ -902,7 +902,7 @@ export async function mergePr({
       );
       extraCompletionOptions = {
         bypassPolicy: true,
-        bypassReason: platformOptions?.azureBypassPolicyReason
+        bypassReason: platformOptions?.azureBypassPolicyReason,
       };
     }
     if (enforcedEvaluations.length) {

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -99,6 +99,8 @@ export interface PlatformPrOptions {
   automergeCommitMessage?: string;
   automergeStrategy?: MergeStrategy;
   azureWorkItemId?: number;
+  azureBypassPolicyTypeIds?: string[];
+  azureBypassPolicyReason?: string;
   bbUseDefaultReviewers?: boolean;
   bbAutoResolvePrTasks?: boolean;
   gitLabIgnoreApprovals?: boolean;
@@ -180,6 +182,7 @@ export interface MergePRConfig {
   branchName?: string;
   id: number;
   strategy?: MergeStrategy;
+  platformOptions?: PlatformPrOptions;
 }
 export interface EnsureCommentConfig {
   number: number;

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -11,6 +11,7 @@ import { scm } from '../../../../modules/platform/scm.ts';
 import type { BranchConfig } from '../../../types.ts';
 import { isScheduledNow } from '../branch/schedule.ts';
 import { resolveBranchStatus } from '../branch/status-checks.ts';
+import { getPlatformPrOptions } from "./index.ts";
 
 export type PrAutomergeBlockReason =
   | 'BranchModified'
@@ -137,6 +138,7 @@ export async function checkAutoMerge(
     branchName,
     id: pr.number,
     strategy: automergeStrategy,
+    platformOptions: getPlatformPrOptions(config),
   });
   if (res) {
     logger.info({ pr: pr.number, prTitle: pr.title }, 'PR automerged');

--- a/lib/workers/repository/update/pr/automerge.ts
+++ b/lib/workers/repository/update/pr/automerge.ts
@@ -11,7 +11,7 @@ import { scm } from '../../../../modules/platform/scm.ts';
 import type { BranchConfig } from '../../../types.ts';
 import { isScheduledNow } from '../branch/schedule.ts';
 import { resolveBranchStatus } from '../branch/status-checks.ts';
-import { getPlatformPrOptions } from "./index.ts";
+import { getPlatformPrOptions } from './index.ts';
 
 export type PrAutomergeBlockReason =
   | 'BranchModified'

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -68,6 +68,8 @@ export function getPlatformPrOptions(
     automergeCommitMessage: config.commitMessage,
     automergeStrategy: config.automergeStrategy,
     azureWorkItemId: config.azureWorkItemId ?? 0,
+    azureBypassPolicyTypeIds: config.azureBypassPolicyTypeIds ?? [],
+    azureBypassPolicyReason: config.azureBypassPolicyReason,
     bbAutoResolvePrTasks: !!config.bbAutoResolvePrTasks,
     bbUseDefaultReviewers: !!config.bbUseDefaultReviewers,
     gitLabIgnoreApprovals: !!config.gitLabIgnoreApprovals,

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -53,6 +53,7 @@ import {
   validatePrCache,
 } from './pr-fingerprint.ts';
 import { tryReuseAutoclosedPr } from './pr-reuse.ts';
+import { coerceArray } from '../../../../util/array.ts';
 
 export function getPlatformPrOptions(
   config: RenovateConfig & PlatformPrOptions,
@@ -68,7 +69,7 @@ export function getPlatformPrOptions(
     automergeCommitMessage: config.commitMessage,
     automergeStrategy: config.automergeStrategy,
     azureWorkItemId: config.azureWorkItemId ?? 0,
-    azureBypassPolicyTypeIds: config.azureBypassPolicyTypeIds ?? [],
+    azureBypassPolicyTypeIds: coerceArray(config.azureBypassPolicyTypeIds),
     azureBypassPolicyReason: config.azureBypassPolicyReason,
     bbAutoResolvePrTasks: !!config.bbAutoResolvePrTasks,
     bbUseDefaultReviewers: !!config.bbUseDefaultReviewers,

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -27,6 +27,7 @@ import {
 } from '../../../../modules/platform/pr-body.ts';
 import { scm } from '../../../../modules/platform/scm.ts';
 import { ExternalHostError } from '../../../../types/errors/external-host-error.ts';
+import { coerceArray } from '../../../../util/array.ts';
 import { getElapsedHours } from '../../../../util/date.ts';
 import { stripEmojis } from '../../../../util/emoji.ts';
 import { fingerprint } from '../../../../util/fingerprint.ts';
@@ -53,7 +54,6 @@ import {
   validatePrCache,
 } from './pr-fingerprint.ts';
 import { tryReuseAutoclosedPr } from './pr-reuse.ts';
-import { coerceArray } from '../../../../util/array.ts';
 
 export function getPlatformPrOptions(
   config: RenovateConfig & PlatformPrOptions,


### PR DESCRIPTION
## Changes

Adds the ability to bypass selected build policies in Azure DevOps platform.
This enables auto-merging the Pull Requests without for example, linked work item or required number of reviewers.

Note: This is heavily based on work from @janicmikes from PR #33626 

Note: This is a re-created version of #45700 as agreed in the conversation in #45679

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

This is linked to discussions: #44473 and #45034

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [x] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @herbatink will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ]  Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository