### PR TITLE
docs(hostRules): replace the stale matchHost port warning

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -2162,7 +2162,7 @@ A preset alternative to the above is:
 }
 ```
 
-To match specific ports you have to add a protocol to `matchHost`:
+To match a specific port, add the port to `matchHost`:
 
 ```json
 {
@@ -2175,8 +2175,9 @@ To match specific ports you have to add a protocol to `matchHost`:
 }
 ```
 
-!!! warning
-  Using `matchHost` without a protocol behaves the same as if you had set no `matchHost` configuration.
+!!! note
+  A `matchHost` with a port or a path but no scheme, like `domain.com:9118` or `domain.com/path`, is treated as `https://domain.com:9118` or `https://domain.com/path`.
+  To match a port over plain `http`, include the scheme.
 
 !!! note
   Disabling a host is only 100% effective if added to self-hosted config.
@@ -2453,7 +2454,7 @@ registry=https://gitlab.myorg.com/api/v4/packages/npm/
 ```
 
 !!! note
-  Values containing a URL path but missing a scheme will be prepended with 'https://' (e.g. `domain.com/path` → `https://domain.com/path`)
+  Values containing a URL path or a port but missing a scheme will be prepended with `https://` (e.g. `domain.com/path` → `https://domain.com/path`, `domain.com:9118` → `https://domain.com:9118`).
 
 ### `hostRules.maxRequestsPerSecond`
 


### PR DESCRIPTION
## Changes

Replaces the warning under the `matchHost` port example in `docs/usage/configuration-options.md` ("Using `matchHost` without a protocol behaves the same as if you had set no `matchHost` configuration") with a note that describes the current behavior, and mentions ports in the note under `hostRules.matchHost`, which so far only mentioned paths.

The warning came from #22007 (May 2023): at that time a `matchHost` with a port but no scheme, such as `domain.com:9118`, was parsed into an empty host and the rule then applied to every host, which is what the sentence described. Since #29487 (37.421.0), `massageHostUrl` in `lib/util/url.ts` prepends `https://` to any `matchHost` that has no scheme and contains a port or a path, and the test that documented the old behavior ("host with port is interpreted as empty") was removed with it. The two notes now contradict each other, which is what https://github.com/renovatebot/renovate/discussions/45876 asks about.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

The docs wording, the commit message and this description were drafted with Claude Code (Claude Opus 5) from my reading of #22007, #29487 and `massageHostUrl` / `matchesHost` at 43.109.5, and I reviewed and edited every line before submitting.

### Use of AI in replying to PR comments

Who answers review comments:

- [ ] @username will read and reply directly. **Name the account.**
- [x] An agent will draft replies and @jmrplens will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [x] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

`prettier --check` and `markdownlint-cli2` pass on the file.