### PR TITLE
feat(manager/dockerfile): re-pin digests of interpolated FROM images

### DIFF
--- a/lib/modules/manager/dockerfile/artifacts.spec.ts
+++ b/lib/modules/manager/dockerfile/artifacts.spec.ts
@@ -1,0 +1,112 @@
+import * as datasource from '../../datasource/index.ts';
+import { updateArtifacts } from './artifacts.ts';
+
+vi.mock('../../datasource/index.ts', async () => {
+  const actual = await vi.importActual<typeof datasource>(
+    '../../datasource/index.ts',
+  );
+  return {
+    ...actual,
+    getDigest: vi.fn(),
+  };
+});
+
+const getDigest = vi.mocked(datasource.getDigest);
+
+const oldDigest = `sha256:${'1'.repeat(64)}`;
+const newDigest = `sha256:${'2'.repeat(64)}`;
+
+const config = {};
+
+const interpolated = [
+  'ARG NODE_VERSION=20',
+  'ARG ALPINE_VERSION=3.19',
+  `FROM node:\${NODE_VERSION}-alpine\${ALPINE_VERSION}@${oldDigest} AS base`,
+  '',
+].join('\n');
+
+function run(newPackageFileContent: string) {
+  return updateArtifacts({
+    packageFileName: 'Dockerfile',
+    updatedDeps: [],
+    newPackageFileContent,
+    config,
+  });
+}
+
+describe('modules/manager/dockerfile/artifacts', () => {
+  describe('updateArtifacts()', () => {
+    it('re-pins the digest of an interpolated FROM image', async () => {
+      getDigest.mockResolvedValueOnce(newDigest);
+
+      const res = await run(interpolated);
+
+      expect(res).toEqual([
+        {
+          file: {
+            type: 'addition',
+            path: 'Dockerfile',
+            contents: interpolated.replace(oldDigest, newDigest),
+          },
+        },
+      ]);
+      expect(getDigest).toHaveBeenCalledWith(
+        { datasource: 'docker', packageName: 'node', registryUrls: undefined },
+        '20-alpine3.19',
+      );
+    });
+
+    it('returns null when there are no deps', async () => {
+      const res = await run('# no deps here\n');
+      expect(res).toBeNull();
+      expect(getDigest).not.toHaveBeenCalled();
+    });
+
+    it('skips a literal FROM image', async () => {
+      const res = await run(`FROM node:20@${oldDigest}\n`);
+      expect(res).toBeNull();
+      expect(getDigest).not.toHaveBeenCalled();
+    });
+
+    it('skips an interpolated FROM image without a digest', async () => {
+      const res = await run(
+        'ARG NODE_VERSION=20\nFROM node:${NODE_VERSION}-alpine\n',
+      );
+      expect(res).toBeNull();
+      expect(getDigest).not.toHaveBeenCalled();
+    });
+
+    it('skips a FROM image with an unresolvable variable', async () => {
+      const res = await run(
+        `ARG REGISTRY\nFROM \${REGISTRY}/node@${oldDigest}\n`,
+      );
+      expect(res).toBeNull();
+      expect(getDigest).not.toHaveBeenCalled();
+    });
+
+    it('returns null when the digest is unchanged', async () => {
+      getDigest.mockResolvedValueOnce(oldDigest);
+      const res = await run(interpolated);
+      expect(res).toBeNull();
+    });
+
+    it('returns null when no digest is resolved', async () => {
+      getDigest.mockResolvedValueOnce(null);
+      const res = await run(interpolated);
+      expect(res).toBeNull();
+    });
+
+    it('returns an artifact error when digest resolution fails', async () => {
+      getDigest.mockRejectedValueOnce(new Error('lookup failed'));
+      const res = await run(interpolated);
+      expect(res).toEqual([
+        {
+          artifactError: {
+            fileName: 'Dockerfile',
+            stderr: 'Failed to resolve digest for node:20-alpine3.19',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/lib/modules/manager/dockerfile/artifacts.ts
+++ b/lib/modules/manager/dockerfile/artifacts.ts
@@ -1,0 +1,113 @@
+import is from '@sindresorhus/is';
+import { logger } from '../../../logger/index.ts';
+import { DockerDatasource } from '../../datasource/docker/index.ts';
+import { getDigest } from '../../datasource/index.ts';
+import type {
+  ExtractConfig,
+  UpdateArtifact,
+  UpdateArtifactsResult,
+} from '../types.ts';
+import { extractPackageFile } from './extract.ts';
+
+/**
+ * Re-pin the digests of FROM images whose tag is composed from `ARG`
+ * interpolation, e.g. `FROM image:${ARG_A}-${ARG_B}@sha256:...`.
+ *
+ * Such an image resolves to a value (`a-b`) that is not a contiguous substring
+ * of the Dockerfile, because it lives across the `${ARG}` references, so the
+ * normal auto-replace flow cannot rewrite the version and leaves the digest
+ * pinned to the previous tag once the args are bumped. This runs after the args
+ * have been updated, recomposes each such tag from the current arg values, and
+ * resolves its digest with the docker datasource, so the digest and the args
+ * land in the same branch.
+ */
+export async function updateArtifacts({
+  packageFileName,
+  newPackageFileContent,
+  config,
+}: UpdateArtifact): Promise<UpdateArtifactsResult[] | null> {
+  const extractConfig: ExtractConfig = {
+    registryAliases: config.registryAliases,
+  };
+  const extracted = extractPackageFile(
+    newPackageFileContent,
+    packageFileName,
+    extractConfig,
+  );
+  if (!extracted?.deps?.length) {
+    return null;
+  }
+
+  let content = newPackageFileContent;
+  for (const dep of extracted.deps) {
+    // extract marks a FROM whose tag is composed from multiple `${ARG}`s with this
+    // skipReason: its version cannot be rewritten in place, so the normal flow leaves
+    // the digest pinned to the previous tag. A literal or single-variable tag is not
+    // marked and is re-pinned by the normal flow, so it is left alone here.
+    if (
+      dep.skipReason !== 'contains-variable' ||
+      dep.datasource !== DockerDatasource.id ||
+      !is.nonEmptyString(dep.packageName) ||
+      !is.nonEmptyString(dep.currentValue) ||
+      !is.nonEmptyString(dep.currentDigest) ||
+      !is.nonEmptyString(dep.replaceString)
+    ) {
+      continue;
+    }
+
+    let newDigest: string | null;
+    try {
+      newDigest = await getDigest(
+        {
+          datasource: dep.datasource,
+          packageName: dep.packageName,
+          registryUrls: dep.registryUrls,
+        },
+        dep.currentValue,
+      );
+    } catch (err) {
+      logger.debug(
+        { err, packageName: dep.packageName, tag: dep.currentValue },
+        'Dockerfile: failed to resolve digest for interpolated FROM image',
+      );
+      return [
+        {
+          artifactError: {
+            fileName: packageFileName,
+            stderr: `Failed to resolve digest for ${dep.packageName}:${dep.currentValue}`,
+          },
+        },
+      ];
+    }
+
+    if (newDigest && newDigest !== dep.currentDigest) {
+      logger.debug(
+        {
+          packageName: dep.packageName,
+          tag: dep.currentValue,
+          currentDigest: dep.currentDigest,
+          newDigest,
+        },
+        'Dockerfile: re-pinning digest for interpolated FROM image',
+      );
+      content = content.replace(
+        dep.replaceString,
+        dep.replaceString.replace(dep.currentDigest, newDigest),
+      );
+    }
+  }
+
+  if (content === newPackageFileContent) {
+    return null;
+  }
+
+  return [
+    {
+      file: {
+        type: 'addition',
+        path: packageFileName,
+        contents: content,
+      },
+    },
+  ];
+}

--- a/lib/modules/manager/dockerfile/extract.spec.ts
+++ b/lib/modules/manager/dockerfile/extract.spec.ts
@@ -1120,6 +1120,33 @@ describe('modules/manager/dockerfile/extract', () => {
       ]);
     });
 
+    it('handles FROM with multiple ARG values and a digest', () => {
+      const digest = `sha256:${'a'.repeat(64)}`;
+      const res = extractPackageFile(
+        `ARG CUDA=9.2\nARG LINUX_VERSION ubuntu16.04\nFROM nvidia/cuda:\${CUDA}-devel-\${LINUX_VERSION}@${digest}\n`,
+        '',
+        {},
+      )?.deps;
+      // The resolved tag is composed from two args, so it is not present verbatim in
+      // the file and its version cannot be rewritten; it is marked skipReason so the
+      // version update is skipped instead of failing, while the FROM-line replaceString
+      // is kept for updateArtifacts to re-pin the digest of the composed tag.
+      expect(res).toEqual([
+        {
+          autoReplaceStringTemplate:
+            'FROM nvidia/cuda:${CUDA}-devel-${LINUX_VERSION}@{{#if newDigest}}{{newDigest}}{{/if}}',
+          currentDigest: digest,
+          currentValue: '9.2-devel-ubuntu16.04',
+          datasource: 'docker',
+          depName: 'nvidia/cuda',
+          packageName: 'nvidia/cuda',
+          depType: 'final',
+          replaceString: `FROM nvidia/cuda:\${CUDA}-devel-\${LINUX_VERSION}@${digest}`,
+          skipReason: 'contains-variable',
+        },
+      ]);
+    });
+
     it('skips scratch if provided in ARG value', () => {
       const res = extractPackageFile(
         'ARG img="scratch"\nFROM $img as base\n',

--- a/lib/modules/manager/dockerfile/extract.ts
+++ b/lib/modules/manager/dockerfile/extract.ts
@@ -64,15 +64,20 @@ function processDepForAutoReplace(
   linefeed: string,
 ): void {
   const lineNumberRangesToReplace: number[][] = [];
+  let currentValueFound = false;
   for (const lineNumberRange of lineNumberRanges) {
     for (const lineNumber of lineNumberRange) {
-      if (
-        (isString(dep.currentValue) &&
-          lines[lineNumber].includes(dep.currentValue)) ||
-        (isString(dep.currentDigest) &&
-          lines[lineNumber].includes(dep.currentDigest))
-      ) {
+      const valueOnLine =
+        isString(dep.currentValue) &&
+        lines[lineNumber].includes(dep.currentValue);
+      const digestOnLine =
+        isString(dep.currentDigest) &&
+        lines[lineNumber].includes(dep.currentDigest);
+      if (valueOnLine || digestOnLine) {
         lineNumberRangesToReplace.push(lineNumberRange);
+      }
+      if (valueOnLine) {
+        currentValueFound = true;
       }
     }
   }
@@ -105,6 +110,14 @@ function processDepForAutoReplace(
   }
 
   dep.autoReplaceStringTemplate = getAutoReplaceTemplate(dep);
+
+  // A FROM tag composed from more than one `${ARG}` resolves to a value that is not
+  // present verbatim in the file, so its version cannot be rewritten in place and a
+  // version update would fail. Skip it; when it also pins a digest, updateArtifacts
+  // re-pins that digest for the composed tag using the replaceString kept above.
+  if (isString(dep.currentValue) && !currentValueFound) {
+    dep.skipReason = 'contains-variable';
+  }
 }
 
 export function splitImageParts(currentFrom: string): PackageDependency {

--- a/lib/modules/manager/dockerfile/index.ts
+++ b/lib/modules/manager/dockerfile/index.ts
@@ -2,6 +2,7 @@ import type { Category } from '../../../constants/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { extractPackageFile } from './extract.ts';
 
+export { updateArtifacts } from './artifacts.ts';
 export { knownDepTypes } from './dep-types.ts';
 export { extractPackageFile };
 


### PR DESCRIPTION
## Changes

The tag of a `FROM` image composed from `${ARG}` interpolation, e.g. `FROM image:${A}-${B}@sha256:...`, cannot be updated in place, so once the args are bumped its pinned digest is left pointing at the previous tag. This adds `updateArtifacts` to the dockerfile manager: after the arg updates are written it recomposes each such tag from the current arg values, resolves the digest with the docker datasource (`getDigest`), and rewrites it through the dep's `replaceString`, so the digest and the args land in the same branch.

Stacked on top of #45908, which marks these FROMs with a `skipReason` so `updateArtifacts` can find them (and so enabling the manager on such a Dockerfile no longer crashes). This branch contains that commit as well; it becomes a single commit once #45908 merges. Please review #45908 first.

## Context

- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

- [x] Yes — substantive assistance (AI-generated non-trivial portions of code, tests, or documentation).

Multiple models were used to write the code and tests.

### Use of AI in replying to PR comments

- [x] An agent will draft replies and @MayCXC will read them before they are posted.

## Documentation

- [x] No documentation update is required

## How I've tested my work

- [x] Newly added/modified unit tests