### PR TITLE
chore(lint): add oxlint rule to block dev-dependency imports in production code

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -236,6 +236,7 @@
       "files": ["lib/**"],
       "excludeFiles": ["**/*.spec.ts"],
       "rules": {
+        "renovate/no-dev-dependency-import": "error",
         "renovate/no-exec-shell-option": "error",
         "renovate/no-hardcoded-docs-url": "error",
         "renovate/no-unquoted-exec-interpolation": "error",

--- a/tools/lint/rules.ts
+++ b/tools/lint/rules.ts
@@ -4,6 +4,7 @@ import enforceTsExtension from './rules/enforce-ts-extension.ts';
 import inlineSingleUseFixtures from './rules/inline-single-use-fixtures.ts';
 import loggerErrKey from './rules/logger-err-key.ts';
 import loggerStaticMessage from './rules/logger-static-message.ts';
+import noDevDependencyImport from './rules/no-dev-dependency-import.ts';
 import noExecShellOption from './rules/no-exec-shell-option.ts';
 import noHardcodedDocsUrl from './rules/no-hardcoded-docs-url.ts';
 import noHostRulesMock from './rules/no-host-rules-mock.ts';
@@ -44,6 +45,7 @@ export default definePlugin({
     'inline-single-use-fixtures': inlineSingleUseFixtures,
     'logger-err-key': loggerErrKey,
     'logger-static-message': loggerStaticMessage,
+    'no-dev-dependency-import': noDevDependencyImport,
     'no-exec-shell-option': noExecShellOption,
     'no-hardcoded-docs-url': noHardcodedDocsUrl,
     'no-host-rules-mock': noHostRulesMock,

--- a/tools/lint/rules/no-dev-dependency-import.spec.ts
+++ b/tools/lint/rules/no-dev-dependency-import.spec.ts
@@ -1,0 +1,88 @@
+import { RuleTester } from 'oxlint/plugins-dev';
+import rule from './no-dev-dependency-import.ts';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+
+const ruleTester = new RuleTester({
+  languageOptions: { parserOptions: { lang: 'ts' } },
+});
+
+// `vitest` is a real `devDependencies` entry; `commander` is a real
+// `dependencies` entry. Both are read from this repo's package.json.
+ruleTester.run('no-dev-dependency-import', rule, {
+  valid: [
+    // relative and absolute imports are never package imports
+    `import { foo } from './foo.ts';`,
+    `import { foo } from '/foo.ts';`,
+    // a real production dependency
+    `import { Command } from 'commander';`,
+    // a devDependency is fine as a type-only import
+    `import type { Something } from 'vitest';`,
+    // a devDependency is fine when every specifier is type-only
+    `import { type Something } from 'vitest';`,
+    // a devDependency is fine as a type-only re-export
+    `export type { Something } from 'vitest';`,
+    `export { type Something } from 'vitest';`,
+    // no source
+    `export const foo = 1;`,
+    `export { foo };`,
+    // dynamic import with a non-literal source
+    `const p = import('../' + name);`,
+    // dynamic import with a non-string literal source
+    `const p = import(42);`,
+    // a devDependency is fine as a type-only `export *`
+    `export type * from 'vitest';`,
+  ],
+  invalid: [
+    {
+      code: `import { describe } from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    {
+      code: `import vitest from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    {
+      code: `import * as vitest from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    // side-effect only import is a runtime import
+    {
+      code: `import 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    // mixed type/value specifiers still produce a runtime import
+    {
+      code: `import { type Something, describe } from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    // deep import from a devDependency
+    {
+      code: `import { describe } from 'vitest/dist/foo.js';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    // scoped devDependency
+    {
+      code: `import { something } from '@types/common-tags/foo.js';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    {
+      code: `export { describe } from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    {
+      code: `export * from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    // re-export with no specifiers is still a runtime import
+    {
+      code: `export {} from 'vitest';`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+    {
+      code: `const p = import('vitest');`,
+      errors: [{ messageId: 'noDevDependencyImport' }],
+    },
+  ],
+});

--- a/tools/lint/rules/no-dev-dependency-import.ts
+++ b/tools/lint/rules/no-dev-dependency-import.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { Context, ESTree } from '@oxlint/plugins';
+import { defineRule } from '@oxlint/plugins';
+
+/** Every literal node oxc emits, all of which share `type: 'Literal'`. */
+type Literal = Extract<ESTree.Node, { type: 'Literal' }>;
+
+const packageJsonPath = path.join(import.meta.dirname, '../../../package.json');
+// oxlint-disable-next-line no-sync -- lint rules run synchronously, so async fs is not an option
+const packageJsonRaw = fs.readFileSync(packageJsonPath, 'utf8');
+const pkg = JSON.parse(packageJsonRaw) as {
+  devDependencies?: Record<string, string>;
+};
+const devDependencies = new Set(Object.keys(pkg.devDependencies ?? {}));
+
+/** Resolves a bare import specifier to the package name it belongs to, or `null` for relative/absolute imports. */
+function packageName(specifier: string): string | null {
+  if (specifier.startsWith('.') || specifier.startsWith('/')) {
+    return null;
+  }
+  const segments = specifier.split('/');
+  return specifier.startsWith('@')
+    ? segments.slice(0, 2).join('/')
+    : segments[0];
+}
+
+function checkSource(context: Context, source: Literal): void {
+  if (typeof source.value !== 'string') {
+    return;
+  }
+  const name = packageName(source.value);
+  if (name && devDependencies.has(name)) {
+    context.report({
+      node: source,
+      messageId: 'noDevDependencyImport',
+      data: { name },
+    });
+  }
+}
+
+export default defineRule({
+  meta: {
+    type: 'problem',
+    messages: {
+      noDevDependencyImport:
+        '`{{name}}` is a devDependency and is not installed for users of the published package. Move it to `dependencies` in package.json, or use a type-only import if only types are needed.',
+    },
+  },
+  createOnce(context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.importKind === 'type') {
+          return;
+        }
+        if (
+          node.specifiers.length > 0 &&
+          node.specifiers.every(
+            (specifier) =>
+              specifier.type === 'ImportSpecifier' &&
+              specifier.importKind === 'type',
+          )
+        ) {
+          return;
+        }
+        checkSource(context, node.source);
+      },
+      ExportNamedDeclaration(node) {
+        if (!node.source || node.exportKind === 'type') {
+          return;
+        }
+        if (
+          node.specifiers.length > 0 &&
+          node.specifiers.every((specifier) => specifier.exportKind === 'type')
+        ) {
+          return;
+        }
+        checkSource(context, node.source);
+      },
+      ExportAllDeclaration(node) {
+        if (node.exportKind === 'type') {
+          return;
+        }
+        checkSource(context, node.source);
+      },
+      ImportExpression(node) {
+        if (node.source.type === 'Literal') {
+          checkSource(context, node.source);
+        }
+      },
+    };
+  },
+});


### PR DESCRIPTION
## Changes


As we've recently had a couple of cases where a `devDependency` has been
used in a production file, and CI hasn't caught it, we end up seeing
i.e.

    ERROR: unhandledRejection
           "err": {
             "code": "ERR_MODULE_NOT_FOUND",
             "message": "Cannot find package 'common-tags' imported from
                         /usr/local/renovate/dist/workers/repository/update/pr/index.js"
             }

(see 5ee51fdf39dfc9574ae54df2fb045dea62442bdd and
1d331437275cada0a0091e2d9a5b85fa0ea90fa1 for two cases this has happened
with)

One option for caching this is a linting rule, which stops runtime usage
in `lib/` on a dependency in `devDependencies`.



## Context

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):



### Use of AI in replying to PR comments

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @jamietanna will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

