### PR TITLE
refactor(tools/docs): extract github-actions community table helpers to utils.ts

### DIFF
--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -257,7 +257,7 @@ function extractRunner(runner: string): PackageDependency | null {
 }
 
 // For official https://github.com/actions
-const versionedActions: Record<string, string> = {
+const builtinVersionedActions: Record<string, string> = {
   go: npmVersioning.id,
   node: nodeVersioning.id,
   python: npmVersioning.id,
@@ -268,7 +268,7 @@ const versionedActions: Record<string, string> = {
 };
 
 function extractVersionedAction(step: UsesStep): PackageDependency | null {
-  for (const [action, versioning] of Object.entries(versionedActions)) {
+  for (const [action, versioning] of Object.entries(builtinVersionedActions)) {
     const actionName = `actions/setup-${action}`;
     if (step.uses !== actionName && !step.uses?.startsWith(`${actionName}@`)) {
       continue;

--- a/lib/modules/manager/github-actions/extract.ts
+++ b/lib/modules/manager/github-actions/extract.ts
@@ -257,7 +257,7 @@ function extractRunner(runner: string): PackageDependency | null {
 }
 
 // For official https://github.com/actions
-const builtinVersionedActions: Record<string, string> = {
+export const builtinVersionedActions: Record<string, string> = {
   go: npmVersioning.id,
   node: nodeVersioning.id,
   python: npmVersioning.id,

--- a/lib/modules/manager/github-actions/readme.md
+++ b/lib/modules/manager/github-actions/readme.md
@@ -214,14 +214,15 @@ This means that Renovate will:
 
 ### with:version support for built-in Actions
 
-Renovate supports updating the "with" version for `actions/setup-go`, `actions/setup-node`, and `actions/setup-python`, although not all syntaxes are supported out of the box.
+Renovate supports updating the "with" version for the following GitHub Actions:
 
-By default, Renovate will use `npm`-style semver versioning for `go` and `python`, and Renovate's built-in `node` versioning for updating `node`.
-The goal of these defaults is to match as closely as possible to what these GitHub Actions support.
+<!-- Autogenerate list of built-in actions in https://github.com/renovatebot/renovate -->
+
+These defaults aim to match as closely as possible to what these GitHub Actions support.
 For example, normally the `^` syntax is not used in `go` or `python`, but it's supported in their respective actions.
 
 Depending on your use case, you may need to change `versioning` manually.
-If you find a use case which you think Renovate could/should automatically detect and support without manual configuration, please raise a Discussion to suggest it.
+If you find a use case which you think Renovate could/should automatically detect and support without manual configuration, please raise [Suggest an Idea Discussion](https://github.com/renovatebot/renovate/discussions/new?category=suggest-an-idea).
 
 ### Updating `with:` values in commonly used Community-maintained GitHub Actions
 

--- a/tools/docs/index.ts
+++ b/tools/docs/index.ts
@@ -7,6 +7,7 @@ import { generateDatasources } from './datasources.ts';
 import { generateEnvOptions } from './env-options.ts';
 import { generateEnvVars } from './env-vars.ts';
 import { getOpenGitHubItems } from './github-query-items.ts';
+import { generateManagerGithubActionsBuiltin } from './manager/github-actions/builtin.ts';
 import { generateManagerGithubActionsCommunity } from './manager/github-actions/community.ts';
 import { generateManagers } from './manager.ts';
 import { generateManagerAsdfSupportedPlugins } from './manager-asdf-supported-plugins.ts';
@@ -57,6 +58,10 @@ export async function generateDocs(
     // managers/asdf supported plugins
     logger.info('* managers/asdf/supported-plugins');
     await generateManagerAsdfSupportedPlugins(dist);
+
+    // managers/github-actions built-in actions
+    logger.info('* managers/github-actions/builtin');
+    await generateManagerGithubActionsBuiltin(dist);
 
     // managers/github-actions community actions
     logger.info('* managers/github-actions/community');

--- a/tools/docs/manager/github-actions/builtin.ts
+++ b/tools/docs/manager/github-actions/builtin.ts
@@ -1,0 +1,36 @@
+import { codeBlock } from 'common-tags';
+import { builtinVersionedActions } from '../../../../lib/modules/manager/github-actions/extract.ts';
+import { readFile, updateFile } from '../../../utils/index.ts';
+import { replaceContent } from '../../utils.ts';
+
+const replaceStart =
+  '<!-- Autogenerate list of built-in actions in https://github.com/renovatebot/renovate -->';
+
+function generateToolingTable(): string {
+  let table = codeBlock`
+    | Action | \`with\` input used | Dependency | Default versioning |
+    | --- | --- | --- | --- |
+    `;
+  table += '\n';
+
+  for (const [action, versioning] of Object.entries(builtinVersionedActions)) {
+    const actionName = `actions/setup-${action}`;
+    const packageName = `actions/${action}-versions`;
+    table += `| [\`${actionName}\`](https://github.com/${actionName}) | \`${action}-version\` | [\`${action}\`](https://github.com/${packageName}) | [\`${versioning}\`](../../versioning/${versioning}/index.md) |\n`;
+  }
+
+  return table;
+}
+
+export async function generateManagerGithubActionsBuiltin(
+  dist: string,
+): Promise<void> {
+  const indexFileName = `${dist}/modules/manager/github-actions/index.md`;
+  let indexContent = await readFile(indexFileName);
+  indexContent = replaceContent(
+    indexContent,
+    generateToolingTable(),
+    replaceStart,
+  );
+  await updateFile(indexFileName, indexContent);
+}

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -1,39 +1,8 @@
 import { codeBlock } from 'common-tags';
-import { z } from 'zod/v4';
 import { communityActions } from '../../../../lib/modules/manager/github-actions/community.ts';
-import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/types.ts';
 import { readFile, updateFile } from '../../../utils/index.ts';
 import { replaceContent } from '../../utils.ts';
-
-function getWithSchemaFields(
-  schema: CommunityActionConfig['withSchema'],
-): string[] {
-  if (!schema) {
-    return ['version'];
-  }
-  // `z.object({...}).transform(...)` produces a ZodPipe in Zod v4, where
-  // `def.in` is the source ZodObject. Walk through any pipes until we hit it.
-  let current: z.ZodType = schema;
-  while ('in' in current.def) {
-    current = current.def.in as z.ZodType;
-  }
-  if (current instanceof z.ZodObject) {
-    return Object.keys(current.shape);
-  }
-  return ['version'];
-}
-
-function determineDependencyToUpdate({
-  depName,
-  packageName,
-}: CommunityActionConfig): string {
-  if (!depName && !packageName) {
-    // some actions determine the depName and packageName dynamically
-    return '(determined from `with` input(s))';
-  }
-
-  return `[\`${depName ?? packageName}\`](https://github.com/${packageName})`;
-}
+import { determineDependencyToUpdate, getWithSchemaFields } from './utils.ts';
 
 function generateToolingTable(): string {
   let table = codeBlock`

--- a/tools/docs/manager/github-actions/utils.ts
+++ b/tools/docs/manager/github-actions/utils.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod/v4';
+import type { CommunityActionConfig } from '../../../../lib/modules/manager/github-actions/types.ts';
+
+export function getWithSchemaFields(
+  schema: CommunityActionConfig['withSchema'],
+): string[] {
+  if (!schema) {
+    return ['version'];
+  }
+  // `z.object({...}).transform(...)` produces a ZodPipe in Zod v4, where
+  // `def.in` is the source ZodObject. Walk through any pipes until we hit it.
+  let current: z.ZodType = schema;
+  while ('in' in current.def) {
+    current = current.def.in as z.ZodType;
+  }
+  if (current instanceof z.ZodObject) {
+    return Object.keys(current.shape);
+  }
+  return ['version'];
+}
+
+export function determineDependencyToUpdate({
+  depName,
+  packageName,
+}: CommunityActionConfig): string {
+  if (!depName && !packageName) {
+    // some actions determine the depName and packageName dynamically
+    return '(determined from `with` input(s))';
+  }
+
+  return `[\`${depName ?? packageName}\`](https://github.com/${packageName})`;
+}


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

To reuse `getWithSchemaFields` and `determineDependencyToUpdate` from
the built-in Actions table generator too, move them out of
community.ts's generator into a shared utils.ts. No generated output
changes.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Sonnet 5) made this refactor.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
