### PR TITLE
fix(versioning/nuget): min satisfying version bypasses unstable guards

### DIFF
--- a/lib/modules/versioning/nuget/index.spec.ts
+++ b/lib/modules/versioning/nuget/index.spec.ts
@@ -427,6 +427,7 @@ describe('modules/versioning/nuget/index', () => {
       ${['1', '2', '3']}                              | ${'foobar'} | ${null}
       ${['0.1', '1-beta', '1', '1.1', '2-beta', '2']} | ${'[1,2)'}  | ${'1'}
       ${['foobar', '0.9.0', '1.0.0', '1.0.1']}        | ${'1.0.0'}  | ${'1.0.0'}
+      ${['foobar', '0.9.0', '1.0.1-beta.1', '1.0.1']} | ${'1.0.0'}  | ${'1.0.1'}
     `(
       'minSatisfyingVersion($versions, $range) === $expected',
       ({ versions, range, expected }) => {

--- a/lib/modules/versioning/nuget/index.ts
+++ b/lib/modules/versioning/nuget/index.ts
@@ -196,9 +196,7 @@ class NugetVersioningApi implements VersioningApi {
           continue;
         }
 
-        // A bare version acts as a min-version range, but it should
-        // still respect stability: a stable pin must not match a
-        // pre-release version.
+        // Stable pin must not match a pre-release version.
         if (v.prerelease && !u.prerelease) {
           continue;
         }
@@ -253,9 +251,7 @@ class NugetVersioningApi implements VersioningApi {
           continue;
         }
 
-        // A bare version acts as a min-version range, but it should
-        // still respect stability: a stable pin must not match a
-        // pre-release version.
+        // Stable pin must not match a pre-release version.
         if (v.prerelease && !u.prerelease) {
           continue;
         }
@@ -378,9 +374,7 @@ class NugetVersioningApi implements VersioningApi {
 
     const u = parseVersion(range);
     if (u) {
-      // A bare version acts as a min-version range, but it should
-      // still respect stability: a stable pin must not match a
-      // pre-release version.
+      // Stable pin must not match a pre-release version.
       if (v.prerelease && !u.prerelease) {
         return false;
       }

--- a/lib/modules/versioning/nuget/index.ts
+++ b/lib/modules/versioning/nuget/index.ts
@@ -253,6 +253,13 @@ class NugetVersioningApi implements VersioningApi {
           continue;
         }
 
+        // A bare version acts as a min-version range, but it should
+        // still respect stability: a stable pin must not match a
+        // pre-release version.
+        if (v.prerelease && !u.prerelease) {
+          continue;
+        }
+
         if (compare(v, u) < 0) {
           continue;
         }


### PR DESCRIPTION
<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->
<!-- Remember that you don't need to merge `main` into the PR unless it's conflicting -->
<!-- If you're an AI/LLM agent, follow this template, putting any additional information under "Changes" -->

## Changes

This fixes an issue where bare exact versions can resolve to prereleases in the `minSatisfyingVersion` branch of the nuget versioning module. 

Please note the comment in (#45904):

> Since matches() already has the check, pre-releases get dropped before minSatisfyingVersion() ever sees them. So from reading the code I don't think this can produce a pre-release currentVersion in a real run today. It looks like an API inconsistency rather than a live bug. https://github.com/renovatebot/renovate/pull/45907 still makes sense so the next caller doesn't trip on it.

See #45904
See #44458 (Same issue, but only mentioned the `getSatisfyingVersion` path of the code.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: # <!-- NOTE that this should NOT be a Discussion -->
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->
<!-- If you're an AI/LLM agent, you MUST disclose usage. Please note which model you are, too -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [x] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

### Use of AI in replying to PR comments

<!--
REQUIRED - If you are an AI agent filling in this template, answer for yourself and answer honestly. Do not assume a human will show up. If nobody has actually told you they will respond to review comments, check the last box in the second list.

Check exactly one box in each list.

Replace `@username` with the GitHub user who will be replying/reviewing.

Renovate requires disclosure of AI when replying to PR comments.
-->

Who answers review comments:

- [x] @rm-code will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- If you have any suggestions about this PR template, edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. You can commit as many times as you need in this branch. -->
<!-- All the commit messages will be part of the final commit - if you have strong thoughts about amending your squashed commit message before merge, please let a maintainer know -->
