### PR TITLE
feat: infer root runtime constraints

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -915,7 +915,6 @@ The downside of this is that you may end up with a very old issue getting "recyc
 ## `constraints`
 
 Constraints are used in package managers which use third-party tools to update "artifacts" like lock files or checksum files.
-Typically, the constraint is detected automatically by Renovate from files within the repository and there is no need to manually configure it.
 
 Constraints are also used to manually restrict which _datasource_ versions are possible to upgrade to based on their language support.
 For now this datasource constraint feature only supports `python`, other compatibility restrictions will be added in the future.
@@ -957,6 +956,13 @@ Additionally, there are several additional constraints that can be specified:
 ## `constraintsFiltering`
 
 This option controls whether Renovate filters new releases based on configured or detected `constraints`.
+Renovate infers recognized runtime constraints from:
+
+- `package.json` `engines` and package-manager declarations
+- repository-root `.tool-versions`
+- repository-root `mise.toml` and `.mise.toml`
+
+For `bun`, `node`, `yarn`, `npm`, `pnpm`, and `vscode`, Renovate uses the primary tool version. Root mise values override `.tool-versions` values. Explicit configuration and constraints in package files take precedence over inferred runtime constraints.
 Renovate supports two options:
 
 - `none`: No release filtering (all releases allowed)

--- a/lib/modules/manager/asdf/extract.spec.ts
+++ b/lib/modules/manager/asdf/extract.spec.ts
@@ -6,6 +6,7 @@ describe('modules/manager/asdf/extract', () => {
     it('returns a result', () => {
       const res = extractPackageFile('nodejs 16.16.0\n');
       expect(res).toEqual({
+        extractedConstraints: { node: '16.16.0' },
         deps: [
           {
             currentValue: '16.16.0',
@@ -16,9 +17,31 @@ describe('modules/manager/asdf/extract', () => {
       });
     });
 
+    it('extracts all runtime constraints, including unsupported tooling', () => {
+      const result = extractPackageFile(
+        'bun 1.3.0\nnodejs 22.11.0\nyarn 4.5.0\nnpm 11.0.0\npnpm 10.34.5\nvscode 1.100.0\n',
+      );
+
+      expect(result).toMatchObject({
+        extractedConstraints: {
+          bun: '1.3.0',
+          node: '22.11.0',
+          yarn: '4.5.0',
+          npm: '11.0.0',
+          pnpm: '10.34.5',
+          vscode: '1.100.0',
+        },
+      });
+      expect(result?.deps).toContainEqual({
+        depName: 'vscode',
+        skipReason: 'unsupported-datasource',
+      });
+    });
+
     it('provides skipReason for lines with unsupported tooling', () => {
       const res = extractPackageFile('unsupported 1.22.5\n');
       expect(res).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             depName: 'unsupported',
@@ -31,6 +54,7 @@ describe('modules/manager/asdf/extract', () => {
     it('only captures the first version', () => {
       const res = extractPackageFile('nodejs 16.16.0 16.15.1');
       expect(res).toEqual({
+        extractedConstraints: { node: '16.16.0' },
         deps: [
           {
             currentValue: '16.16.0',
@@ -155,6 +179,11 @@ dummy 1.2.3
 `,
       );
       expect(res).toEqual({
+        extractedConstraints: {
+          bun: '0.2.2',
+          node: '18.12.0',
+          pnpm: '7.26.2',
+        },
         deps: [
           {
             currentValue: '0.2.54',
@@ -896,6 +925,7 @@ awscli    2.8.6
 `,
       );
       expect(res).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '3.0.0',
@@ -923,6 +953,7 @@ awscli    2.8.6
     it('can handle flutter version channel', () => {
       const withChannel = extractPackageFile('flutter 3.10.0-stable');
       expect(withChannel).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '3.10.0',
@@ -933,6 +964,7 @@ awscli    2.8.6
       });
       const withoutChannel = extractPackageFile('flutter 3.10.0');
       expect(withoutChannel).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '3.10.0',
@@ -946,6 +978,7 @@ awscli    2.8.6
     it('can handle java jre / jdk', () => {
       const adoptOpenJdkRes = extractPackageFile('java adoptopenjdk-16.0.0+36');
       expect(adoptOpenJdkRes).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '16.0.0+36',
@@ -959,6 +992,7 @@ awscli    2.8.6
         'java adoptopenjdk-jre-16.0.0+36',
       );
       expect(adoptOpenJreRes).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '16.0.0+36',
@@ -970,6 +1004,7 @@ awscli    2.8.6
       });
       const temurinJdkRes = extractPackageFile('java temurin-16.0.0+36');
       expect(temurinJdkRes).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '16.0.0+36',
@@ -981,6 +1016,7 @@ awscli    2.8.6
       });
       const temurinJreRes = extractPackageFile('java temurin-jre-16.0.0+36');
       expect(temurinJreRes).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '16.0.0+36',
@@ -992,6 +1028,7 @@ awscli    2.8.6
       });
       const unknownRes = extractPackageFile('java unknown-16.0.0+36');
       expect(unknownRes).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             depName: 'java',
@@ -1004,6 +1041,7 @@ awscli    2.8.6
     it('can handle scala v 2 & 3', () => {
       const v2Res = extractPackageFile('scala 2.0.0');
       expect(v2Res).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '2.0.0',
@@ -1016,6 +1054,7 @@ awscli    2.8.6
       });
       const v3Res = extractPackageFile('scala 3.0.0');
       expect(v3Res).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             currentValue: '3.0.0',
@@ -1027,6 +1066,7 @@ awscli    2.8.6
       });
       const unknownRes = extractPackageFile('scala 0.0.0');
       expect(unknownRes).toEqual({
+        extractedConstraints: {},
         deps: [
           {
             depName: 'scala',
@@ -1054,6 +1094,7 @@ awscli    2.8.6
           it(`entry: '${data.entry}'`, () => {
             const res = extractPackageFile(data.entry);
             expect(res).toEqual({
+              extractedConstraints: { node: data.expect },
               deps: [
                 {
                   currentValue: data.expect,
@@ -1083,6 +1124,7 @@ awscli    2.8.6
           '# this is a full line comment\nnodejs 16.16.0 # this is a comment\n',
         );
         expect(res).toEqual({
+          extractedConstraints: { node: '16.16.0' },
           deps: [
             {
               currentValue: '16.16.0',
@@ -1096,6 +1138,7 @@ awscli    2.8.6
       it('ignores supported tooling with a renovate:ignore comment', () => {
         const res = extractPackageFile('nodejs 16.16.0 # renovate:ignore\n');
         expect(res).toEqual({
+          extractedConstraints: {},
           deps: [
             {
               currentValue: '16.16.0',

--- a/lib/modules/manager/asdf/extract.ts
+++ b/lib/modules/manager/asdf/extract.ts
@@ -1,5 +1,6 @@
 import { isFunction, isTruthy } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import type { ConstraintName } from '../../../util/exec/types.ts';
 import { isSkipComment } from '../../../util/ignore.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { PackageDependency, PackageFileContent } from '../types.ts';
@@ -14,12 +15,29 @@ export function extractPackageFile(content: string): PackageFileContent | null {
   );
 
   const deps: PackageDependency[] = [];
+  const extractedConstraints: Partial<Record<ConstraintName, string>> = {};
+  const constraintNames: ConstraintName[] = [
+    'bun',
+    'node',
+    'yarn',
+    'npm',
+    'pnpm',
+    'vscode',
+  ];
 
   for (const groups of [...content.matchAll(regex)]
     .map((m) => m.groups)
     .filter(isTruthy)) {
     const depName = groups.toolName.trim();
     const version = groups.version.trim();
+    const isIgnored = isSkipComment((groups.comment ?? '').trim());
+    const constraintName =
+      depName === 'nodejs'
+        ? 'node'
+        : constraintNames.find((name) => name === depName);
+    if (!isIgnored && constraintName) {
+      extractedConstraints[constraintName] = version;
+    }
 
     const toolConfig = upgradeableTooling[depName];
     let toolDefinition: StaticTooling | undefined;
@@ -35,7 +53,7 @@ export function extractPackageFile(content: string): PackageFileContent | null {
         depName,
         ...toolDefinition,
       };
-      if (isSkipComment((groups.comment ?? '').trim())) {
+      if (isIgnored) {
         dep.skipReason = 'ignored';
       }
 
@@ -50,5 +68,5 @@ export function extractPackageFile(content: string): PackageFileContent | null {
     }
   }
 
-  return deps.length ? { deps } : null;
+  return deps.length ? { deps, extractedConstraints } : null;
 }

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -53,6 +53,55 @@ describe('modules/manager/mise/extract', () => {
       });
     });
 
+    it('extracts all runtime constraints from tools, including unsupported tooling', async () => {
+      const result = await extractPackageFile(
+        codeBlock`
+          [tools]
+          bun = '1.3.0'
+          node = '22.11.0'
+          "core:node" = '24.0.0'
+          yarn = '4.5.0'
+          npm = '11.0.0'
+          pnpm = '10.34.5'
+          vscode = '1.100.0'
+
+          [tasks.test]
+          tools = { node = '25.0.0' }
+        `,
+        miseFilename,
+      );
+
+      expect(result).toMatchObject({
+        extractedConstraints: {
+          bun: '1.3.0',
+          node: '24.0.0',
+          yarn: '4.5.0',
+          npm: '11.0.0',
+          pnpm: '10.34.5',
+          vscode: '1.100.0',
+        },
+      });
+      expect(result?.deps).toContainEqual({
+        depName: 'vscode',
+        depType: 'tools',
+        skipReason: 'unsupported-datasource',
+      });
+    });
+
+    it('normalizes the asdf nodejs tool name to node', async () => {
+      const result = await extractPackageFile(
+        codeBlock`
+          [tools]
+          "asdf:nodejs" = '22.11.0'
+        `,
+        miseFilename,
+      );
+
+      expect(result).toMatchObject({
+        extractedConstraints: { node: '22.11.0' },
+      });
+    });
+
     it('extracts tools - mise registry tools', async () => {
       const content = codeBlock`
       [tools]
@@ -432,6 +481,7 @@ describe('modules/manager/mise/extract', () => {
           },
         ],
       });
+      expect(result?.extractedConstraints).toEqual({ node: '16' });
     });
 
     it('extracts tools with plugin options', async () => {
@@ -842,6 +892,7 @@ describe('modules/manager/mise/extract', () => {
       [tools]
       java = '21.0.2'
       erlang = []
+      node = []
     `;
       const result = await extractPackageFile(content, miseFilename);
       expect(result).toMatchObject({
@@ -854,8 +905,13 @@ describe('modules/manager/mise/extract', () => {
             depName: 'erlang',
             skipReason: 'unspecified-version',
           },
+          {
+            depName: 'node',
+            skipReason: 'unspecified-version',
+          },
         ],
       });
+      expect(result?.extractedConstraints).not.toHaveProperty('node');
     });
 
     it('complete mise.toml example', async () => {

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -7,6 +7,7 @@ import {
   isString,
 } from '@sindresorhus/is';
 import { logger } from '../../../logger/index.ts';
+import type { ConstraintName } from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
 import { coerceObject } from '../../../util/object.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -56,9 +57,28 @@ export async function extractPackageFile(
   }
 
   const deps: PackageDependency[] = [];
+  const extractedConstraints: Partial<Record<ConstraintName, string>> = {};
+  const constraintNames: ConstraintName[] = [
+    'bun',
+    'node',
+    'yarn',
+    'npm',
+    'pnpm',
+    'vscode',
+  ];
 
   for (const [name, toolData] of Object.entries(misefile.tools)) {
     deps.push(extractToolEntry(name, toolData, 'tools'));
+    const depName = optionInToolNameRegex.exec(name.trim())!.groups!.name;
+    const toolName = depName.substring(depName.indexOf(':') + 1);
+    const constraintName =
+      toolName === 'nodejs'
+        ? 'node'
+        : constraintNames.find((name) => name === toolName);
+    const version = parseVersion(toolData);
+    if (constraintName && version) {
+      extractedConstraints[constraintName] = version;
+    }
   }
 
   for (const [taskName, taskData] of Object.entries(misefile.tasks)) {
@@ -73,7 +93,7 @@ export async function extractPackageFile(
     return null;
   }
 
-  const result: PackageFileContent = { deps };
+  const result: PackageFileContent = { deps, extractedConstraints };
 
   const lockFileName = getLockFileName(packageFile);
   const lockFileContent = await readLocalFile(lockFileName, 'utf8');

--- a/lib/workers/repository/process/fetch.spec.ts
+++ b/lib/workers/repository/process/fetch.spec.ts
@@ -120,6 +120,274 @@ describe('workers/repository/process/fetch', () => {
       });
     });
 
+    it('applies root .tool-versions constraints to other package files', async () => {
+      config.constraints = {};
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: '.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { node: '19.9.0' } }),
+      );
+    });
+
+    it('prefers root mise constraints over root .tool-versions constraints', async () => {
+      config.constraints = {};
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: '.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        mise: [
+          {
+            packageFile: 'mise.toml',
+            extractedConstraints: { node: '22.11.0' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { node: '22.11.0' } }),
+      );
+    });
+
+    it('applies all root .mise.toml constraints to other package files', async () => {
+      config.constraints = {};
+      const packageFiles: any = {
+        mise: [
+          {
+            packageFile: '.mise.toml',
+            extractedConstraints: {
+              bun: '1.3.0',
+              node: '22.11.0',
+              yarn: '4.5.0',
+              npm: '11.0.0',
+              pnpm: '10.34.5',
+              vscode: '1.100.0',
+            },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({
+          constraints: {
+            bun: '1.3.0',
+            node: '22.11.0',
+            yarn: '4.5.0',
+            npm: '11.0.0',
+            pnpm: '10.34.5',
+            vscode: '1.100.0',
+          },
+        }),
+      );
+    });
+
+    it('prefers configured constraints over inferred runtime constraints', async () => {
+      config.constraints = { node: '20.0.0' };
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: '.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { node: '20.0.0' } }),
+      );
+    });
+
+    it('prefers package-file constraints over inferred runtime constraints', async () => {
+      config.constraints = {};
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: '.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            extractedConstraints: { node: '18.0.0' },
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { node: '18.0.0' } }),
+      );
+    });
+
+    it('prefers dependency constraints over inferred runtime constraints', async () => {
+      config.constraints = {};
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: '.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [
+              {
+                datasource: 'npm',
+                depName: '@changesets/cli',
+                extractedConstraints: { node: '18.0.0' },
+              },
+            ],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { node: '18.0.0' } }),
+      );
+    });
+
+    it('prefers manager-scoped constraints over inferred runtime constraints', async () => {
+      config.constraints = {};
+      // @ts-expect-error -- manager configurations are dynamically addressed
+      config.npm = { constraints: { node: '20.0.0' } };
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: '.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: { node: '20.0.0' } }),
+      );
+    });
+
+    it('does not apply nested runtime constraints to other package files', async () => {
+      config.constraints = {};
+      const packageFiles: any = {
+        asdf: [
+          {
+            packageFile: 'subdir/.tool-versions',
+            extractedConstraints: { node: '19.9.0' },
+            deps: [],
+          },
+        ],
+        mise: [
+          {
+            packageFile: 'subdir/mise.toml',
+            extractedConstraints: { node: '22.11.0' },
+            deps: [],
+          },
+          {
+            packageFile: 'subdir/.mise.toml',
+            extractedConstraints: { pnpm: '10.34.5' },
+            deps: [],
+          },
+        ],
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [{ datasource: 'npm', depName: '@changesets/cli' }],
+          },
+        ],
+      };
+      lookupUpdates.mockResolvedValue(
+        Result.ok(partial<UpdateResult>({ updates: [] })),
+      );
+
+      await fetchUpdates(config, packageFiles);
+
+      expect(lookupUpdates).toHaveBeenCalledWith(
+        expect.objectContaining({ constraints: {} }),
+      );
+    });
+
     describe('constraintsVersioning', () => {
       it('is merged from packageFile with config', async () => {
         config.constraintsVersioning = { gomodMod: 'config-version' };
@@ -221,7 +489,7 @@ describe('workers/repository/process/fetch', () => {
       });
     });
 
-    it('prefers configured constraints over extracted constraints', async () => {
+    it('prefers dependency extracted constraints over configured constraints', async () => {
       config.rangeStrategy = 'auto';
       config.constraints = { python: '>=3.9' };
       const packageFiles: any = {
@@ -247,7 +515,7 @@ describe('workers/repository/process/fetch', () => {
 
       expect(lookupUpdates).toHaveBeenCalledWith(
         expect.objectContaining({
-          constraints: { python: '>=3.9' },
+          constraints: { python: '<3.12' },
           datasource: 'maven',
           depName: 'bbb',
         }),

--- a/lib/workers/repository/process/fetch.ts
+++ b/lib/workers/repository/process/fetch.ts
@@ -22,6 +22,32 @@ import type { LookupUpdateConfig, UpdateResult } from './lookup/types.ts';
 
 type LookupResult = Result<PackageDependency>;
 
+function getRuntimeConstraints(
+  packageFiles: Record<string, PackageFile[]>,
+): RenovateConfig['constraints'] {
+  const asdfConstraints = packageFiles.asdf
+    ?.filter(({ packageFile }) => packageFile === '.tool-versions')
+    .reduce(
+      (constraints, { extractedConstraints }) => ({
+        ...constraints,
+        ...extractedConstraints,
+      }),
+      {},
+    );
+  const miseConstraints = packageFiles.mise
+    ?.filter(({ packageFile }) =>
+      ['mise.toml', '.mise.toml'].includes(packageFile),
+    )
+    .reduce(
+      (constraints, { extractedConstraints }) => ({
+        ...constraints,
+        ...extractedConstraints,
+      }),
+      {},
+    );
+  return { ...asdfConstraints, ...miseConstraints };
+}
+
 async function lookup(
   packageFileConfig: RenovateConfig & PackageFile,
   indep: PackageDependency,
@@ -55,8 +81,8 @@ async function lookup(
   let depConfig = mergeChildConfig(packageFileConfig, dep);
   if (dep.extractedConstraints) {
     depConfig.constraints = {
-      ...dep.extractedConstraints,
       ...depConfig.constraints,
+      ...dep.extractedConstraints,
     };
   }
   const datasourceDefaultConfig = await getDefaultConfig(depConfig.datasource!);
@@ -124,15 +150,16 @@ async function fetchManagerPackagerFileUpdates(
   config: RenovateConfig,
   managerConfig: RenovateConfig,
   pFile: PackageFile,
+  runtimeConstraints: RenovateConfig['constraints'],
 ): Promise<void> {
   const { packageFile } = pFile;
   const packageFileConfig = mergeChildConfig(managerConfig, pFile);
-  if (pFile.extractedConstraints) {
-    packageFileConfig.constraints = {
-      ...pFile.extractedConstraints,
-      ...config.constraints,
-    };
-  }
+  packageFileConfig.constraints = {
+    ...runtimeConstraints,
+    ...pFile.extractedConstraints,
+    ...packageFileConfig.constraints,
+    ...config.constraints,
+  };
   const mergedConstraintsVersioning = {
     ...pFile.constraintsVersioning,
     ...config.constraintsVersioning,
@@ -163,11 +190,17 @@ async function fetchManagerUpdates(
   config: RenovateConfig,
   packageFiles: Record<string, PackageFile[]>,
   manager: string,
+  runtimeConstraints: RenovateConfig['constraints'],
 ): Promise<void> {
   const managerConfig = getManagerConfig(config, manager);
   const queue = packageFiles[manager].map(
     (pFile) => (): Promise<void> =>
-      fetchManagerPackagerFileUpdates(config, managerConfig, pFile),
+      fetchManagerPackagerFileUpdates(
+        config,
+        managerConfig,
+        pFile,
+        runtimeConstraints,
+      ),
   );
   logger.trace(
     { manager, queueLength: queue.length },
@@ -181,10 +214,11 @@ export async function fetchUpdates(
   config: RenovateConfig,
   packageFiles: Record<string, PackageFile[]>,
 ): Promise<void> {
+  const runtimeConstraints = getRuntimeConstraints(packageFiles);
   const managers = Object.keys(packageFiles);
   const allManagerJobs = managers.map((manager) =>
     instrument(manager, () =>
-      fetchManagerUpdates(config, packageFiles, manager),
+      fetchManagerUpdates(config, packageFiles, manager, runtimeConstraints),
     ),
   );
   await Promise.all(allManagerJobs);


### PR DESCRIPTION
## Changes

- Infer `bun`, `node`, `yarn`, `npm`, `pnpm`, and `vscode` constraints from root `.tool-versions`, `mise.toml`, and `.mise.toml` files.
- Propagate those constraints to dependency lookups so `constraintsFiltering: "strict"` can filter incompatible releases.
- Preserve precedence: dependency, package, and explicit configured constraints override inferred runtime constraints; root mise values override root asdf values.
- Document the detected runtime constraint sources and precedence.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] Yes - substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

OpenCode, using `github-copilot/gpt-5.6-terra`, assisted with the implementation, tests, documentation, and PR description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] An agent will draft replies and @jonathanmorley will read them before they are posted.

## Documentation (please check one with an [x])

- [x] I have updated the documentation.

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Newly added/modified unit tests.

- `pnpm vitest lib/modules/manager/asdf/extract.spec.ts lib/modules/manager/mise/extract.spec.ts lib/workers/repository/process/fetch.spec.ts` (90 passing)
- `pnpm lint-documentation` (149 passing)
- `pnpm prettier`

The focused suite, documentation checks, and formatting were run under Node 24.11.0. A full Vitest run passed 27,005 tests and has five unrelated existing WASM-PGP failures in `lib/config/decrypt/bcpgp.spec.ts`.
