### PR TITLE
feat(mise): support monorepo root lock files

### DIFF
--- a/lib/modules/manager/mise/artifacts.spec.ts
+++ b/lib/modules/manager/mise/artifacts.spec.ts
@@ -628,6 +628,41 @@ describe('modules/manager/mise/artifacts', () => {
     ]);
   });
 
+  it('updates the monorepo root lock file for a subproject', async () => {
+    fs.findLocalSiblingOrParent.mockResolvedValueOnce('mise.lock');
+    fs.readLocalFile
+      .mockResolvedValueOnce('existing content')
+      .mockResolvedValueOnce(`[[tools.node]]\nversion = "24.16.0"\n`);
+    const execSnapshots = mockExecAll();
+
+    const res = await updateArtifacts({
+      packageFileName: 'packages/a/mise.toml',
+      updatedDeps: [{ depName: 'node' }],
+      newPackageFileContent: '',
+      config,
+    });
+
+    expect(res).toEqual([
+      {
+        file: {
+          contents: expect.stringContaining('version = "24.16.0"'),
+          path: 'mise.lock',
+          type: 'addition',
+        },
+      },
+    ]);
+    expect(fs.readLocalFile).toHaveBeenCalledWith('mise.lock', 'utf8');
+    expect(execSnapshots).toMatchObject([
+      { cmd: trustSubdirCmd },
+      {
+        cmd: updateToolCmd,
+        options: {
+          cwd: '/tmp/github/some/repo/packages/a',
+        },
+      },
+    ]);
+  });
+
   it('handles subdirectory package files', async () => {
     fs.readLocalFile
       .mockResolvedValueOnce('existing content')

--- a/lib/modules/manager/mise/artifacts.ts
+++ b/lib/modules/manager/mise/artifacts.ts
@@ -110,7 +110,7 @@ export async function updateArtifacts({
   updatedDeps,
   config,
 }: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
-  const lockFileName = getLockFileName(packageFileName);
+  const lockFileName = await getLockFileName(packageFileName);
   const existingLockFileContent = await readLocalFile(lockFileName, 'utf8');
   if (!existingLockFileContent) {
     logger.debug({ lockFileName }, 'No mise lock file found');

--- a/lib/modules/manager/mise/extract.spec.ts
+++ b/lib/modules/manager/mise/extract.spec.ts
@@ -1245,6 +1245,35 @@ describe('modules/manager/mise/extract', () => {
       expect(result?.lockFiles).toBeUndefined();
     });
 
+    it('reads the monorepo root lock file for a subproject', async () => {
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('mise.lock');
+      fs.readLocalFile.mockResolvedValueOnce(codeBlock`
+        lockfile_version = 1
+
+        [[tools.node]]
+        version = "24.21.0"
+        backend = "core:node"
+        specifiers = ["24.21.0"]
+
+        [[tools.node]]
+        version = "22.19.0"
+        backend = "core:node"
+        specifiers = ["22"]
+      `);
+      const content = codeBlock`
+        [tools]
+        node = "22"
+        pnpm = "11"
+      `;
+      const result = await extractPackageFile(content, 'packages/a/mise.toml');
+      expect(result?.lockFiles).toEqual(['mise.lock']);
+      expect(result?.deps).toMatchObject([
+        { depName: 'node', currentValue: '22', lockedVersion: '22.19.0' },
+        { depName: 'pnpm', currentValue: '11' },
+      ]);
+      expect(result?.deps[1]).not.toHaveProperty('lockedVersion');
+    });
+
     it('works with environment-specific lock files', async () => {
       const testLockFileContent = codeBlock`
         [[tools.node]]

--- a/lib/modules/manager/mise/extract.ts
+++ b/lib/modules/manager/mise/extract.ts
@@ -76,7 +76,7 @@ export async function extractPackageFile(
 
   const result: PackageFileContent = { deps };
 
-  const lockFileName = getLockFileName(packageFile);
+  const lockFileName = await getLockFileName(packageFile);
   const lockFileContent = await readLocalFile(lockFileName, 'utf8');
 
   if (lockFileContent) {
@@ -87,6 +87,7 @@ export async function extractPackageFile(
         const lockedVersion = getLockedVersion(
           lockFileParsed.data,
           dep.depName!,
+          dep.currentValue,
         );
         if (lockedVersion) {
           dep.lockedVersion = lockedVersion;

--- a/lib/modules/manager/mise/lockfile.spec.ts
+++ b/lib/modules/manager/mise/lockfile.spec.ts
@@ -1,9 +1,12 @@
+import { fs } from '~test/util.ts';
 import {
   getConfigType,
   getLockFileName,
   getLockedVersion,
 } from './lockfile.ts';
 import type { MiseLockFile } from './schema.ts';
+
+vi.mock('../../../util/fs/index.ts');
 
 describe('modules/manager/mise/lockfile', () => {
   describe('getConfigType()', () => {
@@ -37,8 +40,19 @@ describe('modules/manager/mise/lockfile', () => {
       ${'subdir/mise.prod.toml'}    | ${'subdir/mise.prod.lock'}
       ${'conf.d/python.toml'}       | ${'mise.lock'}
       ${'project/conf.d/node.toml'} | ${'project/mise.lock'}
-    `('returns $expected for $configPath', ({ configPath, expected }) => {
-      expect(getLockFileName(configPath)).toBe(expected);
+    `('returns $expected for $configPath', async ({ configPath, expected }) => {
+      await expect(getLockFileName(configPath)).resolves.toBe(expected);
+    });
+
+    it('returns the monorepo root lock file when no colocated lock file exists', async () => {
+      fs.findLocalSiblingOrParent.mockResolvedValueOnce('mise.lock');
+      await expect(getLockFileName('packages/a/mise.toml')).resolves.toBe(
+        'mise.lock',
+      );
+      expect(fs.findLocalSiblingOrParent).toHaveBeenCalledWith(
+        'packages/a/mise.lock',
+        'mise.lock',
+      );
     });
   });
 
@@ -69,6 +83,35 @@ describe('modules/manager/mise/lockfile', () => {
 
     it('returns first version when multiple versions exist', () => {
       expect(getLockedVersion(lockFileData, 'python')).toBe('3.10.17');
+    });
+
+    describe('with specifiers', () => {
+      const rootLockFileData: MiseLockFile = {
+        tools: {
+          node: [
+            { version: '24.21.0', specifiers: ['24.21.0'] },
+            { version: '22.19.0', specifiers: ['22'] },
+            { version: '20.11.0' },
+          ],
+          pnpm: [{ version: '11.25.0' }],
+        },
+      };
+
+      it.each`
+        depName        | currentValue | expected
+        ${'node'}      | ${'22'}      | ${'22.19.0'}
+        ${'core:node'} | ${'24.21.0'} | ${'24.21.0'}
+        ${'node'}      | ${'20'}      | ${undefined}
+        ${'node'}      | ${undefined} | ${'24.21.0'}
+        ${'pnpm'}      | ${'11'}      | ${'11.25.0'}
+      `(
+        'returns $expected for $depName = $currentValue',
+        ({ depName, currentValue, expected }) => {
+          expect(
+            getLockedVersion(rootLockFileData, depName, currentValue),
+          ).toBe(expected);
+        },
+      );
     });
 
     it('handles tools with bracket options in name', () => {

--- a/lib/modules/manager/mise/lockfile.ts
+++ b/lib/modules/manager/mise/lockfile.ts
@@ -1,4 +1,5 @@
 import upath from 'upath';
+import { findLocalSiblingOrParent } from '../../../util/fs/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import type { MiseLockFile } from './schema.ts';
 import type { MiseConfigType } from './types.ts';
@@ -22,8 +23,13 @@ export function getConfigType(configPath: string): MiseConfigType {
 /**
  * Derives the lock file path from a mise config file path.
  * Matches mise's lockfile_path_for_config() logic from src/lockfile.rs
+ *
+ * In monorepo mode (`monorepo_root = true` with `[monorepo] lockfile = true`)
+ * mise writes a single lock file at the monorepo root and removes the
+ * subproject ones, so a colocated lock file wins and otherwise the nearest
+ * ancestor lock file is used.
  */
-export function getLockFileName(configPath: string): string {
+export async function getLockFileName(configPath: string): Promise<string> {
   const dirname = upath.dirname(configPath);
   const parentDirname = upath.basename(dirname);
 
@@ -43,7 +49,9 @@ export function getLockFileName(configPath: string): string {
     lockFileName = 'mise.lock';
   }
 
-  return upath.join(lockDir, lockFileName);
+  const colocated = upath.join(lockDir, lockFileName);
+  const found = await findLocalSiblingOrParent(colocated, lockFileName);
+  return found ?? colocated;
 }
 
 /**
@@ -78,6 +86,7 @@ export function getLockFileName(configPath: string): string {
 export function getLockedVersion(
   lockFileData: MiseLockFile,
   depName: string,
+  currentValue?: string,
 ): string | undefined {
   // Try full name first (for non-registry tools like ubi:, aqua:)
   let lockedTools = lockFileData.tools[depName];
@@ -89,6 +98,14 @@ export function getLockedVersion(
       const shortName = depName.substring(delimiterIndex + 1);
       lockedTools = lockFileData.tools[shortName];
     }
+  }
+
+  // Version 1 lock files record the original request in `specifiers`. A
+  // monorepo root lock file can hold several entries for one tool, so match
+  // on the specifier when the lock file has them.
+  if (currentValue && lockedTools?.some((tool) => tool.specifiers)) {
+    return lockedTools.find((tool) => tool.specifiers?.includes(currentValue))
+      ?.version;
   }
 
   return lockedTools?.[0]?.version;

--- a/lib/modules/manager/mise/lockfile.ts
+++ b/lib/modules/manager/mise/lockfile.ts
@@ -86,7 +86,7 @@ export async function getLockFileName(configPath: string): Promise<string> {
 export function getLockedVersion(
   lockFileData: MiseLockFile,
   depName: string,
-  currentValue?: string,
+  currentValue?: string | null,
 ): string | undefined {
   // Try full name first (for non-registry tools like ubi:, aqua:)
   let lockedTools = lockFileData.tools[depName];

--- a/lib/modules/manager/mise/readme.md
+++ b/lib/modules/manager/mise/readme.md
@@ -31,6 +31,9 @@ Renovate recognizes environment-specific lock files:
 - `mise.{env}.lock` - environment-specific lock files (e.g., `mise.production.lock`)
 - `mise.{env}.local.lock` - environment-specific local lock files, typically ignored alongside `mise.{env}.local.toml`
 
+Renovate also supports [monorepo](https://mise.jdx.dev/tasks/monorepo.html#lockfiles) root lock files (`monorepo_root = true` with `[monorepo] lockfile = true`).
+When a config file has no lock file in its own directory, Renovate uses the nearest lock file in a parent directory and matches locked versions on the lock file's `specifiers`.
+
 For more information about mise lock files, see the [mise lock file documentation](https://mise.jdx.dev/dev-tools/mise-lock.html).
 
 ### Trust model for lock file updates

--- a/lib/modules/manager/mise/schema.ts
+++ b/lib/modules/manager/mise/schema.ts
@@ -43,6 +43,7 @@ export type MiseFile = z.infer<typeof MiseFile>;
 const MiseLockTool = z.object({
   version: z.string(),
   backend: z.string().optional(),
+  specifiers: z.array(z.string()).optional(),
   options: z.record(z.string(), z.string()).optional(),
   platforms: z
     .record(


### PR DESCRIPTION
## Changes

Support mise [monorepo root lock files](https://mise.jdx.dev/tasks/monorepo.html#lockfiles) in the `mise` manager.

Since mise 2026.7.0, a monorepo root config with `monorepo_root = true` and `[monorepo] lockfile = true` makes every subproject write to a single `mise.lock` at the monorepo root, and mise deletes the per-subproject lock files. This becomes the default in mise 2027.6.0.

Renovate's `mise` manager only looked for a lock file next to each config file, so in such a monorepo:

- subproject package files extracted with no `lockFiles` and no `lockedVersion`
- `updateArtifacts` returned early with "No mise lock file found", leaving the root `mise.lock` stale after a subproject update
- a root lock file can hold several `[[tools.<name>]]` entries for the same tool (one per subproject request), and `getLockedVersion` always took the first one

This PR:

- resolves the lock file as the colocated one when it exists, otherwise the nearest one in a parent directory (`findLocalSiblingOrParent`, as the `cargo` manager does for workspaces)
- parses the lock file's `specifiers` (format version 1) and matches the locked version on the dep's `currentValue` when specifiers are present, falling back to the previous first-entry behaviour for legacy lock files
- documents root lock file support in the manager readme

`mise lock <tool>` already writes to the root lock file when run from a subproject directory, so the exec side is unchanged. Verified against a local three-config monorepo with mise 2026.9.1 that Renovate's extractor now reports the correct per-subproject `lockedVersion`.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Investigation, code, tests and docs were written with Claude Code, reviewed and directed by @bo0tzz.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @bo0tzz will read and reply directly.
- [ ] An agent will draft replies and @username will read them before they are posted.
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [x] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: N/A (extractor and `mise lock` behaviour were checked against a local scratch monorepo, not a full Renovate run)
