### PR TITLE
fix(post-upgrade-commands): update all duplicate updatedArtifacts entries

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.spec.ts
@@ -534,6 +534,66 @@ describe('workers/repository/update/branch/execute-post-upgrade-commands', () =>
       expect(res.updatedArtifacts[0].type).toBe('addition');
     });
 
+    it('updates every duplicate artifact entry for the same path', async () => {
+      const commands = partial<BranchUpgradeConfig>([
+        {
+          manager: 'gomod',
+          branchName: 'main',
+          postUpgradeTasks: {
+            executionMode: 'branch',
+            commands: ['echo test'],
+            fileFilters: ['**/go.sum'],
+          },
+        },
+      ]);
+      const config: BranchConfig = {
+        manager: 'gomod',
+        updatedPackageFiles: [],
+        updatedArtifacts: [
+          { type: 'addition', path: 'app/go.sum', contents: 'stale contents' },
+          { type: 'addition', path: 'app/go.sum', contents: 'stale contents' },
+        ],
+        upgrades: [],
+        branchName: 'main',
+        baseBranch: 'base',
+      };
+
+      git.getRepoStatus.mockResolvedValueOnce(
+        partial<StatusResult>({
+          modified: ['app/go.sum'],
+          not_added: [],
+          deleted: [],
+        }),
+      );
+      git.isFileModeEnabled.mockResolvedValue(false);
+
+      const localDir = upath.join(tmpDir.path, 'local');
+      GlobalConfig.set({ localDir, allowedCommands: ['echo test'] });
+
+      exec.exec.mockResolvedValue({ stdout: '', stderr: '' });
+      fs.localPathIsFile.mockResolvedValue(true);
+      fs.localPathExists.mockResolvedValue(true);
+      fs.readLocalFile.mockResolvedValue('post-upgrade contents');
+
+      const res = await postUpgradeCommands.postUpgradeCommandsExecutor(
+        commands,
+        config,
+      );
+
+      expect(res.updatedArtifacts).toEqual([
+        {
+          type: 'addition',
+          path: 'app/go.sum',
+          contents: 'post-upgrade contents',
+        },
+        {
+          type: 'addition',
+          path: 'app/go.sum',
+          contents: 'post-upgrade contents',
+        },
+      ]);
+    });
+
     describe('executable file modes', () => {
       const postUpgradeTask = partial<BranchUpgradeConfig>([
         {

--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -27,7 +27,7 @@ import {
   getRepoStatus,
   isFileModeEnabled,
 } from '../../../../util/git/index.ts';
-import type { FileChange } from '../../../../util/git/types.ts';
+import type { FileAddition, FileChange } from '../../../../util/git/types.ts';
 import { minimatch } from '../../../../util/minimatch.ts';
 import { regEx } from '../../../../util/regex.ts';
 import { sanitize } from '../../../../util/sanitize.ts';
@@ -310,13 +310,20 @@ export async function postUpgradeCommandsExecutor(
               relativePath,
               canReadFileMode,
             );
-            const existingUpdatedArtifacts = updatedArtifacts.find(
-              (ua) => ua.path === relativePath,
+            // A single path can have several entries, because each
+            // updateArtifacts() call appends its own. prepareCommit() writes
+            // them all in order, so every entry needs the new content or a
+            // stale duplicate overwrites the updated one.
+            const existingUpdatedArtifacts = updatedArtifacts.filter(
+              (ua): ua is FileAddition =>
+                ua.path === relativePath && ua.type === 'addition',
             );
-            if (existingUpdatedArtifacts?.type === 'addition') {
-              existingUpdatedArtifacts.contents = existingContent;
-              if (isExecutable !== undefined) {
-                existingUpdatedArtifacts.isExecutable = isExecutable;
+            if (existingUpdatedArtifacts.length > 0) {
+              for (const existingUpdatedArtifact of existingUpdatedArtifacts) {
+                existingUpdatedArtifact.contents = existingContent;
+                if (isExecutable !== undefined) {
+                  existingUpdatedArtifact.isExecutable = isExecutable;
+                }
               }
             } else {
               const updatedArtifact: FileChange = {


### PR DESCRIPTION
## Changes

`postUpgradeCommandsExecutor` writes post-upgrade content back into `updatedArtifacts` with `.find()`, so only the **first** entry for a path gets updated:

```ts
const existingUpdatedArtifacts = updatedArtifacts.find(
  (ua) => ua.path === relativePath,
);
```

A path can have more than one entry, because `updateArtifacts()` is called once per package file and each call appends its own results. `prepareCommit()` then writes every entry to disk in array order, so a later stale duplicate overwrites the entry that was just updated.

The symptom is that `postUpgradeTasks` looks like it worked. The command runs, `Post-upgrade file saved` is logged for the file, and the branch still has the pre-command content.

This updates every `addition` entry for the path, and only appends a new entry when none exists.

## Context

Reported in #42729. The original issue #42710 was auto-closed, as issues are maintainers-only.

That report came from a .NET Central Package Management monorepo. I hit the same thing on a Go workspace, where `gomodTidyAll` makes a shared module's `updateArtifacts()` call also return its dependents' `go.mod`/`go.sum`, while each updated module's own call already returned its own files. Any path in both sets ends up with two entries.

The original report offered two alternatives: dedupe `updatedArtifacts` before committing, or stop managers appending duplicates at the source. Both look worth doing, but this writeback should be correct regardless of how many entries a manager produces. Happy to go a different way if you'd prefer one of those.

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @dlm6693 will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [x] Both unit tests + ran on a real repository

The public repository: https://github.com/dlm6693/renovate-repro-42729

Added `updates every duplicate artifact entry for the same path`. It fails on `main` with the second entry still holding `stale contents`.

I also ran Renovate from source against that reproduction, with `binarySource=global` and Go 1.26.6, before and after this change. Both runs produced the same artifact list and logged the file as saved:

```
"updatedArtifacts": ["app/go.sum", "lib/go.sum", "app/go.mod", "app/go.sum"]
DEBUG: Post-upgrade file saved   "file": "app/go.sum"
DEBUG: Post-upgrade file saved   "file": "lib/go.sum"
DEBUG: 4 file(s) to commit
```

Only the committed result differs. The `postUpgradeTasks` script appends a marker line to both `go.sum` files; `app/go.sum` has two `updatedArtifacts` entries and `lib/go.sum` has one:

| Renovate | `lib/go.sum` | `app/go.sum` |
| --- | --- | --- |
| `main` (282a0f365) | marker present | **marker missing** |
| this PR | marker present | marker present |

Both pushed branches are kept as `evidence/unpatched-main` and `evidence/with-fix`, and the full debug logs from both runs are in `logs/`. A two-dot diff between the branches is the single dropped line:

```console
$ git diff origin/evidence/unpatched-main origin/evidence/with-fix
+// renovate-post-upgrade-marker
```
