### PR TITLE
fix(manager/github-actions): match `actions/setup-` actions referenced by an https:// URL

### DIFF
--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -2,6 +2,7 @@ import { z } from 'zod/v4';
 
 import { regEx } from '../../../util/regex.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
+import { DotnetVersionDatasource } from '../../datasource/dotnet-version/index.ts';
 import { GithubReleaseAttachmentsDatasource } from '../../datasource/github-release-attachments/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
@@ -157,6 +158,12 @@ const RenovateGithubActionWith: ActionSchema = z
  * Community contributed actions with known version input schemas.
  */
 export const communityActions: Record<string, CommunityActionConfig> = {
+  // https://github.com/actions/setup-dotnet
+  'actions/setup-dotnet': {
+    datasource: DotnetVersionDatasource.id,
+    packageName: 'dotnet-sdk',
+    withSchema: valSchema('dotnet-version', (val) => val.includes('\n')),
+  },
   // https://github.com/aquasecurity/setup-trivy
   'aquasecurity/setup-trivy': {
     datasource: GithubReleasesDatasource.id,

--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -15,6 +15,7 @@ import * as condaVersioning from '../../versioning/conda/index.ts';
 import * as npmVersioning from '../../versioning/npm/index.ts';
 import type { PackageDependency } from '../types.ts';
 import type { ActionSchema, CommunityActionConfig } from './types.ts';
+import { actionUsesRegex } from './utils.ts';
 
 export function actionSchema(
   name: string,
@@ -35,9 +36,7 @@ export function actionSchema(
 }
 
 function matchAction(action: string): z.ZodString {
-  return z
-    .string()
-    .regex(regEx(`(?:https?://[^/]+/)?${RegExp.escape(action)}(?:@.+)?$`));
+  return z.string().regex(actionUsesRegex(action));
 }
 
 function parseValue(

--- a/lib/modules/manager/github-actions/community.ts
+++ b/lib/modules/manager/github-actions/community.ts
@@ -5,6 +5,7 @@ import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { DotnetVersionDatasource } from '../../datasource/dotnet-version/index.ts';
 import { GithubReleaseAttachmentsDatasource } from '../../datasource/github-release-attachments/index.ts';
 import { GithubReleasesDatasource } from '../../datasource/github-releases/index.ts';
+import { JavaVersionDatasource } from '../../datasource/java-version/index.ts';
 import { NodeVersionDatasource } from '../../datasource/node-version/index.ts';
 import { NpmDatasource } from '../../datasource/npm/index.ts';
 import { PypiDatasource } from '../../datasource/pypi/index.ts';
@@ -135,6 +136,46 @@ const PnpmSetupWith: ActionSchema = z
     ...parsePnpmRuntime(runtime),
   ]);
 
+// Distributions whose version numbering we can reliably track via the
+// java-version datasource (which sources releases from Adoptium/Eclipse
+// Temurin). Other distributions may not follow the same release cadence
+// or versioning, so we don't attempt to track them.
+const supportedJavaDistributions = new Set(['temurin', 'adopt']);
+
+const SetupJavaWith: ActionSchema = z
+  .object({
+    distribution: z.string().optional(),
+    'java-version': z.string().optional(),
+    'java-package': z.string().optional(),
+  })
+  .transform(
+    ({
+      distribution,
+      'java-version': version,
+      'java-package': javaPackage,
+    }) => {
+      const packageName = javaPackage?.startsWith('jre')
+        ? 'java-jre'
+        : 'java-jdk';
+
+      if (
+        !distribution ||
+        !supportedJavaDistributions.has(distribution.toLowerCase())
+      ) {
+        return [
+          {
+            packageName,
+            depType: 'uses-with',
+            skipStage: 'extract',
+            skipReason: 'unsupported',
+          },
+        ];
+      }
+
+      return [{ packageName, ...parseValue(version) }];
+    },
+  );
+
 const renovateGithubActionDefaultImage = 'ghcr.io/renovatebot/renovate';
 const RenovateGithubActionWith: ActionSchema = z
   .object({
@@ -163,6 +204,12 @@ export const communityActions: Record<string, CommunityActionConfig> = {
     datasource: DotnetVersionDatasource.id,
     packageName: 'dotnet-sdk',
     withSchema: valSchema('dotnet-version', (val) => val.includes('\n')),
+  },
+  // https://github.com/actions/setup-java
+  'actions/setup-java': {
+    datasource: JavaVersionDatasource.id,
+    packageName: '', // determined from `distribution`/`java-package` inputs
+    withSchema: SetupJavaWith,
   },
   // https://github.com/aquasecurity/setup-trivy
   'aquasecurity/setup-trivy': {

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1541,6 +1541,105 @@ describe('modules/manager/github-actions/extract', () => {
     },
     {
       step: {
+        uses: 'actions/setup-java@v4',
+        with: { distribution: 'temurin', 'java-version': '21' },
+      },
+      expected: [
+        {
+          currentValue: '21',
+          datasource: 'java-version',
+          depName: 'java-jdk',
+          depType: 'uses-with',
+          packageName: 'java-jdk',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'actions/setup-java@v4',
+        with: { distribution: 'adopt', 'java-version': '11' },
+      },
+      expected: [
+        {
+          currentValue: '11',
+          datasource: 'java-version',
+          depName: 'java-jdk',
+          depType: 'uses-with',
+          packageName: 'java-jdk',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'actions/setup-java@v4',
+        with: {
+          distribution: 'temurin',
+          'java-version': '21',
+          'java-package': 'jre',
+        },
+      },
+      expected: [
+        {
+          currentValue: '21',
+          datasource: 'java-version',
+          depName: 'java-jre',
+          depType: 'uses-with',
+          packageName: 'java-jre',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'actions/setup-java@v4',
+        with: { distribution: 'temurin' },
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unspecified-version',
+          datasource: 'java-version',
+          depName: 'java-jdk',
+          depType: 'uses-with',
+          packageName: 'java-jdk',
+        },
+      ],
+    },
+    {
+      // we can't reliably track version updates for distributions other
+      // than Temurin/Adopt
+      step: {
+        uses: 'actions/setup-java@v4',
+        with: { distribution: 'zulu', 'java-version': '21' },
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unsupported',
+          datasource: 'java-version',
+          depName: 'java-jdk',
+          depType: 'uses-with',
+          packageName: 'java-jdk',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'actions/setup-java@v4',
+        with: { 'java-version': '21' },
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unsupported',
+          datasource: 'java-version',
+          depName: 'java-jdk',
+          depType: 'uses-with',
+          packageName: 'java-jdk',
+        },
+      ],
+    },
+    {
+      step: {
         uses: 'aquasecurity/setup-trivy@v0.2.6',
         with: {},
       },

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1209,6 +1209,34 @@ describe('modules/manager/github-actions/extract', () => {
       ]);
     });
 
+    it('extracts x-version from actions/setup-x referenced by an https:// URL', async () => {
+      const yamlContent = codeBlock`
+        jobs:
+          build:
+            steps:
+              - uses: https://github.com/actions/setup-node@v4.4.0
+                with:
+                  node-version: '23.7.0'
+        `;
+
+      const res = await extractPackageFile(yamlContent, 'workflow.yml');
+      expect(res?.deps).toMatchObject([
+        {
+          depName: 'https://github.com/actions/setup-node',
+          depType: 'action',
+        },
+        {
+          depName: 'node',
+          packageName: 'actions/node-versions',
+          currentValue: '23.7.0',
+          datasource: 'github-releases',
+          versioning: 'node',
+          extractVersion: '^(?<version>\\d+\\.\\d+\\.\\d+)(-\\d+)?$',
+          depType: 'uses-with',
+        },
+      ]);
+    });
+
     it('handles actions/setup-x without x-version field', async () => {
       const yamlContent = codeBlock`
         jobs:

--- a/lib/modules/manager/github-actions/extract.spec.ts
+++ b/lib/modules/manager/github-actions/extract.spec.ts
@@ -1492,6 +1492,55 @@ describe('modules/manager/github-actions/extract', () => {
   it.each([
     {
       step: {
+        uses: 'actions/setup-dotnet@v4',
+        with: { 'dotnet-version': '8.0.404' },
+      },
+      expected: [
+        {
+          currentValue: '8.0.404',
+          datasource: 'dotnet-version',
+          depName: 'dotnet-sdk',
+          depType: 'uses-with',
+          packageName: 'dotnet-sdk',
+        },
+      ],
+    },
+    {
+      step: {
+        uses: 'actions/setup-dotnet@v4',
+        with: {},
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'unspecified-version',
+          datasource: 'dotnet-version',
+          depName: 'dotnet-sdk',
+          depType: 'uses-with',
+          packageName: 'dotnet-sdk',
+        },
+      ],
+    },
+    {
+      // multiple SDKs, one per line, aren't a single version we can update
+      step: {
+        uses: 'actions/setup-dotnet@v4',
+        with: { 'dotnet-version': '3.1.x\n5.0.x' },
+      },
+      expected: [
+        {
+          skipStage: 'extract',
+          skipReason: 'invalid-version',
+          currentValue: '3.1.x\n5.0.x',
+          datasource: 'dotnet-version',
+          depName: 'dotnet-sdk',
+          depType: 'uses-with',
+          packageName: 'dotnet-sdk',
+        },
+      ],
+    },
+    {
+      step: {
         uses: 'aquasecurity/setup-trivy@v0.2.6',
         with: {},
       },

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -257,7 +257,7 @@ function extractRunner(runner: string): PackageDependency | null {
 }
 
 // For official https://github.com/actions
-const versionedActions: Record<string, string> = {
+const builtinVersionedActions: Record<string, string> = {
   go: npmVersioning.id,
   node: nodeVersioning.id,
   python: npmVersioning.id,
@@ -268,7 +268,7 @@ const versionedActions: Record<string, string> = {
 };
 
 function extractVersionedAction(step: UsesStep): PackageDependency | null {
-  for (const [action, versioning] of Object.entries(versionedActions)) {
+  for (const [action, versioning] of Object.entries(builtinVersionedActions)) {
     const actionName = `actions/setup-${action}`;
     if (step.uses !== actionName && !step.uses?.startsWith(`${actionName}@`)) {
       continue;

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -257,7 +257,7 @@ function extractRunner(runner: string): PackageDependency | null {
 }
 
 // For official https://github.com/actions
-const builtinVersionedActions: Record<string, string> = {
+export const builtinVersionedActions: Record<string, string> = {
   go: npmVersioning.id,
   node: nodeVersioning.id,
   python: npmVersioning.id,

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -32,6 +32,7 @@ import type {
   LockfileState,
   RepositoryReference,
 } from './types.ts';
+import { matchesAction } from './utils.ts';
 
 // detects if we run against a Github Enterprise Server and adds the URL to the beginning of the registryURLs for looking up Actions
 // This reflects the behavior of how GitHub looks up Actions
@@ -262,15 +263,14 @@ export const builtinVersionedActions: Record<string, string> = {
   node: nodeVersioning.id,
   python: npmVersioning.id,
 
-  // Not covered yet because they use different datasources/packageNames:
-  // - dotnet
-  // - java
+  // dotnet and java are covered by `communityActions` instead, as they use
+  // different datasources/packageNames.
 };
 
 function extractVersionedAction(step: UsesStep): PackageDependency | null {
   for (const [action, versioning] of Object.entries(builtinVersionedActions)) {
     const actionName = `actions/setup-${action}`;
-    if (step.uses !== actionName && !step.uses?.startsWith(`${actionName}@`)) {
+    if (!matchesAction(step.uses, actionName)) {
       continue;
     }
 

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -214,14 +214,15 @@ This means that Renovate will:
 
 ### with:version support for built-in Actions
 
-Renovate supports updating the "with" version for `actions/setup-go`, `actions/setup-node`, and `actions/setup-python`, although not all syntaxes are supported out of the box.
+Renovate supports updating the "with" version for the following GitHub Actions:
 
-By default, Renovate will use `npm`-style semver versioning for `go` and `python`, and Renovate's built-in `node` versioning for updating `node`.
-The goal of these defaults is to match as closely as possible to what these GitHub Actions support.
+<!-- Autogenerate list of built-in actions in https://github.com/renovatebot/renovate -->
+
+These defaults aim to match as closely as possible to what these GitHub Actions support.
 For example, normally the `^` syntax is not used in `go` or `python`, but it's supported in their respective actions.
 
 Depending on your use case, you may need to change `versioning` manually.
-If you find a use case which you think Renovate could/should automatically detect and support without manual configuration, please raise a Discussion to suggest it.
+If you find a use case which you think Renovate could/should automatically detect and support without manual configuration, please raise [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
 ### Updating `with:` values in commonly used Community-maintained GitHub Actions
 

--- a/lib/modules/manager/github-actions/utils.ts
+++ b/lib/modules/manager/github-actions/utils.ts
@@ -1,0 +1,17 @@
+import { regEx } from '../../../util/regex.ts';
+
+export function actionUsesRegex(action: string): RegExp {
+  return regEx(`(?:https?://[^/]+/)?${RegExp.escape(action)}(?:@.+)?$`);
+}
+
+/**
+ * Whether a `uses:` value refers to the given `owner/repo` action, allowing
+ * for an optional `https://<host>/` prefix (e.g. a self-hosted Forgejo/Gitea
+ * instance, or GitHub Enterprise Server).
+ */
+export function matchesAction(
+  uses: string | null | undefined,
+  action: string,
+): boolean {
+  return !!uses && actionUsesRegex(action).test(uses);
+}

--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -7,6 +7,7 @@ import { generateDatasources } from './datasources.ts';
 import { generateEnvOptions } from './env-options.ts';
 import { generateEnvVars } from './env-vars.ts';
 import { getOpenGitHubItems } from './github-query-items.ts';
+import { generateManagerGithubActionsBuiltin } from './manager/github-actions/builtin.ts';
 import { generateManagerGithubActionsCommunity } from './manager/github-actions/community.ts';
 import { generateManagers } from './manager.ts';
 import { generateManagerAsdfSupportedPlugins } from './manager-asdf-supported-plugins.ts';
@@ -57,6 +58,10 @@ export async function generateDocs(
     // managers/asdf supported plugins
     logger.info('* managers/asdf/supported-plugins');
     await generateManagerAsdfSupportedPlugins(dist);
+
+    // managers/github-actions built-in actions
+    logger.info('* managers/github-actions/builtin');
+    await generateManagerGithubActionsBuiltin(dist);
 
     // managers/github-actions community actions
     logger.info('* managers/github-actions/community');

--- a/tools/docs/manager/github-actions/builtin.ts
+++ b/tools/docs/manager/github-actions/builtin.ts
@@ -1,14 +1,16 @@
 import { codeBlock } from 'common-tags';
+import { communityActions } from '../../../../lib/modules/manager/github-actions/community.ts';
 import { builtinVersionedActions } from '../../../../lib/modules/manager/github-actions/extract.ts';
 import { readFile, updateFile } from '../../../utils/index.ts';
 import { replaceContent } from '../../utils.ts';
+import { determineDependencyToUpdate, getWithSchemaFields } from './utils.ts';
 
 const replaceStart =
   '<!-- Autogenerate list of built-in actions in https://github.com/renovatebot/renovate -->';
 
 function generateToolingTable(): string {
   let table = codeBlock`
-    | Action | \`with\` input used | Dependency | Default versioning |
+    | Action | \`with\` input(s) used | Dependency | Default versioning |
     | --- | --- | --- | --- |
     `;
   table += '\n';
@@ -17,6 +19,23 @@ function generateToolingTable(): string {
     const actionName = `actions/setup-${action}`;
     const packageName = `actions/${action}-versions`;
     table += `| [\`${actionName}\`](https://github.com/${actionName}) | \`${action}-version\` | [\`${action}\`](https://github.com/${packageName}) | [\`${versioning}\`](../../versioning/${versioning}/index.md) |\n`;
+  }
+
+  // `actions/*` community-action-config entries: GitHub's own first-party
+  // Actions that need a schema richer than the simple
+  // `builtinVersionedActions` map above, so they're configured alongside
+  // community actions but documented here as built-in.
+  for (const [name, cfg] of Object.entries(communityActions)) {
+    if (!name.startsWith('actions/')) {
+      continue;
+    }
+
+    const withFields = getWithSchemaFields(cfg.withSchema);
+    const versioning = cfg.versioning
+      ? `[\`${cfg.versioning}\`](../../versioning/${cfg.versioning}/index.md)`
+      : '`default`';
+
+    table += `| [\`${name}\`](https://github.com/${name}) | \`${withFields.join('`, `')}\` | ${determineDependencyToUpdate(cfg)} | ${versioning} |\n`;
   }
 
   return table;

--- a/tools/docs/manager/github-actions/builtin.ts
+++ b/tools/docs/manager/github-actions/builtin.ts
@@ -1,0 +1,36 @@
+import { codeBlock } from 'common-tags';
+import { builtinVersionedActions } from '../../../../lib/modules/manager/github-actions/extract.ts';
+import { readFile, updateFile } from '../../../utils/index.ts';
+import { replaceContent } from '../../utils.ts';
+
+const replaceStart =
+  '<!-- Autogenerate list of built-in actions in https://github.com/renovatebot/renovate -->';
+
+function generateToolingTable(): string {
+  let table = codeBlock`
+    | Action | \`with\` input used | Dependency | Default versioning |
+    | --- | --- | --- | --- |
+    `;
+  table += '\n';
+
+  for (const [action, versioning] of Object.entries(builtinVersionedActions)) {
+    const actionName = `actions/setup-${action}`;
+    const packageName = `actions/${action}-versions`;
+    table += `| [\`${actionName}\`](https://github.com/${actionName}) | \`${action}-version\` | [\`${action}\`](https://github.com/${packageName}) | [\`${versioning}\`](../../versioning/${versioning}/index.md) |\n`;
+  }
+
+  return table;
+}
+
+export async function generateManagerGithubActionsBuiltin(
+  dist: string,
+): Promise<void> {
+  const indexFileName = `${dist}/modules/manager/github-actions/index.md`;
+  let indexContent = await readFile(indexFileName);
+  indexContent = replaceContent(
+    indexContent,
+    generateToolingTable(),
+    replaceStart,
+  );
+  await updateFile(indexFileName, indexContent);
+}

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -1,39 +1,8 @@
 import { codeBlock } from 'common-tags';
-import { z } from 'zod/v4';
 import { communityActions } from '../../../../lib/modules/manager/github-actions/community.ts';
-import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/types.ts';
 import { readFile, updateFile } from '../../../utils/index.ts';
 import { replaceContent } from '../../utils.ts';
-
-function getWithSchemaFields(
-  schema: CommunityActionConfig['withSchema'],
-): string[] {
-  if (!schema) {
-    return ['version'];
-  }
-  // `z.object({...}).transform(...)` produces a ZodPipe in Zod v4, where
-  // `def.in` is the source ZodObject. Walk through any pipes until we hit it.
-  let current: z.ZodType = schema;
-  while ('in' in current.def) {
-    current = current.def.in as z.ZodType;
-  }
-  if (current instanceof z.ZodObject) {
-    return Object.keys(current.shape);
-  }
-  return ['version'];
-}
-
-function determineDependencyToUpdate({
-  depName,
-  packageName,
-}: CommunityActionConfig): string {
-  if (!depName && !packageName) {
-    // some actions determine the depName and packageName dynamically
-    return '(determined from `with` input(s))';
-  }
-
-  return `[\`${depName ?? packageName}\`](https://github.com/${packageName})`;
-}
+import { determineDependencyToUpdate, getWithSchemaFields } from './utils.ts';
 
 function generateToolingTable(): string {
   let table = codeBlock`

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -12,6 +12,12 @@ function generateToolingTable(): string {
   table += '\n';
 
   for (const [name, cfg] of Object.entries(communityActions)) {
+    // `actions/*` are GitHub's own first-party Actions, documented separately
+    // as "built-in" rather than here as community-maintained.
+    if (name.startsWith('actions/')) {
+      continue;
+    }
+
     const withFields = getWithSchemaFields(cfg.withSchema);
 
     table += `| [\`${name}\`](https://github.com/${name}) | \`${withFields.join('`, `')}\` | ${determineDependencyToUpdate(cfg)} |\n`;

--- a/tools/docs/manager/github-actions/utils.ts
+++ b/tools/docs/manager/github-actions/utils.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/types.ts';
+
+export function getWithSchemaFields(
+  schema: CommunityActionConfig['withSchema'],
+): string[] {
+  if (!schema) {
+    return ['version'];
+  }
+  // `z.object({...}).transform(...)` produces a ZodPipe in Zod v4, where
+  // `def.in` is the source ZodObject. Walk through any pipes until we hit it.
+  let current: z.ZodType = schema;
+  while ('in' in current.def) {
+    current = current.def.in as z.ZodType;
+  }
+  if (current instanceof z.ZodObject) {
+    return Object.keys(current.shape);
+  }
+  return ['version'];
+}
+
+export function determineDependencyToUpdate({
+  depName,
+  packageName,
+}: CommunityActionConfig): string {
+  if (!depName && !packageName) {
+    // some actions determine the depName and packageName dynamically
+    return '(determined from `with` input(s))';
+  }
+
+  return `[\`${depName ?? packageName}\`](https://github.com/${packageName})`;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Via [0], we have cases where a self-hosted user who doesn't run against
github.com leads to cases where they can't update the builtin Actions
when they're referenced by an `https://` URL.

As we already handle this for community actions, we can also handle this
for the builtin ones.

[0]: https://github.com/renovatebot/renovate/discussions/35777

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Sonnet 5) generated the code and the accompanying unit tests.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
