### PR TITLE
docs(manager/github-actions): don't include `actions/*` in community table

### DIFF
--- a/tools/docs/manager/github-actions/builtin.ts
+++ b/tools/docs/manager/github-actions/builtin.ts
@@ -1,14 +1,16 @@
 import { codeBlock } from 'common-tags';
+import { communityActions } from '../../../../lib/modules/manager/github-actions/community.ts';
 import { builtinVersionedActions } from '../../../../lib/modules/manager/github-actions/extract.ts';
 import { readFile, updateFile } from '../../../utils/index.ts';
 import { replaceContent } from '../../utils.ts';
+import { determineDependencyToUpdate, getWithSchemaFields } from './utils.ts';
 
 const replaceStart =
   '<!-- Autogenerate list of built-in actions in https://github.com/renovatebot/renovate -->';
 
 function generateToolingTable(): string {
   let table = codeBlock`
-    | Action | \`with\` input used | Dependency | Default versioning |
+    | Action | \`with\` input(s) used | Dependency | Default versioning |
     | --- | --- | --- | --- |
     `;
   table += '\n';
@@ -17,6 +19,23 @@ function generateToolingTable(): string {
     const actionName = `actions/setup-${action}`;
     const packageName = `actions/${action}-versions`;
     table += `| [\`${actionName}\`](https://github.com/${actionName}) | \`${action}-version\` | [\`${action}\`](https://github.com/${packageName}) | [\`${versioning}\`](../../versioning/${versioning}/index.md) |\n`;
+  }
+
+  // `actions/*` community-action-config entries: GitHub's own first-party
+  // Actions that need a schema richer than the simple
+  // `builtinVersionedActions` map above, so they're configured alongside
+  // community actions but documented here as built-in.
+  for (const [name, cfg] of Object.entries(communityActions)) {
+    if (!name.startsWith('actions/')) {
+      continue;
+    }
+
+    const withFields = getWithSchemaFields(cfg.withSchema);
+    const versioning = cfg.versioning
+      ? `[\`${cfg.versioning}\`](../../versioning/${cfg.versioning}/index.md)`
+      : '`default`';
+
+    table += `| [\`${name}\`](https://github.com/${name}) | \`${withFields.join('`, `')}\` | ${determineDependencyToUpdate(cfg)} | ${versioning} |\n`;
   }
 
   return table;

--- a/tools/docs/manager/github-actions/community.ts
+++ b/tools/docs/manager/github-actions/community.ts
@@ -12,6 +12,12 @@ function generateToolingTable(): string {
   table += '\n';
 
   for (const [name, cfg] of Object.entries(communityActions)) {
+    // `actions/*` are GitHub's own first-party Actions, documented separately
+    // as "built-in" rather than here as community-maintained.
+    if (name.startsWith('actions/')) {
+      continue;
+    }
+
     const withFields = getWithSchemaFields(cfg.withSchema);
 
     table += `| [\`${name}\`](https://github.com/${name}) | \`${withFields.join('`, `')}\` | ${determineDependencyToUpdate(cfg)} |\n`;


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

Since community.ts's config also holds first-party GitHub Actions
(e.g. actions/setup-dotnet, actions/setup-java) that need a schema
richer than the simple versionedActions map, we can't rely on that map
alone to tell "built-in" apart from "community" any more.

We can make sure the two generated tables stay accurate as more
actions/* entries are added to community.ts's config: the community
table now skips any actions/* entry, and the built-in table picks
them up alongside the existing versionedActions-based rows.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Claude Code (Claude Sonnet 5) made these changes to the docs generator.

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @jamietanna will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
