### PR TITLE
test: close remaining line coverage gaps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -541,10 +541,10 @@ jobs:
       - name: Check coverage threshold
         run: |
           pnpm nyc check-coverage -t ./coverage/nyc \
-            --statements 99.99 \
-            --branches 98.70 \
+            --statements 100 \
+            --branches 98.71 \
             --functions 100 \
-            --lines 99.99 \
+            --lines 100 \
 
   # Catch-all required check for test matrix and coverage
   test-success:

--- a/lib/modules/datasource/nuget/index.spec.ts
+++ b/lib/modules/datasource/nuget/index.spec.ts
@@ -581,6 +581,69 @@ describe('modules/datasource/nuget/index', () => {
         );
         expect(res?.sourceUrl).toBeUndefined();
       });
+
+      it('silences 404 when the nupkg is not found', async () => {
+        const nugetIndex = codeBlock`
+          {
+            "version": "3.0.0",
+            "resources": [
+              {
+                "@id": "https://some-registry/v3/metadata",
+                "@type": "RegistrationsBaseUrl/3.0.0-beta",
+                "comment": "Get package metadata."
+              }
+            ]
+          }
+        `;
+        const nlogRegistration = codeBlock`
+          {
+            "count": 1,
+            "items": [
+              {
+                "@id": "https://some-registry/v3/metadata/nlog/4.7.3.json",
+                "lower": "4.7.3",
+                "upper": "4.7.3",
+                "count": 1,
+                "items": [
+                  {
+                    "@id": "foo",
+                    "catalogEntry": {
+                      "id": "NLog",
+                      "version": "4.7.3",
+                      "packageContent": "https://some-registry/v3-flatcontainer/nlog/4.7.3/nlog.4.7.3.nupkg"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        `;
+        httpMock
+          .scope('https://some-registry')
+          .get('/v3/index.json')
+          .twice()
+          .reply(200, nugetIndex)
+          .get('/v3/metadata/nlog/index.json')
+          .reply(200, nlogRegistration)
+          .get('/v3-flatcontainer/nlog/4.7.3/nlog.4.7.3.nupkg')
+          .reply(404);
+        const res = await getPkgReleases({
+          datasource,
+          versioning,
+          packageName: 'NLog',
+          registryUrls: ['https://some-registry/v3/index.json'],
+        });
+
+        expect(logger.logger.debug).toHaveBeenCalledWith(
+          {
+            registryUrl: 'https://some-registry/v3/index.json',
+            pkgName: 'NLog',
+            pkgVersion: '4.7.3',
+          },
+          'package manifest (.nuspec) not found',
+        );
+        expect(res?.sourceUrl).toBeUndefined();
+      });
     });
 
     it('returns null for non 200 (v3v2)', async () => {

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -245,6 +245,7 @@ export async function initPlatform({
   if (!gitAuthor) {
     if (platformConfig.isGHApp) {
       platformConfig.userDetails ??= await getAppDetails(token);
+      // v8 ignore next -- TODO: coverage error #40625
       discoveredGitAuthor = `${platformConfig.userDetails.name} <${platformConfig.userDetails.id}+${platformConfig.userDetails.username}@users.noreply.${ghHostname}>`;
     } else {
       platformConfig.userDetails ??= await getUserDetails(

--- a/lib/modules/versioning/rez/index.spec.ts
+++ b/lib/modules/versioning/rez/index.spec.ts
@@ -445,6 +445,18 @@ describe('modules/versioning/rez/index', () => {
     },
   );
 
+  it('getNewValue() replaces a plain version with a four-component version', () => {
+    // rez versions may have more than three components, which npm rejects,
+    // so the new value is determined via pep440 instead of version precision
+    const res = versioning.getNewValue({
+      currentValue: '1.2.3',
+      rangeStrategy: 'replace',
+      currentVersion: '1.2.3',
+      newVersion: '1.2.3.4',
+    });
+    expect(res).toBe('1.2.3.4');
+  });
+
   it.each`
     version    | expected
     ${'1.2.0'} | ${true}


### PR DESCRIPTION
## Changes

A full coverage run on `main` reported three uncovered lines. This closes all three, bringing line and statement coverage to 100%.

| Location | Why it was uncovered | Change |
| --- | --- | --- |
| `lib/modules/versioning/rez/transform.ts:76` | `rez2pep440()` was never reached with a plain version: `getNewValue()` short-circuits via `matchVersionPrecision()` whenever the new version is valid for npm | New test using a four-component rez version (`1.2.3` → `1.2.3.4`), which npm rejects, so the pep440 path runs |
| `lib/modules/datasource/nuget/v3.ts:286-289` | Only the inner nuspec 404 was covered; a 404 escaping from the `.nupkg` download into the outer catch was not | New test where `PackageBaseAddress` is absent and the `.nupkg` request replies 404 |
| `lib/modules/platform/github/index.ts:248` | v8/source-map false negative: the statement after `await` in the GitHub App branch runs (4× in the existing tests, per the statement counts) but is counted zero | `// v8 ignore next -- TODO: coverage error #40625`, matching the sibling branch on line 254 |

On the last one: that branch used to carry its own ignore comment. In #44587 the `ghHostname` block was hoisted out of the branch and the comment travelled with the moved code, leaving the next statement exposed to the same artifact. The line-247 statement shows 4 executions while line 248 shows 0, which cannot happen for real.

With those closed, a full run reports:

```
Statements   : 100% ( 49776/49776 )
Branches     : 98.72% ( 25756/26089 )
Functions    : 100% ( 7403/7403 )
Lines        : 100% ( 49256/49256 )
```

so the `coverage-threshold` job in `.github/workflows/build.yml` is ratcheted up to match: statements and lines from `99.99` to `100`, branches from `98.70` to `98.71`. Branches keep the same round-down margin the previous value had; the two new tests happen to cover two extra branches, which is the only reason that number moves at all.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Opus 5, via Claude Code: located the uncovered lines from a full coverage run, wrote the two new tests and the `v8 ignore` comment, and wrote this description.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @viceice will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`pnpm check --all` passes (1008 test files, 27024 tests), and a full coverage run afterwards reports no uncovered statements, functions, or lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
