### PR TITLE
feat(changelog): aggregate datasource-provided release notes

### DIFF
--- a/lib/modules/datasource/custom/index.spec.ts
+++ b/lib/modules/datasource/custom/index.spec.ts
@@ -120,6 +120,79 @@ describe('modules/datasource/custom/index', () => {
       expect(result).toEqual(expected);
     });
 
+    it('returns per-release changelog content from a direct custom datasource response', async () => {
+      const changelogContent = codeBlock`
+        ### Catalog upgrade notes
+
+        - Replaces \`example.v1.0.0\`.
+        - This bundle is available on the \`stable\` channel.
+      `;
+      const expected = {
+        releases: [
+          {
+            version: 'v1.0.0',
+          },
+          {
+            changelogContent,
+            changelogUrl: 'https://example.com/foo/releases/v1.1.0',
+            version: 'v1.1.0',
+          },
+        ],
+      };
+      httpMock
+        .scope('https://example.com')
+        .get('/v1/changelog')
+        .reply(200, expected);
+
+      const result = await getPkgReleases({
+        datasource: `${CustomDatasource.id}.foo`,
+        packageName: 'myPackage',
+        customDatasources: {
+          foo: {
+            defaultRegistryUrlTemplate: 'https://example.com/v1/changelog',
+          },
+        },
+      });
+
+      expect(result).toEqual(expected);
+    });
+
+    it('drops non-string changelog content but keeps the release', async () => {
+      const content = {
+        releases: [
+          {
+            changelogContent: { body: 'Not a string' },
+            changelogUrl: 'https://example.com/foo/releases/v1.0.0',
+            version: 'v1.0.0',
+          },
+        ],
+      };
+      httpMock
+        .scope('https://example.com')
+        .get('/v1/invalid-changelog')
+        .reply(200, content);
+
+      const result = await getPkgReleases({
+        datasource: `${CustomDatasource.id}.foo`,
+        packageName: 'myPackage',
+        customDatasources: {
+          foo: {
+            defaultRegistryUrlTemplate:
+              'https://example.com/v1/invalid-changelog',
+          },
+        },
+      });
+
+      expect(result).toEqual({
+        releases: [
+          {
+            changelogUrl: 'https://example.com/foo/releases/v1.0.0',
+            version: 'v1.0.0',
+          },
+        ],
+      });
+    });
+
     it('return releases with tags and other optional fields for api directly exposing in renovate format', async () => {
       const expected = {
         releases: [

--- a/lib/modules/datasource/custom/readme.md
+++ b/lib/modules/datasource/custom/readme.md
@@ -70,6 +70,7 @@ All available options:
       "version": "v1.0.0",
       "isDeprecated": true,
       "releaseTimestamp": "2022-12-24T18:21Z",
+      "changelogContent": "Release notes in Markdown.",
       "changelogUrl": "https://github.com/demo-org/demo/blob/main/CHANGELOG.md#v0710",
       "sourceUrl": "https://github.com/demo-org/demo",
       "sourceDirectory": "monorepo/folder",
@@ -83,6 +84,35 @@ All available options:
   "homepage": "https://demo.org"
 }
 ```
+
+### Embedded release notes
+
+`changelogContent` is optional Markdown describing only its release.
+Do not include cumulative history in each entry: Renovate combines applicable entries, which would repeat that history.
+Use `changelogUrl` on each release to link to its full notes.
+Providing a URL alone does not make Renovate fetch Markdown from that URL.
+
+When the current and target versions are available, Renovate combines supplied notes in `(currentVersion, newVersion]`: after the current version, up to and including the selected target.
+It applies the configured versioning's compatibility and prerelease rules, orders releases newest first, and includes at most one entry per equivalent version.
+For example, an update from `1.0.0` to `1.3.0` can display notes for `1.3.0`, `1.2.0`, and `1.1.0`, but not `1.0.0` or `1.4.0`.
+Only releases returned by the datasource can contribute embedded notes.
+
+If any applicable entries contain notes, these take precedence over normal repository changelog retrieval, even when `sourceUrl` points to GitHub or GitLab.
+Renovate does not fetch missing entries from those platforms to complete a partially supplied changelog.
+If no applicable embedded entries are available, Renovate falls back to the selected target's supplied content, when present, and otherwise to normal changelog retrieval.
+Omit `changelogContent` to use normal retrieval; an empty string on the selected target still counts as supplied content in that fallback.
+
+Missing, empty, or non-string content is excluded from the combined release notes without removing the release from update consideration.
+Non-string content is discarded during custom datasource validation.
+An update can therefore still be proposed when its changelog is unavailable.
+
+In grouped PRs, supplied notes are kept separately for each dependency, even when dependencies share a repository or source URL.
+Renovate does not compare the supplied text for duplicates across dependencies.
+Notes fetched through normal repository retrieval retain their existing deduplication behavior.
+
+Embedded notes respect [`fetchChangeLogs`](../../../configuration-options.md#fetchchangelogs), including `"off"`.
+They use Renovate's existing Markdown sanitization, PR template, and platform-specific body truncation.
+The final PR body limit does not limit the earlier datasource response or the memory used to retain supplied content.
 
 ### Debugging
 

--- a/lib/modules/datasource/custom/schema.ts
+++ b/lib/modules/datasource/custom/schema.ts
@@ -10,6 +10,9 @@ export const ReleaseResultZod = z.object({
         releaseTimestamp: MaybeTimestamp,
         sourceUrl: z.string().optional(),
         sourceDirectory: z.string().optional(),
+        // Release notes are cosmetic, so malformed content must not discard the
+        // whole lookup and block updates for the package.
+        changelogContent: z.string().optional().catch(undefined),
         changelogUrl: z.string().optional(),
         digest: z.string().optional(),
         isStable: z.boolean().optional(),

--- a/lib/modules/datasource/types.ts
+++ b/lib/modules/datasource/types.ts
@@ -69,6 +69,12 @@ export interface GetPkgReleasesConfig {
 }
 
 export interface Release {
+  /**
+   * Markdown for this release only, not cumulative history. Applicable entries
+   * are combined for the update range and take precedence over repository
+   * changelog retrieval; missing entries are not fetched separately.
+   * Omit this field from all releases to allow normal repository retrieval.
+   */
   changelogContent?: string;
   changelogUrl?: string;
   checksumUrl?: string;
@@ -90,6 +96,20 @@ export interface Release {
   currentAge?: string;
   isLatest?: boolean;
   attestation?: boolean;
+}
+
+/**
+ * The subset of {@link Release} needed to render embedded release notes.
+ *
+ * Carried on every update and branch config, so it deliberately omits the
+ * lookup-only fields of a full `Release`.
+ */
+export interface ChangelogRelease {
+  version: string;
+  changelogContent: string;
+  changelogUrl?: string;
+  releaseTimestamp?: Timestamp | null;
+  gitRef?: string;
 }
 
 export interface ReleaseTags {

--- a/lib/modules/manager/types.ts
+++ b/lib/modules/manager/types.ts
@@ -21,7 +21,10 @@ import type {
 import type { FileChange } from '../../util/git/types.ts';
 import type { MergeConfidence } from '../../util/merge-confidence/types.ts';
 import type { Timestamp } from '../../util/timestamp.ts';
-import type { RegistryStrategy } from '../datasource/index.ts';
+import type {
+  ChangelogRelease,
+  RegistryStrategy,
+} from '../datasource/index.ts';
 import type { CustomExtractConfig } from './custom/types.ts';
 
 export interface ManagerData<T> {
@@ -170,6 +173,7 @@ export interface PackageDependency<
   packageFileVersion?: string;
   gitRef?: boolean;
   sourceUrl?: string | null;
+  changelogReleases?: ChangelogRelease[];
   pinDigests?: boolean;
   currentRawValue?: string;
   major?: { enabled?: boolean };

--- a/lib/workers/repository/changelog/index.spec.ts
+++ b/lib/workers/repository/changelog/index.spec.ts
@@ -1,4 +1,5 @@
 import { partial } from '~test/util.ts';
+import type { Timestamp } from '../../../util/timestamp.ts';
 import type { BranchUpgradeConfig } from '../../types.ts';
 import { getChangeLogJSON } from '../update/pr/changelog/index.ts';
 import { embedChangelogs } from './index.ts';
@@ -39,6 +40,7 @@ describe('workers/repository/changelog/index', () => {
         changelogContent: 'testContent',
         logJSON: {
           hasReleaseNotes: true,
+          perDependencyNotes: true,
           project: {},
           versions: [
             {
@@ -111,4 +113,270 @@ describe('workers/repository/changelog/index', () => {
       expect.objectContaining({ groupName: 'fetchChangeLogs is off' }),
     );
   });
+
+  it('embeds every release with content in the update range newest-first', async () => {
+    const upgrades = [
+      partial<BranchUpgradeConfig>({
+        branchName: 'update/example',
+        changelogContent: 'targetContent',
+        changelogReleases: [
+          {
+            changelogContent: 'oldContent',
+            changelogUrl: 'https://example.com/releases/0.9.0',
+            version: '0.9.0',
+          },
+          {
+            changelogContent: 'currentContent',
+            changelogUrl: 'https://example.com/releases/1.0.0',
+            version: '1.0.0',
+          },
+          {
+            changelogContent: 'intermediateContent',
+            changelogUrl: 'https://example.com/releases/1.1.0',
+            gitRef: 'release-1.1.0',
+            releaseTimestamp: '2026-01-02T00:00:00.000Z' as Timestamp,
+            version: '1.1.0',
+          },
+          {
+            changelogContent: 'prereleaseContent',
+            version: '1.2.1-rc.1',
+          },
+          {
+            changelogContent: 'targetContent',
+            changelogUrl: 'https://example.com/releases/1.3.0',
+            releaseTimestamp: '2026-01-04T00:00:00.000Z' as Timestamp,
+            version: '1.3.0',
+          },
+          {
+            changelogContent: 'futureContent',
+            changelogUrl: 'https://example.com/releases/1.4.0',
+            version: '1.4.0',
+          },
+        ],
+        currentVersion: '1.0.0',
+        depName: 'example',
+        fetchChangeLogs: 'pr',
+        newVersion: '1.3.0',
+        packageName: 'example',
+        versioning: 'npm',
+      }),
+    ];
+
+    await embedChangelogs({ upgrades, stage: 'pr' });
+
+    expect(getChangeLogJSON).not.toHaveBeenCalled();
+    expect(upgrades[0].logJSON).toEqual({
+      hasReleaseNotes: true,
+      perDependencyNotes: true,
+      project: {
+        apiBaseUrl: undefined,
+        baseUrl: undefined,
+        depName: 'example',
+        packageName: 'example',
+        repository: undefined,
+        sourceDirectory: undefined,
+        sourceUrl: undefined,
+        type: undefined,
+      },
+      versions: [
+        {
+          changes: [],
+          compare: {},
+          date: '2026-01-04T00:00:00.000Z',
+          gitRef: undefined,
+          releaseNotes: {
+            body: 'targetContent',
+            notesSourceUrl: undefined,
+            url: 'https://example.com/releases/1.3.0',
+          },
+          version: '1.3.0',
+        },
+        {
+          changes: [],
+          compare: {},
+          date: '2026-01-02T00:00:00.000Z',
+          gitRef: 'release-1.1.0',
+          releaseNotes: {
+            body: 'intermediateContent',
+            notesSourceUrl: undefined,
+            url: 'https://example.com/releases/1.1.0',
+          },
+          version: '1.1.0',
+        },
+      ],
+    });
+  });
+
+  it('uses intermediate content when the target release has no content', async () => {
+    const upgrades = [
+      partial<BranchUpgradeConfig>({
+        changelogReleases: [
+          {
+            changelogContent: 'intermediateContent',
+            changelogUrl: 'https://example.com/releases/1.1.0',
+            version: '1.1.0',
+          },
+        ],
+        currentVersion: '1.0.0',
+        fetchChangeLogs: 'pr',
+        newVersion: '1.2.0',
+        versioning: 'npm',
+      }),
+    ];
+
+    await embedChangelogs({ upgrades, stage: 'pr' });
+
+    expect(getChangeLogJSON).not.toHaveBeenCalled();
+    expect(upgrades[0].logJSON?.versions).toEqual([
+      expect.objectContaining({
+        releaseNotes: {
+          body: 'intermediateContent',
+          notesSourceUrl: undefined,
+          url: 'https://example.com/releases/1.1.0',
+        },
+        version: '1.1.0',
+      }),
+    ]);
+  });
+
+  it('normalizes versions and excludes incompatible release content', async () => {
+    const upgrades = [
+      partial<BranchUpgradeConfig>({
+        changelogReleases: [
+          {
+            changelogContent: 'alpineContent',
+            version: '1.0.1-alpine',
+          },
+          {
+            changelogContent: 'bookwormContent',
+            version: '1.0.2-bookworm',
+          },
+          {
+            changelogContent: 'targetContent',
+            version: '1.0.3-alpine',
+          },
+        ],
+        currentValue: '1.0.0-alpine',
+        currentVersion: '1.0.0',
+        fetchChangeLogs: 'pr',
+        newVersion: '1.0.3',
+        versioning: 'docker',
+      }),
+    ];
+
+    await embedChangelogs({ upgrades, stage: 'pr' });
+
+    expect(upgrades[0].logJSON?.versions).toEqual([
+      expect.objectContaining({
+        releaseNotes: expect.objectContaining({ body: 'targetContent' }),
+        version: '1.0.3',
+      }),
+      expect.objectContaining({
+        releaseNotes: expect.objectContaining({ body: 'alpineContent' }),
+        version: '1.0.1',
+      }),
+    ]);
+  });
+
+  it('filters release content independently for each update target', async () => {
+    const changelogReleases = [
+      { changelogContent: 'oneOne', version: '1.1.0' },
+      { changelogContent: 'oneTwo', version: '1.2.0' },
+      { changelogContent: 'twoZero', version: '2.0.0' },
+    ];
+    const upgrades = [
+      partial<BranchUpgradeConfig>({
+        changelogReleases,
+        currentVersion: '1.0.0',
+        fetchChangeLogs: 'pr',
+        newVersion: '1.2.0',
+        versioning: 'npm',
+      }),
+      partial<BranchUpgradeConfig>({
+        changelogReleases,
+        currentVersion: '1.0.0',
+        fetchChangeLogs: 'pr',
+        newVersion: '2.0.0',
+        versioning: 'npm',
+      }),
+    ];
+
+    await embedChangelogs({ upgrades, stage: 'pr' });
+
+    expect(
+      upgrades[0].logJSON?.versions?.map(({ version }) => version),
+    ).toEqual(['1.2.0', '1.1.0']);
+    expect(
+      upgrades[1].logJSON?.versions?.map(({ version }) => version),
+    ).toEqual(['2.0.0', '1.2.0', '1.1.0']);
+  });
+
+  it('falls back to the normal changelog lookup when no content is in range', async () => {
+    const expected = { hasReleaseNotes: true };
+    vi.mocked(getChangeLogJSON).mockResolvedValueOnce(expected);
+    const upgrades = [
+      partial<BranchUpgradeConfig>({
+        changelogReleases: [
+          { changelogContent: 'oldContent', version: '0.9.0' },
+          { changelogContent: 'futureContent', version: '2.0.0' },
+        ],
+        currentVersion: '1.0.0',
+        fetchChangeLogs: 'pr',
+        newVersion: '1.1.0',
+        versioning: 'npm',
+      }),
+    ];
+
+    await embedChangelogs({ upgrades, stage: 'pr' });
+
+    expect(getChangeLogJSON).toHaveBeenCalledExactlyOnceWith(upgrades[0]);
+    expect(upgrades[0].logJSON).toBe(expected);
+  });
+
+  it('deduplicates versions which are equal under the configured versioning', async () => {
+    const upgrades = [
+      partial<BranchUpgradeConfig>({
+        changelogReleases: [
+          { changelogContent: 'releaseContent', version: '1.1.0' },
+          { changelogContent: 'releaseContent', version: 'v1.1.0' },
+        ],
+        currentVersion: '1.0.0',
+        fetchChangeLogs: 'pr',
+        newVersion: '1.1.0',
+        versioning: 'npm',
+      }),
+    ];
+
+    await embedChangelogs({ upgrades, stage: 'pr' });
+
+    expect(upgrades[0].logJSON?.versions).toHaveLength(1);
+  });
+
+  it.each`
+    missing             | upgrade
+    ${'versioning'}     | ${{ currentVersion: '1.0.0', newVersion: '1.1.0' }}
+    ${'currentVersion'} | ${{ newVersion: '1.1.0', versioning: 'npm' }}
+    ${'newVersion'}     | ${{ currentVersion: '1.0.0', versioning: 'npm' }}
+  `(
+    'uses the single-release fallback when $missing is missing',
+    async ({ upgrade }) => {
+      const upgrades = [
+        partial<BranchUpgradeConfig>({
+          ...upgrade,
+          changelogContent: 'fallbackContent',
+          changelogReleases: [
+            { changelogContent: 'releaseContent', version: '1.1.0' },
+          ],
+          fetchChangeLogs: 'pr',
+        }),
+      ];
+
+      await embedChangelogs({ upgrades, stage: 'pr' });
+
+      expect(upgrades[0].logJSON?.versions?.[0].releaseNotes?.body).toBe(
+        'fallbackContent',
+      );
+      expect(getChangeLogJSON).not.toHaveBeenCalled();
+    },
+  );
 });

--- a/lib/workers/repository/changelog/index.ts
+++ b/lib/workers/repository/changelog/index.ts
@@ -1,7 +1,67 @@
+import { isNonEmptyArray, isNonEmptyString } from '@sindresorhus/is';
+import * as allVersioning from '../../../modules/versioning/index.ts';
 import * as p from '../../../util/promises.ts';
 import type { BranchUpgradeConfig } from '../../types.ts';
 import { getChangeLogJSON } from '../update/pr/changelog/index.ts';
+import { filterInRangeReleases } from '../update/pr/changelog/releases.ts';
+import type { ChangeLogResult } from '../update/pr/changelog/types.ts';
 import type { EmbedChangelogsOptions } from './types.ts';
+
+function getReleaseChangelog(
+  upgrade: BranchUpgradeConfig,
+): ChangeLogResult | null {
+  if (
+    !isNonEmptyArray(upgrade.changelogReleases) ||
+    !isNonEmptyString(upgrade.versioning) ||
+    !isNonEmptyString(upgrade.currentVersion) ||
+    !isNonEmptyString(upgrade.newVersion)
+  ) {
+    return null;
+  }
+
+  const versioning = allVersioning.get(upgrade.versioning);
+  const releases = filterInRangeReleases(upgrade, upgrade.changelogReleases)
+    .filter((release) =>
+      versioning.isGreaterThan(release.version, upgrade.currentVersion!),
+    )
+    .sort((a, b) => versioning.sortVersions(b.version, a.version))
+    .filter(
+      (release, index, sorted) =>
+        index === 0 ||
+        !versioning.equals(release.version, sorted[index - 1].version),
+    );
+
+  if (!isNonEmptyArray(releases)) {
+    return null;
+  }
+
+  return {
+    hasReleaseNotes: true,
+    perDependencyNotes: true,
+    project: {
+      packageName: upgrade.packageName,
+      depName: upgrade.depName,
+      type: undefined!,
+      apiBaseUrl: undefined!,
+      baseUrl: undefined!,
+      repository: upgrade.repository!,
+      sourceUrl: upgrade.sourceUrl!,
+      sourceDirectory: upgrade.sourceDirectory,
+    },
+    versions: releases.map((release) => ({
+      changes: [],
+      compare: {},
+      date: release.releaseTimestamp!,
+      releaseNotes: {
+        body: release.changelogContent,
+        notesSourceUrl: undefined!,
+        url: release.changelogUrl!,
+      },
+      gitRef: release.gitRef!,
+      version: release.version,
+    })),
+  };
+}
 
 export async function embedChangelog(
   upgrade: BranchUpgradeConfig,
@@ -11,11 +71,18 @@ export async function embedChangelog(
     return;
   }
 
+  const releaseChangelog = getReleaseChangelog(upgrade);
+  if (releaseChangelog) {
+    upgrade.logJSON = releaseChangelog;
+    return;
+  }
+
   if (upgrade.changelogContent === undefined) {
     upgrade.logJSON = await getChangeLogJSON(upgrade);
   } else {
     upgrade.logJSON = {
       hasReleaseNotes: true,
+      perDependencyNotes: true,
       project: {
         packageName: upgrade.packageName,
         depName: upgrade.depName,

--- a/lib/workers/repository/process/lookup/index.spec.ts
+++ b/lib/workers/repository/process/lookup/index.spec.ts
@@ -6634,6 +6634,11 @@ describe('workers/repository/process/lookup/index', () => {
             version: '8.0.0',
           },
           {
+            changelogContent: 'intermediateContent',
+            changelogUrl: 'http://intermediateChangelogUrl',
+            version: '8.0.1',
+          },
+          {
             changelogContent: 'testContent',
             changelogUrl: 'http://testChangelogUrl',
             version: '8.1.0',
@@ -6647,6 +6652,18 @@ describe('workers/repository/process/lookup/index', () => {
 
       expect(res).toEqual({
         changelogContent: 'testContent',
+        changelogReleases: [
+          {
+            changelogContent: 'intermediateContent',
+            changelogUrl: 'http://intermediateChangelogUrl',
+            version: '8.0.1',
+          },
+          {
+            changelogContent: 'testContent',
+            changelogUrl: 'http://testChangelogUrl',
+            version: '8.1.0',
+          },
+        ],
         changelogUrl: 'http://testChangelogUrl',
         currentVersion: '8.0.0',
         fixedVersion: '8.0.0',
@@ -6695,6 +6712,13 @@ describe('workers/repository/process/lookup/index', () => {
 
       expect(res).toEqual({
         changelogContent: 'testContent',
+        changelogReleases: [
+          {
+            changelogContent: 'testContent',
+            changelogUrl: 'http://testChangelogUrl',
+            version: '8.1.0',
+          },
+        ],
         changelogUrl: 'http://testChangelogUrl',
         currentVersion: '8.0.0',
         isSingleVersion: false,
@@ -6717,6 +6741,92 @@ describe('workers/repository/process/lookup/index', () => {
         versioning: 'maven',
         warnings: [],
       });
+    });
+
+    it('preserves intermediate changelog content when the target release has none', async () => {
+      config.currentValue = '8.0.0';
+      config.packageName = 'node';
+      config.datasource = DockerDatasource.id;
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: '8.0.0',
+          },
+          {
+            changelogContent: 'intermediateContent',
+            changelogUrl: 'http://intermediateChangelogUrl',
+            version: '8.1.0',
+          },
+          {
+            version: '8.2.0',
+          },
+        ],
+      });
+
+      const res = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(res.updates).toHaveLength(1);
+      expect(res.changelogReleases).toEqual([
+        {
+          changelogContent: 'intermediateContent',
+          changelogUrl: 'http://intermediateChangelogUrl',
+          version: '8.1.0',
+        },
+      ]);
+      expect(res.updates[0]).toMatchObject({
+        newValue: '8.2.0',
+        newVersion: '8.2.0',
+      });
+      expect(res.changelogContent).toBeUndefined();
+      expect(res.changelogUrl).toBeUndefined();
+    });
+
+    it('stores changelog releases once when generating multiple updates', async () => {
+      config.currentValue = '8.0.0';
+      config.packageName = 'node';
+      config.datasource = DockerDatasource.id;
+      config.separateMajorMinor = true;
+      getDockerReleases.mockResolvedValueOnce({
+        releases: [
+          {
+            version: '8.0.0',
+          },
+          {
+            changelogContent: 'minorContent',
+            version: '8.1.0',
+          },
+          {
+            changelogContent: 'majorContent',
+            version: '9.0.0',
+          },
+        ],
+      });
+
+      const res = await Result.wrap(
+        lookup.lookupUpdates(config),
+      ).unwrapOrThrow();
+
+      expect(res.changelogContent).toBe('minorContent');
+      expect(res.changelogReleases).toEqual([
+        {
+          changelogContent: 'minorContent',
+          version: '8.1.0',
+        },
+        {
+          changelogContent: 'majorContent',
+          version: '9.0.0',
+        },
+      ]);
+      expect(res.updates).toHaveLength(2);
+      expect(res.updates.map(({ newVersion }) => newVersion)).toEqual([
+        '8.1.0',
+        '9.0.0',
+      ]);
+      for (const update of res.updates) {
+        expect(update).not.toHaveProperty('changelogReleases');
+      }
     });
   });
 });

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -978,6 +978,23 @@ export async function lookupUpdates(
       );
     }
 
+    const changelogReleases = dependency?.releases.flatMap((release) =>
+      isNonEmptyString(release.changelogContent)
+        ? [
+            {
+              version: release.version,
+              changelogContent: release.changelogContent,
+              changelogUrl: release.changelogUrl,
+              releaseTimestamp: release.releaseTimestamp,
+              gitRef: release.gitRef,
+            },
+          ]
+        : [],
+    );
+    if (changelogReleases?.length) {
+      res.changelogReleases = changelogReleases;
+    }
+
     const release =
       res.updates.length > 0
         ? (dependency?.releases.find(

--- a/lib/workers/repository/process/lookup/types.ts
+++ b/lib/workers/repository/process/lookup/types.ts
@@ -2,6 +2,7 @@ import type {
   RenovateConfig,
   ValidationMessage,
 } from '../../../../config/types.ts';
+import type { ChangelogRelease } from '../../../../modules/datasource/types.ts';
 import type {
   LookupUpdate,
   RangeConfig,
@@ -63,6 +64,7 @@ export interface LookupUpdateConfig
 export interface UpdateResult {
   sourceDirectory?: string;
   changelogContent?: string;
+  changelogReleases?: ChangelogRelease[];
   changelogUrl?: string;
   dependencyUrl?: string;
   homepage?: string;

--- a/lib/workers/repository/update/pr/changelog/releases.ts
+++ b/lib/workers/repository/update/pr/changelog/releases.ts
@@ -34,9 +34,6 @@ export async function getInRangeReleases(
   config: BranchUpgradeConfig,
 ): Promise<Release[] | null> {
   return await instrument(`getInRangeReleases`, async () => {
-    const versioning = config.versioning!;
-    const currentVersion = config.currentVersion!;
-    const newVersion = config.newVersion!;
     const depName = config.depName!;
     const datasource = config.datasource!;
     // istanbul ignore if
@@ -45,63 +42,71 @@ export async function getInRangeReleases(
     }
     try {
       const pkgReleases = (await getPkgReleases(config))!.releases;
-      const version = get(versioning);
-      const compatibilityVersion = version.valueToVersion
-        ? (config.currentValue ?? currentVersion)
-        : currentVersion;
-
-      const previousReleases = pkgReleases
-        .filter((release) =>
-          version.isCompatible(release.version, compatibilityVersion),
-        )
-        .map((release) => ({
-          ...release,
-          version: version.valueToVersion?.(release.version) ?? release.version,
-        }))
-        .filter(
-          (release) => !version.isGreaterThan(release.version, newVersion),
-        )
-        .filter(
-          (release) =>
-            version.isStable(release.version) ||
-            matchesUnstable(version, currentVersion, release.version) ||
-            matchesUnstable(version, newVersion, release.version),
-        );
-
-      const releases = previousReleases.filter(
-        (release) =>
-          version.equals(release.version, currentVersion) ||
-          version.isGreaterThan(release.version, currentVersion),
-      );
-
-      /**
-       * If there is only one release, it can be one of two things:
-       *
-       *   1. There really is only one release
-       *
-       *   2. Pinned version doesn't actually exist, i.e pinning `^1.2.3` to `1.2.3`
-       *      while only `1.2.2` and `1.2.4` exist.
-       */
-      if (releases.length === 1) {
-        const newRelease = releases[0];
-        const closestPreviousRelease = previousReleases
-          .filter((release) => !version.equals(release.version, newVersion))
-          .sort((b, a) => version.sortVersions(a.version, b.version))
-          .shift();
-
-        if (
-          closestPreviousRelease &&
-          closestPreviousRelease.version !== newRelease.version
-        ) {
-          releases.unshift(closestPreviousRelease);
-        }
-      }
-
-      return releases;
+      return filterInRangeReleases(config, pkgReleases);
     } catch (err) /* istanbul ignore next */ {
       logger.debug({ err }, 'getInRangeReleases err');
       logger.debug(`Error getting releases for ${depName} from ${datasource}`);
       return null;
     }
   });
+}
+
+export function filterInRangeReleases<T extends { version: string }>(
+  config: BranchUpgradeConfig,
+  pkgReleases: T[],
+): T[] {
+  const versioning = config.versioning!;
+  const currentVersion = config.currentVersion!;
+  const newVersion = config.newVersion!;
+  const version = get(versioning);
+  const compatibilityVersion = version.valueToVersion
+    ? (config.currentValue ?? currentVersion)
+    : currentVersion;
+
+  const previousReleases = pkgReleases
+    .filter((release) =>
+      version.isCompatible(release.version, compatibilityVersion),
+    )
+    .map((release) => ({
+      ...release,
+      version: version.valueToVersion?.(release.version) ?? release.version,
+    }))
+    .filter((release) => !version.isGreaterThan(release.version, newVersion))
+    .filter(
+      (release) =>
+        version.isStable(release.version) ||
+        matchesUnstable(version, currentVersion, release.version) ||
+        matchesUnstable(version, newVersion, release.version),
+    );
+
+  const releases = previousReleases.filter(
+    (release) =>
+      version.equals(release.version, currentVersion) ||
+      version.isGreaterThan(release.version, currentVersion),
+  );
+
+  /**
+   * If there is only one release, it can be one of two things:
+   *
+   *   1. There really is only one release
+   *
+   *   2. Pinned version doesn't actually exist, i.e pinning `^1.2.3` to `1.2.3`
+   *      while only `1.2.2` and `1.2.4` exist.
+   */
+  if (releases.length === 1) {
+    const newRelease = releases[0];
+    const closestPreviousRelease = previousReleases
+      .filter((release) => !version.equals(release.version, newVersion))
+      .sort((b, a) => version.sortVersions(a.version, b.version))
+      .shift();
+
+    if (
+      closestPreviousRelease &&
+      closestPreviousRelease.version !== newRelease.version
+    ) {
+      releases.unshift(closestPreviousRelease);
+    }
+  }
+
+  return releases;
 }

--- a/lib/workers/repository/update/pr/changelog/types.ts
+++ b/lib/workers/repository/update/pr/changelog/types.ts
@@ -45,6 +45,12 @@ export interface ChangeLogResult {
   project?: ChangeLogProject;
   versions?: ChangeLogRelease[];
   error?: ChangeLogError;
+  /**
+   * Notes were supplied by the dependency's own datasource response rather than
+   * fetched from a shared upstream source, so they are unique per dependency
+   * and must not be deduplicated against other upgrades.
+   */
+  perDependencyNotes?: boolean;
 }
 
 export interface ChangeLogFile {

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -949,6 +949,175 @@ describe('workers/repository/update/pr/index', () => {
         });
       });
 
+      it('retains distinct embedded changelogs sharing a release URL', async () => {
+        const { embedChangelogs: actualEmbedChangelogs } =
+          await vi.importActual<typeof import('../../changelog/index.ts')>(
+            '../../changelog/index.ts',
+          );
+        vi.mocked(embedChangelogs).mockImplementationOnce(
+          actualEmbedChangelogs,
+        );
+        platform.createPr.mockResolvedValueOnce(pr);
+        const changelogUrl = 'https://example.com/releases/1.1.0';
+        const upgrades = ['alpha', 'beta'].map((depName) =>
+          partial<BranchUpgradeConfig>({
+            depName,
+            packageName: depName,
+            manager: 'npm',
+            repository: 'some/repo',
+            sourceUrl: 'https://github.com/example/monorepo',
+            sourceDirectory: depName,
+            versioning: 'npm',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            fetchChangeLogs: 'pr',
+            changelogReleases: [
+              {
+                version: '1.1.0',
+                changelogContent: `${depName} release notes`,
+                changelogUrl,
+              },
+            ],
+          }),
+        );
+
+        const res = await ensurePr({ ...config, upgrades });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        const [[bodyConfig]] = prBody.getPrBody.mock.calls;
+        expect(bodyConfig.upgrades).toMatchObject(
+          ['alpha', 'beta'].map((depName) => ({
+            depName,
+            hasReleaseNotes: true,
+            releases: [
+              {
+                version: '1.1.0',
+                releaseNotes: {
+                  body: `${depName} release notes`,
+                  url: changelogUrl,
+                },
+              },
+            ],
+          })),
+        );
+      });
+
+      it('retains distinct embedded changelogs without a source directory', async () => {
+        const { embedChangelogs: actualEmbedChangelogs } =
+          await vi.importActual<typeof import('../../changelog/index.ts')>(
+            '../../changelog/index.ts',
+          );
+        vi.mocked(embedChangelogs).mockImplementationOnce(
+          actualEmbedChangelogs,
+        );
+        platform.createPr.mockResolvedValueOnce(pr);
+        const upgrades = ['stable-4.21', 'stable-4.22'].map((depName) =>
+          partial<BranchUpgradeConfig>({
+            depName,
+            packageName: depName,
+            manager: 'regex',
+            repository: 'some/repo',
+            sourceUrl: 'https://multi.ocp.releases.ci.openshift.org',
+            versioning: 'semver',
+            currentVersion: '1.0.0',
+            newVersion: '1.1.0',
+            fetchChangeLogs: 'pr',
+            changelogReleases: [
+              {
+                version: '1.1.0',
+                changelogContent: `${depName} release notes`,
+                changelogUrl: `https://access.redhat.com/errata/${depName}`,
+              },
+            ],
+          }),
+        );
+
+        const res = await ensurePr({ ...config, upgrades });
+
+        expect(res).toEqual({ type: 'with-pr', pr });
+        const [[bodyConfig]] = prBody.getPrBody.mock.calls;
+        expect(bodyConfig.upgrades).toMatchObject(
+          ['stable-4.21', 'stable-4.22'].map((depName) => ({
+            depName,
+            hasReleaseNotes: true,
+            releases: [
+              {
+                version: '1.1.0',
+                releaseNotes: { body: `${depName} release notes` },
+              },
+            ],
+          })),
+        );
+      });
+
+      it.each`
+        platformName
+        ${'github'}
+        ${'gitlab'}
+      `(
+        'uses $platformName body limits for grouped embedded changelogs',
+        async ({ platformName }) => {
+          const { embedChangelogs: actualEmbedChangelogs } =
+            await vi.importActual<typeof import('../../changelog/index.ts')>(
+              '../../changelog/index.ts',
+            );
+          const { getPrBody } =
+            await vi.importActual<typeof import('./body/index.ts')>(
+              './body/index.ts',
+            );
+          const actualPlatform = await vi.importActual<
+            typeof import('../../../../modules/platform/github/index.ts')
+          >(`../../../../modules/platform/${platformName}/index.ts`);
+          vi.mocked(embedChangelogs).mockImplementationOnce(
+            actualEmbedChangelogs,
+          );
+          prBody.getPrBody.mockImplementationOnce(getPrBody);
+          platform.massageMarkdown.mockImplementation(
+            actualPlatform.massageMarkdown,
+          );
+          platform.createPr.mockResolvedValueOnce(pr);
+          const maxBodyLength = actualPlatform.maxBodyLength();
+          const upgrades = ['alpha', 'beta'].map((depName) =>
+            partial<BranchUpgradeConfig>({
+              depName,
+              packageName: depName,
+              manager: 'npm',
+              repository: 'some/repo',
+              sourceUrl: 'https://github.com/example/monorepo',
+              sourceDirectory: depName,
+              versioning: 'npm',
+              currentVersion: '1.0.0',
+              newVersion: '1.1.0',
+              fetchChangeLogs: 'pr',
+              changelogReleases: [
+                {
+                  version: '1.1.0',
+                  changelogContent: `${depName} release notes\n\n${'x'.repeat(
+                    Math.ceil(maxBodyLength * 0.6),
+                  )}`,
+                  changelogUrl: `https://example.com/${depName}/1.1.0`,
+                },
+              ],
+            }),
+          );
+
+          const res = await ensurePr({
+            ...config,
+            upgrades,
+            prBodyTemplate: '{{{changelogs}}}{{{configDescription}}}',
+          });
+
+          expect(res).toEqual({ type: 'with-pr', pr });
+          expect(platform.createPr).toHaveBeenCalledTimes(1);
+          const [{ prBody: renderedBody }] = platform.createPr.mock.calls[0];
+          expect(renderedBody.length).toBeLessThanOrEqual(maxBodyLength);
+          expect(renderedBody).toContain('alpha release notes');
+          expect(renderedBody).toContain('beta release notes');
+          expect(renderedBody).toContain('truncated due to platform limits');
+          expect(renderedBody).toContain('### Configuration');
+        },
+      );
+
       it('handles missing GitHub token', async () => {
         platform.createPr.mockResolvedValueOnce(pr);
 

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -322,12 +322,15 @@ export async function ensurePr(
         }
         upgrade.hasReleaseNotes = false;
         upgrade.releases = [];
-        if (
-          logJSON.hasReleaseNotes &&
-          upgrade.repoName &&
-          !commitRepos.includes(getRepoNameWithSourceDirectory(upgrade))
-        ) {
-          commitRepos.push(getRepoNameWithSourceDirectory(upgrade));
+        const repoNameWithSourceDirectory =
+          getRepoNameWithSourceDirectory(upgrade);
+        const isDuplicateRepo =
+          !logJSON.perDependencyNotes &&
+          commitRepos.includes(repoNameWithSourceDirectory);
+        if (logJSON.hasReleaseNotes && upgrade.repoName && !isDuplicateRepo) {
+          if (!logJSON.perDependencyNotes) {
+            commitRepos.push(repoNameWithSourceDirectory);
+          }
           upgrade.hasReleaseNotes = logJSON.hasReleaseNotes;
           if (logJSON.versions) {
             for (const version of logJSON.versions) {
@@ -363,6 +366,10 @@ export async function ensurePr(
 
   const releaseNotesSources: string[] = [];
   for (const upgrade of config.upgrades) {
+    if (upgrade.logJSON?.perDependencyNotes) {
+      continue;
+    }
+
     let notesSourceUrl = upgrade.releases?.[0]?.releaseNotes?.notesSourceUrl;
     // TODO: types (#22198)
     notesSourceUrl ??= `${upgrade.sourceUrl!}${

--- a/lib/workers/repository/updates/flatten.spec.ts
+++ b/lib/workers/repository/updates/flatten.spec.ts
@@ -285,6 +285,36 @@ describe('workers/repository/updates/flatten', () => {
       expect(res.find((update) => update.depName === 'foo')).toBeDefined();
     });
 
+    it('propagates dependency changelog releases to every update', async () => {
+      const changelogReleases = [
+        { changelogContent: 'minorContent', version: '1.1.0' },
+        { changelogContent: 'majorContent', version: '2.0.0' },
+      ];
+      const packageFiles: Record<string, PackageFile[]> = {
+        npm: [
+          {
+            packageFile: 'package.json',
+            deps: [
+              {
+                changelogReleases,
+                depName: 'foo',
+                updates: [
+                  { newValue: '1.1.0', updateType: 'minor' },
+                  { newValue: '2.0.0', updateType: 'major' },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      const res = await flattenUpdates(config, packageFiles);
+
+      expect(res).toHaveLength(2);
+      expect(res[0].changelogReleases).toEqual(changelogReleases);
+      expect(res[1].changelogReleases).toEqual(changelogReleases);
+    });
+
     it('when a skipReason is found on a dependency, it is filtered', async () => {
       const packageFiles = {
         npm: [


### PR DESCRIPTION
## Changes

Allow datasources to supply individual release notes and have Renovate include the notes between the installed and target versions in the PR body.

Currently, custom datasource validation strips `releases[].changelogContent`. The existing embedded-content path also uses only the selected target release's content, so exposing the field alone would still omit intermediate release notes.

This PR:

- Preserves optional `changelogContent` in custom datasource responses. Missing or malformed content does not reject the release or block updates.
- Aggregates supplied notes in `(currentVersion, newVersion]`, newest first, using the existing version-range filtering and one entry per equivalent version.
- Preserves each dependency's embedded notes in grouped PRs, including when dependencies share a repository or source URL.
- Reuses the existing changelog renderer, Markdown sanitization, `fetchChangeLogs` handling, and platform PR-body limits.

For example, an update from `1.0.0` to `1.3.0` can include notes for `1.3.0`, `1.2.0`, and `1.1.0`. Releases without content are omitted from the notes. Each entry should describe its own release; producers do not need to repeat the complete upgrade history in every target entry.

### Why this is needed

[olm-catalog-datasource](https://github.com/MindTooth/olm-catalog-datasource) exposes OpenShift releases to Renovate and supplies Markdown from OpenShift's release infrastructure. These notes are not available as a matching set of GitHub/GitLab repository releases, and `changelogUrl` alone does not make Renovate fetch and embed arbitrary Markdown.

Preserving and aggregating this content lets an OpenShift update show the supplied intermediate changes directly in the PR. The datasource remains responsible for update eligibility and available history; Renovate handles version selection and presentation without OpenShift-specific logic.

### Scope and compatibility

The aggregation runs in the shared changelog pipeline:

| Datasource | Effect |
| --- | --- |
| `custom.<name>` | Can supply per-release Markdown through the validated response. |
| `unity3d-packages`, `azure-pipelines-tasks`, `nextcloud` | Existing per-release content can now contribute intermediate notes. |
| Datasources without supplied content | Continue using normal repository retrieval. |

Root-level `ReleaseResult.changelogContent`, such as NuGet's metadata field, is outside the new per-release propagation.

The main behavior change is **automatic aggregation without an opt-in**. Applicable embedded notes take precedence over repository retrieval, including when only intermediate releases have content. Missing entries are not filled by fetching GitHub/GitLab notes. Feedback on whether this should require an opt-in is welcome.

The existing selected-release fallback is retained, including its empty-string behavior. Both aggregated and selected-release embedded notes bypass cross-dependency repository/source deduplication; repository-fetched notes retain their existing deduplication.

Only version, content, URL, timestamp, and Git ref are propagated. These arrays are copied during normal update configuration merging, so large release histories can increase memory use. Existing PR-body limits constrain rendered output, not the earlier datasource payload.

### Validation

Added coverage for schema handling, propagation through lookup and flattening, version-range selection, missing content, grouped dependencies, and GitHub/GitLab PR-body truncation.

The recorded targeted run passed 30 suites with 681 passing tests and one expected failure. TypeScript and targeted lint/format checks also passed. This run preceded the final upstream merge and documentation updates; it is not a full CI run on the current head. No real-repository end-to-end validation was performed.

Related: [discussion #45328](https://github.com/renovatebot/renovate/discussions/45328), which proposed custom datasource schema support. This PR additionally implements aggregation and preservation of grouped dependency notes.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

OpenAI Codex/ChatGPT assisted with implementation, tests, documentation, and validation. The recorded assistance includes GPT-5 and rework attributed to Claude Fable 5. Codex also assisted with this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @MindTooth will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @MindTooth will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: Not applicable; validation used unit tests.
