### PR TITLE
feat(manager/npm): support pnpm v11.23 url-keyed registries

### DIFF
--- a/lib/modules/manager/npm/extract/index.spec.ts
+++ b/lib/modules/manager/npm/extract/index.spec.ts
@@ -432,6 +432,51 @@ describe('modules/manager/npm/extract/index', () => {
       ).toBeArrayIncludingOnly(['https://private.example.com/', undefined]);
     });
 
+    it('reads url-keyed registries from pnpm-workspace.yaml', async () => {
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, otherFile): Promise<string | null> => {
+          if (
+            packageFile === 'package.json' &&
+            otherFile === 'pnpm-workspace.yaml'
+          ) {
+            return Promise.resolve('pnpm-workspace.yaml');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === 'pnpm-workspace.yaml') {
+          return Promise.resolve(codeBlock`
+            registries:
+              https://private.example.com/:
+                serverType: artifactory
+                scopes: ["@babel"]
+              https://default.example.com/:
+                scopes: ["@"]
+          `);
+        }
+        return Promise.resolve(null);
+      });
+
+      const res = await npmExtract.extractPackageFile(
+        input02Content,
+        'package.json',
+        {},
+      );
+
+      expect(res?.deps).toMatchObject([
+        {
+          depName: '@babel/core',
+          registryUrls: ['https://private.example.com/'],
+        },
+        { depName: 'config', registryUrls: ['https://default.example.com/'] },
+        {
+          depName: 'express>cookie',
+          registryUrls: ['https://default.example.com/'],
+        },
+      ]);
+    });
+
     it('reads top-level registry from pnpm-workspace.yaml', async () => {
       fs.findLocalSiblingOrParent.mockImplementation(
         (packageFile, otherFile): Promise<string | null> => {
@@ -522,7 +567,7 @@ describe('modules/manager/npm/extract/index', () => {
       expect(res?.deps[0].registryUrls).toBeUndefined();
     });
 
-    it('ignores an unparseable pnpm-workspace.yaml', async () => {
+    it('ignores an unusable registries setting in pnpm-workspace.yaml', async () => {
       fs.findLocalSiblingOrParent.mockImplementation(
         (packageFile, otherFile): Promise<string | null> => {
           if (
@@ -548,6 +593,43 @@ describe('modules/manager/npm/extract/index', () => {
       expect(
         res?.deps.flatMap((dep) => dep.registryUrls),
       ).toBeArrayIncludingOnly([undefined]);
+    });
+
+    it('ignores an unparseable pnpm-workspace.yaml', async () => {
+      fs.findLocalSiblingOrParent.mockImplementation(
+        (packageFile, otherFile): Promise<string | null> => {
+          if (
+            packageFile === 'package.json' &&
+            otherFile === 'pnpm-workspace.yaml'
+          ) {
+            return Promise.resolve('pnpm-workspace.yaml');
+          }
+          return Promise.resolve(null);
+        },
+      );
+      fs.readLocalFile.mockImplementation((fileName): Promise<any> => {
+        if (fileName === 'pnpm-workspace.yaml') {
+          return Promise.resolve('packages: not-an-array');
+        }
+        return Promise.resolve(null);
+      });
+
+      const res = await npmExtract.extractPackageFile(
+        input02Content,
+        'package.json',
+        {},
+      );
+
+      expect(
+        res?.deps.flatMap((dep) => dep.registryUrls),
+      ).toBeArrayIncludingOnly([undefined]);
+      expect(logger.debug).toHaveBeenCalledWith(
+        {
+          packageFile: 'pnpm-workspace.yaml',
+          err: expect.any(Error),
+        },
+        'Failed to parse pnpm-workspace.yaml',
+      );
     });
 
     it('finds complex yarn workspaces', async () => {

--- a/lib/modules/manager/npm/extract/pnpm.spec.ts
+++ b/lib/modules/manager/npm/extract/pnpm.spec.ts
@@ -592,6 +592,70 @@ describe('modules/manager/npm/extract/pnpm', () => {
       });
     });
 
+    it('applies url-keyed registries to catalog deps', async () => {
+      const parsed = await PnpmWorkspaceFile.safeParseAsync(codeBlock`
+        catalog:
+          "@my-org/pkg": 1.0.0
+          react: 18.3.0
+        registries:
+          https://private.example.com/:
+            serverType: artifactory
+            scopes: ["@my-org", "@my-other-org"]
+            prefix: work
+          https://default.example.com/:
+            scopes: ["@"]
+            supportsTimeField: true
+      `);
+
+      await expect(
+        extractPnpmWorkspaceFile(parsed.data!, 'pnpm-workspace.yaml'),
+      ).resolves.toMatchObject({
+        deps: [
+          {
+            depName: '@my-org/pkg',
+            registryUrls: ['https://private.example.com/'],
+          },
+          {
+            depName: 'react',
+            registryUrls: ['https://default.example.com/'],
+          },
+        ],
+      });
+    });
+
+    it('skips unusable url-keyed registries when parsing', async () => {
+      const parsed = await PnpmWorkspaceFile.safeParseAsync(codeBlock`
+        registries:
+          https://\${TOKEN}.example.com/:
+            scopes: ["@env-var-org"]
+          https://user:pass@credentials.example.com/:
+            scopes: ["@credentials-org"]
+          not-a-url:
+            scopes: ["@invalid-url-org"]
+          https://unrouted.example.com/:
+          https://private.example.com/:
+            scopes: ["@my-org"]
+      `);
+
+      expect(parsed.data?.registries).toEqual({
+        '@my-org': 'https://private.example.com/',
+      });
+    });
+
+    it('ignores registries which mix both shapes', async () => {
+      const parsed = await PnpmWorkspaceFile.safeParseAsync(codeBlock`
+        catalog:
+          react: 18.3.0
+        registries:
+          "@my-org": https://private.example.com/
+          https://default.example.com/:
+            scopes: ["@"]
+      `);
+
+      expect(parsed.data?.registries).toBeUndefined();
+      expect(parsed.data?.catalog).toEqual({ react: '18.3.0' });
+    });
+
     it('does not apply registries to non-npm catalog deps', async () => {
       const res = await extractPnpmWorkspaceFile(
         {

--- a/lib/modules/manager/npm/schema.ts
+++ b/lib/modules/manager/npm/schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { coerceArray } from '../../../util/array.ts';
 import { regEx } from '../../../util/regex.ts';
 import {
   Json,
@@ -6,6 +7,7 @@ import {
   Nullish,
   Yaml,
 } from '../../../util/schema-utils/index.ts';
+import { parseUrl } from '../../../util/url.ts';
 
 // pnpm ignores registry URLs containing `${...}` env-var interpolation since v11.5.3
 function hasEnvVar(value: string): boolean {
@@ -18,6 +20,59 @@ function withoutEnvVarRegistries(
   return Object.fromEntries(
     Object.entries(registries).filter(([, url]) => !hasEnvVar(url)),
   );
+}
+
+/**
+ * pnpm ignores a registry URL which interpolates an env var, and refuses one
+ * which embeds credentials, because `pnpm-workspace.yaml` is committed to the
+ * repository.
+ */
+function isUsableRegistryUrl(url: string): boolean {
+  if (hasEnvVar(url)) {
+    return false;
+  }
+
+  const parsed = parseUrl(url);
+  return !!parsed && !parsed.username && !parsed.password;
+}
+
+/**
+ * A registry of the URL-keyed `registries` shape, added in pnpm v11.23.
+ *
+ * Only `scopes` routes packages to the registry: `prefix` names a
+ * bare-specifier alias which we do not support yet, while `serverType` and
+ * `supportsTimeField` merely describe the server.
+ *
+ * https://pnpm.io/registries
+ */
+const PnpmRegistry = Nullish(
+  z.object({
+    scopes: z.array(z.string()).optional(),
+  }),
+);
+type PnpmRegistry = z.infer<typeof PnpmRegistry>;
+
+/**
+ * Flatten the URL-keyed shape into the older `<scope>: <url>` one, so that both
+ * shapes resolve the same way.
+ */
+function scopeRoutesFromRegistries(
+  registries: Record<string, PnpmRegistry>,
+): Record<string, string> {
+  const result: Record<string, string> = {};
+
+  for (const [url, registry] of Object.entries(registries)) {
+    if (!isUsableRegistryUrl(url)) {
+      continue;
+    }
+
+    for (const scope of coerceArray(registry?.scopes)) {
+      // the bare `@` scope routes the scope-less default registry
+      result[scope === '@' ? 'default' : scope] = url;
+    }
+  }
+
+  return result;
 }
 
 export const PnpmCatalogs = z.object({
@@ -59,9 +114,17 @@ export const PnpmWorkspaceFile = Yaml.pipe(
       minimumReleaseAgeExclude: z.array(z.string()).optional(),
       overrides: z.record(z.string(), z.string()).optional(),
       registry: Nullish(z.string()),
+      // pnpm accepts `<scope>: <url>` and, since v11.23, `<url>: <registry>`.
+      // The two shapes cannot be mixed, and an unparseable one is ignored so
+      // that it does not cost us the catalogs of the same file.
       registries: Nullish(
-        z.record(z.string(), z.string()).transform(withoutEnvVarRegistries),
-      ),
+        z.union([
+          z.record(z.string(), z.string()).transform(withoutEnvVarRegistries),
+          z
+            .record(z.string(), PnpmRegistry)
+            .transform(scopeRoutesFromRegistries),
+        ]),
+      ).catch(undefined),
     })
     .and(PnpmCatalogs),
 );


### PR DESCRIPTION
## Changes

pnpm v11.23 reshaped the [`registries`](https://pnpm.io/registries) setting in `pnpm-workspace.yaml`: it is now keyed by the registry URL, with the scopes routed to it listed in the entry.

```yaml
registries:
  https://npm.corp.example.com/:
    serverType: artifactory
    scopes: ['@acme', '@corp-tools']
  https://verdaccio.corp.example.com/:
    scopes: ['@']
```

We only accepted the older `<scope>: <url>` shape, so a workspace file using the new one failed `PnpmWorkspaceFile` parsing outright — not just losing the registry URLs, but taking the file's catalogs and overrides with it, so nothing in it was extracted or updated any more.

`registries` is now a union of both shapes, with the new one flattened into the old one so that `resolveRegistryUrl()` and everything downstream is unchanged:

- each entry's `scopes` route to its URL key, and the bare `"@"` scope becomes `default`, i.e. the scope-less registry
- URL keys are skipped when they interpolate an env var (`${...}`, ignored by pnpm since v11.5.3), embed `user:pass@` credentials, or are unparseable — pnpm ignores or refuses all three, because the file is committed
- `serverType` and `supportsTimeField` describe the tarball layout and the metadata document, so they are accepted and ignored
- a `registries` value which parses as neither shape (for example the two mixed, which pnpm rejects) now falls back to `undefined` instead of failing the whole file

Not included: `prefix` and the deprecated `namedRegistries`, i.e. bare-specifier aliases like `"lib": "work:^2.0.0"`. We do not resolve those specifiers anywhere today, `package.json` included, so that is a separate feature rather than part of the shape change.

The existing `ignores an unparseable pnpm-workspace.yaml` test is retargeted: its fixture (`registries: not-an-object`) is tolerated now, so it covers that, and a new test uses `packages: not-an-array` to keep the parse-failure path covered.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Written with Claude Code (Claude Opus 5): code, tests and this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @viceice will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

Reading registries from `pnpm-workspace.yaml` has no user-facing docs page today; the setting itself is documented by pnpm, and the code links to it.

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)
