### PR TITLE
fix(manager/dockerfile): skip version update for a multi-arg interpolated FROM

### DIFF
--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -1120,6 +1120,33 @@ describe('modules/manager/dockerfile/extract', () => {
       ]);
     });
 
+    it('handles FROM with multiple ARG values and a digest', () => {
+      const digest = `sha256:${'a'.repeat(64)}`;
+      const res = extractPackageFile(
+        `ARG CUDA=9.2\nARG LINUX_VERSION ubuntu16.04\nFROM nvidia/cuda:\${CUDA}-devel-\${LINUX_VERSION}@${digest}\n`,
+        '',
+        {},
+      )?.deps;
+      // The resolved tag is composed from two args, so it is not present verbatim in
+      // the file and its version cannot be rewritten; it is marked skipReason so the
+      // version update is skipped instead of failing, while the FROM-line replaceString
+      // is kept for updateArtifacts to re-pin the digest of the composed tag.
+      expect(res).toEqual([
+        {
+          autoReplaceStringTemplate:
+            'FROM nvidia/cuda:${CUDA}-devel-${LINUX_VERSION}@{{#if newDigest}}{{newDigest}}{{/if}}',
+          currentDigest: digest,
+          currentValue: '9.2-devel-ubuntu16.04',
+          datasource: 'docker',
+          depName: 'nvidia/cuda',
+          packageName: 'nvidia/cuda',
+          depType: 'final',
+          replaceString: `FROM nvidia/cuda:\${CUDA}-devel-\${LINUX_VERSION}@${digest}`,
+          skipReason: 'contains-variable',
+        },
+      ]);
+    });
+
     it('skips scratch if provided in ARG value', () => {
       const res = extractPackageFile(
         'ARG img="scratch"\nFROM $img as base\n',

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -64,15 +64,20 @@ function processDepForAutoReplace(
   linefeed: string,
 ): void {
   const lineNumberRangesToReplace: number[][] = [];
+  let currentValueFound = false;
   for (const lineNumberRange of lineNumberRanges) {
     for (const lineNumber of lineNumberRange) {
-      if (
-        (isString(dep.currentValue) &&
-          lines[lineNumber].includes(dep.currentValue)) ||
-        (isString(dep.currentDigest) &&
-          lines[lineNumber].includes(dep.currentDigest))
-      ) {
+      const valueOnLine =
+        isString(dep.currentValue) &&
+        lines[lineNumber].includes(dep.currentValue);
+      const digestOnLine =
+        isString(dep.currentDigest) &&
+        lines[lineNumber].includes(dep.currentDigest);
+      if (valueOnLine || digestOnLine) {
         lineNumberRangesToReplace.push(lineNumberRange);
+      }
+      if (valueOnLine) {
+        currentValueFound = true;
       }
     }
   }
@@ -105,6 +110,14 @@ function processDepForAutoReplace(
   }
 
   dep.autoReplaceStringTemplate = getAutoReplaceTemplate(dep);
+
+  // A FROM tag composed from more than one `${ARG}` resolves to a value that is not
+  // present verbatim in the file, so its version cannot be rewritten in place and a
+  // version update would fail. Skip it; when it also pins a digest, updateArtifacts
+  // re-pins that digest for the composed tag using the replaceString kept above.
+  if (isString(dep.currentValue) && !currentValueFound) {
+    dep.skipReason = 'contains-variable';
+  }
 }
 
 export function splitImageParts(currentFrom: string): PackageDependency {


### PR DESCRIPTION
## Changes

A `FROM` image whose tag is composed from more than one `${ARG}` interpolation, e.g. `FROM image:${A}-${B}@sha256:...`, resolves to a value that is not present verbatim in the Dockerfile, so its version cannot be rewritten in place. When such a `FROM` also pins a digest, a version update was attempted anyway and failed the whole file update (`WORKER_FILE_UPDATE_FAILED`), because the auto-replace string was built from the `FROM` line and could rewrite the digest but not the composed version.

This marks such deps with a `skipReason` (`contains-variable`) during extraction, so the lookup short-circuits and no unwritable version update is attempted. The `FROM`-line `replaceString` is preserved, which lets a follow-up re-pin the digest for the composed tag.

Verified against the current `main`: extracting such a `FROM` and running `doAutoReplace` with a version update throws `WORKER_FILE_UPDATE_FAILED`; with this change extraction marks the dep so that update is skipped instead.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Multiple models were used to write the code and tests.

### Use of AI in replying to PR comments

- [x] An agent will draft replies and @MayCXC will read them before they are posted.

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Newly added/modified unit tests