### PR TITLE
feat(presets/monorepo): add fumadocs monorepo

### DIFF
--- a/lib/data/monorepo.json
+++ b/lib/data/monorepo.json
@@ -23,6 +23,7 @@
     "embroider": "/^@embroider//",
     "forge": "/^@forge//",
     "fullcalendar": "/^@fullcalendar//",
+    "fumadocs": ["fumadocs-core", "fumadocs-ui"],
     "oracle-database": [
       "/^com.oracle.database.jdbc:/",
       "/^com.oracle.database.nls:/"


### PR DESCRIPTION
## Changes

Adds `fumadocs` to `patternGroups`, covering exactly two packages:

```json
"fumadocs": ["fumadocs-core", "fumadocs-ui"],
```

### This is a narrowed retry of #36781, which was reverted by #37250

#36781 added fumadocs as a **`repoGroup`** (`https://github.com/fuma-nama/fumadocs`), which groups every package published from that repo. In https://github.com/renovatebot/renovate/pull/36781#issuecomment-3041071135 @rarkins asked:

> Can the packages be upgraded independently, or do they frequently break if upgraded one by one?

That went unanswered and the entry was reverted, correctly — as a `repoGroup` it was wrong. Here is the answer, and why the pattern-scoped form is not.

### `fumadocs-core` + `fumadocs-ui` cannot be upgraded independently

`fumadocs-ui` declares an **exact** peer on `fumadocs-core` — not a range:

| `fumadocs-ui` | its `peerDependencies.fumadocs-core` |
| --- | --- |
| [16.15.8](https://www.npmjs.com/package/fumadocs-ui/v/16.15.8?activeTab=code) | `16.15.8` |
| [16.15.9](https://www.npmjs.com/package/fumadocs-ui/v/16.15.9?activeTab=code) | `16.15.9` |

They are also published at identical versions, seconds apart, every release (`registry.npmjs.org` `time` field):

| version | `fumadocs-core` | `fumadocs-ui` |
| --- | --- | --- |
| 16.15.6 | `2026-09-04T04:06:45.382Z` | `2026-09-04T04:06:56.054Z` |
| 16.15.7 | `2026-09-04T16:33:04.341Z` | `2026-09-04T16:33:26.882Z` |
| 16.15.8 | `2026-09-07T05:21:42.962Z` | `2026-09-07T05:22:11.606Z` |
| 16.15.9 | `2026-09-10T15:18:57.082Z` | `2026-09-10T15:19:08.343Z` |

So they satisfy both halves of the bar in [`lib/data/readme.md`](https://github.com/renovatebot/renovate/blob/main/lib/data/readme.md): same version *and* strictly needing to be merged together.

Concretely, ungrouped, the 16.15.9 release arrived as two PRs in our repo. The `fumadocs-ui` one went **green** with `fumadocs-ui@16.15.9` resolved against `fumadocs-core@16.15.8` — a peer violation one merge away from `main`, because the lockfile only moved the one package the PR was for.

### Everything else in that repo *can* be upgraded independently

This is why it is a `patternGroup` and not a `repoGroup`. `fuma-nama/fumadocs` publishes many packages, each on its own version line and cadence:

| package | latest |
| --- | --- |
| `fumadocs-core` | 16.15.9 |
| `fumadocs-ui` | 16.15.9 |
| `fumadocs-mdx` | 15.4.0 |
| `fumadocs-openapi` | 11.4.2 |
| `fumadocs-typescript` | 5.4.0 |
| `fumadocs-docgen` | 3.1.0 |
| `@fumadocs/mdx-remote` | 1.5.1 |
| `@fumadocs/satteri` | 0.5.0 |
| `@fumadocs/tailwind` | 0.1.1 |

`fumadocs-mdx` peers `fumadocs-core` on a caret range (`^16.15.3`), not an exact pin, and has not released since 2026-08-27 while core/ui shipped five more versions. Grouping those nine together is the immortal-PR case the readme warns about — which is what #36781 did and #37250 rightly undid. Limiting the group to the exact-pinned pair leaves every other package updating on its own.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Written by Claude Opus 5 via Claude Code: it found the upstream gap while fixing the split 16.15.9 bump in our repo, gathered the registry evidence above, located #36781/#37250, and drafted this PR and its commit message.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [x] Nobody has explicitly committed to replying.

Answering honestly per the template: nobody has committed to this yet. Given #36781 was reverted for exactly this reason, I would rather state it plainly than overpromise — @JeffreyUrban owns this fork and can update this box. The evidence above is intended to stand on its own if no follow-up arrives.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

Existing tests cover the entry: `lib/data/index.spec.ts` (alphabetical ordering — `fumadocs` sits between `fullcalendar` and `oracle-database`) and `lib/config/presets/internal/monorepos.spec.ts` (preset name matches `/^[a-z0-9-]+$/`). Also checked against `tools/schemas/monorepo-schema.json` and confirmed the file is prettier-clean. I have not run a patched Renovate against a live repo; the split-PR behaviour described above is from stock Renovate without this entry.
