### PR TITLE
feat(host-rules): allow more control over restricting access to internal hosts

### DIFF
--- a/docs/usage/config-presets.md
+++ b/docs/usage/config-presets.md
@@ -370,6 +370,11 @@ Parameters are supported similar to other methods:
 }
 ```
 
+!!! note
+  Renovate warns about HTTP requests to internal hosts (loopback, private ranges, and similar) by default, and can be set to block them - see [`internalHostAccess`](./self-hosted-configuration.md#internalhostaccess).
+  Because a preset's response becomes configuration, fetching presets from an internal host needs a deliberate grant from the self-hosted administrator: a `hostRules` entry in their own configuration setting [`allowInternal=true`](./self-hosted-configuration.md#hostrulesallowinternal), scoped with a `hostType` or a URL-prefix `matchHost`.
+  This applies to `npm:` presets too, where the scoped grant names the registry, for example `{ "matchHost": "https://registry.corp/", "hostType": "npm", "allowInternal": true }`.
+
 ## Templating presets
 
 You can use [Handlebars](https://handlebarsjs.com/) templates to be flexible with your presets.

--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2182,6 +2182,10 @@ To match specific ports you have to add a protocol to `matchHost`:
   Disabling a host is only 100% effective if added to self-hosted config.
   Renovate currently still checks its _cache_ for results first before trying to connect, so if a public host is blocked in your repository config (e.g. `renovate.json`) then it's possible you may get cached _results_ from that host if another repository using the same Renovate deployment has successfully queried for the same dependency recently.
 
+!!! note
+  `enabled` is not resolved by specificity alone: host rules from the self-hosted administrator's own config are resolved at a higher trust level than those from repository config or a preset.
+  So if the administrator's own rules set `enabled` for a host, repository config or a preset cannot re-enable - or disable - that host, no matter how specific its `matchHost` is.
+
 ### `hostRules.abortIgnoreStatusCodes`
 
 This field can be used to configure status codes that Renovate ignores and passes through when `abortOnError` is set to `true`.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -1042,6 +1042,9 @@ The inherited config may include all valid repository config and these config op
 
 This way organizations can change/control the default behavior, like whether configs are required and how repositories are onboarded.
 
+Configured `hostRules` in inherited config are treated as if they are repository configuration, when applying precedence and whether [`internalHostAccess`](#internalhostaccess) can be configured.
+If you trust each organisation onboarded to this Renovate deployment to be able to specify at an organisation level whether they should be able to access internal hosts, you can set [`inheritConfigTrusted=true`](#inheritconfigtrusted).
+
 We disabled `inheritConfig` in the Mend Renovate App to avoid wasting millions of API calls per week.
 This is because each `404` response from the GitHub API due to a missing org inherited config counts as a used API call.
 We will add a smart/dynamic approach in future, so that we can selectively enable `inheritConfig` per organization.
@@ -1063,6 +1066,37 @@ When you set `inheritConfigStrict=true` then Renovate will abort the run and rai
 
 !!! warning
   Only set this config option to `true` if _every_ organization has an inherited config file _and_ you want to make sure Renovate _always_ uses that inherited config.
+
+## `inheritConfigTrusted`
+
+!!! warning
+  Only set this to `true` if everyone who can push to the `inheritConfigRepoName` repositories are trusted to control these additional settings.
+  This trust is transitive: `hostRules` defined in any preset the inherited config `extends` are trusted at the same level, so everyone who can change those preset sources must be trusted too.
+  If you're running a multi-tenant platform, it is recommended you leave this disabled.
+
+### Host Rules
+
+By default, `hostRules` in inherited config are treated like a repository's own: they may carry credentials or headers, but they cannot grant access to internal hosts.
+
+This is because the `inheritConfigRepoName` repository is controlled by each organization's administrators, rather than the self-hosted administrators themselves.
+As this repository is outside of the self-hosted administrator's control, there may be looser access control than may be wanted on the repository and its ability to provide settings, and so an additional level of opt-in trust is required.
+
+If you opt in by setting `inheritConfigTrusted=true`, this will permit the inherited config to set `hostRules`:
+
+- set [`allowInternal`](#hostrulesallowinternal), which is otherwise a fatal config error there
+- implicitly permit an internal host by naming it in a rule's `matchHost` - whether or not the rule carries credentials - the same way the self-hosted config's `hostRules` do
+
+A self-hosted administrator's configuration still takes precedence for:
+
+- specifying `allowInternal`, allowing you to "veto" access to any hosts
+- `headers`, which are applied last
+- `enabled`, which cannot be overridden by inherited config
+- inherited config still cannot change [`internalHostAccess`](#internalhostaccess), or any other option that is not marked `inheritConfigSupport`
+
+Inherited config cannot permit the hosts of its own `extends` presets, whatever this option is set to: those presets are resolved before its `hostRules` are registered.
+A preset that inherited config extends from an internal host still needs a grant in global config.
+
+Trust does however extend to the `hostRules` defined _in_ those presets: once the inherited config's `extends` are resolved, the `hostRules` they contribute are registered at the same inherited trust level, as if the inherited config had defined them itself.
 
 ## `internalHostAccess`
 
@@ -1100,10 +1134,13 @@ Hosts without one only need naming:
 ```
 
 The first rule permits an internal registry the same way a credentialed rule would, and the second deliberately permits fetching HTTP presets from an internal host.
-Anything whose response becomes configuration - HTTP presets, and `npm:` presets - always requires such an explicit, scoped [`allowInternal`](./self-hosted-configuration.md#hostrulesallowinternal) grant, even for a host your other rules already permit.
+Anything whose response becomes configuration - HTTP presets, and `npm:` presets - always requires such an explicit, scoped [`allowInternal`](#hostrulesallowinternal) grant, even for a host your other rules already permit.
 
 Once your grants are in place and the warnings have stopped, set `internalHostAccess=block` to enforce the policy today, rather than waiting for the default to change.
 Set `internalHostAccess=allow` only as a temporary escape hatch while you work out which hosts to permit.
+
+If you manage `hostRules` centrally through [`inheritConfig`](#inheritconfig), those rules do not grant anything by default, because that repository is the organization's rather than yours.
+Either opt into trusting them with [`inheritConfigTrusted=true`](#inheritconfigtrusted), or move the rules for internal hosts into your own global config or a `repositories[]` entry.
 
 Cloud instance-metadata endpoints (such as `169.254.169.254`, `169.254.170.2` and `metadata.google.internal`) are **always** blocked, regardless of `internalHostAccess`' setting, as Renovate's HTTP layer never has a legitimate reason to request them.
 This does not affect Renovate's cloud environment detection or cloud SDK authentication, which do not use Renovate's HTTP layer - see [`useCloudMetadataServices`](#usecloudmetadataservices).

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -880,6 +880,13 @@ Use the `extends` field instead of this if, for example, you need the ability fo
   When Renovate resolves `globalExtends` it does not fully process the configuration.
   This means that Renovate does not have the authentication it needs to fetch private things.
 
+## `hostRules`
+
+These `hostRules` fields are only allowed in self-hosted config, and are ignored (or rejected with a config error) if set in repository config or a preset.
+See [`hostRules`](./configuration-options.md#hostrules) for the rest of the available fields.
+
+### `hostRules.allowInternal`
+
 ## `httpCacheTtlDays`
 
 This option sets the number of days that Renovate will cache HTTP responses.

--- a/docs/usage/self-hosted-configuration.md
+++ b/docs/usage/self-hosted-configuration.md
@@ -885,7 +885,109 @@ Use the `extends` field instead of this if, for example, you need the ability fo
 These `hostRules` fields are only allowed in self-hosted config, and are ignored (or rejected with a config error) if set in repository config or a preset.
 See [`hostRules`](./configuration-options.md#hostrules) for the rest of the available fields.
 
+When Renovate prepares outgoing HTTP traffic, it considers:
+
+> could this outbound HTTP call lead to configuration being included? (i.e. it's part of an `extends`, but _not_ part of i.e. `customDatasources`)
+
+If it is, Renovate treats it more cautiously, alongside the current configuration for [`internalHostAccess`](./self-hosted-configuration.md#internalhostaccess).
+
+| Could request become config | `internalHostAccess` setting | Host being requested                                                    | Result                   | How to allow traffic                                                                                                       |
+| --------------------------- | ---------------------------- | ----------------------------------------------------------------------- | ------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| Yes                         | `internalHostAccess=block`   | `https://docs.renovatebot.com`                                          | Allowed                  |                                                                                                                            |
+| Yes                         | `internalHostAccess=block`   | `169.254.169.254`                                                       | Blocked                  | Not possible                                                                                                               |
+| Yes                         | `internalHostAccess=block`   | `http://172.16.1.5:8081/artifactory/repo/internal-presets/default.json` | Blocked                  | Create a host rule setting `allowInternal=true`, scoped with a `hostType` or a URL-prefix `matchHost`                      |
+| No                          | `internalHostAccess=block`   | `https://docs.renovatebot.com`                                          | Allowed                  |                                                                                                                            |
+| No                          | `internalHostAccess=block`   | `169.254.169.254`                                                       | Blocked                  | Not possible                                                                                                               |
+| No                          | `internalHostAccess=block`   | `http://172.16.1.5:8081/artifactory/repo/internal-presets/default.json` | Blocked                  | Create a host rule naming the host with `matchHost` (trusted<sup>1</sup>), or one setting `allowInternal=true`             |
+| Yes                         | `internalHostAccess=warn`    | `https://docs.renovatebot.com`                                          | Allowed                  |                                                                                                                            |
+| Yes                         | `internalHostAccess=warn`    | `169.254.169.254`                                                       | Blocked                  | Not possible                                                                                                               |
+| Yes                         | `internalHostAccess=warn`    | `http://172.16.1.5:8081/artifactory/repo/internal-presets/default.json` | Allowed, with a WARN log | Create a host rule setting `allowInternal=true`, scoped with a `hostType` or a URL-prefix `matchHost`<sup>2</sup>          |
+| No                          | `internalHostAccess=warn`    | `https://docs.renovatebot.com`                                          | Allowed                  |                                                                                                                            |
+| No                          | `internalHostAccess=warn`    | `169.254.169.254`                                                       | Blocked                  | Not possible                                                                                                               |
+| No                          | `internalHostAccess=warn`    | `http://172.16.1.5:8081/artifactory/repo/internal-presets/default.json` | Allowed, with a WARN log | Create a host rule naming the host with `matchHost` (trusted<sup>1</sup>), or one setting `allowInternal=true`<sup>2</sup> |
+| Yes                         | `internalHostAccess=allow`   | `https://docs.renovatebot.com`                                          | Allowed                  |                                                                                                                            |
+| Yes                         | `internalHostAccess=allow`   | `169.254.169.254`                                                       | Blocked                  | Not possible                                                                                                               |
+| Yes                         | `internalHostAccess=allow`   | `http://172.16.1.5:8081/artifactory/repo/internal-presets/default.json` | Allowed, no warning      | Already allowed - no host rule needed                                                                                      |
+| No                          | `internalHostAccess=allow`   | `https://docs.renovatebot.com`                                          | Allowed                  |                                                                                                                            |
+| No                          | `internalHostAccess=allow`   | `169.254.169.254`                                                       | Blocked                  | Not possible                                                                                                               |
+| No                          | `internalHostAccess=allow`   | `http://172.16.1.5:8081/artifactory/repo/internal-presets/default.json` | Allowed, no warning      | Already allowed - no host rule needed                                                                                      |
+
+<sup>1</sup>: a "trusted" host rule is one that's configured by the self-hosted administrator
+
+<sup>2</sup>: under `internalHostAccess=warn`, the request is allowed either way - the host rule only silences the WARN log, it isn't required for the request to go through
+
 ### `hostRules.allowInternal`
+
+As seen above, specifying `allowInternal` is required when Renovate interacts with private addresses, and is dependent on how [`internalHostAccess`](./self-hosted-configuration.md#internalhostaccess) is configured.
+
+If a host is being used i.e. in a `customDatasources` or a `registryUrl` configuration, then an _implicit_ grant is sufficient.
+For instance, if the self-hosted configuration authenticates to a private Artifactory deployment:
+
+```json {configType=global}
+{
+  "hostRules": [
+    {
+      "matchHost": "http://172.16.1.5:8081/artifactory",
+      "username": "renovate-user",
+      "password": "{{ secrets.ARTIFACTORY_PASSWORD }}"
+    }
+  ]
+}
+```
+
+!!! warning
+  An implicit grant does not depend on the rule carrying credentials.
+  _Any_ host rule in your own configuration whose `matchHost` matches the host grants internal access to it, even a rule that only sets something like `timeout` or `concurrentRequestLimit`.
+  This means that when you upgrade, the `hostRules` you already have silently become internal-access grants for the hosts they name.
+
+If there are hosts that you do not want Renovate to access, it is worth explicitly blocking them with:
+
+```json {configType=global}
+{
+  "hostRules": [
+    {
+      "matchHost": "http://localhost:8500/v1/flags/",
+      "allowInternal": false
+    }
+  ]
+}
+```
+
+Setting `allowInternal=false` is also how you keep a rule you need for another reason - credentials, for instance - without it granting internal access to the host it names.
+
+It is recommended to use a URL-prefix `matchHost` (as above) over a bare hostname when permitting loopback addresses, so that only the intended service - and not everything else running on the same host - becomes reachable.
+Include the port in that prefix for the same reason.
+A bare hostname `matchHost` also matches every subdomain of that host, so prefer a URL prefix whenever you want the grant to stay narrow.
+
+If a host is being used i.e. in an `extends`, an _explicit_ grant is required to permit fetching that configuration.
+This covers HTTP presets, and `npm:` presets - whose registry a repository can point at any host with its own `npmrc`.
+The grant must be deliberately scoped, by setting `allowInternal` on a rule with a `hostType`, or on one with a URL-prefix `matchHost`:
+
+```json {configType=global}
+{
+  "hostRules": [
+    {
+      "hostType": "preset",
+      "matchHost": "https://config-server.corp/renovate-presets/",
+      "allowInternal": true
+    },
+    {
+      "hostType": "npm",
+      "matchHost": "https://registry.corp/",
+      "allowInternal": true
+    }
+  ]
+}
+```
+
+The first rule permits HTTP presets from that server, the second `npm:` presets from that registry.
+
+!!! note
+  A URL-form `matchHost` is scoped enough on its own, so a `hostType` is not required.
+  A rule such as `{ "matchHost": "http://10.1.2.3", "allowInternal": true }` therefore permits config-fetching requests - such as HTTP presets - to that URL prefix, and not only lookups.
+  A bare hostname such as `{ "matchHost": "10.1.2.3", "allowInternal": true }` is not scoped, and permits lookups only.
+
+Cloud instance-metadata endpoints are always blocked, and cannot be permitted with this field.
 
 ## `httpCacheTtlDays`
 
@@ -961,6 +1063,55 @@ When you set `inheritConfigStrict=true` then Renovate will abort the run and rai
 
 !!! warning
   Only set this config option to `true` if _every_ organization has an inherited config file _and_ you want to make sure Renovate _always_ uses that inherited config.
+
+## `internalHostAccess`
+
+Controls whether Renovate may make HTTP requests to internal hosts: loopback, RFC1918 private ranges, link-local, carrier-grade NAT, IPv6 unique-local, and similar special-use addresses.
+This applies whether the URL names an IP address directly, or a hostname which resolves to one, and covers redirects too.
+
+- `warn` (default): requests to internal hosts are permitted, but each request that `block` would refuse is logged as a warning
+- `block`: requests to internal hosts are refused, unless the host is your configured platform `endpoint`, or is permitted by a `hostRule` in your own (self-hosted administrator) configuration
+- `allow`: requests to internal hosts are permitted, and not logged
+
+The default will become `block` in a future major release, so treat the warnings as the work to do before then.
+Hosted platforms, such as the Mend Renovate App, may run with `block` regardless of this setting.
+
+!!! warning
+  `allow` is a migration escape hatch, and we plan to remove it in a future major release.
+  After that, every internal host Renovate should reach needs a `hostRules` entry permitting it, and there is no way to silence the warnings in bulk.
+  Use the time before then to add those grants, rather than to keep `allow` set.
+
+The policy applies no matter where the URL came from - repository configuration such as `extends` presets or `registryUrls`, package file contents, or your own configuration - if Renovate should be able to reach an internal host, you need to permit it with a `hostRule` rather than setting `allow`.
+
+For most deployments there is nothing to do: internal registries nearly always already have a `hostRules` entry carrying their credentials, which permits them implicitly, and so are never warned about.
+Hosts without one only need naming:
+
+```json {configType=global}
+{
+  "hostRules": [
+    { "matchHost": "artifactory.corp" },
+    {
+      "hostType": "preset",
+      "matchHost": "https://config-server.corp/renovate-presets/",
+      "allowInternal": true
+    }
+  ]
+}
+```
+
+The first rule permits an internal registry the same way a credentialed rule would, and the second deliberately permits fetching HTTP presets from an internal host.
+Anything whose response becomes configuration - HTTP presets, and `npm:` presets - always requires such an explicit, scoped [`allowInternal`](./self-hosted-configuration.md#hostrulesallowinternal) grant, even for a host your other rules already permit.
+
+Once your grants are in place and the warnings have stopped, set `internalHostAccess=block` to enforce the policy today, rather than waiting for the default to change.
+Set `internalHostAccess=allow` only as a temporary escape hatch while you work out which hosts to permit.
+
+Cloud instance-metadata endpoints (such as `169.254.169.254`, `169.254.170.2` and `metadata.google.internal`) are **always** blocked, regardless of `internalHostAccess`' setting, as Renovate's HTTP layer never has a legitimate reason to request them.
+This does not affect Renovate's cloud environment detection or cloud SDK authentication, which do not use Renovate's HTTP layer - see [`useCloudMetadataServices`](#usecloudmetadataservices).
+
+If you run Renovate behind a proxy (`HTTP_PROXY` or `HTTPS_PROXY`), the proxy resolves the target hostname, so Renovate cannot check the address it actually connects to.
+Renovate still checks the URL itself and every redirect target, and resolves the hostname up front as a best-effort check, but as the proxy resolves the name again the two answers can differ - such as with DNS rebinding, or split-horizon DNS.
+Renovate lets the request through when it cannot resolve the hostname itself, which is common in locked-down proxy environments.
+Restrict what your proxy may reach with egress controls on the proxy, for defense in depth.
 
 ## `logContext`
 

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -43,6 +43,7 @@ export class GlobalConfig {
     'httpCacheTtlDays',
     'ignorePrAuthor',
     'includeMirrors',
+    'internalHostAccess',
     /** NOTE that this is not a config option, but an internal variable **/
     'localDir',
     'migratePresets',

--- a/lib/config/global.ts
+++ b/lib/config/global.ts
@@ -43,6 +43,7 @@ export class GlobalConfig {
     'httpCacheTtlDays',
     'ignorePrAuthor',
     'includeMirrors',
+    'inheritConfigTrusted',
     'internalHostAccess',
     /** NOTE that this is not a config option, but an internal variable **/
     'localDir',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -101,6 +101,17 @@ const options: Readonly<RenovateOptions>[] = [
     globalOnly: true,
   },
   {
+    name: 'internalHostAccess',
+    description:
+      'Whether Renovate may make HTTP requests to internal hosts, such as loopback, private-range and link-local addresses. `warn` logs the requests which `block` would refuse.',
+    type: 'string',
+    allowedValues: ['allow', 'warn', 'block'],
+    default: 'warn',
+    globalOnly: true,
+    experimental: true,
+    advancedUse: true,
+  },
+  {
     name: 'useCloudMetadataServices',
     description:
       'If `false`, Renovate does not try to access cloud metadata services.',
@@ -2906,7 +2917,8 @@ const options: Readonly<RenovateOptions>[] = [
   },
   {
     name: 'allowInternal',
-    description: 'Whether requests to this host may reach internal addresses',
+    description:
+      "Whether requests to this host may reach internal addresses when `internalHostAccess=block`. Only honored from the self-hosted administrator's own configuration.",
     type: 'boolean',
     stage: 'repository',
     parents: ['hostRules'],

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -870,6 +870,16 @@ const options: Readonly<RenovateOptions>[] = [
     globalOnly: true,
   },
   {
+    name: 'inheritConfigTrusted',
+    description:
+      'If `true`, `hostRules` in inherited config may grant access to internal hosts.',
+    type: 'boolean',
+    default: false,
+    globalOnly: true,
+    experimental: true,
+    advancedUse: true,
+  },
+  {
     name: 'requireConfig',
     description:
       "Controls Renovate's behavior regarding repository config files such as `renovate.json`.",
@@ -2918,7 +2928,7 @@ const options: Readonly<RenovateOptions>[] = [
   {
     name: 'allowInternal',
     description:
-      "Whether requests to this host may reach internal addresses when `internalHostAccess=block`. Only honored from the self-hosted administrator's own configuration.",
+      "Whether requests to this host may reach internal addresses when `internalHostAccess=block`. Only honored from the self-hosted administrator's own configuration, or from inherited config when `inheritConfigTrusted=true`.",
     type: 'boolean',
     stage: 'repository',
     parents: ['hostRules'],
@@ -2926,6 +2936,7 @@ const options: Readonly<RenovateOptions>[] = [
     env: false,
     advancedUse: true,
     globalOnly: true,
+    inheritConfigSupport: true,
   },
   {
     name: 'abortOnError',

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2905,6 +2905,17 @@ const options: Readonly<RenovateOptions>[] = [
     advancedUse: true,
   },
   {
+    name: 'allowInternal',
+    description: 'Whether requests to this host may reach internal addresses',
+    type: 'boolean',
+    stage: 'repository',
+    parents: ['hostRules'],
+    cli: false,
+    env: false,
+    advancedUse: true,
+    globalOnly: true,
+  },
+  {
     name: 'abortOnError',
     description:
       'If enabled, Renovate aborts its run when HTTP request errors occur.',

--- a/lib/config/presets/github/index.spec.ts
+++ b/lib/config/presets/github/index.spec.ts
@@ -31,6 +31,25 @@ describe('config/presets/github/index', () => {
       expect(res).toEqual({ from: 'api' });
     });
 
+    it('fetches from the endpoint host even for a hostile repo string', async () => {
+      // the repo part of a preset string has no host component: whatever it contains only ever becomes a path on the configured endpoint (`..` segments are normalized within it)
+      httpMock
+        .scope(githubApiHost)
+        .get('/repos/evil.example.com/x/contents/default.json')
+        .reply(200, {
+          content: toBase64('{"from":"api"}'),
+        });
+
+      const res = await github.fetchJSONFile(
+        'some/repo/../../evil.example.com/x',
+        'default.json',
+        githubApiHost,
+        undefined,
+      );
+
+      expect(res).toEqual({ from: 'api' });
+    });
+
     it('throws external host error', async () => {
       httpMock
         .scope(githubApiHost)

--- a/lib/config/presets/http/index.spec.ts
+++ b/lib/config/presets/http/index.spec.ts
@@ -1,6 +1,8 @@
 import { hostRules } from '~test/host-rules.ts';
 import * as httpMock from '~test/http-mock.ts';
+import { HOST_BLOCKED } from '../../../constants/error-messages.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
+import { GlobalConfig } from '../../global.ts';
 import { PRESET_DEP_NOT_FOUND, PRESET_INVALID_JSON } from '../util.ts';
 import * as http from './index.ts';
 
@@ -36,6 +38,46 @@ describe('config/presets/http/index', () => {
       const repo = 'https://my.server/test-preset.jsonc';
 
       await expect(http.getPreset({ repo })).resolves.toEqual({ foo: 'bar' });
+    });
+
+    describe('internal hosts', () => {
+      beforeEach(() => {
+        GlobalConfig.set({ internalHostAccess: 'block' });
+      });
+
+      afterEach(() => {
+        GlobalConfig.reset();
+      });
+
+      it('throws a distinct error for a blocked host', async () => {
+        // no mocked response: the request is blocked before it is ever made
+        await expect(
+          http.getPreset({ repo: 'http://10.1.2.3/test-preset.json' }),
+        ).rejects.toThrow(HOST_BLOCKED);
+      });
+
+      it('stays blocked when the admin only named the host', async () => {
+        hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+
+        await expect(
+          http.getPreset({ repo: 'http://10.1.2.3/test-preset.json' }),
+        ).rejects.toThrow(HOST_BLOCKED);
+      });
+
+      it('is fetched under a scoped grant', async () => {
+        hostRules.add(
+          { hostType: 'preset', matchHost: '10.1.2.3', allowInternal: true },
+          { trusted: true },
+        );
+        httpMock
+          .scope('http://10.1.2.3')
+          .get('/test-preset.json')
+          .reply(200, { foo: 'bar' });
+
+        await expect(
+          http.getPreset({ repo: 'http://10.1.2.3/test-preset.json' }),
+        ).resolves.toEqual({ foo: 'bar' });
+      });
     });
 
     it('throws if fails to parse', async () => {

--- a/lib/config/presets/http/index.ts
+++ b/lib/config/presets/http/index.ts
@@ -1,3 +1,4 @@
+import { HOST_BLOCKED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { memCacheProvider } from '../../../util/http/cache/memory-http-cache-provider.ts';
@@ -25,6 +26,11 @@ export async function getPreset({
     response = await http.getText(url, { cacheProvider: memCacheProvider });
   } catch (err) {
     if (err instanceof ExternalHostError) {
+      throw err;
+    }
+
+    // keep the block distinguishable from a plain 404, so it surfaces as its own config validation error
+    if (err.message === HOST_BLOCKED) {
       throw err;
     }
 

--- a/lib/config/presets/http/index.ts
+++ b/lib/config/presets/http/index.ts
@@ -7,7 +7,8 @@ import { parseUrl } from '../../../util/url.ts';
 import type { Preset, PresetConfig } from '../types.ts';
 import { PRESET_DEP_NOT_FOUND, parsePreset } from '../util.ts';
 
-const http = new Http('preset');
+// every response this instance fetches becomes Renovate configuration, so an internal host needs a deliberately-scoped `allowInternal` grant
+const http = new Http('preset', { responseBecomesConfig: true });
 
 export async function getPreset({
   repo: url,

--- a/lib/config/presets/index.spec.ts
+++ b/lib/config/presets/index.spec.ts
@@ -3,6 +3,7 @@ import { Fixtures } from '~test/fixtures.ts';
 import { logger } from '~test/util.ts';
 import {
   CONFIG_VALIDATION,
+  HOST_BLOCKED,
   PLATFORM_RATE_LIMIT_EXCEEDED,
 } from '../../constants/error-messages.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
@@ -137,6 +138,30 @@ describe('config/presets/index', () => {
           ' Note: this is a *nested* preset so please contact the preset author if you are unable to fix it yourself.',
       );
       expect(e!.validationMessage).toBeUndefined();
+    });
+
+    it('throws if the preset host is blocked', async () => {
+      config.extends = ['http://10.1.2.3/preset.json'];
+      http.getPreset.mockRejectedValueOnce(new Error(HOST_BLOCKED));
+      let e: Error | undefined;
+      try {
+        await presets.resolveConfigPresets(config);
+      } catch (err) {
+        e = err;
+      }
+      expect(e).toBeDefined();
+      expect(e!.validationError).toBe(
+        'Preset host is blocked by this Renovate instance (http://10.1.2.3/preset.json). If this is intended, ask your Renovate administrator to permit it with a `hostRules` entry setting `allowInternal=true`, scoped either by `hostType` (for example `preset` or `npm`) or by a URL-prefix `matchHost`',
+      );
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        {
+          preset: 'http://10.1.2.3/preset.json',
+          documentationUrl: expect.stringContaining(
+            'self-hosted-configuration/#hostrulesallowinternal',
+          ),
+        },
+        'Preset host is blocked by this Renovate instance',
+      );
     });
 
     it('throws if invalid preset', async () => {

--- a/lib/config/presets/index.ts
+++ b/lib/config/presets/index.ts
@@ -6,6 +6,7 @@ import {
 } from '@sindresorhus/is';
 import {
   CONFIG_VALIDATION,
+  HOST_BLOCKED,
   PLATFORM_RATE_LIMIT_EXCEEDED,
 } from '../../constants/error-messages.ts';
 import { logger } from '../../logger/index.ts';
@@ -398,7 +399,17 @@ async function fetchPreset(
       throw err;
     }
     const error = new Error(CONFIG_VALIDATION);
-    if (err.message === PRESET_DEP_NOT_FOUND) {
+    if (err.message === HOST_BLOCKED) {
+      logger.warn(
+        {
+          preset,
+          documentationUrl: `${GlobalConfig.get('productLinks').documentation}self-hosted-configuration/#hostrulesallowinternal`,
+        },
+        'Preset host is blocked by this Renovate instance',
+      );
+      // a preset's response becomes configuration, so a plain hostname grant is not enough - say what the administrator actually has to configure
+      error.validationError = `Preset host is blocked by this Renovate instance (${preset}). If this is intended, ask your Renovate administrator to permit it with a \`hostRules\` entry setting \`allowInternal=true\`, scoped either by \`hostType\` (for example \`preset\` or \`npm\`) or by a URL-prefix \`matchHost\``;
+    } else if (err.message === PRESET_DEP_NOT_FOUND) {
       error.validationError = `Cannot find preset's package (${preset})`;
     } else if (err.message === PRESET_RENOVATE_CONFIG_NOT_FOUND) {
       error.validationError = `Preset package is missing a renovate-config entry (${preset})`;

--- a/lib/config/presets/npm/index.spec.ts
+++ b/lib/config/presets/npm/index.spec.ts
@@ -1,11 +1,15 @@
+import { hostRules } from '~test/host-rules.ts';
 import * as httpMock from '~test/http-mock.ts';
+import { HOST_BLOCKED } from '../../../constants/error-messages.ts';
 import { defaultRegistryUrl } from '../../../modules/datasource/npm/common.ts';
+import { setNpmrc } from '../../../modules/datasource/npm/npmrc.ts';
 import { GlobalConfig } from '../../global.ts';
 import * as npm from './index.ts';
 
 describe('config/presets/npm/index', () => {
   beforeEach(() => {
     GlobalConfig.reset();
+    setNpmrc();
   });
 
   it('should throw if no package', async () => {
@@ -116,5 +120,46 @@ describe('config/presets/npm/index', () => {
       .reply(200, presetPackage);
     const res = await npm.getPreset({ repo: 'workingpreset' });
     expect(res).toEqual({ rangeStrategy: 'auto' });
+  });
+
+  describe('internal registry hosts', () => {
+    const presetPackage = {
+      name: 'internalpreset',
+      versions: {
+        '0.0.1': {
+          'renovate-config': { default: { rangeStrategy: 'auto' } },
+        },
+      },
+      'dist-tags': { latest: '0.0.1' },
+    };
+
+    beforeEach(() => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+      // the repository's own `npmrc` picks the registry, so this is a repo-controlled URL
+      setNpmrc('registry=http://10.1.2.3/');
+    });
+
+    it('is blocked when the admin only named the registry host', async () => {
+      hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+
+      await expect(npm.getPreset({ repo: 'internalpreset' })).rejects.toThrow(
+        HOST_BLOCKED,
+      );
+    });
+
+    it('is fetched under a scoped grant', async () => {
+      hostRules.add(
+        { hostType: 'npm', matchHost: '10.1.2.3', allowInternal: true },
+        { trusted: true },
+      );
+      httpMock
+        .scope('http://10.1.2.3')
+        .get('/internalpreset')
+        .reply(200, presetPackage);
+
+      const res = await npm.getPreset({ repo: 'internalpreset' });
+
+      expect(res).toEqual({ rangeStrategy: 'auto' });
+    });
   });
 });

--- a/lib/config/presets/npm/index.ts
+++ b/lib/config/presets/npm/index.ts
@@ -1,3 +1,4 @@
+import { HOST_BLOCKED } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import {
   resolvePackageUrl,
@@ -16,7 +17,8 @@ import {
 
 const id = 'npm';
 
-const http = new Http(id);
+// the registry URL comes from `npmrc`, which a repository can set for itself, and the `renovate-config` fetched from it becomes Renovate configuration - so an internal host needs a deliberately-scoped `allowInternal` grant, as for any other preset source
+const http = new Http(id, { responseBecomesConfig: true });
 
 export async function getPreset({
   repo: pkg,
@@ -39,7 +41,12 @@ export async function getPreset({
     ).body;
     // TODO: check null #22198
     dep = body.versions![body['dist-tags']!.latest];
-  } catch {
+  } catch (err) {
+    // keep the block distinguishable from a missing package, so it surfaces as its own config validation error
+    if (err.message === HOST_BLOCKED) {
+      throw err;
+    }
+
     throw new Error(PRESET_DEP_NOT_FOUND);
   }
   if (!dep?.['renovate-config']) {

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -34,6 +34,7 @@ export type RenovateSplit =
 export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
 export type RepositoryCacheType = 'local' | (string & {});
 export type DryRunConfig = 'extract' | 'lookup' | 'full';
+export type InternalHostAccess = 'allow' | 'warn' | 'block';
 export type RequiredConfig = 'required' | 'optional' | 'ignored';
 
 export interface GroupConfig extends Record<string, unknown> {
@@ -252,6 +253,7 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   gitTimeout?: number;
   githubTokenWarn?: boolean;
   includeMirrors?: boolean;
+  internalHostAccess?: InternalHostAccess;
   migratePresets?: Record<string, string>;
   platform?: PlatformId;
   prCacheSyncMaxPages?: number;

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -253,6 +253,7 @@ export interface RepoGlobalConfig extends GlobalInheritableConfig {
   gitTimeout?: number;
   githubTokenWarn?: boolean;
   includeMirrors?: boolean;
+  inheritConfigTrusted?: boolean;
   internalHostAccess?: InternalHostAccess;
   migratePresets?: Record<string, string>;
   platform?: PlatformId;

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2401,6 +2401,85 @@ describe('config/validation', () => {
       expect(errors).toBeEmptyArray();
     });
 
+    it('reports `allowInternal` in inherited config as a security error, saying how to permit it', async () => {
+      const config = {
+        hostRules: [
+          {
+            matchHost: 'http://10.1.2.3',
+            allowInternal: true,
+          },
+        ],
+      };
+
+      const { warnings, errors } = await configValidation.validateConfig(
+        'inherit',
+        config,
+      );
+
+      expect(warnings).toBeEmptyArray();
+      expect(errors).toMatchObject([
+        {
+          message:
+            'hostRules `allowInternal` is not allowed in inherited config, as this Renovate instance has not set `inheritConfigTrusted=true`. The administrator can either set it, or move the rule to their global config or a `repositories[]` entry.',
+          topic: 'Config security error',
+        },
+      ]);
+    });
+
+    it('allows `allowInternal` in inherited config with `inheritConfigTrusted`', async () => {
+      GlobalConfig.set({ inheritConfigTrusted: true });
+
+      const config = {
+        hostRules: [
+          {
+            matchHost: 'http://10.1.2.3',
+            allowInternal: true,
+          },
+        ],
+      };
+
+      const { warnings, errors } = await configValidation.validateConfig(
+        'inherit',
+        config,
+      );
+
+      expect(warnings).toBeEmptyArray();
+      expect(errors).toBeEmptyArray();
+    });
+
+    it('still reports `allowInternal` in repo config with `inheritConfigTrusted`', async () => {
+      // `inheritConfigTrusted` says nothing about a repository's own config, or the presets it extends
+      GlobalConfig.set({ inheritConfigTrusted: true });
+
+      const config = {
+        hostRules: [
+          {
+            matchHost: 'http://10.1.2.3',
+            allowInternal: true,
+          },
+        ],
+      };
+
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+
+      expect(warnings).toMatchObject([
+        {
+          message: `The "allowInternal" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file.`,
+          topic: 'Configuration Error',
+        },
+      ]);
+      expect(errors).toMatchObject([
+        {
+          message:
+            "hostRules `allowInternal` is only allowed in the self-hosted administrator's own configuration.",
+          topic: 'Config security error',
+        },
+      ]);
+    });
+
     it('errors if forbidden header in hostRules', async () => {
       GlobalConfig.set({ allowedHeaders: ['X-*'] });
 

--- a/lib/config/validation.spec.ts
+++ b/lib/config/validation.spec.ts
@@ -2352,6 +2352,55 @@ describe('config/validation', () => {
       expect(warnings).toBeEmptyArray();
     });
 
+    it('reports `allowInternal` in repo config as a security error', async () => {
+      const config = {
+        hostRules: [
+          {
+            matchHost: 'http://10.1.2.3',
+            allowInternal: true,
+          },
+        ],
+      };
+
+      const { warnings, errors } = await configValidation.validateConfig(
+        'repo',
+        config,
+      );
+
+      expect(warnings).toMatchObject([
+        {
+          message: `The "allowInternal" option is a global option reserved only for Renovate's global configuration and cannot be configured within a repository's config file.`,
+          topic: 'Configuration Error',
+        },
+      ]);
+      expect(errors).toMatchObject([
+        {
+          message:
+            "hostRules `allowInternal` is only allowed in the self-hosted administrator's own configuration.",
+          topic: 'Config security error',
+        },
+      ]);
+    });
+
+    it('allows `allowInternal` in global config', async () => {
+      const config = {
+        hostRules: [
+          {
+            matchHost: 'http://10.1.2.3',
+            allowInternal: false,
+          },
+        ],
+      };
+
+      const { warnings, errors } = await configValidation.validateConfig(
+        'global',
+        config,
+      );
+
+      expect(warnings).toBeEmptyArray();
+      expect(errors).toBeEmptyArray();
+    });
+
     it('errors if forbidden header in hostRules', async () => {
       GlobalConfig.set({ allowedHeaders: ['X-*'] });
 

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -1039,6 +1039,16 @@ export async function validateConfig(
               });
             }
 
+            if (configType !== 'global' && !isUndefined(rule.allowInternal)) {
+              errors.push({
+                // like disallowed `headers` below, `Security` only where the rules are actually applied - see the comment there
+                topic: parentPath
+                  ? ConfigValidationTopic.Error
+                  : ConfigValidationTopic.Security,
+                message: `hostRules \`allowInternal\` is only allowed in the self-hosted administrator's own configuration.`,
+              });
+            }
+
             if (!rule.headers) {
               continue;
             }

--- a/lib/config/validation.ts
+++ b/lib/config/validation.ts
@@ -248,8 +248,32 @@ function stripRelativePresetsFromValue(value: unknown): boolean {
   return stripped;
 }
 
+type ConfigType = 'global' | 'inherit' | 'repo';
+
+/**
+ * Whether a `hostRules` `allowInternal` is honored from this kind of config.
+ *
+ * Only the self-hosted administrator's own configuration may grant access to internal hosts. The inherited config repository belongs to the organization rather than to them, so its rules only count where the administrator has opted into trusting them with `inheritConfigTrusted`.
+ */
+function mayGrantInternalHostAccess(configType: ConfigType): boolean {
+  if (configType === 'global') {
+    return true;
+  }
+  if (configType === 'inherit') {
+    return GlobalConfig.get('inheritConfigTrusted');
+  }
+  return false;
+}
+
+function allowInternalNotAllowedMessage(configType: ConfigType): string {
+  if (configType === 'inherit') {
+    return 'hostRules `allowInternal` is not allowed in inherited config, as this Renovate instance has not set `inheritConfigTrusted=true`. The administrator can either set it, or move the rule to their global config or a `repositories[]` entry.';
+  }
+  return `hostRules \`allowInternal\` is only allowed in the self-hosted administrator's own configuration.`;
+}
+
 export async function validateConfig(
-  configType: 'global' | 'inherit' | 'repo',
+  configType: ConfigType,
   config: AllConfig,
   isPreset?: boolean,
   parentPath?: string,
@@ -1039,13 +1063,16 @@ export async function validateConfig(
               });
             }
 
-            if (configType !== 'global' && !isUndefined(rule.allowInternal)) {
+            if (
+              !isUndefined(rule.allowInternal) &&
+              !mayGrantInternalHostAccess(configType)
+            ) {
               errors.push({
                 // like disallowed `headers` below, `Security` only where the rules are actually applied - see the comment there
                 topic: parentPath
                   ? ConfigValidationTopic.Error
                   : ConfigValidationTopic.Security,
-                message: `hostRules \`allowInternal\` is only allowed in the self-hosted administrator's own configuration.`,
+                message: allowInternalNotAllowedMessage(configType),
               });
             }
 

--- a/lib/constants/error-messages.ts
+++ b/lib/constants/error-messages.ts
@@ -105,6 +105,7 @@ export const FILE_ACCESS_VIOLATION_ERROR = 'file-access-violation-error';
 // Host error
 export const EXTERNAL_HOST_ERROR = 'external-host-error';
 export const IGNORABLE_HOST_ERROR = 'ignorable-host-error';
+export const HOST_BLOCKED = 'host-blocked';
 export const HOST_DISABLED = 'host-disabled';
 
 // Worker Error

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -1,5 +1,6 @@
 import { isNonEmptyString, isString, isUndefined } from '@sindresorhus/is';
 import {
+  HOST_BLOCKED,
   HOST_DISABLED,
   PAGE_NOT_FOUND_ERROR,
 } from '../../../constants/error-messages.ts';
@@ -17,6 +18,7 @@ import type {
   HttpResponse,
   OutgoingHttpHeaders,
 } from '../../../util/http/types.ts';
+import { refusedHostMessage } from '../../../util/http/util.ts';
 import type { ParamsChallenge } from '../../../util/http/www-authenticate.ts';
 import { BearerScheme, parse } from '../../../util/http/www-authenticate.ts';
 import { coerceObject } from '../../../util/object.ts';
@@ -264,8 +266,11 @@ export async function getAuthHeaders(
       throw err;
     }
     /* v8 ignore if -- hostRules-disabled host is swallowed silently, not mocked in specs */
-    if (err.message === HOST_DISABLED) {
-      logger.trace({ registryHost, dockerRepository, err }, 'Host disabled');
+    if ([HOST_BLOCKED, HOST_DISABLED].includes(err.message)) {
+      logger.trace(
+        { registryHost, dockerRepository, err },
+        refusedHostMessage(err),
+      );
       return undefined;
     }
     logger.warn(

--- a/lib/modules/datasource/index.spec.ts
+++ b/lib/modules/datasource/index.spec.ts
@@ -4,6 +4,7 @@ import { logger } from '~test/util.ts';
 import { GlobalConfig } from '../../config/global.ts';
 import {
   EXTERNAL_HOST_ERROR,
+  HOST_BLOCKED,
   HOST_DISABLED,
 } from '../../constants/error-messages.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
@@ -851,6 +852,25 @@ describe('modules/datasource/index', () => {
           const registries: RegistriesMock = {
             'https://reg1.com': () => {
               throw new ExternalHostError(new Error(HOST_DISABLED));
+            },
+            'https://reg2.com': { releases: [{ version: '1.0.0' }] },
+          };
+          const registryUrls = Object.keys(registries);
+          datasources.set(datasource, new HuntRegistriyDatasource(registries));
+
+          const res = await getPkgReleases({
+            datasource,
+            packageName,
+            registryUrls,
+          });
+
+          expect(res).toBeNull();
+        });
+
+        it('returns null for HOST_BLOCKED', async () => {
+          const registries: RegistriesMock = {
+            'https://reg1.com': () => {
+              throw new ExternalHostError(new Error(HOST_BLOCKED));
             },
             'https://reg2.com': { releases: [{ version: '1.0.0' }] },
           };

--- a/lib/modules/datasource/index.ts
+++ b/lib/modules/datasource/index.ts
@@ -7,7 +7,7 @@ import {
 } from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { GlobalConfig } from '../../config/global.ts';
-import { HOST_DISABLED } from '../../constants/error-messages.ts';
+import { HOST_BLOCKED, HOST_DISABLED } from '../../constants/error-messages.ts';
 import { instrument } from '../../instrumentation/index.ts';
 import {
   ATTR_RENOVATE_DATASOURCE,
@@ -428,7 +428,10 @@ async function fetchReleases(
       );
     }
   } catch (err) {
-    if (err.message === HOST_DISABLED || err.err?.message === HOST_DISABLED) {
+    if (
+      [HOST_BLOCKED, HOST_DISABLED].includes(err.message) ||
+      [HOST_BLOCKED, HOST_DISABLED].includes(err.err?.message)
+    ) {
       return null;
     }
     if (err instanceof ExternalHostError) {

--- a/lib/modules/datasource/maven/util.ts
+++ b/lib/modules/datasource/maven/util.ts
@@ -1,13 +1,17 @@
 import { Readable } from 'node:stream';
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { XmlDocument } from 'xmldoc';
-import { HOST_DISABLED } from '../../../constants/error-messages.ts';
+import {
+  HOST_BLOCKED,
+  HOST_DISABLED,
+} from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import * as packageCache from '../../../util/cache/package/index.ts';
 import { PackageHttpCacheProvider } from '../../../util/http/cache/package-http-cache-provider.ts';
 import { type Http, HttpError } from '../../../util/http/index.ts';
 import type { HttpOptions, HttpResponse } from '../../../util/http/types.ts';
+import { refusedHostMessage } from '../../../util/http/util.ts';
 import { regEx } from '../../../util/regex.ts';
 import { Result } from '../../../util/result.ts';
 import { getS3Client, parseS3Url } from '../../../util/s3.ts';
@@ -146,8 +150,8 @@ export async function downloadHttpProtocol(
       }
 
       const failedUrl = url;
-      if (err.message === HOST_DISABLED) {
-        logger.trace({ failedUrl }, 'Host disabled');
+      if ([HOST_BLOCKED, HOST_DISABLED].includes(err.message)) {
+        logger.trace({ failedUrl }, refusedHostMessage(err));
         return Result.err({ type: 'host-disabled' });
       }
 

--- a/lib/modules/datasource/npm/get.ts
+++ b/lib/modules/datasource/npm/get.ts
@@ -1,6 +1,9 @@
 import { isNonEmptyString, isString } from '@sindresorhus/is';
 import { z } from 'zod/v4';
-import { HOST_DISABLED } from '../../../constants/error-messages.ts';
+import {
+  HOST_BLOCKED,
+  HOST_DISABLED,
+} from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import * as hostRules from '../../../util/host-rules.ts';
@@ -184,6 +187,7 @@ export async function getDependency(
     const ignoredStatusCodes = [401, 402, 403, 404];
     const ignoredResponseCodes = ['ENOTFOUND'];
     if (
+      actualError.message === HOST_BLOCKED ||
       actualError.message === HOST_DISABLED ||
       ignoredStatusCodes.includes(actualError.statusCode) ||
       ignoredResponseCodes.includes(actualError.code)

--- a/lib/modules/datasource/pod/index.ts
+++ b/lib/modules/datasource/pod/index.ts
@@ -1,10 +1,14 @@
 import crypto from 'node:crypto';
-import { HOST_DISABLED } from '../../../constants/error-messages.ts';
+import {
+  HOST_BLOCKED,
+  HOST_DISABLED,
+} from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
 import { GithubHttp } from '../../../util/http/github.ts';
 import type { HttpError } from '../../../util/http/index.ts';
+import { refusedHostMessage } from '../../../util/http/util.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import { Datasource } from '../datasource.ts';
 import { massageGithubUrl } from '../metadata.ts';
@@ -67,8 +71,8 @@ function handleError(packageName: string, err: HttpError): void {
     logger.debug(errorData, 'Authorization error');
   } else if (statusCode === 404) {
     logger.debug(errorData, 'Package lookup error');
-  } else if (err.message === HOST_DISABLED) {
-    logger.trace(errorData, 'Host disabled');
+  } else if ([HOST_BLOCKED, HOST_DISABLED].includes(err.message)) {
+    logger.trace(errorData, refusedHostMessage(err));
   } else {
     logger.warn(errorData, 'CocoaPods lookup failure: Unknown error');
   }

--- a/lib/modules/datasource/repology/index.ts
+++ b/lib/modules/datasource/repology/index.ts
@@ -1,8 +1,12 @@
 import { isNonEmptyArray } from '@sindresorhus/is';
-import { HOST_DISABLED } from '../../../constants/error-messages.ts';
+import {
+  HOST_BLOCKED,
+  HOST_DISABLED,
+} from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { ExternalHostError } from '../../../types/errors/external-host-error.ts';
 import { withCache } from '../../../util/cache/package/with-cache.ts';
+import { refusedHostMessage } from '../../../util/http/util.ts';
 import { getQueryString, joinUrlParts } from '../../../util/url.ts';
 import { Datasource } from '../datasource.ts';
 import type { GetReleasesConfig, ReleaseResult } from '../types.ts';
@@ -228,8 +232,8 @@ export class RepologyDatasource extends Datasource {
       }));
       return { releases };
     } catch (err) {
-      if (err.message === HOST_DISABLED) {
-        logger.trace({ packageName, err }, 'Host disabled');
+      if ([HOST_BLOCKED, HOST_DISABLED].includes(err.message)) {
+        logger.trace({ packageName, err }, refusedHostMessage(err));
       } else {
         logger.once.warn(
           { packageName, err },

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -10,6 +10,11 @@ export interface HostRule {
   /**
    * Whether requests to this host may reach internal addresses.
    *
+   * As they have been marked as trusted by the administrator:
+   *
+   * - when `internalHostAccess=block`, these are not blocked
+   * - when `internalHostAccess=warn`, no warning occurs
+   *
    * This is only allowed in global self-hosted configuration, and if found in repository or preset config, it is stripped.
    */
   allowInternal?: boolean;

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -39,11 +39,13 @@ export interface HostRule {
 }
 
 /**
- * How the self-hosted administrator's host rules treat internal-host access for a request, computed by `find()`. Never settable through configuration: only rules from the administrator's own config contribute to it.
+ * How the trusted host rules treat internal-host access for a request, computed by `find()`. Never settable through configuration: only rules from the administrator's own config, and from organization-inherited config the administrator has opted into trusting through `inheritConfigTrusted`, contribute to it.
+ *
+ * The administrator's own rules are resolved first, and an `allowInternal: false` of theirs vetoes every field below: inherited config can never re-grant a host the administrator refused, in any grant shape.
  */
 export interface InternalHostGrant {
   /**
-   * The `allowInternal` value of the administrator's matching rules, with the most specific rule winning. `undefined` when none of them set it.
+   * The `allowInternal` value of the matching trusted rules, with the most specific rule winning, and the administrator's own rules winning over inherited config's. `undefined` when none of them set it.
    */
   explicit?: boolean;
   /**
@@ -51,7 +53,7 @@ export interface InternalHostGrant {
    */
   scoped?: boolean;
   /**
-   * Whether any of the administrator's rules naming a host (`matchHost`) matched the request: hosts the administrator has named in their own config are implicitly permitted.
+   * Whether any trusted rule naming a host (`matchHost`) matched the request: hosts named in configuration the administrator trusts are implicitly permitted. Always `false` under an administrator's veto.
    */
   implicit: boolean;
 }

--- a/lib/types/host-rules.ts
+++ b/lib/types/host-rules.ts
@@ -7,6 +7,12 @@ export interface HostRule {
   timeout?: number;
   abortOnError?: boolean;
   abortIgnoreStatusCodes?: number[];
+  /**
+   * Whether requests to this host may reach internal addresses.
+   *
+   * This is only allowed in global self-hosted configuration, and if found in repository or preset config, it is stripped.
+   */
+  allowInternal?: boolean;
   enabled?: boolean;
   enableHttp2?: boolean;
   concurrentRequestLimit?: number;
@@ -27,7 +33,33 @@ export interface HostRule {
   readOnly?: boolean;
 }
 
+/**
+ * How the self-hosted administrator's host rules treat internal-host access for a request, computed by `find()`. Never settable through configuration: only rules from the administrator's own config contribute to it.
+ */
+export interface InternalHostGrant {
+  /**
+   * The `allowInternal` value of the administrator's matching rules, with the most specific rule winning. `undefined` when none of them set it.
+   */
+  explicit?: boolean;
+  /**
+   * As `explicit`, but counting only rules deliberately scoped by a `hostType` or by a URL-prefix `matchHost`. Surfaces where a grant must be deliberate - such as HTTP presets, whose responses become config - check this value instead of `explicit`.
+   */
+  scoped?: boolean;
+  /**
+   * Whether any of the administrator's rules naming a host (`matchHost`) matched the request: hosts the administrator has named in their own config are implicitly permitted.
+   */
+  implicit: boolean;
+}
+
 export type CombinedHostRule = Omit<
   HostRule,
-  'encrypted' | 'hostType' | 'matchHost' | 'resolvedHost' | 'readOnly'
->;
+  | 'encrypted'
+  | 'hostType'
+  | 'matchHost'
+  | 'resolvedHost'
+  | 'readOnly'
+  | 'allowInternal'
+> & {
+  /** computed by `find()` - see {@link InternalHostGrant} */
+  internalHostGrant?: InternalHostGrant;
+};

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -18,7 +18,11 @@ export type { BranchResult, PrBlockedBy } from '../workers/types.ts';
 export type { ModuleApi, RenovatePackageJson } from './base.ts';
 export type { BranchStatus } from './branch-status.ts';
 export type { CommitMessageJSON } from './commit-message-json.ts';
-export type { CombinedHostRule, HostRule } from './host-rules.ts';
+export type {
+  CombinedHostRule,
+  HostRule,
+  InternalHostGrant,
+} from './host-rules.ts';
 export type { PrState } from './pr-state.ts';
 export type { SkipReason, StageName } from './skip-reason.ts';
 export type { RangeStrategy } from './versioning.ts';

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -34,6 +34,7 @@ describe('util/host-rules', () => {
       timeout: true,
       abortOnError: true,
       abortIgnoreStatusCodes: true,
+      allowInternal: true,
       enabled: true,
       enableHttp2: true,
       concurrentRequestLimit: true,
@@ -562,6 +563,7 @@ describe('util/host-rules', () => {
       expect(find({ url: 'https://registry.example.com' })).toEqual({
         token: 'from-admin',
         headers: { 'X-From-Admin': 'yes', 'X-From-Repo': 'yes' },
+        internalHostGrant: { implicit: true },
       });
     });
 
@@ -583,6 +585,7 @@ describe('util/host-rules', () => {
         find({ url: 'https://registry.example.com/some/path/resource' }),
       ).toEqual({
         headers: { 'X-Custom': 'from-admin' },
+        internalHostGrant: { implicit: true },
       });
     });
 
@@ -623,9 +626,11 @@ describe('util/host-rules', () => {
 
       expect(find({ url: 'https://untrusted.example.com' })).toEqual({
         headers: { 'X-Other': 'yes' },
+        internalHostGrant: { implicit: true },
       });
       expect(find({ url: 'https://trusted.example.com' })).toEqual({
         headers: { 'X-Api-Key': 'secret' },
+        internalHostGrant: { implicit: true },
       });
     });
 
@@ -649,6 +654,7 @@ describe('util/host-rules', () => {
       // the repo's narrower rule masks its own broader one, but cannot mask the admin's
       expect(find({ url: 'https://untrusted.example.com' })).toEqual({
         headers: { 'X-Other-Repo-Header': 'yes', 'X-From-Admin': 'yes' },
+        internalHostGrant: { implicit: true },
       });
     });
 
@@ -669,6 +675,7 @@ describe('util/host-rules', () => {
 
       expect(find({ url: 'https://registry.example.com' })).toEqual({
         headers: { 'X-From-Admin': 'from-repo', 'X-Other-Admin-Header': 'yes' },
+        internalHostGrant: { implicit: true },
       });
     });
 
@@ -687,6 +694,121 @@ describe('util/host-rules', () => {
         find({ url: 'https://registry.example.com/some/path/resource' }),
       ).toEqual({
         headers: { 'X-Custom': 'yes' },
+      });
+    });
+
+    describe('internalHostGrant', () => {
+      it('is absent when no trusted rule matches', () => {
+        add({ matchHost: 'registry.example.com', token: 'abc' });
+
+        expect(
+          find({ url: 'https://registry.example.com' }).internalHostGrant,
+        ).toBeUndefined();
+      });
+
+      it('is implicit for a host the admin named', () => {
+        add(
+          { matchHost: 'registry.example.com', token: 'abc' },
+          { trusted: true },
+        );
+
+        expect(find({ url: 'https://registry.example.com' })).toEqual({
+          token: 'abc',
+          internalHostGrant: { implicit: true },
+        });
+      });
+
+      it('is not implicit for a host-less trusted rule', () => {
+        add({ hostType: 'nuget', token: 'abc' }, { trusted: true });
+
+        expect(
+          find({ hostType: 'nuget', url: 'https://internal.example.com' })
+            .internalHostGrant,
+        ).toBeUndefined();
+      });
+
+      it('ignores allowInternal from untrusted config', () => {
+        add({ matchHost: 'internal.example.com', allowInternal: true });
+
+        expect(
+          find({ url: 'https://internal.example.com' }).internalHostGrant,
+        ).toBeUndefined();
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'Ignoring hostRules allowInternal for internal.example.com from untrusted config',
+        );
+      });
+
+      it('ignores allowInternal from an untrusted host-less rule', () => {
+        add({ hostType: 'nuget', allowInternal: true });
+
+        expect(
+          find({ hostType: 'nuget', url: 'https://internal.example.com' })
+            .internalHostGrant,
+        ).toBeUndefined();
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          'Ignoring hostRules allowInternal for nuget from untrusted config',
+        );
+      });
+
+      it('takes explicit allowInternal from the admin, most specific rule winning', () => {
+        add(
+          { matchHost: 'example.com', allowInternal: true },
+          { trusted: true },
+        );
+        add(
+          { matchHost: 'https://secure.example.com', allowInternal: false },
+          { trusted: true },
+        );
+
+        expect(
+          find({ url: 'https://other.example.com' }).internalHostGrant,
+        ).toEqual({ explicit: true, implicit: true });
+        expect(
+          find({ url: 'https://secure.example.com' }).internalHostGrant,
+        ).toEqual({ explicit: false, scoped: false, implicit: true });
+      });
+
+      it('marks a grant scoped by hostType', () => {
+        add(
+          {
+            hostType: 'preset',
+            matchHost: 'presets.example.com',
+            allowInternal: true,
+          },
+          { trusted: true },
+        );
+
+        expect(
+          find({ hostType: 'preset', url: 'https://presets.example.com' })
+            .internalHostGrant,
+        ).toEqual({ explicit: true, scoped: true, implicit: true });
+      });
+
+      it('does not mark a bare-hostname grant as scoped', () => {
+        add(
+          { matchHost: 'internal.example.com', allowInternal: true },
+          { trusted: true },
+        );
+
+        expect(
+          find({ url: 'https://internal.example.com' }).internalHostGrant,
+        ).toEqual({ explicit: true, implicit: true });
+      });
+
+      it('does not let a repository rule override the admin allowInternal', () => {
+        add(
+          { matchHost: 'https://internal.example.com', allowInternal: false },
+          { trusted: true },
+        );
+        add({
+          matchHost: 'https://internal.example.com/deeper/path',
+          allowInternal: true,
+        });
+
+        expect(
+          find({ url: 'https://internal.example.com/deeper/path/file' })
+            .internalHostGrant,
+        ).toEqual({ explicit: false, scoped: false, implicit: true });
       });
     });
 

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -679,6 +679,59 @@ describe('util/host-rules', () => {
       });
     });
 
+    it('applies the headers of the three trust tiers in order', () => {
+      // the admin's own value must survive both of the tiers below theirs, and inherited config's must survive a repository's
+      add(
+        {
+          matchHost: 'registry.example.com',
+          headers: { 'X-Custom': 'from-admin' },
+        },
+        { trusted: true },
+      );
+      add(
+        {
+          matchHost: 'https://registry.example.com/deeper',
+          headers: { 'X-Custom': 'from-inherited', 'X-Inherited': 'yes' },
+        },
+        { inherited: true },
+      );
+      add({
+        matchHost: 'https://registry.example.com/deeper/still',
+        headers: {
+          'X-Custom': 'from-repo',
+          'X-Inherited': 'from-repo',
+          'X-Repo': 'yes',
+        },
+      });
+
+      expect(
+        find({ url: 'https://registry.example.com/deeper/still/resource' })
+          .headers,
+      ).toEqual({
+        'X-Custom': 'from-admin',
+        'X-Inherited': 'yes',
+        'X-Repo': 'yes',
+      });
+    });
+
+    it('applies inherited headers over a repository rule when the admin sets none', () => {
+      add(
+        {
+          matchHost: 'registry.example.com',
+          headers: { 'X-Custom': 'from-inherited' },
+        },
+        { inherited: true },
+      );
+      add({
+        matchHost: 'https://registry.example.com/deeper',
+        headers: { 'X-Custom': 'from-repo' },
+      });
+
+      expect(
+        find({ url: 'https://registry.example.com/deeper/resource' }).headers,
+      ).toEqual({ 'X-Custom': 'from-inherited' });
+    });
+
     it('does not let a rule whose headers were all denied suppress another rule of its tier', () => {
       GlobalConfig.set({ allowedHeaders: ['X-*'] });
       add({
@@ -765,7 +818,7 @@ describe('util/host-rules', () => {
         ).toEqual({ explicit: true, implicit: true });
         expect(
           find({ url: 'https://secure.example.com' }).internalHostGrant,
-        ).toEqual({ explicit: false, scoped: false, implicit: true });
+        ).toEqual({ explicit: false, scoped: false, implicit: false });
       });
 
       it('marks a grant scoped by hostType', () => {
@@ -808,7 +861,155 @@ describe('util/host-rules', () => {
         expect(
           find({ url: 'https://internal.example.com/deeper/path/file' })
             .internalHostGrant,
-        ).toEqual({ explicit: false, scoped: false, implicit: true });
+        ).toEqual({ explicit: false, scoped: false, implicit: false });
+      });
+
+      it('is implicit for a host named by trusted inherited config', () => {
+        add(
+          { matchHost: 'registry.example.com', token: 'abc' },
+          { inherited: true },
+        );
+
+        expect(find({ url: 'https://registry.example.com' })).toEqual({
+          token: 'abc',
+          internalHostGrant: { implicit: true },
+        });
+      });
+
+      it('takes explicit allowInternal from trusted inherited config', () => {
+        add(
+          { matchHost: 'internal.example.com', allowInternal: true },
+          { inherited: true },
+        );
+
+        expect(
+          find({ url: 'https://internal.example.com' }).internalHostGrant,
+        ).toEqual({ explicit: true, implicit: true });
+      });
+
+      it('marks a grant scoped by trusted inherited config', () => {
+        add(
+          {
+            hostType: 'preset',
+            matchHost: 'https://presets.example.com/renovate/',
+            allowInternal: true,
+          },
+          { inherited: true },
+        );
+
+        expect(
+          find({
+            hostType: 'preset',
+            url: 'https://presets.example.com/renovate/default',
+          }).internalHostGrant,
+        ).toEqual({ explicit: true, scoped: true, implicit: true });
+      });
+
+      it('does not let inherited config override the admin allowInternal', () => {
+        // the admin's decision stands even though the inherited rule out-specifies theirs
+        add(
+          { matchHost: 'https://internal.example.com', allowInternal: false },
+          { trusted: true },
+        );
+        add(
+          {
+            hostType: 'preset',
+            matchHost: 'https://internal.example.com/deeper/path',
+            allowInternal: true,
+          },
+          { inherited: true },
+        );
+
+        expect(
+          find({
+            hostType: 'preset',
+            url: 'https://internal.example.com/deeper/path/file',
+          }).internalHostGrant,
+        ).toEqual({ explicit: false, scoped: false, implicit: false });
+      });
+
+      it('does not let an inherited scoped grant fill in for a bare admin veto', () => {
+        // the admin's rule sets no scoped verdict of its own, so a scoped inherited grant must not be the one that answers for it - config-fetching requests consult `scoped` alone
+        add(
+          { matchHost: 'internal.example.com', allowInternal: false },
+          { trusted: true },
+        );
+        add(
+          {
+            matchHost: 'https://internal.example.com/presets/',
+            allowInternal: true,
+          },
+          { inherited: true },
+        );
+
+        expect(
+          find({ url: 'https://internal.example.com/presets/default' })
+            .internalHostGrant,
+        ).toEqual({ explicit: false, scoped: false, implicit: false });
+      });
+
+      it('does not let an inherited bare grant fill in for a scoped admin veto', () => {
+        add(
+          {
+            matchHost: 'https://internal.example.com/presets/',
+            allowInternal: false,
+          },
+          { trusted: true },
+        );
+        add(
+          { matchHost: 'internal.example.com', allowInternal: true },
+          { inherited: true },
+        );
+
+        expect(
+          find({ url: 'https://internal.example.com/presets/default' })
+            .internalHostGrant,
+        ).toEqual({ explicit: false, scoped: false, implicit: false });
+      });
+
+      it('does not leave an implicit grant behind for a host the admin vetoed', () => {
+        add(
+          { matchHost: 'internal.example.com', allowInternal: false },
+          { trusted: true },
+        );
+        add(
+          { matchHost: 'internal.example.com', token: 'abc' },
+          { inherited: true },
+        );
+
+        expect(
+          find({ url: 'https://internal.example.com' }).internalHostGrant,
+        ).toEqual({ explicit: false, scoped: false, implicit: false });
+      });
+
+      it('lets the admin mask their own allowInternal without vetoing', () => {
+        add(
+          { matchHost: 'example.com', allowInternal: false },
+          { trusted: true },
+        );
+        add(
+          { matchHost: 'https://example.com/ok/', allowInternal: true },
+          { trusted: true },
+        );
+
+        expect(
+          find({ url: 'https://example.com/ok/resource' }).internalHostGrant,
+        ).toEqual({ explicit: true, scoped: true, implicit: true });
+      });
+
+      it('takes a scoped grant from inherited config when no admin rule matches', () => {
+        add(
+          {
+            matchHost: 'https://internal.example.com/presets/',
+            allowInternal: true,
+          },
+          { inherited: true },
+        );
+
+        expect(
+          find({ url: 'https://internal.example.com/presets/default' })
+            .internalHostGrant,
+        ).toEqual({ explicit: true, scoped: true, implicit: true });
       });
     });
 
@@ -848,6 +1049,33 @@ describe('util/host-rules', () => {
         add({ matchHost: 'https://ok.example.com', enabled: true });
 
         expect(find({ url: 'https://ok.example.com' }).enabled).toBeTrue();
+      });
+
+      it('does not let inherited config re-enable a host the admin disabled', () => {
+        add(
+          { matchHost: 'bad.example.com', enabled: false },
+          { trusted: true },
+        );
+        add(
+          { matchHost: 'https://bad.example.com/deeper', enabled: true },
+          { inherited: true },
+        );
+
+        expect(
+          find({ url: 'https://bad.example.com/deeper/path' }).enabled,
+        ).toBeFalse();
+      });
+
+      it('does not let a repository rule re-enable a host inherited config disabled', () => {
+        add(
+          { matchHost: 'bad.example.com', enabled: false },
+          { inherited: true },
+        );
+        add({ matchHost: 'https://bad.example.com/deeper', enabled: true });
+
+        expect(
+          find({ url: 'https://bad.example.com/deeper/path' }).enabled,
+        ).toBeFalse();
       });
     });
 
@@ -1007,6 +1235,7 @@ describe('util/host-rules', () => {
           resolvedHost: 'nuget.org',
           username: 'root',
           matchHost: 'nuget.org',
+          trustTier: 'untrusted',
         },
       ]);
     });

--- a/lib/util/host-rules.spec.ts
+++ b/lib/util/host-rules.spec.ts
@@ -690,6 +690,45 @@ describe('util/host-rules', () => {
       });
     });
 
+    describe('enabled trust tiers', () => {
+      it('does not let a more specific repository rule re-enable a host the admin disabled', () => {
+        add(
+          { matchHost: 'bad.example.com', enabled: false },
+          { trusted: true },
+        );
+        add({ matchHost: 'https://bad.example.com/deeper', enabled: true });
+
+        expect(
+          find({ url: 'https://bad.example.com/deeper/path' }).enabled,
+        ).toBeFalse();
+      });
+
+      it('does not let a repository rule disable a host the admin enabled', () => {
+        add(
+          { matchHost: 'good.example.com', enabled: true },
+          { trusted: true },
+        );
+        add({ matchHost: 'https://good.example.com/deeper', enabled: false });
+
+        expect(
+          find({ url: 'https://good.example.com/deeper/path' }).enabled,
+        ).toBeTrue();
+      });
+
+      it('keeps repository rules able to disable a host of their own', () => {
+        add({ matchHost: 'flaky.example.com', enabled: false });
+
+        expect(find({ url: 'https://flaky.example.com' }).enabled).toBeFalse();
+      });
+
+      it('lets the most specific rule of a tier win', () => {
+        add({ matchHost: 'example.com', enabled: false });
+        add({ matchHost: 'https://ok.example.com', enabled: true });
+
+        expect(find({ url: 'https://ok.example.com' }).enabled).toBeTrue();
+      });
+    });
+
     it('prefers the longest matchHost for a header they both set', () => {
       add({
         matchHost: 'https://registry.example.com',

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -19,13 +19,25 @@ import { matchRegexOrGlobList } from './string-match.ts';
 import { isHttpUrl, massageHostUrl, parseUrl } from './url.ts';
 
 /**
+ * How much a host rule is trusted, according to the configuration it came from, from most to least trusted:
+ *
+ * - `admin`: the self-hosted administrator's own configuration - their global config, or a `repositories[]` entry
+ * - `inherit`: organization-inherited config, and only where the administrator has opted into trusting it through `inheritConfigTrusted`
+ * - `untrusted`: repository configuration, and the presets it extends
+ */
+type HostRuleTrustTier = 'admin' | 'inherit' | 'untrusted';
+
+/**
  * A host rule as registered through {@link add}.
  *
- * `trusted` is deliberately not a field of `HostRule`: it is set from {@link AddHostRuleOptions} at registration time and must never be settable through configuration.
+ * `trustTier` is deliberately not a field of `HostRule`: it is set from {@link AddHostRuleOptions} at registration time and must never be settable through configuration.
  */
 interface RegisteredHostRule extends HostRule {
-  /** whether the rule came from the self-hosted administrator's own global config, rather than from repository or preset config */
-  trusted?: boolean;
+  /** which configuration the rule came from - see {@link HostRuleTrustTier}. Always set by `add()`, but optional so that `find()` can delete it from its result */
+  trustTier?: HostRuleTrustTier;
+
+  /** never set by us, and declared only so that a `trusted` smuggled in through configuration can be deleted before the rule is registered. It was the boolean `trustTier` replaced, so a rule carrying one may well be an attempt at the administrator's precedence */
+  trusted?: never;
 }
 
 let hostRules: RegisteredHostRule[] = [];
@@ -140,24 +152,46 @@ export interface AddHostRuleOptions {
   allowedHeaders?: string[];
 
   /**
-   * Whether this rule comes from the self-hosted administrator's own global config, rather than from repository or preset config.
+   * Whether this rule comes from the self-hosted administrator's own configuration, rather than from repository or preset config.
    *
-   * Only affects how `headers` are combined (see {@link find}), and is deliberately opt-in: a caller that says nothing registers into the untrusted tier, so a new call site cannot grant itself the administrator's precedence by omission.
+   * Registers the rule into the `admin` tier - see {@link HostRuleTrustTier}.
    */
   trusted?: boolean;
+
+  /**
+   * Whether this rule comes from organization-inherited config which the administrator has opted into trusting, through `inheritConfigTrusted`.
+   *
+   * Registers the rule into the `inherit` tier - see {@link HostRuleTrustTier}. Ignored when `trusted` is also set.
+   */
+  inherited?: boolean;
+}
+
+/**
+ * The trust tier a caller asked for.
+ *
+ * Deliberately opt-in: a caller that says nothing registers into the untrusted tier, so a new call site cannot grant itself the administrator's precedence by omission.
+ */
+function trustTierFor(options?: AddHostRuleOptions): HostRuleTrustTier {
+  if (options?.trusted) {
+    return 'admin';
+  }
+  if (options?.inherited) {
+    return 'inherit';
+  }
+  return 'untrusted';
 }
 
 export function add(params: HostRule, options?: AddHostRuleOptions): void {
-  let rule: RegisteredHostRule = migrateRule(params);
-
-  // set only from `options`, and dropped first so that it cannot be carried over from `params`: `HostRule` has no `trusted` field, but configuration is parsed from JSON, so a repository could otherwise smuggle one in and have its headers treated as the administrator's
+  let rule: RegisteredHostRule = {
+    ...migrateRule(params),
+    // set only from `options`, and assigned unconditionally so that it cannot be carried over from `params`: `HostRule` has no `trustTier` field, but configuration is parsed from JSON, so a repository could otherwise smuggle one in and have its rules treated as the administrator's
+    trustTier: trustTierFor(options),
+  };
+  // as above, for the boolean this tier replaced
   delete rule.trusted;
-  if (options?.trusted) {
-    rule.trusted = true;
-  }
 
-  // like `trusted`, `allowInternal` may only come from the administrator's own config: a repository or preset rule must not be able to grant itself access to internal hosts
-  if (!isUndefined(rule.allowInternal) && !rule.trusted) {
+  // like the trust tier, `allowInternal` may only come from configuration the administrator trusts: a repository or preset rule must not be able to grant itself access to internal hosts
+  if (!isUndefined(rule.allowInternal) && rule.trustTier === 'untrusted') {
     logger.debug(
       `Ignoring hostRules allowInternal for ${rule.matchHost ?? rule.hostType} from untrusted config`,
     );
@@ -283,6 +317,15 @@ function lastDefined<T>(values: (T | undefined)[]): T | undefined {
   return values.filter((value) => !isUndefined(value)).pop();
 }
 
+/**
+ * The rules whose grant is deliberately scoped, by a `hostType` or by a URL-prefix `matchHost` - see {@link InternalHostGrant}.
+ */
+function scopedRules(rules: RegisteredHostRule[]): RegisteredHostRule[] {
+  return rules.filter(
+    (rule) => isNonEmptyString(rule.hostType) || isHttpUrl(rule.matchHost),
+  );
+}
+
 export function find(search: HostRuleSearch): CombinedHostRule {
   if ([search.hostType, search.url].every(isFalsy)) {
     logger.warn({ search }, 'Invalid hostRules search');
@@ -330,43 +373,69 @@ export function find(search: HostRuleSearch): CombinedHostRule {
   const res: RegisteredHostRule & Pick<CombinedHostRule, 'internalHostGrant'> =
     Object.assign({}, ...matchedRules);
 
+  // the sensitive fields below are resolved a trust tier at a time, so that the outcome cannot depend on how specific a rule from a less trusted tier makes itself
+  const trustedRules = matchedRules.filter(
+    (rule) => rule.trustTier === 'admin',
+  );
+  const inheritedRules = matchedRules.filter(
+    (rule) => rule.trustTier === 'inherit',
+  );
+  const untrustedRules = matchedRules.filter(
+    (rule) => rule.trustTier === 'untrusted',
+  );
+
   // `headers` are resolved per trust tier and then combined key by key, so that repository or preset config can no longer discard - or substitute - the headers a self-hosted admin configured for the same host
   // Within a tier nothing changes: the most specific rule's `headers` still replace those of the broader rules it is combined with, so an admin masking their own broad rule with a narrower one keeps working, as does a repository doing the same among its own rules
   // This is deliberately scoped to `headers` alone, as combining any more of the fields than we already do has caused authentication regressions before: an inherited `token` and a specific rule's `username`/`password` are not meant to be used together
-  const untrustedHeaders = headersOfLastRuleToSetThem(
-    matchedRules.filter((rule) => !rule.trusted),
-  );
-  const trustedHeaders = headersOfLastRuleToSetThem(
-    matchedRules.filter((rule) => rule.trusted),
-  );
-  if (untrustedHeaders ?? trustedHeaders) {
-    // the admin's own headers are applied last, so a repository cannot override one they set for this host either
-    res.headers = { ...untrustedHeaders, ...trustedHeaders };
+  const untrustedHeaders = headersOfLastRuleToSetThem(untrustedRules);
+  const inheritedHeaders = headersOfLastRuleToSetThem(inheritedRules);
+  const trustedHeaders = headersOfLastRuleToSetThem(trustedRules);
+  if (untrustedHeaders ?? inheritedHeaders ?? trustedHeaders) {
+    // the admin's own headers are applied last, so neither a repository nor inherited config can override one they set for this host
+    res.headers = {
+      ...untrustedHeaders,
+      ...inheritedHeaders,
+      ...trustedHeaders,
+    };
   }
 
   // `enabled` is resolved per trust tier like `headers`: a repository or preset rule must not be able to re-enable a host the administrator's own rules disabled (or vice versa) by out-specifying them with a longer `matchHost`
-  const trustedRules = matchedRules.filter((rule) => rule.trusted);
-  const untrustedEnabled = lastDefined(
-    matchedRules.filter((rule) => !rule.trusted).map((rule) => rule.enabled),
-  );
-  const trustedEnabled = lastDefined(trustedRules.map((rule) => rule.enabled));
-  const enabled = trustedEnabled ?? untrustedEnabled;
+  const enabled =
+    lastDefined(trustedRules.map((rule) => rule.enabled)) ??
+    lastDefined(inheritedRules.map((rule) => rule.enabled)) ??
+    lastDefined(untrustedRules.map((rule) => rule.enabled));
   if (!isUndefined(enabled)) {
     res.enabled = enabled;
   }
 
-  // computed here and never from configuration: `add()` strips `allowInternal` from untrusted registrations, so only the administrator's own rules can contribute
+  // computed here and never from configuration: `add()` strips `allowInternal` from untrusted registrations, so only rules from configuration the administrator trusts can contribute
+  // the admin's own rules are resolved first, and an `allowInternal: false` of theirs is an absolute veto: inherited config cannot talk an organization's way back in through any grant shape, whether scoped, unscoped, or merely implicit in naming the host
+  // each shape must therefore be resolved from the admin tier's verdict rather than falling through to the inherit tier on its own - a bare admin rule sets no scoped verdict, and an inherited scoped grant would otherwise fill the gap for exactly the requests which consult it, such as fetching config over HTTP
+  const trustedExplicit = lastDefined(
+    trustedRules.map((rule) => rule.allowInternal),
+  );
+  const trustedScoped = lastDefined(
+    scopedRules(trustedRules).map((rule) => rule.allowInternal),
+  );
+  // derived from the resolved values, so an admin masking a broad `allowInternal: false` of their own with a narrower `true` is not a veto
+  const adminVeto = trustedExplicit === false || trustedScoped === false;
+  // a vetoed request has no inherit tier left to fall through to, and is clamped to `false` rather than to undefined so that a consumer's `explicit ?? implicit` still short-circuits
+  const inheritedExplicit = adminVeto
+    ? false
+    : lastDefined(inheritedRules.map((rule) => rule.allowInternal));
+  const inheritedScoped = adminVeto
+    ? false
+    : lastDefined(
+        scopedRules(inheritedRules).map((rule) => rule.allowInternal),
+      );
   const internalHostGrant: InternalHostGrant = {
-    explicit: lastDefined(matchedRules.map((rule) => rule.allowInternal)),
-    scoped: lastDefined(
-      matchedRules
-        .filter(
-          (rule) =>
-            isNonEmptyString(rule.hostType) || isHttpUrl(rule.matchHost),
-        )
-        .map((rule) => rule.allowInternal),
-    ),
-    implicit: trustedRules.some((rule) => isNonEmptyString(rule.matchHost)),
+    explicit: trustedExplicit ?? inheritedExplicit,
+    scoped: trustedScoped ?? inheritedScoped,
+    implicit:
+      !adminVeto &&
+      [...trustedRules, ...inheritedRules].some((rule) =>
+        isNonEmptyString(rule.matchHost),
+      ),
   };
   if (
     !isUndefined(internalHostGrant.explicit) ||
@@ -380,6 +449,7 @@ export function find(search: HostRuleSearch): CombinedHostRule {
   delete res.resolvedHost;
   delete res.matchHost;
   delete res.readOnly;
+  delete res.trustTier;
   delete res.trusted;
   delete res.allowInternal;
   return res;

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -1,7 +1,17 @@
-import { isFalsy, isString, isTruthy, isUndefined } from '@sindresorhus/is';
+import {
+  isFalsy,
+  isNonEmptyString,
+  isString,
+  isTruthy,
+  isUndefined,
+} from '@sindresorhus/is';
 import { GlobalConfig } from '../config/global.ts';
 import { logger } from '../logger/index.ts';
-import type { CombinedHostRule, HostRule } from '../types/index.ts';
+import type {
+  CombinedHostRule,
+  HostRule,
+  InternalHostGrant,
+} from '../types/index.ts';
 import { clone } from './clone.ts';
 import * as sanitize from './sanitize.ts';
 import { toBase64 } from './string.ts';
@@ -144,6 +154,14 @@ export function add(params: HostRule, options?: AddHostRuleOptions): void {
   delete rule.trusted;
   if (options?.trusted) {
     rule.trusted = true;
+  }
+
+  // like `trusted`, `allowInternal` may only come from the administrator's own config: a repository or preset rule must not be able to grant itself access to internal hosts
+  if (!isUndefined(rule.allowInternal) && !rule.trusted) {
+    logger.debug(
+      `Ignoring hostRules allowInternal for ${rule.matchHost ?? rule.hostType} from untrusted config`,
+    );
+    delete rule.allowInternal;
   }
 
   if (rule.headers) {
@@ -309,7 +327,8 @@ export function find(search: HostRuleSearch): CombinedHostRule {
     }
   }
 
-  const res: RegisteredHostRule = Object.assign({}, ...matchedRules);
+  const res: RegisteredHostRule & Pick<CombinedHostRule, 'internalHostGrant'> =
+    Object.assign({}, ...matchedRules);
 
   // `headers` are resolved per trust tier and then combined key by key, so that repository or preset config can no longer discard - or substitute - the headers a self-hosted admin configured for the same host
   // Within a tier nothing changes: the most specific rule's `headers` still replace those of the broader rules it is combined with, so an admin masking their own broad rule with a narrower one keeps working, as does a repository doing the same among its own rules
@@ -336,11 +355,33 @@ export function find(search: HostRuleSearch): CombinedHostRule {
     res.enabled = enabled;
   }
 
+  // computed here and never from configuration: `add()` strips `allowInternal` from untrusted registrations, so only the administrator's own rules can contribute
+  const internalHostGrant: InternalHostGrant = {
+    explicit: lastDefined(matchedRules.map((rule) => rule.allowInternal)),
+    scoped: lastDefined(
+      matchedRules
+        .filter(
+          (rule) =>
+            isNonEmptyString(rule.hostType) || isHttpUrl(rule.matchHost),
+        )
+        .map((rule) => rule.allowInternal),
+    ),
+    implicit: trustedRules.some((rule) => isNonEmptyString(rule.matchHost)),
+  };
+  if (
+    !isUndefined(internalHostGrant.explicit) ||
+    !isUndefined(internalHostGrant.scoped) ||
+    internalHostGrant.implicit
+  ) {
+    res.internalHostGrant = internalHostGrant;
+  }
+
   delete res.hostType;
   delete res.resolvedHost;
   delete res.matchHost;
   delete res.readOnly;
   delete res.trusted;
+  delete res.allowInternal;
   return res;
 }
 

--- a/lib/util/host-rules.ts
+++ b/lib/util/host-rules.ts
@@ -258,6 +258,13 @@ function headersOfLastRuleToSetThem(
     .pop();
 }
 
+/**
+ * The last defined value, following the same "most specific rule wins" ordering as {@link headersOfLastRuleToSetThem}.
+ */
+function lastDefined<T>(values: (T | undefined)[]): T | undefined {
+  return values.filter((value) => !isUndefined(value)).pop();
+}
+
 export function find(search: HostRuleSearch): CombinedHostRule {
   if ([search.hostType, search.url].every(isFalsy)) {
     logger.warn({ search }, 'Invalid hostRules search');
@@ -316,6 +323,17 @@ export function find(search: HostRuleSearch): CombinedHostRule {
   if (untrustedHeaders ?? trustedHeaders) {
     // the admin's own headers are applied last, so a repository cannot override one they set for this host either
     res.headers = { ...untrustedHeaders, ...trustedHeaders };
+  }
+
+  // `enabled` is resolved per trust tier like `headers`: a repository or preset rule must not be able to re-enable a host the administrator's own rules disabled (or vice versa) by out-specifying them with a longer `matchHost`
+  const trustedRules = matchedRules.filter((rule) => rule.trusted);
+  const untrustedEnabled = lastDefined(
+    matchedRules.filter((rule) => !rule.trusted).map((rule) => rule.enabled),
+  );
+  const trustedEnabled = lastDefined(trustedRules.map((rule) => rule.enabled));
+  const enabled = trustedEnabled ?? untrustedEnabled;
+  if (!isUndefined(enabled)) {
+    res.enabled = enabled;
   }
 
   delete res.hostType;

--- a/lib/util/http/host-guard.spec.ts
+++ b/lib/util/http/host-guard.spec.ts
@@ -1,11 +1,50 @@
+import dns from 'node:dns';
+import dnsPromises from 'node:dns/promises';
+import type { NormalizedOptions, PlainResponse } from 'got';
+import { logger, partial } from '~test/util.ts';
+import { GlobalConfig } from '../../config/global.ts';
+import { HOST_BLOCKED } from '../../constants/error-messages.ts';
+import { hasProxy } from '../../proxy.ts';
+import type { InternalHostGrant } from '../../types/index.ts';
+import * as hostRules from '../host-rules.ts';
 import { parseUrl } from '../url.ts';
 import {
+  applyHostGuard,
+  checkUrl,
   classifyHostname,
   classifyIpAddress,
   classifyUrl,
 } from './host-guard.ts';
 
+vi.mock('node:dns', () => ({
+  default: { lookup: vi.fn() },
+}));
+vi.mock('node:dns/promises', () => ({
+  default: { lookup: vi.fn() },
+}));
+vi.mock('../../proxy.ts', () => ({
+  hasProxy: vi.fn(),
+}));
+
+const lookupMock = vi.mocked(dns.lookup);
+const promisesLookupMock = vi.mocked(dnsPromises.lookup);
+const hasProxyMock = vi.mocked(hasProxy);
+
+/** Resolves the given addresses for a `dns.promises.lookup(host, { all: true })` call. */
+function mockResolvedAddresses(...addresses: string[]): void {
+  promisesLookupMock.mockResolvedValue(
+    addresses.map((address) => ({
+      address,
+      family: address.includes(':') ? 6 : 4,
+    })) as never,
+  );
+}
+
 describe('util/http/host-guard', () => {
+  beforeEach(() => {
+    GlobalConfig.reset();
+    hostRules.clear();
+  });
   describe('classifyIpAddress', () => {
     it.each`
       address              | expected
@@ -87,7 +126,13 @@ describe('util/http/host-guard', () => {
       ${'::ffff:169.254.169.254'} | ${'metadata'}
       ${'::ffff:a9fe:a9fe'}       | ${'metadata'}
       ${'fd00:ec2::254'}          | ${'metadata'}
+      ${'169.254.170.2'}          | ${'metadata'}
+      ${'::ffff:169.254.170.2'}   | ${'metadata'}
+      ${'169.254.170.23'}         | ${'metadata'}
+      ${'100.100.100.200'}        | ${'metadata'}
       ${'169.254.169.253'}        | ${'internal'}
+      ${'169.254.170.3'}          | ${'internal'}
+      ${'100.100.100.201'}        | ${'internal'}
     `(
       'classifies metadata endpoint $address as $expected',
       ({ address, expected }) => {
@@ -172,5 +217,824 @@ describe('util/http/host-guard', () => {
         expect(classifyUrl(parseUrl(url)!)).toBe(expected);
       },
     );
+  });
+
+  describe('checkUrl', () => {
+    it('throws for a metadata endpoint even when internal hosts are allowed', () => {
+      GlobalConfig.set({ internalHostAccess: 'allow' });
+
+      expect(() =>
+        checkUrl(
+          parseUrl('http://169.254.169.254/latest/')!,
+          'dummy',
+          undefined,
+        ),
+      ).toThrow(HOST_BLOCKED);
+      expect(() =>
+        checkUrl(
+          parseUrl('http://metadata.google.internal/')!,
+          'dummy',
+          undefined,
+        ),
+      ).toThrow(HOST_BLOCKED);
+    });
+
+    it.each`
+      url
+      ${'http://169.254.170.2/v2/credentials/'}
+      ${'http://169.254.170.23/v1/credentials'}
+      ${'http://100.100.100.200/latest/meta-data/'}
+    `(
+      'throws for credential-handing metadata endpoint $url however it is permitted',
+      ({ url }: { url: string }) => {
+        GlobalConfig.set({ internalHostAccess: 'allow' });
+
+        expect(() => checkUrl(parseUrl(url)!, 'dummy', undefined)).toThrow(
+          HOST_BLOCKED,
+        );
+
+        GlobalConfig.reset();
+
+        expect(() =>
+          checkUrl(
+            parseUrl(url)!,
+            'dummy',
+            partial<InternalHostGrant>({ explicit: true }),
+          ),
+        ).toThrow(HOST_BLOCKED);
+      },
+    );
+
+    it('throws for an internal host with internalHostAccess=block', () => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.3:8080/')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+      expect(() =>
+        checkUrl(parseUrl('http://[::1]:6379/')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+    });
+
+    it('warns instead of throwing for an internal host by default', () => {
+      expect(
+        checkUrl(parseUrl('http://10.1.2.3:8080/')!, 'dummy', undefined),
+      ).toBe('warn-dns');
+
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        { hostname: '10.1.2.3', hostType: 'dummy' },
+        'HTTP request to an internal host, which `internalHostAccess=block` would refuse - permit it with a `hostRules` entry naming the host, or one setting `allowInternal: true`, or set `internalHostAccess=block` to enforce this now. The default will become `block` in a future major release.',
+      );
+    });
+
+    it('returns check-dns for a hostname without a grant', () => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+
+      expect(
+        checkUrl(parseUrl('https://example.com/')!, 'dummy', undefined),
+      ).toBe('check-dns');
+    });
+
+    it('returns warn-dns for a hostname without a grant by default', () => {
+      expect(
+        checkUrl(parseUrl('https://example.com/')!, 'dummy', undefined),
+      ).toBe('warn-dns');
+      expect(logger.logger.once.warn).not.toHaveBeenCalled();
+    });
+
+    it('grants everything except metadata with internalHostAccess=allow', () => {
+      GlobalConfig.set({ internalHostAccess: 'allow' });
+
+      expect(checkUrl(parseUrl('http://10.1.2.3/')!, 'dummy', undefined)).toBe(
+        'granted',
+      );
+      expect(
+        checkUrl(parseUrl('https://example.com/')!, 'dummy', undefined),
+      ).toBe('granted');
+    });
+
+    it('grants the platform endpoint origin', () => {
+      GlobalConfig.set({
+        endpoint: 'http://10.1.2.3/api/v4/',
+        internalHostAccess: 'block',
+      });
+
+      expect(
+        checkUrl(parseUrl('http://10.1.2.3/foo')!, 'dummy', undefined),
+      ).toBe('granted');
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.4/foo')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+    });
+
+    it('does not grant another port on the platform endpoint host', () => {
+      GlobalConfig.set({
+        endpoint: 'http://10.1.2.3:8080/api/v4',
+        internalHostAccess: 'block',
+      });
+
+      expect(
+        checkUrl(parseUrl('http://10.1.2.3:8080/foo')!, 'dummy', undefined),
+      ).toBe('granted');
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.3:6379/x.json')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.3:9200/')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.3/foo')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+    });
+
+    it('does not grant another scheme on the platform endpoint host', () => {
+      GlobalConfig.set({
+        endpoint: 'https://10.1.2.3/api/v4',
+        internalHostAccess: 'block',
+      });
+
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.3/foo')!, 'dummy', undefined),
+      ).toThrow(HOST_BLOCKED);
+    });
+
+    it('grants the platform endpoint origin spelled with its default port', () => {
+      GlobalConfig.set({ endpoint: 'https://10.1.2.3:443/api/v4' });
+
+      expect(
+        checkUrl(parseUrl('https://10.1.2.3/foo')!, 'dummy', undefined),
+      ).toBe('granted');
+    });
+
+    it('grants via an explicit allowInternal', () => {
+      expect(
+        checkUrl(parseUrl('http://10.1.2.3/')!, 'dummy', {
+          explicit: true,
+          implicit: true,
+        }),
+      ).toBe('granted');
+      expect(logger.logger.once.info).toHaveBeenCalledWith(
+        'Internal host 10.1.2.3 permitted by configuration',
+      );
+      // a granted host must not warn, so that administrators can converge on no warnings before the default becomes `block`
+      expect(logger.logger.once.warn).not.toHaveBeenCalled();
+    });
+
+    it('grants implicitly for a host the admin named', () => {
+      expect(
+        checkUrl(parseUrl('http://10.1.2.3/')!, 'dummy', { implicit: true }),
+      ).toBe('granted');
+    });
+
+    it('blocks when an explicit allowInternal=false overrides the implicit grant', () => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+
+      expect(() =>
+        checkUrl(parseUrl('http://10.1.2.3/')!, 'dummy', {
+          explicit: false,
+          implicit: true,
+        }),
+      ).toThrow(HOST_BLOCKED);
+    });
+
+    it('requires a scoped grant when the response becomes config', () => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+      const url = parseUrl('http://10.1.2.3/some-preset.json')!;
+
+      expect(() => checkUrl(url, 'npm', { implicit: true }, true)).toThrow(
+        HOST_BLOCKED,
+      );
+      expect(() =>
+        checkUrl(url, 'npm', { explicit: true, implicit: true }, true),
+      ).toThrow(HOST_BLOCKED);
+      expect(
+        checkUrl(
+          url,
+          'npm',
+          { explicit: true, scoped: true, implicit: true },
+          true,
+        ),
+      ).toBe('granted');
+    });
+
+    it('warns about an unscoped grant when the response becomes config', () => {
+      const url = parseUrl('http://10.1.2.3/some-preset.json')!;
+
+      expect(
+        checkUrl(url, 'npm', { explicit: true, implicit: true }, true),
+      ).toBe('warn-dns');
+
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        { hostname: '10.1.2.3', hostType: 'npm' },
+        'HTTP request to an internal host whose response becomes configuration, which `internalHostAccess=block` would refuse - permit it with a `hostRules` entry setting `allowInternal: true`, scoped with a `hostType` or a URL-prefix `matchHost`, or set `internalHostAccess=block` to enforce this now. The default will become `block` in a future major release.',
+      );
+    });
+
+    it('does not warn about a scoped grant when the response becomes config', () => {
+      const url = parseUrl('http://10.1.2.3/some-preset.json')!;
+
+      expect(checkUrl(url, 'npm', { scoped: true, implicit: true }, true)).toBe(
+        'granted',
+      );
+      expect(logger.logger.once.warn).not.toHaveBeenCalled();
+    });
+
+    it('accepts an implicit grant when the response is not config', () => {
+      const url = parseUrl('http://10.1.2.3/some-package')!;
+
+      expect(checkUrl(url, 'npm', { implicit: true })).toBe('granted');
+      expect(checkUrl(url, 'npm', { implicit: true }, false)).toBe('granted');
+    });
+
+    it('still permits the platform endpoint when the response becomes config', () => {
+      GlobalConfig.set({ endpoint: 'http://10.1.2.3/api/v4/' });
+
+      expect(
+        checkUrl(parseUrl('http://10.1.2.3/foo')!, 'npm', undefined, true),
+      ).toBe('granted');
+    });
+  });
+
+  describe('applyHostGuard', () => {
+    it('blocks resolved internal addresses for ungranted hosts', () => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+      const guard = applyHostGuard(
+        parseUrl('https://internal.example.com/')!,
+        'dummy',
+        undefined,
+      );
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: string, family: number) => void,
+      ) => cb(null, '10.0.0.1', 4)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('internal.example.com', {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ message: HOST_BLOCKED }),
+        '10.0.0.1',
+        4,
+      );
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { hostname: 'internal.example.com', address: '10.0.0.1' },
+        'Blocked HTTP request: hostname resolves to a blocked address',
+      );
+    });
+
+    it('passes public addresses through', () => {
+      const guard = applyHostGuard(
+        parseUrl('https://example.com/')!,
+        'dummy',
+        undefined,
+      );
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: string, family: number) => void,
+      ) => cb(null, '93.184.216.34', 4)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('example.com', {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, '93.184.216.34', 4);
+    });
+
+    it('validates every record when resolving all addresses', () => {
+      GlobalConfig.set({ internalHostAccess: 'block' });
+      const guard = applyHostGuard(
+        parseUrl('https://example.com/')!,
+        'dummy',
+        undefined,
+      );
+      const addresses = [
+        { address: '93.184.216.34', family: 4 },
+        { address: '127.0.0.1', family: 4 },
+      ];
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: unknown) => void,
+      ) => cb(null, addresses)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('example.com', { all: true }, callback);
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ message: HOST_BLOCKED }),
+        addresses,
+        undefined,
+      );
+    });
+
+    it('passes lookup errors through', () => {
+      const guard = applyHostGuard(
+        parseUrl('https://example.com/')!,
+        'dummy',
+        undefined,
+      );
+      const lookupError = new Error('ENOTFOUND');
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address?: string, family?: number) => void,
+      ) => cb(lookupError)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('example.com', {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(lookupError, undefined, undefined);
+    });
+
+    it('still blocks resolved metadata addresses for granted hosts', () => {
+      GlobalConfig.set({ internalHostAccess: 'allow' });
+      const guard = applyHostGuard(
+        parseUrl('https://internal.example.com/')!,
+        'dummy',
+        undefined,
+      );
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: string, family: number) => void,
+      ) => cb(null, '169.254.169.254', 4)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('internal.example.com', {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ message: HOST_BLOCKED }),
+        '169.254.169.254',
+        4,
+      );
+    });
+
+    it('permits resolved internal addresses for granted hosts', () => {
+      GlobalConfig.set({ internalHostAccess: 'allow' });
+      const guard = applyHostGuard(
+        parseUrl('https://internal.example.com/')!,
+        'dummy',
+        undefined,
+      );
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: string, family: number) => void,
+      ) => cb(null, '10.0.0.1', 4)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('internal.example.com', {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, '10.0.0.1', 4);
+    });
+
+    it('warns instead of blocking resolved internal addresses by default', () => {
+      const guard = applyHostGuard(
+        parseUrl('https://internal.example.com/')!,
+        'dummy',
+        undefined,
+      );
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: string, family: number) => void,
+      ) => cb(null, '10.0.0.1', 4)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('internal.example.com', {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(null, '10.0.0.1', 4);
+      expect(logger.logger.once.warn).toHaveBeenCalledWith(
+        { hostname: 'internal.example.com', hostType: 'dummy' },
+        expect.stringContaining('HTTP request to an internal host'),
+      );
+    });
+
+    it('still blocks a resolved metadata address by default', () => {
+      const guard = applyHostGuard(
+        parseUrl('https://internal.example.com/')!,
+        'dummy',
+        undefined,
+      );
+      const addresses = [
+        { address: '10.0.0.1', family: 4 },
+        { address: '169.254.169.254', family: 4 },
+      ];
+      lookupMock.mockImplementation(((
+        _hostname: string,
+        _options: unknown,
+        cb: (err: Error | null, address: unknown) => void,
+      ) => cb(null, addresses)) as never);
+
+      const callback = vi.fn();
+      guard.dnsLookup('internal.example.com', { all: true }, callback);
+
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({ message: HOST_BLOCKED }),
+        addresses,
+        undefined,
+      );
+      expect(logger.logger.warn).toHaveBeenCalledWith(
+        { hostname: 'internal.example.com', address: '169.254.169.254' },
+        'Blocked HTTP request: hostname resolves to a blocked address',
+      );
+      expect(logger.logger.once.warn).not.toHaveBeenCalled();
+    });
+
+    describe('beforeRedirect', () => {
+      it('blocks a redirect to an internal target', () => {
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('http://127.0.0.1/steal')!,
+          headers: {},
+        });
+
+        expect(() => guard.beforeRedirect(options, partial())).toThrow(
+          HOST_BLOCKED,
+        );
+      });
+
+      it('fails closed when the redirect target is not a parsed URL', () => {
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({ url: undefined });
+
+        expect(() => guard.beforeRedirect(options, partial())).toThrow(
+          HOST_BLOCKED,
+        );
+      });
+
+      it('keeps requiring a scoped grant for a config-fetching redirect', () => {
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'npm',
+          undefined,
+          true,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('http://10.1.2.3/presets/evil.json')!,
+          headers: {},
+        });
+
+        expect(() => guard.beforeRedirect(options, partial())).toThrow(
+          HOST_BLOCKED,
+        );
+
+        hostRules.add(
+          { matchHost: 'http://10.1.2.3/presets/', allowInternal: true },
+          { trusted: true },
+        );
+
+        expect(() => guard.beforeRedirect(options, partial())).not.toThrow();
+      });
+
+      it('warns instead of blocking a redirect to an internal target by default', () => {
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('http://127.0.0.1/steal')!,
+          headers: {},
+        });
+
+        expect(() => guard.beforeRedirect(options, partial())).not.toThrow();
+        expect(logger.logger.once.warn).toHaveBeenCalledWith(
+          { hostname: '127.0.0.1', hostType: 'dummy' },
+          expect.stringContaining('HTTP request to an internal host'),
+        );
+      });
+
+      it('re-evaluates grants for the redirect target host', () => {
+        hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('http://10.1.2.3/artifact')!,
+          headers: {},
+        });
+
+        expect(() => guard.beforeRedirect(options, partial())).not.toThrow();
+        expect(options.dnsLookup).toBeFunction();
+      });
+
+      // got strips the credentials it knows about (`authorization`, `cookie`, URL userinfo) before this hook runs, but not `Private-token`, and not whatever a `hostRules` entry configured
+      describe('cross-origin credentials', () => {
+        function redirect(
+          from: string,
+          to: string,
+          headers: Record<string, string>,
+        ): NormalizedOptions {
+          const guard = applyHostGuard(parseUrl(from)!, 'gitlab', undefined);
+          const options = partial<NormalizedOptions>({
+            url: parseUrl(to)!,
+            headers: { ...headers },
+          });
+          void guard.beforeRedirect(
+            options,
+            partial<PlainResponse>({ url: from }),
+          );
+          return options;
+        }
+
+        it('strips credential headers when the redirect leaves the origin', () => {
+          const options = redirect(
+            'https://gitlab.example.com/api/v4/x',
+            'https://evil.example.com/x',
+            {
+              'private-token': 'glpat-secret',
+              authorization: 'Bearer secret',
+              cookie: 'session=secret',
+              accept: 'application/json',
+            },
+          );
+
+          expect(options.headers).toEqual({ accept: 'application/json' });
+        });
+
+        it('strips credential headers when the redirect downgrades to http', () => {
+          const options = redirect(
+            'https://gitlab.example.com/api/v4/x',
+            'http://gitlab.example.com/x',
+            { 'private-token': 'glpat-secret' },
+          );
+
+          expect(options.headers).toEqual({});
+        });
+
+        it('keeps credential headers on a same-origin redirect', () => {
+          const headers = {
+            'private-token': 'glpat-secret',
+            authorization: 'Bearer secret',
+          };
+          const options = redirect(
+            'https://gitlab.example.com/api/v4/x',
+            'https://gitlab.example.com/api/v4/y',
+            headers,
+          );
+
+          expect(options.headers).toEqual(headers);
+        });
+
+        it('strips the headers a hostRule configured for the source host', () => {
+          hostRules.add(
+            {
+              matchHost: 'registry.example.com',
+              headers: { 'X-Api-Key': 'secret' },
+            },
+            { trusted: true },
+          );
+
+          const options = redirect(
+            'https://registry.example.com/artifact',
+            'https://cdn.example.com/artifact',
+            { 'x-api-key': 'secret', accept: 'application/json' },
+          );
+
+          expect(options.headers).toEqual({ accept: 'application/json' });
+        });
+
+        it('strips credential headers when the source URL cannot be parsed', () => {
+          const guard = applyHostGuard(
+            parseUrl('https://gitlab.example.com/')!,
+            'gitlab',
+            undefined,
+          );
+          const options = partial<NormalizedOptions>({
+            url: parseUrl('https://evil.example.com/')!,
+            headers: {
+              'private-token': 'glpat-secret',
+              accept: 'application/json',
+            },
+          });
+
+          void guard.beforeRedirect(
+            options,
+            partial<PlainResponse>({ url: 'not a url' }),
+          );
+
+          expect(options.headers).toEqual({ accept: 'application/json' });
+        });
+      });
+    });
+
+    describe('beforeRequest pre-flight for proxied requests', () => {
+      it('is not added when no proxy is configured', () => {
+        hasProxyMock.mockReturnValue(false);
+
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+
+        expect(guard.beforeRequest).toBeUndefined();
+      });
+
+      it('blocks a hostname which resolves to an internal address', async () => {
+        hasProxyMock.mockReturnValue(true);
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        mockResolvedAddresses('93.184.216.34', '10.0.0.1');
+        const guard = applyHostGuard(
+          parseUrl('https://internal.example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('https://internal.example.com/')!,
+        });
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).rejects.toThrow(HOST_BLOCKED);
+        expect(promisesLookupMock).toHaveBeenCalledWith(
+          'internal.example.com',
+          { all: true },
+        );
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { hostname: 'internal.example.com', address: '10.0.0.1' },
+          'Blocked HTTP request: hostname resolves to a blocked address',
+        );
+      });
+
+      it('permits a hostname which resolves to a public address', async () => {
+        hasProxyMock.mockReturnValue(true);
+        mockResolvedAddresses('93.184.216.34');
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('https://example.com/')!,
+        });
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('permits internal addresses for a granted host, but not metadata ones', async () => {
+        hasProxyMock.mockReturnValue(true);
+        GlobalConfig.set({ internalHostAccess: 'allow' });
+        const guard = applyHostGuard(
+          parseUrl('https://internal.example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('https://internal.example.com/')!,
+        });
+
+        mockResolvedAddresses('10.0.0.1');
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+
+        mockResolvedAddresses('169.254.169.254');
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).rejects.toThrow(HOST_BLOCKED);
+      });
+
+      it('fails open when the hostname cannot be resolved locally', async () => {
+        hasProxyMock.mockReturnValue(true);
+        promisesLookupMock.mockRejectedValue(new Error('ENOTFOUND'));
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('https://example.com/')!,
+        });
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+        expect(logger.logger.once.debug).toHaveBeenCalledWith(
+          'Host guard could not resolve example.com - relying on the proxy for this request',
+        );
+      });
+
+      it('does not resolve IP-literal hosts', async () => {
+        hasProxyMock.mockReturnValue(true);
+        GlobalConfig.set({ internalHostAccess: 'allow' });
+        const guard = applyHostGuard(
+          parseUrl('http://[fd00::1]/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('http://[fd00::1]/')!,
+        });
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+        expect(promisesLookupMock).not.toHaveBeenCalled();
+      });
+
+      it('warns about a hostname which resolves to an internal address by default', async () => {
+        hasProxyMock.mockReturnValue(true);
+        mockResolvedAddresses('93.184.216.34', '10.0.0.1');
+        const guard = applyHostGuard(
+          parseUrl('https://internal.example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('https://internal.example.com/')!,
+        });
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+        expect(logger.logger.once.warn).toHaveBeenCalledWith(
+          { hostname: 'internal.example.com', hostType: 'dummy' },
+          expect.stringContaining('HTTP request to an internal host'),
+        );
+      });
+
+      it('validates the redirect target, with its own grant', async () => {
+        hasProxyMock.mockReturnValue(true);
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        mockResolvedAddresses('10.0.0.1');
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({
+          url: parseUrl('https://internal.example.com/redirected')!,
+          headers: {},
+        });
+
+        await guard.beforeRedirect(options, partial());
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).rejects.toThrow(HOST_BLOCKED);
+
+        hostRules.add(
+          { matchHost: 'internal.example.com', allowInternal: true },
+          { trusted: true },
+        );
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('does not grant a config-fetching request an unscoped grant', async () => {
+        hasProxyMock.mockReturnValue(true);
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        mockResolvedAddresses('10.0.0.1');
+        hostRules.add(
+          { matchHost: 'internal.example.com', allowInternal: true },
+          { trusted: true },
+        );
+        const url = parseUrl('https://internal.example.com/preset.json')!;
+        const options = partial<NormalizedOptions>({ url });
+
+        const configGuard = applyHostGuard(url, 'npm', undefined, true);
+        await expect(
+          configGuard.beforeRequest!(options, { retryCount: 0 }),
+        ).rejects.toThrow(HOST_BLOCKED);
+
+        const plainGuard = applyHostGuard(url, 'npm', undefined);
+        await expect(
+          plainGuard.beforeRequest!(options, { retryCount: 0 }),
+        ).resolves.toBeUndefined();
+      });
+
+      it('fails closed when the request target is not a parsed URL', async () => {
+        hasProxyMock.mockReturnValue(true);
+        const guard = applyHostGuard(
+          parseUrl('https://example.com/')!,
+          'dummy',
+          undefined,
+        );
+        const options = partial<NormalizedOptions>({ url: undefined });
+
+        await expect(
+          guard.beforeRequest!(options, { retryCount: 0 }),
+        ).rejects.toThrow(HOST_BLOCKED);
+      });
+    });
   });
 });

--- a/lib/util/http/host-guard.spec.ts
+++ b/lib/util/http/host-guard.spec.ts
@@ -1,0 +1,176 @@
+import { parseUrl } from '../url.ts';
+import {
+  classifyHostname,
+  classifyIpAddress,
+  classifyUrl,
+} from './host-guard.ts';
+
+describe('util/http/host-guard', () => {
+  describe('classifyIpAddress', () => {
+    it.each`
+      address              | expected
+      ${'8.8.8.8'}         | ${null}
+      ${'1.1.1.1'}         | ${null}
+      ${'0.0.0.0'}         | ${'internal'}
+      ${'0.255.255.255'}   | ${'internal'}
+      ${'9.255.255.255'}   | ${null}
+      ${'10.0.0.0'}        | ${'internal'}
+      ${'10.255.255.255'}  | ${'internal'}
+      ${'11.0.0.0'}        | ${null}
+      ${'100.63.255.255'}  | ${null}
+      ${'100.64.0.0'}      | ${'internal'}
+      ${'100.127.255.255'} | ${'internal'}
+      ${'100.128.0.0'}     | ${null}
+      ${'126.255.255.255'} | ${null}
+      ${'127.0.0.1'}       | ${'internal'}
+      ${'127.255.255.255'} | ${'internal'}
+      ${'128.0.0.0'}       | ${null}
+      ${'169.253.255.255'} | ${null}
+      ${'169.254.0.1'}     | ${'internal'}
+      ${'169.254.255.255'} | ${'internal'}
+      ${'169.255.0.0'}     | ${null}
+      ${'172.15.255.255'}  | ${null}
+      ${'172.16.0.0'}      | ${'internal'}
+      ${'172.31.255.255'}  | ${'internal'}
+      ${'172.32.0.0'}      | ${null}
+      ${'192.167.255.255'} | ${null}
+      ${'192.168.0.0'}     | ${'internal'}
+      ${'192.168.255.255'} | ${'internal'}
+      ${'192.169.0.0'}     | ${null}
+      ${'223.255.255.255'} | ${null}
+      ${'224.0.0.1'}       | ${'internal'}
+      ${'239.255.255.255'} | ${'internal'}
+    `('classifies IPv4 $address as $expected', ({ address, expected }) => {
+      expect(classifyIpAddress(address)).toBe(expected);
+    });
+
+    it.each`
+      address                   | expected
+      ${'2606:4700:4700::1111'} | ${null}
+      ${'2001:db8::1'}          | ${null}
+      ${'::'}                   | ${'internal'}
+      ${'::1'}                  | ${'internal'}
+      ${'0:0:0:0:0:0:0:1'}      | ${'internal'}
+      ${'fbff::1'}              | ${null}
+      ${'fc00::1'}              | ${'internal'}
+      ${'fd00::1'}              | ${'internal'}
+      ${'fdff:ffff::1'}         | ${'internal'}
+      ${'fe00::1'}              | ${null}
+      ${'fe7f::1'}              | ${null}
+      ${'fe80::1'}              | ${'internal'}
+      ${'febf::1'}              | ${'internal'}
+      ${'fec0::1'}              | ${null}
+    `('classifies IPv6 $address as $expected', ({ address, expected }) => {
+      expect(classifyIpAddress(address)).toBe(expected);
+    });
+
+    it.each`
+      address                   | expected
+      ${'::ffff:8.8.8.8'}       | ${null}
+      ${'::ffff:0808:0808'}     | ${null}
+      ${'::ffff:10.0.0.1'}      | ${'internal'}
+      ${'::ffff:a00:1'}         | ${'internal'}
+      ${'0:0:0:0:0:ffff:a00:1'} | ${'internal'}
+      ${'::ffff:127.0.0.1'}     | ${'internal'}
+      ${'::ffff:192.168.1.1'}   | ${'internal'}
+      ${'::ffff:c0a8:0101'}     | ${'internal'}
+    `(
+      'classifies IPv4-mapped IPv6 $address as $expected',
+      ({ address, expected }) => {
+        expect(classifyIpAddress(address)).toBe(expected);
+      },
+    );
+
+    it.each`
+      address                     | expected
+      ${'169.254.169.254'}        | ${'metadata'}
+      ${'::ffff:169.254.169.254'} | ${'metadata'}
+      ${'::ffff:a9fe:a9fe'}       | ${'metadata'}
+      ${'fd00:ec2::254'}          | ${'metadata'}
+      ${'169.254.169.253'}        | ${'internal'}
+    `(
+      'classifies metadata endpoint $address as $expected',
+      ({ address, expected }) => {
+        expect(classifyIpAddress(address)).toBe(expected);
+      },
+    );
+
+    it('fails closed for strings which are not IP addresses', () => {
+      expect(classifyIpAddress('not-an-ip')).toBe('internal');
+      expect(classifyIpAddress('')).toBe('internal');
+    });
+  });
+
+  describe('classifyHostname', () => {
+    it.each`
+      hostname                                  | expected
+      ${'metadata.google.internal'}             | ${'metadata'}
+      ${'METADATA.GOOGLE.INTERNAL'}             | ${'metadata'}
+      ${'metadata.google.internal.'}            | ${'metadata'}
+      ${'metadata.packet.net'}                  | ${'metadata'}
+      ${'example.com'}                          | ${null}
+      ${'localhost'}                            | ${null}
+      ${'metadata.google.internal.example.com'} | ${null}
+    `('classifies $hostname as $expected', ({ hostname, expected }) => {
+      expect(classifyHostname(hostname)).toBe(expected);
+    });
+
+    it.each`
+      hostname                | reason
+      ${'metadata.azure.com'} | ${'Azure serves instance metadata at 169.254.169.254, not under this name'}
+      ${'anything.internal'}  | ${'the reserved TLD says nothing about what the name resolves to'}
+      ${'mydevice.local'}     | ${'an mDNS name still has to resolve to a blocked address to be blocked'}
+      ${'registry.corp'}      | ${'a private registry is only blocked by the address it resolves to'}
+    `(
+      'leaves $hostname to DNS-time classification, as $reason',
+      ({ hostname }) => {
+        expect(classifyHostname(hostname)).toBeNull();
+      },
+    );
+  });
+
+  describe('classifyUrl', () => {
+    it.each`
+      url                                      | expected
+      ${'https://example.com/path'}            | ${null}
+      ${'http://localhost:8080/'}              | ${null}
+      ${'http://10.1.2.3:8080/'}               | ${'internal'}
+      ${'http://127.0.0.1/'}                   | ${'internal'}
+      ${'http://0x7f000001/'}                  | ${'internal'}
+      ${'http://0177.0.0.1/'}                  | ${'internal'}
+      ${'http://2130706433/'}                  | ${'internal'}
+      ${'http://[::1]:6379/'}                  | ${'internal'}
+      ${'http://[fe80::1]/'}                   | ${'internal'}
+      ${'http://[::ffff:10.0.0.1]/'}           | ${'internal'}
+      ${'http://169.254.169.254/latest/'}      | ${'metadata'}
+      ${'http://[::ffff:169.254.169.254]/'}    | ${'metadata'}
+      ${'http://metadata.google.internal/v1/'} | ${'metadata'}
+      ${'https://8.8.8.8/'}                    | ${null}
+    `('classifies $url as $expected', ({ url, expected }) => {
+      expect(classifyUrl(parseUrl(url)!)).toBe(expected);
+    });
+
+    it('classifies hostnames which only resolve internally as unknown', () => {
+      // `localhost` can only be decided at DNS lookup time
+      expect(classifyUrl(parseUrl('http://localhost/')!)).toBeNull();
+    });
+
+    // userinfo is the classic way to make a URL read as one host while naming another - only what is after the `@` is the host
+    it.each`
+      url                                               | expected
+      ${'http://user:pass@127.0.0.1/'}                  | ${'internal'}
+      ${'http://example.com@127.0.0.1/'}                | ${'internal'}
+      ${'http://example.com:8080@169.254.169.254/'}     | ${'metadata'}
+      ${'http://user@metadata.google.internal/'}        | ${'metadata'}
+      ${'http://user:pass@[::1]/'}                      | ${'internal'}
+      ${'http://127.0.0.1@example.com/'}                | ${null}
+      ${'http://169.254.169.254:80@example.com/'}       | ${null}
+      ${'http://metadata.google.internal@example.com/'} | ${null}
+    `(
+      'classifies $url by its host, not its userinfo, as $expected',
+      ({ url, expected }) => {
+        expect(classifyUrl(parseUrl(url)!)).toBe(expected);
+      },
+    );
+  });
+});

--- a/lib/util/http/host-guard.ts
+++ b/lib/util/http/host-guard.ts
@@ -1,0 +1,108 @@
+import net from 'node:net';
+import { regEx } from '../regex.ts';
+
+/** Why a host must not be requested. */
+export type BlockedHostCategory =
+  /** loopback, RFC1918, link-local, and other special-use addresses that are never routable on the public Internet */
+  | 'internal'
+  /** Cloud provider instance-metadata services (IMDS and equivalents), which can potentially hand out credentials to anything that can reach them, and should never be accessible from an HTTP request from Renovate, regardless of any self-hosted administrator allowlisting */
+  | 'metadata';
+
+/**
+ * Instance-metadata hostnames, blocked regardless of what they resolve to.
+ *
+ * Only names which serve nothing but metadata belong here: a name in this set can never be permitted, whatever the configuration says. Providers whose metadata service is only reachable by IP (AWS, Azure, ...) are covered by {@link metadataBlockList} instead.
+ */
+const metadataHostnames = new Set([
+  'metadata.google.internal',
+  // Equinix Metal (formerly Packet)
+  'metadata.packet.net',
+]);
+
+// `BlockList.check()` classifies IPv4-mapped IPv6 addresses (in dotted-quad, hexadecimal, and uncompressed spellings) against IPv4 rules, so e.g. `::ffff:169.254.169.254` matches `169.254.169.254` without any normalization on our side.
+const metadataBlockList = new net.BlockList();
+// AWS/GCP/Azure/... IMDS
+metadataBlockList.addAddress('169.254.169.254', 'ipv4');
+// AWS IMDS IPv6 endpoint
+metadataBlockList.addAddress('fd00:ec2::254', 'ipv6');
+
+const internalBlockList = new net.BlockList();
+// "this network" (routes to localhost on Linux)
+internalBlockList.addSubnet('0.0.0.0', 8, 'ipv4');
+// RFC1918 private ranges
+internalBlockList.addSubnet('10.0.0.0', 8, 'ipv4');
+internalBlockList.addSubnet('172.16.0.0', 12, 'ipv4');
+internalBlockList.addSubnet('192.168.0.0', 16, 'ipv4');
+// carrier-grade NAT
+internalBlockList.addSubnet('100.64.0.0', 10, 'ipv4');
+// loopback
+internalBlockList.addSubnet('127.0.0.0', 8, 'ipv4');
+// link-local, including the cloud metadata endpoints
+internalBlockList.addSubnet('169.254.0.0', 16, 'ipv4');
+// multicast
+internalBlockList.addSubnet('224.0.0.0', 4, 'ipv4');
+// IPv6 unspecified and loopback
+internalBlockList.addAddress('::', 'ipv6');
+internalBlockList.addAddress('::1', 'ipv6');
+// IPv6 unique-local
+internalBlockList.addSubnet('fc00::', 7, 'ipv6');
+// IPv6 link-local
+internalBlockList.addSubnet('fe80::', 10, 'ipv6');
+
+/**
+ * Classifies an IP address, returning the category it is blocked under, or `null` for a public address.
+ *
+ * A string that is not a valid IP address is classified as `internal` - we should fail closed instead of possibly connecting to something we shouldn't be.
+ */
+export function classifyIpAddress(address: string): BlockedHostCategory | null {
+  const version = net.isIP(address);
+  if (version === 0) {
+    return 'internal';
+  }
+
+  const family = version === 4 ? 'ipv4' : 'ipv6';
+
+  if (metadataBlockList.check(address, family)) {
+    return 'metadata';
+  }
+
+  if (internalBlockList.check(address, family)) {
+    return 'internal';
+  }
+
+  return null;
+}
+
+/**
+ * Classifies a hostname against the metadata-endpoint hostname list.
+ *
+ * Only metadata hostnames can be classified without DNS resolution - any other hostname needs its resolved addresses checked via {@link classifyIpAddress}.
+ */
+export function classifyHostname(hostname: string): BlockedHostCategory | null {
+  // handle trailing-dot FQDN forms like `metadata.google.internal.`
+  const normalized = hostname.toLowerCase().replace(regEx(/\.$/), '');
+  if (metadataHostnames.has(normalized)) {
+    return 'metadata';
+  }
+  return null;
+}
+
+/**
+ * Classifies a URL from its host alone: IP-literal hosts are classified by address, and metadata hostnames by name.
+ *
+ * Returns `null` when nothing can be decided at the URL level - i.e. the host is a regular hostname, whose resolved addresses must be checked via {@link classifyIpAddress} at DNS lookup time.
+ */
+export function classifyUrl(url: URL): BlockedHostCategory | null {
+  let { hostname } = url;
+
+  // URL keeps IPv6 hosts in bracketed form
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    hostname = hostname.slice(1, -1);
+  }
+
+  if (net.isIP(hostname) !== 0) {
+    return classifyIpAddress(hostname);
+  }
+
+  return classifyHostname(hostname);
+}

--- a/lib/util/http/host-guard.ts
+++ b/lib/util/http/host-guard.ts
@@ -1,5 +1,22 @@
+import dns from 'node:dns';
+import dnsPromises from 'node:dns/promises';
 import net from 'node:net';
+import { isString } from '@sindresorhus/is';
+import type {
+  BeforeRedirectHook,
+  BeforeRequestHook,
+  NormalizedOptions,
+  PlainResponse,
+} from 'got';
+import { GlobalConfig } from '../../config/global.ts';
+import { HOST_BLOCKED } from '../../constants/error-messages.ts';
+import { logger } from '../../logger/index.ts';
+import { hasProxy } from '../../proxy.ts';
+import type { InternalHostGrant } from '../../types/index.ts';
+import * as hostRules from '../host-rules.ts';
+import { coerceObject } from '../object.ts';
 import { regEx } from '../regex.ts';
+import { parseUrl } from '../url.ts';
 
 /** Why a host must not be requested. */
 export type BlockedHostCategory =
@@ -25,6 +42,12 @@ const metadataBlockList = new net.BlockList();
 metadataBlockList.addAddress('169.254.169.254', 'ipv4');
 // AWS IMDS IPv6 endpoint
 metadataBlockList.addAddress('fd00:ec2::254', 'ipv6');
+// AWS ECS task credentials endpoint
+metadataBlockList.addAddress('169.254.170.2', 'ipv4');
+// AWS EKS Pod Identity endpoint
+metadataBlockList.addAddress('169.254.170.23', 'ipv4');
+// Alibaba Cloud/Tencent Cloud metadata
+metadataBlockList.addAddress('100.100.100.200', 'ipv4');
 
 const internalBlockList = new net.BlockList();
 // "this network" (routes to localhost on Linux)
@@ -87,22 +110,416 @@ export function classifyHostname(hostname: string): BlockedHostCategory | null {
   return null;
 }
 
+/** Strips the brackets `URL` keeps around IPv6 hosts, leaving other hosts as they are. */
+function unbracketHostname(hostname: string): string {
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
+
 /**
  * Classifies a URL from its host alone: IP-literal hosts are classified by address, and metadata hostnames by name.
  *
  * Returns `null` when nothing can be decided at the URL level - i.e. the host is a regular hostname, whose resolved addresses must be checked via {@link classifyIpAddress} at DNS lookup time.
  */
 export function classifyUrl(url: URL): BlockedHostCategory | null {
-  let { hostname } = url;
-
-  // URL keeps IPv6 hosts in bracketed form
-  if (hostname.startsWith('[') && hostname.endsWith(']')) {
-    hostname = hostname.slice(1, -1);
-  }
+  const hostname = unbracketHostname(url.hostname);
 
   if (net.isIP(hostname) !== 0) {
     return classifyIpAddress(hostname);
   }
 
   return classifyHostname(hostname);
+}
+
+/**
+ * What the URL-level check decided for a request, and so how the addresses its host resolves to must be treated.
+ */
+export type HostGuardDecision =
+  /** internal addresses are permitted for this request, and only metadata addresses need blocking at resolution time */
+  | 'granted'
+  /** every address the host resolves to must be validated at DNS lookup time, with internal ones blocking the request */
+  | 'check-dns'
+  /** as `check-dns`, but an internal address only warns - the `internalHostAccess=warn` default lets the request through */
+  | 'warn-dns';
+
+interface BlockedAddress {
+  address: string;
+  category: BlockedHostCategory;
+}
+
+/**
+ * Returns the resolved address which decides the outcome for a hostname, or `null` when every one of them is a public address.
+ *
+ * Each resolved record is a potential connection target, so each must pass. A metadata address decides the outcome over an internal one, as it is blocked in every mode.
+ */
+function findBlockedAddress(addresses: string[]): BlockedAddress | null {
+  let internal: BlockedAddress | null = null;
+  for (const address of addresses) {
+    const category = classifyIpAddress(address);
+    if (category === 'metadata') {
+      return { address, category };
+    }
+    if (category === 'internal') {
+      internal ??= { address, category };
+    }
+  }
+  return internal;
+}
+
+/**
+ * Applies `decision` to the addresses a hostname resolved to, logging the outcome, and returning `true` when the request must not be made.
+ */
+function isResolutionBlocked(
+  hostname: string,
+  addresses: string[],
+  decision: HostGuardDecision,
+  hostType: string | undefined,
+  responseBecomesConfig: boolean | undefined,
+): boolean {
+  const blocked = findBlockedAddress(addresses);
+  if (!blocked) {
+    return false;
+  }
+
+  if (blocked.category === 'internal') {
+    if (decision === 'granted') {
+      return false;
+    }
+    if (decision === 'warn-dns') {
+      warnInternalHost(hostname, hostType, responseBecomesConfig);
+      return false;
+    }
+  }
+
+  logger.warn(
+    { hostname, address: blocked.address },
+    'Blocked HTTP request: hostname resolves to a blocked address',
+  );
+  return true;
+}
+
+/**
+ * Validates every address a hostname resolves to, on every connection, which also catches a host whose answer changes between checks (DNS rebinding).
+ *
+ * The guard is built per request, as the policy it enforces is read from the configuration when the request is made.
+ */
+function makeGuardedLookup(
+  decision: HostGuardDecision,
+  hostType: string | undefined,
+  responseBecomesConfig: boolean | undefined,
+): typeof dns.lookup {
+  return function guardedLookup(
+    hostname: string,
+    options: dns.LookupOptions,
+    callback: (
+      err: NodeJS.ErrnoException | null,
+      address: string | dns.LookupAddress[],
+      family?: number,
+    ) => void,
+  ): void {
+    dns.lookup(hostname, options, (err, address, family) => {
+      if (err) {
+        callback(err, address, family);
+        return;
+      }
+
+      // with `options.all`, the result is an array of every record
+      const addresses = isString(address)
+        ? [address]
+        : address.map((entry) => entry.address);
+      if (
+        isResolutionBlocked(
+          hostname,
+          addresses,
+          decision,
+          hostType,
+          responseBecomesConfig,
+        )
+      ) {
+        callback(new Error(HOST_BLOCKED), address, family);
+        return;
+      }
+
+      callback(err, address, family);
+    });
+    // `dns.lookup` is an overloaded function, so the single signature implemented here is not assignable to it without a cast - got only ever calls the `(hostname, options, callback)` overload
+  } as typeof dns.lookup;
+}
+
+function isPlatformEndpoint(url: URL): boolean {
+  const endpoint = GlobalConfig.get('endpoint');
+  if (!endpoint) {
+    return false;
+  }
+  // the whole origin must match: another port or scheme on the platform's host is a different service, which the administrator has not vouched for
+  return parseUrl(endpoint)?.origin === url.origin;
+}
+
+/**
+ * Whether the administrator has permitted internal access for this request, leaving aside the `internalHostAccess` mode: a permitted request neither blocks nor warns, whatever the mode is.
+ */
+function isInternalGranted(
+  url: URL,
+  grant: InternalHostGrant | undefined,
+  responseBecomesConfig: boolean | undefined,
+): boolean {
+  // without its platform, Renovate cannot run at all - the endpoint is the administrator's own choice of host
+  if (isPlatformEndpoint(url)) {
+    return true;
+  }
+
+  // a response which becomes configuration can redirect Renovate at anything, so the administrator must have named this host for this purpose, not merely named it
+  if (responseBecomesConfig) {
+    return grant?.scoped === true;
+  }
+
+  return grant?.explicit ?? grant?.implicit ?? false;
+}
+
+/**
+ * Warns about a request which `internalHostAccess=block` would refuse, once per host, naming the grant which would permit it.
+ */
+function warnInternalHost(
+  hostname: string,
+  hostType: string | undefined,
+  responseBecomesConfig: boolean | undefined,
+): void {
+  // a response which becomes config needs the deliberately-scoped grant, so pointing at a plain host rule would be misleading advice
+  if (responseBecomesConfig) {
+    logger.once.warn(
+      { hostname, hostType },
+      'HTTP request to an internal host whose response becomes configuration, which `internalHostAccess=block` would refuse - permit it with a `hostRules` entry setting `allowInternal: true`, scoped with a `hostType` or a URL-prefix `matchHost`, or set `internalHostAccess=block` to enforce this now. The default will become `block` in a future major release.',
+    );
+    return;
+  }
+
+  logger.once.warn(
+    { hostname, hostType },
+    'HTTP request to an internal host, which `internalHostAccess=block` would refuse - permit it with a `hostRules` entry naming the host, or one setting `allowInternal: true`, or set `internalHostAccess=block` to enforce this now. The default will become `block` in a future major release.',
+  );
+}
+
+/**
+ * Enforce the internal-host policy on a request URL, throwing `HOST_BLOCKED` when the request must not be made.
+ *
+ * Metadata endpoints are blocked no matter what the configuration says: Renovate's HTTP layer never has a legitimate reason to request them.
+ */
+export function checkUrl(
+  url: URL,
+  hostType: string | undefined,
+  grant: InternalHostGrant | undefined,
+  responseBecomesConfig?: boolean,
+): HostGuardDecision {
+  const category = classifyUrl(url);
+  if (category === 'metadata') {
+    logger.warn(
+      { url: url.href, hostType },
+      'Blocked HTTP request to a cloud instance-metadata endpoint',
+    );
+    throw new Error(HOST_BLOCKED);
+  }
+
+  const mode = GlobalConfig.get('internalHostAccess');
+  if (
+    mode === 'allow' ||
+    isInternalGranted(url, grant, responseBecomesConfig)
+  ) {
+    if (category === 'internal') {
+      logger.once.info(
+        `Internal host ${url.hostname} permitted by configuration`,
+      );
+    }
+    return 'granted';
+  }
+
+  // `warn` reports what `block` would refuse, without refusing it, so that administrators can add the grants they need before the default changes
+  if (mode === 'warn') {
+    if (category === 'internal') {
+      warnInternalHost(url.hostname, hostType, responseBecomesConfig);
+    }
+    return 'warn-dns';
+  }
+
+  if (category === 'internal') {
+    logger.warn(
+      { url: url.href, hostType },
+      'Blocked HTTP request to an internal host - a self-hosted administrator can permit it via `hostRules`, or with `internalHostAccess=allow`',
+    );
+    throw new Error(HOST_BLOCKED);
+  }
+  return 'check-dns';
+}
+
+/**
+ * Validates what a request's hostname resolves to, before the request is made, for deployments where `dnsLookup` cannot do it.
+ *
+ * A proxy agent connects to the proxy and hands it the target hostname, so the target is resolved by the proxy and Renovate's `dnsLookup` guard never runs. Resolving here instead is best-effort only: the proxy re-resolves the hostname itself, so a DNS-rebinding or split-horizon answer can still differ from what we saw. Pair it with egress controls on the proxy.
+ */
+async function preflightHostname(
+  url: URL,
+  decision: HostGuardDecision,
+  hostType: string | undefined,
+  responseBecomesConfig: boolean | undefined,
+): Promise<void> {
+  const hostname = unbracketHostname(url.hostname);
+  if (net.isIP(hostname) !== 0) {
+    // an IP-literal host needs no resolution - `checkUrl` has already classified it
+    return;
+  }
+
+  let addresses: dns.LookupAddress[];
+  try {
+    addresses = await dnsPromises.lookup(hostname, { all: true });
+  } catch {
+    // fail open: a locked-down proxy environment often has no resolver which can answer for public names at all, and failing closed would break every such deployment
+    logger.once.debug(
+      `Host guard could not resolve ${hostname} - relying on the proxy for this request`,
+    );
+    return;
+  }
+
+  if (
+    isResolutionBlocked(
+      hostname,
+      addresses.map((entry) => entry.address),
+      decision,
+      hostType,
+      responseBecomesConfig,
+    )
+  ) {
+    throw new Error(HOST_BLOCKED);
+  }
+}
+
+function makeBeforeRequest(
+  hostType: string | undefined,
+  responseBecomesConfig: boolean | undefined,
+): BeforeRequestHook {
+  return async function hostGuardBeforeRequest(
+    options: NormalizedOptions,
+  ): Promise<void> {
+    const url = options.url instanceof URL ? options.url : null;
+    if (!url) {
+      // fail closed: without a parsed target there is nothing to validate
+      throw new Error(HOST_BLOCKED);
+    }
+
+    // got runs this hook again for every redirect target, so the decision is re-made for whatever host is about to be requested rather than carried over
+    const grant = hostRules.find({
+      hostType,
+      url: url.toString(),
+    }).internalHostGrant;
+    await preflightHostname(
+      url,
+      checkUrl(url, hostType, grant, responseBecomesConfig),
+      hostType,
+      responseBecomesConfig,
+    );
+  };
+}
+
+/**
+ * Removes the credentials belonging to the host a request is being redirected away from, so that a redirect cannot hand them to another origin.
+ *
+ * got strips the credentials it knows about itself - `authorization`, `cookie` and any URL userinfo - before this hook runs, and treats a scheme downgrade as a different origin, so an `https:` to `http:` redirect is covered. What it does not know about survives: the `Private-token` header GitLab personal access tokens are sent in (see `applyAuthorization`), and any credential an administrator configured through a `hostRules` `headers` entry.
+ *
+ * Those headers are dropped rather than replaced with the target host's own: `hostRules` headers are resolved once, when the request is built, so there is nothing to re-apply here. Sending none is the safe outcome.
+ */
+function stripCrossOriginCredentials(
+  options: NormalizedOptions,
+  fromUrl: URL | null,
+  toUrl: URL,
+  hostType: string | undefined,
+): void {
+  if (fromUrl?.origin === toUrl.origin) {
+    // the credentials are still going to the host they were configured for
+    return;
+  }
+
+  // an unparseable source URL is treated as cross-origin: it cannot be shown to be the same origin, so nothing is carried over
+  if (fromUrl) {
+    const configured = hostRules.find({
+      hostType,
+      url: fromUrl.toString(),
+    }).headers;
+    for (const name of Object.keys(coerceObject(configured))) {
+      // got normalizes header names to lower case
+      delete options.headers[name.toLowerCase()];
+    }
+  }
+
+  // defence in depth: got has removed these already, but they must never reach another origin
+  delete options.headers.authorization;
+  delete options.headers.cookie;
+  delete options.headers['private-token'];
+}
+
+function makeBeforeRedirect(
+  hostType: string | undefined,
+  responseBecomesConfig: boolean | undefined,
+): BeforeRedirectHook {
+  return function hostGuardBeforeRedirect(
+    options: NormalizedOptions,
+    response: PlainResponse,
+  ): void {
+    const url = options.url instanceof URL ? options.url : null;
+    if (!url) {
+      // fail closed: without a parsed target there is nothing to validate
+      throw new Error(HOST_BLOCKED);
+    }
+
+    const fromUrl = isString(response.url) ? parseUrl(response.url) : null;
+    stripCrossOriginCredentials(options, fromUrl, url, hostType);
+
+    // the original host's verdict must not carry over: the new host gets its own grant lookup and decision
+    const grant = hostRules.find({
+      hostType,
+      url: url.toString(),
+    }).internalHostGrant;
+    // a redirect target of a config-fetching request is still config-fetching, so the flag carries over even though the verdict does not
+    options.dnsLookup = makeGuardedLookup(
+      checkUrl(url, hostType, grant, responseBecomesConfig),
+      hostType,
+      responseBecomesConfig,
+    );
+  };
+}
+
+export interface HostGuard {
+  dnsLookup: typeof dns.lookup;
+  beforeRedirect: BeforeRedirectHook;
+  /** Only set when a proxy is configured, which makes `dnsLookup` inert. */
+  beforeRequest?: BeforeRequestHook;
+}
+
+/**
+ * Enforce the internal-host policy for a request to `url`, throwing `HOST_BLOCKED` when the request must not be made at all.
+ *
+ * The returned got options carry the policy through the rest of the request's lifetime: `dnsLookup` validates what hostnames resolve to (on every connection, which also covers DNS rebinding), and `beforeRedirect` re-runs this check for every redirect target.
+ *
+ * When a proxy is configured, the proxy agent resolves the target hostname itself and `dnsLookup` is never called, so a `beforeRequest` hook resolves and validates the hostname up front instead - see {@link preflightHostname} for what that can and cannot catch.
+ *
+ * `responseBecomesConfig` marks a request whose response is interpreted as Renovate configuration, which an internal host may only serve under a deliberately-scoped `allowInternal` grant.
+ *
+ * Under the `internalHostAccess=warn` default, an internal host which no grant permits is logged rather than blocked, so that administrators can add the grants they need before the default becomes `block`.
+ */
+export function applyHostGuard(
+  url: URL,
+  hostType: string | undefined,
+  grant: InternalHostGrant | undefined,
+  responseBecomesConfig?: boolean,
+): HostGuard {
+  const decision = checkUrl(url, hostType, grant, responseBecomesConfig);
+  const guard: HostGuard = {
+    dnsLookup: makeGuardedLookup(decision, hostType, responseBecomesConfig),
+    beforeRedirect: makeBeforeRedirect(hostType, responseBecomesConfig),
+  };
+
+  if (hasProxy()) {
+    guard.beforeRequest = makeBeforeRequest(hostType, responseBecomesConfig);
+  }
+
+  return guard;
 }

--- a/lib/util/http/host-rules.ts
+++ b/lib/util/http/host-rules.ts
@@ -10,7 +10,7 @@ import {
 } from '../../constants/index.ts';
 import { logger } from '../../logger/index.ts';
 import { hasProxy } from '../../proxy.ts';
-import type { HostRule } from '../../types/index.ts';
+import type { CombinedHostRule, HostRule } from '../../types/index.ts';
 import * as hostRules from '../host-rules.ts';
 import { matchRegexOrGlobList } from '../string-match.ts';
 import { parseUrl } from '../url.ts';
@@ -40,7 +40,7 @@ export type HostRulesGotOptions = Pick<
 export function findMatchingRule<GotOptions extends HostRulesGotOptions>(
   url: string,
   options: GotOptions,
-): HostRule {
+): CombinedHostRule {
   const { hostType, readOnly } = options;
   let res = hostRules.find({ hostType, url, readOnly });
 

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -1,13 +1,14 @@
 import { isPlainObject, isUndefined } from '@sindresorhus/is';
 import merge from 'deepmerge';
 import type { Options, OptionsInit, RetryObject } from 'got';
-import type { Merge, SetRequired } from 'type-fest';
+import type { SetRequired } from 'type-fest';
 import type { z } from 'zod/v4';
 import { ZodType } from 'zod/v4';
 import { GlobalConfig } from '../../config/global.ts';
 import { HOST_DISABLED } from '../../constants/error-messages.ts';
 import { logger } from '../../logger/index.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
+import type { HostRule } from '../../types/index.ts';
 import * as memCache from '../cache/memory/index.ts';
 import { getEnv } from '../env.ts';
 import { hash } from '../hash.ts';
@@ -28,7 +29,6 @@ import { getRetryAfter, wrapWithRetry } from './retry-after.ts';
 import { getThrottle } from './throttle.ts';
 import type {
   GotOptions,
-  GotStreamOptions,
   GotTask,
   HttpMethod,
   HttpOptions,
@@ -102,6 +102,49 @@ export abstract class HttpBase<
     );
   }
 
+  /**
+   * Builds the final got options for a request to a given `url`
+   *
+   * This merges instance options, applies default headers, host rules and authorization, and rejects requests to disabled hosts.
+   *
+   * Both the `request()` and `stream()` paths must use this single entry point so that policy applied here covers every outbound request.
+   */
+  private prepareOptions(
+    url: string,
+    httpOptions: InternalHttpOptions,
+  ): {
+    options: InternalGotOptions & InternalHttpOptions;
+    hostRule: HostRule;
+  } {
+    let options = merge<InternalGotOptions, InternalHttpOptions>(
+      {
+        ...this.options,
+        hostType: this.hostType,
+      },
+      httpOptions,
+      { isMergeableObject: isPlainObject },
+    );
+
+    applyDefaultHeaders(options);
+
+    if (
+      isUndefined(options.readOnly) &&
+      ['head', 'get'].includes(options.method.toLowerCase())
+    ) {
+      options.readOnly = true;
+    }
+
+    const hostRule = findMatchingRule(url, options);
+    options = applyHostRule(url, options, hostRule);
+    if (options.enabled === false) {
+      logger.debug(`Host is disabled - rejecting request. HostUrl: ${url}`);
+      throw new Error(HOST_DISABLED);
+    }
+    options = applyAuthorization(options);
+
+    return { options, hostRule };
+  }
+
   private async request(
     requestUrl: string | URL,
     httpOptions: InternalHttpOptions,
@@ -128,33 +171,13 @@ export abstract class HttpBase<
 
     this.processOptions(resolvedUrl, httpOptions);
 
-    let options = merge<InternalGotOptions, InternalHttpOptions>(
-      {
-        ...this.options,
-        hostType: this.hostType,
-      },
-      httpOptions,
-      { isMergeableObject: isPlainObject },
-    );
+    const { options, hostRule } = this.prepareOptions(url, httpOptions);
 
     const method = options.method.toLowerCase();
     const isReadMethod = ['head', 'get'].includes(method);
 
     logger.trace(`HTTP request: ${method.toUpperCase()} ${url}`);
 
-    applyDefaultHeaders(options);
-
-    if (isUndefined(options.readOnly) && isReadMethod) {
-      options.readOnly = true;
-    }
-
-    const hostRule = findMatchingRule(url, options);
-    options = applyHostRule(url, options, hostRule);
-    if (options.enabled === false) {
-      logger.debug(`Host is disabled - rejecting request. HostUrl: ${url}`);
-      throw new Error(HOST_DISABLED);
-    }
-    options = applyAuthorization(options);
     const timeout = options.timeout ?? 60000;
     options.timeout = timeout;
 
@@ -659,34 +682,12 @@ export abstract class HttpBase<
   }
 
   stream(url: string, options?: HttpOptions): NodeJS.ReadableStream {
-    let combinedOptions: Merge<
-      GotStreamOptions,
-      SetRequired<InternalHttpOptions, 'method'>
-    > = {
-      ...this.options,
-      hostType: this.hostType,
-      ...options,
-      method: 'get',
-    };
-
     const resolvedUrl = this.resolveUrl(url, options).toString();
 
-    applyDefaultHeaders(combinedOptions);
-
-    // v8 ignore else -- TODO: add test #40625
-    if (
-      isUndefined(combinedOptions.readOnly) &&
-      ['head', 'get'].includes(combinedOptions.method)
-    ) {
-      combinedOptions.readOnly = true;
-    }
-
-    const hostRule = findMatchingRule(url, combinedOptions);
-    combinedOptions = applyHostRule(resolvedUrl, combinedOptions, hostRule);
-    if (combinedOptions.enabled === false) {
-      throw new Error(HOST_DISABLED);
-    }
-    combinedOptions = applyAuthorization(combinedOptions);
+    const { options: combinedOptions } = this.prepareOptions(resolvedUrl, {
+      ...options,
+      method: 'get',
+    });
 
     return stream(resolvedUrl, this._normalizeOptions(combinedOptions));
   }

--- a/lib/util/http/http.ts
+++ b/lib/util/http/http.ts
@@ -8,7 +8,8 @@ import { GlobalConfig } from '../../config/global.ts';
 import { HOST_DISABLED } from '../../constants/error-messages.ts';
 import { logger } from '../../logger/index.ts';
 import { ExternalHostError } from '../../types/errors/external-host-error.ts';
-import type { HostRule } from '../../types/index.ts';
+import type { CombinedHostRule } from '../../types/index.ts';
+import { coerceArray } from '../array.ts';
 import * as memCache from '../cache/memory/index.ts';
 import { getEnv } from '../env.ts';
 import { hash } from '../hash.ts';
@@ -23,6 +24,7 @@ import { parseSingleYaml } from '../yaml.ts';
 import { applyAuthorization } from './auth.ts';
 import type { HttpCacheProvider } from './cache/types.ts';
 import { fetch, normalize, stream } from './got.ts';
+import { applyHostGuard } from './host-guard.ts';
 import { applyHostRule, findMatchingRule } from './host-rules.ts';
 import { getQueue } from './queue.ts';
 import { getRetryAfter, wrapWithRetry } from './retry-after.ts';
@@ -110,12 +112,14 @@ export abstract class HttpBase<
    * Both the `request()` and `stream()` paths must use this single entry point so that policy applied here covers every outbound request.
    */
   private prepareOptions(
-    url: string,
+    resolvedUrl: URL,
     httpOptions: InternalHttpOptions,
   ): {
     options: InternalGotOptions & InternalHttpOptions;
-    hostRule: HostRule;
+    hostRule: CombinedHostRule;
   } {
+    const url = resolvedUrl.toString();
+
     let options = merge<InternalGotOptions, InternalHttpOptions>(
       {
         ...this.options,
@@ -141,6 +145,28 @@ export abstract class HttpBase<
       throw new Error(HOST_DISABLED);
     }
     options = applyAuthorization(options);
+
+    // enforced here so it runs before anything else - including cache lookups - can act on the URL, and for the stream path too
+    const guard = applyHostGuard(
+      resolvedUrl,
+      options.hostType,
+      hostRule.internalHostGrant,
+      options.responseBecomesConfig,
+    );
+    options.dnsLookup = guard.dnsLookup;
+    options.hooks = {
+      ...options.hooks,
+      beforeRedirect: [
+        ...coerceArray(options.hooks?.beforeRedirect),
+        guard.beforeRedirect,
+      ],
+    };
+    if (guard.beforeRequest) {
+      options.hooks.beforeRequest = [
+        ...coerceArray(options.hooks.beforeRequest),
+        guard.beforeRequest,
+      ];
+    }
 
     return { options, hostRule };
   }
@@ -171,7 +197,7 @@ export abstract class HttpBase<
 
     this.processOptions(resolvedUrl, httpOptions);
 
-    const { options, hostRule } = this.prepareOptions(url, httpOptions);
+    const { options, hostRule } = this.prepareOptions(resolvedUrl, httpOptions);
 
     const method = options.method.toLowerCase();
     const isReadMethod = ['head', 'get'].includes(method);
@@ -303,7 +329,12 @@ export abstract class HttpBase<
    * @returns extra Renovate options.
    */
   protected extraOptions(): readonly string[] {
-    return ['baseUrl', 'cacheProvider', 'readOnly'] as (keyof HttpOptions)[];
+    return [
+      'baseUrl',
+      'cacheProvider',
+      'readOnly',
+      'responseBecomesConfig',
+    ] as (keyof HttpOptions)[];
   }
 
   protected processOptions(_url: URL, _options: InternalHttpOptions): void {
@@ -682,14 +713,17 @@ export abstract class HttpBase<
   }
 
   stream(url: string, options?: HttpOptions): NodeJS.ReadableStream {
-    const resolvedUrl = this.resolveUrl(url, options).toString();
+    const resolvedUrl = this.resolveUrl(url, options);
 
     const { options: combinedOptions } = this.prepareOptions(resolvedUrl, {
       ...options,
       method: 'get',
     });
 
-    return stream(resolvedUrl, this._normalizeOptions(combinedOptions));
+    return stream(
+      resolvedUrl.toString(),
+      this._normalizeOptions(combinedOptions),
+    );
   }
 
   async getToml<Schema extends ZodType<any, any, any>>(

--- a/lib/util/http/index.spec.ts
+++ b/lib/util/http/index.spec.ts
@@ -1,12 +1,15 @@
+import dnsPromises from 'node:dns/promises';
 import { ZodError, z } from 'zod/v4';
 import * as httpMock from '~test/http-mock.ts';
 import { logger } from '~test/util.ts';
 import { GlobalConfig } from '../../config/global.ts';
 import {
   EXTERNAL_HOST_ERROR,
+  HOST_BLOCKED,
   HOST_DISABLED,
 } from '../../constants/error-messages.ts';
 import { pkg } from '../../expose.ts';
+import { hasProxy } from '../../proxy.ts';
 import * as memCache from '../cache/memory/index.ts';
 import { resetCache } from '../cache/repository/index.ts';
 import * as hostRules from '../host-rules.ts';
@@ -15,6 +18,13 @@ import { Http, HttpError } from './index.ts';
 import * as queue from './queue.ts';
 import * as throttle from './throttle.ts';
 import type { HttpResponse } from './types.ts';
+
+vi.mock('node:dns/promises', () => ({
+  default: { lookup: vi.fn() },
+}));
+vi.mock('../../proxy.ts', () => ({
+  hasProxy: vi.fn(),
+}));
 
 const baseUrl = 'http://renovate.com';
 
@@ -338,6 +348,343 @@ describe('util/http/index', () => {
     expect(() => http.stream('http://renovate.com/test')).toThrow(
       HOST_DISABLED,
     );
+  });
+
+  describe('host guard', () => {
+    afterEach(() => {
+      GlobalConfig.reset();
+    });
+
+    describe('by default', () => {
+      describe('when response does not become config', () => {
+        it('warns about, but allows, requests to internal hosts', async () => {
+          httpMock.scope('http://10.1.2.3').get('/test').reply(200, 'ok');
+
+          const res = await http.getText('http://10.1.2.3/test');
+
+          expect(res.body).toBe('ok');
+          expect(logger.logger.once.warn).toHaveBeenCalledWith(
+            { hostname: '10.1.2.3', hostType: 'dummy' },
+            expect.stringContaining('HTTP request to an internal host'),
+          );
+        });
+
+        it('permits the platform endpoint host', async () => {
+          GlobalConfig.set({ endpoint: 'http://10.1.2.3/api/v4/' });
+          httpMock.scope('http://10.1.2.3').get('/test').reply(200, 'ok');
+
+          const res = await http.getText('http://10.1.2.3/test');
+
+          expect(res.body).toBe('ok');
+        });
+
+        it('permits a host the admin named in a trusted hostRule', async () => {
+          hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+          httpMock.scope('http://10.1.2.3').get('/test').reply(200, 'ok');
+
+          const res = await http.getText('http://10.1.2.3/test');
+
+          expect(res.body).toBe('ok');
+        });
+
+        it('does not require a scoped grant for a request which is not config', async () => {
+          const plainHttp = new Http('preset');
+          hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+          httpMock
+            .scope('http://10.1.2.3')
+            .get('/preset.json')
+            .reply(200, '{}');
+
+          const res = await plainHttp.getText('http://10.1.2.3/preset.json');
+
+          expect(res.body).toBe('{}');
+        });
+      });
+
+      describe('when response becomes config', () => {
+        it('warns about, but allows, an internal host with only an implicit grant', async () => {
+          const presetHttp = new Http('preset', {
+            responseBecomesConfig: true,
+          });
+          // an implicit grant is enough for lookups, but only warns for something which becomes config
+          hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+          httpMock
+            .scope('http://10.1.2.3')
+            .get('/preset.json')
+            .reply(200, '{}');
+
+          const res = await presetHttp.getText('http://10.1.2.3/preset.json');
+
+          expect(res.body).toBe('{}');
+          expect(logger.logger.once.warn).toHaveBeenCalledWith(
+            { hostname: '10.1.2.3', hostType: 'preset' },
+            expect.stringContaining('whose response becomes configuration'),
+          );
+        });
+      });
+    });
+
+    describe('when internalHostAccess=block', () => {
+      describe('when response does not become config', () => {
+        it('blocks requests to internal hosts', async () => {
+          GlobalConfig.set({ internalHostAccess: 'block' });
+
+          await expect(http.get('http://127.0.0.1:8080/test')).rejects.toThrow(
+            HOST_BLOCKED,
+          );
+          await expect(http.get('http://10.1.2.3/test')).rejects.toThrow(
+            HOST_BLOCKED,
+          );
+        });
+
+        it('does not let an untrusted hostRule permit an internal host', async () => {
+          GlobalConfig.set({ internalHostAccess: 'block' });
+          hostRules.add({ matchHost: '10.1.2.3' });
+
+          await expect(http.get('http://10.1.2.3/test')).rejects.toThrow(
+            HOST_BLOCKED,
+          );
+        });
+
+        it('blocks the stream path too', () => {
+          GlobalConfig.set({ internalHostAccess: 'block' });
+
+          expect(() => http.stream('http://127.0.0.1/test')).toThrow(
+            HOST_BLOCKED,
+          );
+        });
+      });
+
+      describe('when response becomes config', () => {
+        it('requires a scoped grant', async () => {
+          GlobalConfig.set({ internalHostAccess: 'block' });
+          const presetHttp = new Http('preset', {
+            responseBecomesConfig: true,
+          });
+          // an implicit grant is enough for lookups, but not for anything which becomes config
+          hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+
+          await expect(
+            presetHttp.get('http://10.1.2.3/preset.json'),
+          ).rejects.toThrow(HOST_BLOCKED);
+
+          hostRules.add(
+            { hostType: 'preset', matchHost: '10.1.2.3', allowInternal: true },
+            { trusted: true },
+          );
+          httpMock
+            .scope('http://10.1.2.3')
+            .get('/preset.json')
+            .reply(200, '{}');
+
+          const res = await presetHttp.getText('http://10.1.2.3/preset.json');
+
+          expect(res.body).toBe('{}');
+        });
+      });
+    });
+
+    describe('when internalHostAccess=warn', () => {
+      describe('when response does not become config', () => {
+        it('warns about, but allows, requests to internal hosts', async () => {
+          GlobalConfig.set({ internalHostAccess: 'warn' });
+          httpMock.scope('http://10.1.2.3').get('/test').reply(200, 'ok');
+
+          const res = await http.getText('http://10.1.2.3/test');
+
+          expect(res.body).toBe('ok');
+          expect(logger.logger.once.warn).toHaveBeenCalledWith(
+            { hostname: '10.1.2.3', hostType: 'dummy' },
+            expect.stringContaining('HTTP request to an internal host'),
+          );
+        });
+      });
+
+      describe('when response becomes config', () => {
+        it('warns about, but allows, an internal host with only an implicit grant', async () => {
+          GlobalConfig.set({ internalHostAccess: 'warn' });
+          const presetHttp = new Http('preset', {
+            responseBecomesConfig: true,
+          });
+          hostRules.add({ matchHost: '10.1.2.3' }, { trusted: true });
+          httpMock
+            .scope('http://10.1.2.3')
+            .get('/preset.json')
+            .reply(200, '{}');
+
+          const res = await presetHttp.getText('http://10.1.2.3/preset.json');
+
+          expect(res.body).toBe('{}');
+          expect(logger.logger.once.warn).toHaveBeenCalledWith(
+            { hostname: '10.1.2.3', hostType: 'preset' },
+            expect.stringContaining('whose response becomes configuration'),
+          );
+        });
+      });
+    });
+
+    describe('when internalHostAccess=allow', () => {
+      describe('when response does not become config', () => {
+        it('blocks requests to metadata endpoints', async () => {
+          GlobalConfig.set({ internalHostAccess: 'allow' });
+
+          await expect(
+            http.get('http://169.254.169.254/latest/meta-data/'),
+          ).rejects.toThrow(HOST_BLOCKED);
+          await expect(
+            http.get('http://metadata.google.internal/computeMetadata/v1/'),
+          ).rejects.toThrow(HOST_BLOCKED);
+        });
+
+        it('permits internal hosts', async () => {
+          GlobalConfig.set({ internalHostAccess: 'allow' });
+          httpMock.scope('http://10.1.2.3').get('/test').reply(200, 'ok');
+
+          const res = await http.getText('http://10.1.2.3/test');
+
+          expect(res.body).toBe('ok');
+        });
+      });
+
+      describe('when response becomes config', () => {
+        it('permits an internal host even without a scoped grant', async () => {
+          GlobalConfig.set({ internalHostAccess: 'allow' });
+          const presetHttp = new Http('preset', {
+            responseBecomesConfig: true,
+          });
+          httpMock
+            .scope('http://10.1.2.3')
+            .get('/preset.json')
+            .reply(200, '{}');
+
+          const res = await presetHttp.getText('http://10.1.2.3/preset.json');
+
+          expect(res.body).toBe('{}');
+        });
+      });
+    });
+
+    describe('redirects', () => {
+      it('blocks a redirect to an internal host', async () => {
+        httpMock
+          .scope(baseUrl)
+          .get('/redirect')
+          .reply(302, '', { location: 'http://169.254.169.254/latest/' });
+
+        await expect(http.get(`${baseUrl}/redirect`)).rejects.toThrow(
+          HOST_BLOCKED,
+        );
+        expect(logger.logger.warn).toHaveBeenCalledWith(
+          { url: 'http://169.254.169.254/latest/', hostType: 'dummy' },
+          'Blocked HTTP request to a cloud instance-metadata endpoint',
+        );
+      });
+
+      it('follows a redirect to a permitted host', async () => {
+        httpMock
+          .scope(baseUrl)
+          .get('/redirect')
+          .reply(302, '', { location: `${baseUrl}/target` });
+        httpMock.scope(baseUrl).get('/target').reply(200, 'ok');
+
+        const res = await http.getText(`${baseUrl}/redirect`);
+
+        expect(res.body).toBe('ok');
+      });
+
+      it('strips authorization when redirected to another host', async () => {
+        hostRules.add({ matchHost: 'renovate.com', token: 'secret-token' });
+        httpMock
+          .scope(baseUrl)
+          .get('/redirect')
+          .reply(302, '', { location: 'http://other.example.com/target' });
+        httpMock
+          .scope('http://other.example.com', {
+            badheaders: ['authorization'],
+          })
+          .get('/target')
+          .reply(200, 'ok');
+
+        const res = await http.getText(`${baseUrl}/redirect`);
+
+        expect(res.body).toBe('ok');
+      });
+
+      it('strips authorization when a redirect downgrades https to http', async () => {
+        hostRules.add({ matchHost: 'renovate.com', token: 'secret-token' });
+        httpMock
+          .scope('https://renovate.com')
+          .get('/redirect')
+          .reply(302, '', { location: 'http://renovate.com/target' });
+        httpMock
+          .scope('http://renovate.com', {
+            badheaders: ['authorization'],
+          })
+          .get('/target')
+          .reply(200, 'ok');
+
+        const res = await http.getText('https://renovate.com/redirect');
+
+        expect(res.body).toBe('ok');
+      });
+    });
+
+    describe('caching', () => {
+      it('does not serve a cached response for a URL that is now blocked', async () => {
+        GlobalConfig.set({ internalHostAccess: 'allow' });
+        httpMock.scope('http://10.1.2.3').get('/cached').reply(200, 'ok');
+        const res = await http.getText('http://10.1.2.3/cached');
+        expect(res.body).toBe('ok');
+
+        GlobalConfig.set({ internalHostAccess: 'block' });
+
+        await expect(http.getText('http://10.1.2.3/cached')).rejects.toThrow(
+          HOST_BLOCKED,
+        );
+      });
+    });
+
+    describe('proxied deployments', () => {
+      beforeEach(() => {
+        // a proxy agent resolves the target hostname itself, so the `dnsLookup` guard is replaced by a pre-flight lookup
+        vi.mocked(hasProxy).mockReturnValue(true);
+      });
+
+      it('blocks a hostname which resolves to an internal address', async () => {
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        vi.mocked(dnsPromises.lookup).mockResolvedValue([
+          { address: '10.0.0.1', family: 4 },
+        ] as never);
+
+        await expect(http.get(`${baseUrl}/test`)).rejects.toThrow(HOST_BLOCKED);
+      });
+
+      it('warns about a hostname which resolves to an internal address by default', async () => {
+        vi.mocked(dnsPromises.lookup).mockResolvedValue([
+          { address: '10.0.0.1', family: 4 },
+        ] as never);
+        httpMock.scope(baseUrl).get('/test').reply(200, 'ok');
+
+        const res = await http.getText(`${baseUrl}/test`);
+
+        expect(res.body).toBe('ok');
+        expect(logger.logger.once.warn).toHaveBeenCalledWith(
+          { hostname: 'renovate.com', hostType: 'dummy' },
+          expect.stringContaining('HTTP request to an internal host'),
+        );
+      });
+
+      it('allows a hostname which resolves to a public address', async () => {
+        vi.mocked(dnsPromises.lookup).mockResolvedValue([
+          { address: '93.184.216.34', family: 4 },
+        ] as never);
+        httpMock.scope(baseUrl).get('/test').reply(200, 'ok');
+
+        const res = await http.getText(`${baseUrl}/test`);
+
+        expect(res.body).toBe('ok');
+      });
+    });
   });
 
   it('limits concurrency by host', async () => {

--- a/lib/util/http/types.ts
+++ b/lib/util/http/types.ts
@@ -93,6 +93,13 @@ export interface HttpOptions {
   memCache?: boolean;
   cacheProvider?: HttpCacheProvider;
   readOnly?: boolean;
+
+  /**
+   * The response body becomes Renovate configuration, so an internal host must be permitted by a deliberately-scoped `allowInternal` grant rather than an implicit one - see `applyHostGuard`.
+   *
+   * Set it on any request whose response is interpreted as config, no matter which `hostType` the request is made with.
+   */
+  responseBecomesConfig?: boolean;
 }
 
 export interface HttpHeaders extends IncomingHttpHeaders {

--- a/lib/util/http/util.spec.ts
+++ b/lib/util/http/util.spec.ts
@@ -1,0 +1,13 @@
+import { HOST_BLOCKED, HOST_DISABLED } from '../../constants/error-messages.ts';
+import { refusedHostMessage } from './util.ts';
+
+describe('util/http/util', () => {
+  describe('refusedHostMessage', () => {
+    it('distinguishes a blocked host from a disabled one', () => {
+      expect(refusedHostMessage(new Error(HOST_BLOCKED))).toBe('Host blocked');
+      expect(refusedHostMessage(new Error(HOST_DISABLED))).toBe(
+        'Host disabled',
+      );
+    });
+  });
+});

--- a/lib/util/http/util.ts
+++ b/lib/util/http/util.ts
@@ -1,3 +1,4 @@
+import { HOST_BLOCKED } from '../../constants/error-messages.ts';
 import { clone } from '../clone.ts';
 import type { HttpResponse } from './types.ts';
 
@@ -20,4 +21,13 @@ export function copyResponse<T>(
   }
 
   return res;
+}
+
+/**
+ * The log message for a request the HTTP layer refused, distinguishing a host blocked by the internal-host policy from one an administrator disabled.
+ *
+ * Both are reported the same way by their callers - traced and swallowed - so only the wording tells them apart in the logs.
+ */
+export function refusedHostMessage(err: Error): string {
+  return err.message === HOST_BLOCKED ? 'Host blocked' : 'Host disabled';
 }

--- a/lib/workers/global/index.spec.ts
+++ b/lib/workers/global/index.spec.ts
@@ -246,6 +246,7 @@ describe('workers/global/index', () => {
 
     expect(hostRules.find({ url: 'https://registry.example.com' })).toEqual({
       headers: { 'X-Allowed': 'yes' },
+      internalHostGrant: { implicit: true },
     });
     expect(logger.logger.warn).toHaveBeenCalledWith(
       { denied: ['Authorization'] },

--- a/lib/workers/global/initialize.spec.ts
+++ b/lib/workers/global/initialize.spec.ts
@@ -98,6 +98,7 @@ describe('workers/global/initialize', () => {
 
       expect(hostRules.find({ url: 'https://registry.example.com' })).toEqual({
         headers: { 'X-Allowed': 'yes' },
+        internalHostGrant: { implicit: true },
       });
       expect(logger.logger.warn).toHaveBeenCalledWith(
         { denied: ['Authorization'] },

--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -71,9 +71,14 @@ describe('workers/repository/init/inherited', () => {
 
   it('should throw an error if config includes an invalid option', async () => {
     platform.getRawFile.mockResolvedValue('{"something": "invalid"}');
-    await expect(mergeInheritedConfig(config)).rejects.toThrow(
-      CONFIG_VALIDATION,
-    );
+
+    // the detail names the inherited config, which the repository's owners may be unable to see, let alone fix
+    await expect(mergeInheritedConfig(config)).rejects.toMatchObject({
+      message: CONFIG_VALIDATION,
+      validationSource: 'Inherited config (`config.json` in `inherit/repo`)',
+      validationError: 'The inherited config contains some invalid settings',
+      validationMessage: 'Invalid configuration option: something',
+    });
   });
 
   it('should throw an error if config includes an invalid value', async () => {
@@ -284,9 +289,12 @@ describe('workers/repository/init/inherited', () => {
         unmerged: [],
       },
     });
-    await expect(mergeInheritedConfig(config)).rejects.toThrow(
-      CONFIG_VALIDATION,
-    );
+    await expect(mergeInheritedConfig(config)).rejects.toMatchObject({
+      message: CONFIG_VALIDATION,
+      validationSource: 'Inherited config (`config.json` in `inherit/repo`)',
+      validationError: 'The inherited config contains some invalid settings',
+      validationMessage: 'some error',
+    });
 
     expect(logger.warn).toHaveBeenCalledWith(
       {

--- a/lib/workers/repository/init/inherited.spec.ts
+++ b/lib/workers/repository/init/inherited.spec.ts
@@ -5,6 +5,7 @@ import {
   setUserConfigFileNames,
 } from '../../../config/app-strings.ts';
 import * as decrypt from '../../../config/decrypt.ts';
+import { GlobalConfig } from '../../../config/global.ts';
 import { InheritConfig } from '../../../config/inherit.ts';
 import * as presets_ from '../../../config/presets/index.ts';
 import type { RenovateConfig } from '../../../config/types.ts';
@@ -34,6 +35,7 @@ describe('workers/repository/init/inherited', () => {
     };
     hostRules.clear();
     InheritConfig.reset();
+    GlobalConfig.reset();
   });
 
   it('should return the same config if repository or inheritConfig is not defined', async () => {
@@ -189,6 +191,120 @@ describe('workers/repository/init/inherited', () => {
       },
     ]);
     expect(res.hostRules).toBeUndefined();
+  });
+
+  describe('hostRules trust tier', () => {
+    const credentialedRule = codeBlock`
+      {
+        "hostRules": [
+          {
+            "matchHost": "https://internal.example.com/",
+            "token": "some-token"
+          }
+        ]
+      }
+    `;
+
+    const grantingRule = codeBlock`
+      {
+        "hostRules": [
+          {
+            "matchHost": "https://internal.example.com/",
+            "allowInternal": true
+          }
+        ]
+      }
+    `;
+
+    it('registers inherited hostRules as untrusted by default', async () => {
+      platform.getRawFile.mockResolvedValue(credentialedRule);
+
+      await mergeInheritedConfig(config);
+
+      expect(hostRules.getAll()).toEqual([
+        {
+          matchHost: 'https://internal.example.com/',
+          resolvedHost: 'internal.example.com',
+          token: 'some-token',
+          trustTier: 'untrusted',
+        },
+      ]);
+      expect(
+        hostRules.find({ url: 'https://internal.example.com/api' }),
+      ).toEqual({ token: 'some-token' });
+    });
+
+    it('refuses allowInternal in inherited config, saying how to permit it', async () => {
+      platform.getRawFile.mockResolvedValue(grantingRule);
+
+      await expect(mergeInheritedConfig(config)).rejects.toMatchObject({
+        message: CONFIG_VALIDATION,
+        validationSource: 'Inherited config (`config.json` in `inherit/repo`)',
+        validationError: 'The inherited config contains some invalid settings',
+        validationMessage:
+          'hostRules `allowInternal` is not allowed in inherited config, as this Renovate instance has not set `inheritConfigTrusted=true`. The administrator can either set it, or move the rule to their global config or a `repositories[]` entry.',
+      });
+    });
+
+    it('registers inherited hostRules in the inherit tier when trusted', async () => {
+      GlobalConfig.set({ inheritConfigTrusted: true });
+      platform.getRawFile.mockResolvedValue(credentialedRule);
+
+      await mergeInheritedConfig(config);
+
+      expect(hostRules.getAll()).toEqual([
+        {
+          matchHost: 'https://internal.example.com/',
+          resolvedHost: 'internal.example.com',
+          token: 'some-token',
+          trustTier: 'inherit',
+        },
+      ]);
+      // the credentialed rule now implicitly permits the internal host it names
+      expect(
+        hostRules.find({ url: 'https://internal.example.com/api' }),
+      ).toEqual({
+        token: 'some-token',
+        internalHostGrant: { implicit: true },
+      });
+    });
+
+    it('accepts allowInternal in inherited config when trusted', async () => {
+      GlobalConfig.set({ inheritConfigTrusted: true });
+      platform.getRawFile.mockResolvedValue(grantingRule);
+
+      await mergeInheritedConfig(config);
+
+      expect(
+        hostRules.find({ url: 'https://internal.example.com/api' })
+          .internalHostGrant,
+      ).toEqual({ explicit: true, scoped: true, implicit: true });
+    });
+
+    it('registers hostRules from inherited presets in the inherit tier when trusted', async () => {
+      GlobalConfig.set({ inheritConfigTrusted: true });
+      platform.getRawFile.mockResolvedValue(
+        '{"extends":["local>org/renovate-config"]}',
+      );
+      presets.resolveConfigPresets.mockResolvedValue({
+        config: {
+          hostRules: [
+            { matchHost: 'https://internal.example.com/', allowInternal: true },
+          ],
+        },
+        visitedPresets: {
+          merged: [],
+          unmerged: [],
+        },
+      });
+
+      await mergeInheritedConfig(config);
+
+      expect(
+        hostRules.find({ url: 'https://internal.example.com/api' })
+          .internalHostGrant,
+      ).toEqual({ explicit: true, scoped: true, implicit: true });
+    });
   });
 
   it('should resolve presets found in inherited config', async () => {

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -2,6 +2,7 @@ import { isNonEmptyArray, isNullOrUndefined, isString } from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { setUserConfigFileNames } from '../../../config/app-strings.ts';
 import { decryptConfig } from '../../../config/decrypt.ts';
+import { GlobalConfig } from '../../../config/global.ts';
 import { mergeChildConfig, removeGlobalConfig } from '../../../config/index.ts';
 import { InheritConfig } from '../../../config/inherit.ts';
 import { parseFileConfig } from '../../../config/parse.ts';
@@ -19,6 +20,7 @@ import {
 } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
 import { platform } from '../../../modules/platform/index.ts';
+import type { AddHostRuleOptions } from '../../../util/host-rules.ts';
 import { coerceObject } from '../../../util/object.ts';
 import * as template from '../../../util/template/index.ts';
 import { applyHostRules } from './merge.ts';
@@ -40,6 +42,18 @@ function throwInheritedConfigValidationError(
   error.validationError = inheritedConfigValidationError;
   error.validationMessage = errors.map((err) => err.message).join(', ');
   throw error;
+}
+
+/**
+ * How the inherited config's `hostRules` are registered.
+ *
+ * The inherited config repository is controlled by the organization's administrators rather than by the self-hosted administrator, so its rules are untrusted unless the administrator has opted into trusting them.
+ */
+function inheritedHostRuleOptions(): AddHostRuleOptions | undefined {
+  if (!GlobalConfig.get('inheritConfigTrusted')) {
+    return undefined;
+  }
+  return { inherited: true };
 }
 
 export async function mergeInheritedConfig(
@@ -149,7 +163,7 @@ export async function mergeInheritedConfig(
       secrets: coerceObject(config.secrets),
       variables: coerceObject(config.variables),
     });
-    applyHostRules(filteredConfig);
+    applyHostRules(filteredConfig, inheritedHostRuleOptions());
     filteredConfig = InheritConfig.set(filteredConfig);
     return mergeChildConfig(config, filteredConfig);
   }
@@ -197,7 +211,7 @@ export async function mergeInheritedConfig(
     secrets: coerceObject(config.secrets),
     variables: coerceObject(config.variables),
   });
-  applyHostRules(filteredConfig);
+  applyHostRules(filteredConfig, inheritedHostRuleOptions());
   filteredConfig = InheritConfig.set(filteredConfig);
   return mergeChildConfig(config, filteredConfig);
 }

--- a/lib/workers/repository/init/inherited.ts
+++ b/lib/workers/repository/init/inherited.ts
@@ -7,7 +7,10 @@ import { InheritConfig } from '../../../config/inherit.ts';
 import { parseFileConfig } from '../../../config/parse.ts';
 import { resolveConfigPresets } from '../../../config/presets/index.ts';
 import { applySecretsAndVariablesToConfig } from '../../../config/secrets.ts';
-import type { RenovateConfig } from '../../../config/types.ts';
+import type {
+  RenovateConfig,
+  ValidationMessage,
+} from '../../../config/types.ts';
 import { validateConfig } from '../../../config/validation.ts';
 import {
   CONFIG_INHERIT_NOT_FOUND,
@@ -19,6 +22,25 @@ import { platform } from '../../../modules/platform/index.ts';
 import { coerceObject } from '../../../util/object.ts';
 import * as template from '../../../util/template/index.ts';
 import { applyHostRules } from './merge.ts';
+
+const inheritedConfigValidationError =
+  'The inherited config contains some invalid settings';
+
+/**
+ * Report an inherited config validation failure against the inherited config, rather than the repository being processed.
+ *
+ * The inherited config repository is managed by the organization's administrators, so a fault there is not one the repository's owners have introduced - and they may not even be able to read the file to see it.
+ */
+function throwInheritedConfigValidationError(
+  validationSource: string,
+  errors: ValidationMessage[],
+): never {
+  const error = new Error(CONFIG_VALIDATION);
+  error.validationSource = validationSource;
+  error.validationError = inheritedConfigValidationError;
+  error.validationMessage = errors.map((err) => err.message).join(', ');
+  throw error;
+}
 
 export async function mergeInheritedConfig(
   config: RenovateConfig,
@@ -83,6 +105,7 @@ export async function mergeInheritedConfig(
     logger.debug({ parseResult }, 'Error parsing inherited config.');
     throw new Error(CONFIG_INHERIT_PARSE_ERROR);
   }
+  const inheritedConfigSource = `Inherited config (\`${config.inheritConfigFileName}\` in \`${inheritConfigRepoName}\`)`;
   const inheritedConfig = parseResult.parsedContents as RenovateConfig;
   logger.debug({ config: inheritedConfig }, `Inherited config`);
   const res = await validateConfig('inherit', inheritedConfig);
@@ -91,7 +114,7 @@ export async function mergeInheritedConfig(
       { errors: res.errors },
       'Found errors in inherited configuration.',
     );
-    throw new Error(CONFIG_VALIDATION);
+    throwInheritedConfigValidationError(inheritedConfigSource, res.errors);
   }
   if (res.warnings.length) {
     logger.warn(
@@ -145,7 +168,10 @@ export async function mergeInheritedConfig(
       { errors: validationRes.errors },
       'Found errors in presets inside the inherited configuration.',
     );
-    throw new Error(CONFIG_VALIDATION);
+    throwInheritedConfigValidationError(
+      inheritedConfigSource,
+      validationRes.errors,
+    );
   }
   if (validationRes.warnings.length) {
     logger.warn(

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -1,6 +1,7 @@
 import { isNullOrUndefined } from '@sindresorhus/is';
 import { codeBlock } from 'common-tags';
 import type { MockInstance } from 'vitest';
+import * as httpMock from '~test/http-mock.ts';
 import type { RenovateConfig } from '~test/util.ts';
 import { fs, logger, partial, platform, scm } from '~test/util.ts';
 import * as decrypt from '../../../config/decrypt.ts';
@@ -10,6 +11,7 @@ import * as _migrateAndValidate from '../../../config/migrate-validate.ts';
 import * as _migrate from '../../../config/migration.ts';
 import type { AllConfig } from '../../../config/types.ts';
 import * as configValidation from '../../../config/validation.ts';
+import { CONFIG_VALIDATION } from '../../../constants/error-messages.ts';
 import * as npmApi from '../../../modules/datasource/npm/index.ts';
 import type { HostRule } from '../../../types/index.ts';
 import * as memCache from '../../../util/cache/memory/index.ts';
@@ -809,6 +811,88 @@ describe('workers/repository/init/merge', () => {
         );
       });
 
+      it("applies a `repositories[]` entry's `allowInternal` without a validation error", async () => {
+        fs.readLocalFile.mockResolvedValue(JSON.stringify({}));
+
+        await expect(
+          mergeRenovateConfig({
+            ...config,
+            repositoryEntryConfig: {
+              hostRules: [
+                {
+                  matchHost: 'http://10.1.2.3',
+                  allowInternal: true,
+                },
+              ],
+            },
+          }),
+        ).toResolve();
+
+        expect(
+          hostRules.find({ url: 'http://10.1.2.3' }).internalHostGrant,
+        ).toEqual({ explicit: true, scoped: true, implicit: true });
+      });
+
+      it('permits an internal HTTP preset granted by the repositories[] entry', async () => {
+        // proves the entry's trusted rules are registered before the repository config's presets resolve
+        httpMock
+          .scope('http://10.1.2.3')
+          .get('/granted-preset.json')
+          .reply(200, {});
+        fs.readLocalFile.mockResolvedValue(
+          JSON.stringify({ extends: ['http://10.1.2.3/granted-preset.json'] }),
+        );
+
+        await expect(
+          mergeRenovateConfig({
+            ...config,
+            repositoryEntryConfig: {
+              hostRules: [
+                {
+                  hostType: 'preset',
+                  matchHost: 'http://10.1.2.3/',
+                  allowInternal: true,
+                },
+              ],
+            },
+          }),
+        ).toResolve();
+      });
+
+      it('rejects an internal HTTP preset without a deliberate grant', async () => {
+        GlobalConfig.set({ internalHostAccess: 'block' });
+        fs.readLocalFile.mockResolvedValue(
+          JSON.stringify({
+            extends: ['http://10.1.2.3/ungranted-preset.json'],
+          }),
+        );
+
+        await expect(mergeRenovateConfig(config)).rejects.toMatchObject({
+          message: CONFIG_VALIDATION,
+          validationError: expect.stringContaining(
+            'Preset host is blocked by this Renovate instance',
+          ),
+        });
+      });
+
+      it('rejects `allowInternal` injected by a preset as a security error', async () => {
+        memCache.set('preset:local>internalPreset', {
+          hostRules: [{ matchHost: 'http://10.1.2.3', allowInternal: true }],
+        });
+        fs.readLocalFile.mockResolvedValue(
+          JSON.stringify({ extends: ['local>internalPreset'] }),
+        );
+
+        await expect(mergeRenovateConfig(config)).rejects.toMatchObject({
+          message: CONFIG_VALIDATION,
+          validationMessage:
+            "hostRules `allowInternal` is only allowed in the self-hosted administrator's own configuration.",
+        });
+        expect(
+          hostRules.find({ url: 'http://10.1.2.3' }).internalHostGrant,
+        ).toBeUndefined();
+      });
+
       it('drops `repositories[]` entry headers, if it is not in `allowedHeaders`', async () => {
         // previously this would apply due to a gap in re-validating `allowedHeaders` against the resolved config.
         // `applyHostRules` filters by header name at request time, so this does not reach the final HTTP call, but we should make sure this also doesn't break
@@ -955,6 +1039,28 @@ describe('workers/repository/init/merge', () => {
         expect.anything(),
         "Ignoring env variables not permitted by this Renovate instance's `allowedEnv`",
       );
+    });
+
+    it('exempts `allowInternal` a repositories[] entry preset contributes', async () => {
+      // the entry, and everything the presets it extends contribute, is the self-hosted admin's own config, so its `allowInternal` is not a violation
+      memCache.set('preset:local>entryGrantsInternal', {
+        hostRules: [
+          { matchHost: 'http://10.1.2.3', allowInternal: true },
+          // host-less rules are the admin's own too
+          { allowInternal: false },
+        ],
+      });
+      fs.readLocalFile.mockResolvedValue(JSON.stringify({}));
+
+      const res = await mergeRenovateConfig({
+        ...config,
+        repositoryEntryConfig: { extends: ['local>entryGrantsInternal'] },
+      });
+
+      expect(res).toBeDefined();
+      expect(
+        hostRules.find({ url: 'http://10.1.2.3' }).internalHostGrant,
+      ).toEqual({ explicit: true, scoped: true, implicit: true });
     });
 
     it("reports a repository preset replaying the admin's header to a host of its own choosing", async () => {

--- a/lib/workers/repository/init/merge.spec.ts
+++ b/lib/workers/repository/init/merge.spec.ts
@@ -804,6 +804,7 @@ describe('workers/repository/init/merge', () => {
               'custom-header': 'Bearer admin-secret',
               'X-Allowed': 'yes',
             },
+            internalHostGrant: { implicit: true },
           },
         );
       });
@@ -827,7 +828,7 @@ describe('workers/repository/init/merge', () => {
         });
 
         expect(hostRules.find({ url: 'https://registry.example.com' })).toEqual(
-          {},
+          { internalHostGrant: { implicit: true } },
         );
         expect(logger.logger.warn).toHaveBeenCalledWith(
           { denied: ['Authorization'] },
@@ -1680,6 +1681,7 @@ describe('workers/repository/init/merge', () => {
 
       expect(hostRules.find({ url: 'https://registry.example.com' })).toEqual({
         headers: { 'X-From-Admin': 'yes', 'X-From-Repo': 'yes' },
+        internalHostGrant: { implicit: true },
       });
     });
 
@@ -1708,6 +1710,7 @@ describe('workers/repository/init/merge', () => {
         }),
       ).toEqual({
         headers: { 'X-Api-Key': 'from-admin' },
+        internalHostGrant: { implicit: true },
       });
     });
 

--- a/lib/workers/repository/init/merge.ts
+++ b/lib/workers/repository/init/merge.ts
@@ -3,6 +3,7 @@ import {
   isNonEmptyObject,
   isNonEmptyString,
   isString,
+  isUndefined,
 } from '@sindresorhus/is';
 import { dequal } from 'dequal';
 import { getConfigFileNames } from '../../../config/app-strings.ts';
@@ -335,6 +336,8 @@ function migrateConfigOrWarn(config: RenovateConfig): MigratedConfig {
 interface AdminSuppliedValues {
   env: Set<string>;
   headers: Map<string, Set<string | null>>;
+  /** the `allowInternal` values ('true'/'false') the admin set, recording the `matchHost` values each is set for (`null` for a host-less rule) */
+  internalGrants: Map<string, Set<string | null>>;
 }
 
 /**
@@ -359,25 +362,33 @@ function adminSuppliedValues(
 ): AdminSuppliedValues {
   const env = new Set<string>();
   const headers = new Map<string, Set<string | null>>();
+  const internalGrants = new Map<string, Set<string | null>>();
 
   for (const adminConfig of adminConfigs) {
     for (const source of [adminConfig, adminConfig.force]) {
       for (const [name, value] of Object.entries(coerceObject(source?.env))) {
         env.add(nameValueIdentity(name, value));
       }
-      for (const [identity, matchHosts] of headersByIdentity(
-        migratedHostRules(source?.hostRules),
-      )) {
+      const rules = migratedHostRules(source?.hostRules);
+      for (const [identity, matchHosts] of headersByIdentity(rules)) {
         const hosts = headers.get(identity) ?? new Set<string | null>();
         for (const matchHost of matchHosts) {
           hosts.add(matchHost);
         }
         headers.set(identity, hosts);
       }
+      for (const rule of rules) {
+        if (!isUndefined(rule.allowInternal)) {
+          const key = rule.allowInternal.toString();
+          const hosts = internalGrants.get(key) ?? new Set<string | null>();
+          hosts.add(rule.matchHost ?? null);
+          internalGrants.set(key, hosts);
+        }
+      }
     }
   }
 
-  return { env, headers };
+  return { env, headers, internalGrants };
 }
 
 /**
@@ -403,30 +414,56 @@ function withoutAdminSuppliedValues(
 
   // A header is the admin's own when its name and value match one the admin set for hosts that already cover this rule's hosts - the exact `matchHost` spelling must not matter, as migration and presets can re-spell (e.g. add a scheme) or narrow (e.g. a subpath) it
   if (result.hostRules) {
-    result.hostRules = result.hostRules.map((rule) => ({
-      ...rule,
-      headers: Object.fromEntries(
-        Object.entries(coerceObject(rule.headers)).filter(([name, value]) => {
-          const adminHosts = admin.headers.get(nameValueIdentity(name, value));
-          if (!adminHosts) {
-            // not a header the admin set - report it
-            return true;
-          }
-          if (adminHosts.has(null)) {
-            // the admin already sends it to every host
-            return false;
-          }
-          // a host-less rule reaches every host, so only a host-less admin header (above) can exempt it
-          return !(
-            rule.matchHost &&
-            [...adminHosts].some(
-              (adminHost) =>
-                adminHost !== null && isWithinHost(rule.matchHost!, adminHost),
-            )
-          );
-        }),
-      ),
-    }));
+    result.hostRules = result.hostRules.map((rule) => {
+      const filtered: HostRule = {
+        ...rule,
+        headers: Object.fromEntries(
+          Object.entries(coerceObject(rule.headers)).filter(([name, value]) => {
+            const adminHosts = admin.headers.get(
+              nameValueIdentity(name, value),
+            );
+            if (!adminHosts) {
+              // not a header the admin set - report it
+              return true;
+            }
+            if (adminHosts.has(null)) {
+              // the admin already sends it to every host
+              return false;
+            }
+            // a host-less rule reaches every host, so only a host-less admin header (above) can exempt it
+            return !(
+              rule.matchHost &&
+              [...adminHosts].some(
+                (adminHost) =>
+                  adminHost !== null &&
+                  isWithinHost(rule.matchHost!, adminHost),
+              )
+            );
+          }),
+        ),
+      };
+
+      // same principle for `allowInternal`: the admin's own value, for hosts their own rules already cover, is not a violation
+      if (!isUndefined(filtered.allowInternal)) {
+        const adminHosts = admin.internalGrants.get(
+          filtered.allowInternal.toString(),
+        );
+        const covered =
+          adminHosts &&
+          (adminHosts.has(null) ||
+            (!!filtered.matchHost &&
+              [...adminHosts].some(
+                (adminHost) =>
+                  adminHost !== null &&
+                  isWithinHost(filtered.matchHost!, adminHost),
+              )));
+        if (covered) {
+          delete filtered.allowInternal;
+        }
+      }
+
+      return filtered;
+    });
   }
 
   // `mergeChildConfig` promotes `force` values into the config it returns, so the admin's own `force.env`/`force.hostRules[].headers` are applied - and exempted - the same way their top-level equivalents are

--- a/test/docs/documentation.spec.ts
+++ b/test/docs/documentation.spec.ts
@@ -191,11 +191,74 @@ describe('docs/documentation', () => {
         );
       }
 
-      function getRequiredSelfHostedOptions(): string[] {
-        return options
+      // Sub-options (e.g. `hostRules.allowInternal`) are only valid in self-hosted
+      // config, so their parent (e.g. `hostRules`) needs its own top-level header
+      // here even though the parent option itself isn't `globalOnly`.
+      function getSelfHostedParentNames(): Set<string> {
+        const childrens = options
           .filter((option) => option.globalOnly)
-          .map((option) => option.name)
+          .filter(
+            (option) =>
+              option.parents &&
+              option.parents.length > 0 &&
+              !option.parents.includes('.'),
+          );
+
+        const parentNames = new Set<string>();
+        for (const children of childrens) {
+          for (const parent of children.parents ?? []) {
+            parentNames.add(parent);
+          }
+        }
+
+        return parentNames;
+      }
+
+      function getRequiredSelfHostedOptions(): string[] {
+        const topLevelOptions = options
+          .filter((option) => option.globalOnly)
+          // Only include top-level options, which have no parents (implicit root) or explicitly define the
+          // root ('.') as their parent.
+          .filter(
+            (option) =>
+              !option.parents ||
+              option.parents.length === 0 ||
+              option.parents.includes('.'),
+          )
+          .map((option) => option.name);
+
+        return [
+          ...new Set([...topLevelOptions, ...getSelfHostedParentNames()]),
+        ].sort();
+      }
+
+      async function getSelfHostedSubHeaders(file: string): Promise<string[]> {
+        const content = await fs.readFile(`docs/usage/${file}`, 'utf8');
+        const matches = content.matchAll(/\n###\s`?(?<child>[\w.]+)`?\n/g);
+        return [...matches]
+          .map((match) => match.groups?.child)
+          .filter((child): child is string => !!child)
           .sort();
+      }
+
+      function getRequiredSelfHostedSubOptions(): string[] {
+        return (
+          options
+            .filter((option) => option.globalOnly)
+            // Only include true sub-options: options which have parents but none of those are explicitly the root ('.').
+            .filter(
+              (option) =>
+                option.parents &&
+                option.parents.length > 0 &&
+                !option.parents.includes('.'),
+            )
+            .flatMap((option) =>
+              (option.parents ?? [])
+                .filter((parent) => parent !== '.')
+                .map((parent) => `${parent}.${option.name}`),
+            )
+            .sort()
+        );
       }
 
       it('has headers sorted alphabetically', async () => {
@@ -211,6 +274,31 @@ describe('docs/documentation', () => {
           getSelfHostedHeaders('self-hosted-configuration.md'),
         ).resolves.toEqual(getRequiredSelfHostedOptions());
       });
+
+      it('has headers for every required sub-option', async () => {
+        await expect(
+          getSelfHostedSubHeaders('self-hosted-configuration.md'),
+        ).resolves.toEqual(getRequiredSelfHostedSubOptions());
+      });
+
+      it.each([...getSelfHostedParentNames()])(
+        '%s has sub-headers sorted alphabetically',
+        async (parentName: string) => {
+          await expect(
+            getConfigOptionSubHeaders(
+              'self-hosted-configuration.md',
+              parentName,
+            ),
+          ).resolves.toEqual(
+            (
+              await getConfigOptionSubHeaders(
+                'self-hosted-configuration.md',
+                parentName,
+              )
+            ).sort(),
+          );
+        },
+      );
     });
 
     describe('docs/usage/self-hosted-experimental.md', () => {


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Allow self-hosted admins more control over access to internal hosts, and:

- don't allow repo/preset config to override `enabled` on a host


## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
