### PR TITLE
fix: exit non-zero after an unhandled rejection

### DIFF
--- a/lib/renovate.ts
+++ b/lib/renovate.ts
@@ -13,7 +13,7 @@ void (async (): Promise<void> => {
   /* v8 ignore next -- not easily testable */
   process.on('unhandledRejection', (err) => {
     logger.logger.error({ err }, 'unhandledRejection');
-    process.exitCode ||= 1;
+    process.exitCode ??= 1;
   });
   await logger.init();
 

--- a/lib/renovate.ts
+++ b/lib/renovate.ts
@@ -13,6 +13,7 @@ void (async (): Promise<void> => {
   /* v8 ignore next -- not easily testable */
   process.on('unhandledRejection', (err) => {
     logger.logger.error({ err }, 'unhandledRejection');
+    process.exitCode ||= 1;
   });
   await logger.init();
 


### PR DESCRIPTION
## Changes

Set `process.exitCode ??= 1` in the `unhandledRejection` handler in `lib/renovate.ts`, so a rejection before `start()` runs makes the process exit non-zero. Today a rejected bootstrap import logs `ERROR: unhandledRejection` and exits 0, so the job that launched Renovate reports success while no repository was processed; that happened in 44.63.0 (`tar`) and again in 44.78.0 and 44.79.0 (`common-tags`). 

The reproduced failure happens before `start()` runs, so nothing later assigns the exit code. During a run the final status is still whatever `start()` returns, which is 1 whenever the handler's error record reached the problem list. The `??=` only applies while no exit code has been decided, so a rejection that arrives after `start()` has returned leaves its code untouched, including an error-specific one from `exitCodeForErrors`.

Verified on the published `renovate/renovate:44.78.0` image by applying this one-line change to `dist/renovate.js` and running `renovate --platform=local --dry-run=extract` in a one-commit local Git repository: exit 0 before, exit 1 after, with the same `unhandledRejection` log line.

Discussion: #45894

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @cplieger will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted. Name the account.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: none; the change was exercised on the published `renovate/renovate:44.78.0` image against a temporary local Git repository with `--platform=local`, as described under Changes.
