### PR TITLE
refactor(manager): share repo status to file change conversion

### DIFF
--- a/lib/modules/manager/apm/artifacts.ts
+++ b/lib/modules/manager/apm/artifacts.ts
@@ -9,8 +9,10 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 
 export async function updateArtifacts({
   packageFileName,
@@ -54,19 +56,14 @@ export async function updateArtifacts({
     // instruction files go stale after a bump. `apm_modules/` is the gitignored
     // cache, so it is not reported here.
     const status = await getRepoStatus();
-    const res: UpdateArtifactsResult[] = [];
-    for (const path of [...status.modified, ...status.not_added]) {
-      // the manifest itself is committed as an updated package file
-      if (path === packageFileName) {
-        continue;
-      }
-      res.push({
-        file: { type: 'addition', path, contents: await readLocalFile(path) },
-      });
-    }
-    for (const path of status.deleted) {
-      res.push({ file: { type: 'deletion', path } });
-    }
+    const res = fileChangesToArtifactResults([
+      ...(await collectFileChanges(status, {
+        include: ['modified', 'not_added'],
+        // the manifest itself is committed as an updated package file
+        filter: (path) => path !== packageFileName,
+      })),
+      ...(await collectFileChanges(status, { include: ['deleted'] })),
+    ]);
     if (!res.length) {
       logger.debug('apm: no changed files after install');
       return null;

--- a/lib/modules/manager/cocoapods/artifacts.ts
+++ b/lib/modules/manager/cocoapods/artifacts.ts
@@ -2,7 +2,6 @@ import { quote } from 'shlex';
 import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
@@ -11,9 +10,11 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import { newlineRegex, regEx } from '../../../util/regex.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 
 const pluginRegex = regEx(`^\\s*plugin\\s*(['"])(?<plugin>[^'"]+)(['"])`);
 
@@ -123,25 +124,15 @@ export async function updateArtifacts({
   const podsDir = upath.join(upath.dirname(packageFileName), 'Pods');
   const podsManifestFileName = upath.join(podsDir, 'Manifest.lock');
   if (await readLocalFile(podsManifestFileName, 'utf8')) {
-    for (const f of status.modified.concat(status.not_added)) {
-      if (f.startsWith(podsDir)) {
-        res.push({
-          file: {
-            type: 'addition',
-            path: f,
-            contents: await readLocalFile(f),
-          },
-        });
-      }
-    }
-    for (const f of coerceArray(status.deleted)) {
-      res.push({
-        file: {
-          type: 'deletion',
-          path: f,
-        },
-      });
-    }
+    res.push(
+      ...fileChangesToArtifactResults([
+        ...(await collectFileChanges(status, {
+          include: ['modified', 'not_added'],
+          filter: (f) => f.startsWith(podsDir),
+        })),
+        ...(await collectFileChanges(status, { include: ['deleted'] })),
+      ]),
+    );
   }
   return res;
 }

--- a/lib/modules/manager/composer/artifacts.ts
+++ b/lib/modules/manager/composer/artifacts.ts
@@ -26,6 +26,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { coerceObject } from '../../../util/object.ts';
@@ -35,6 +36,7 @@ import { coerceString } from '../../../util/string.ts';
 import { GitTagsDatasource } from '../../datasource/git-tags/index.ts';
 import { PackagistDatasource } from '../../datasource/packagist/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 import { Lockfile, PackageFile } from './schema.ts';
 import type { AuthJson } from './types.ts';
 import {
@@ -232,25 +234,15 @@ export async function updateArtifacts({
     }
 
     logger.debug(`Committing vendor files in ${vendorDir}`);
-    for (const f of [...status.modified, ...status.not_added]) {
-      if (f.startsWith(vendorDir)) {
-        res.push({
-          file: {
-            type: 'addition',
-            path: f,
-            contents: await readLocalFile(f),
-          },
-        });
-      }
-    }
-    for (const f of status.deleted) {
-      res.push({
-        file: {
-          type: 'deletion',
-          path: f,
-        },
-      });
-    }
+    res.push(
+      ...fileChangesToArtifactResults([
+        ...(await collectFileChanges(status, {
+          include: ['modified', 'not_added'],
+          filter: (f) => f.startsWith(vendorDir),
+        })),
+        ...(await collectFileChanges(status, { include: ['deleted'] })),
+      ]),
+    );
 
     return res;
   } catch (err) {

--- a/lib/modules/manager/copier/artifacts.ts
+++ b/lib/modules/manager/copier/artifacts.ts
@@ -3,8 +3,9 @@ import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { logger } from '../../../logger/index.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
-import { readLocalFile, statLocalFile } from '../../../util/fs/index.ts';
+import { statLocalFile } from '../../../util/fs/index.ts';
 import { withGitEnvironment } from '../../../util/git/exec.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus, isFileModeEnabled } from '../../../util/git/index.ts';
 import type {
   UpdateArtifact,
@@ -133,55 +134,27 @@ export async function updateArtifacts({
 
   const canReadFileMode = await isFileModeEnabled();
 
-  for (const f of [
-    ...status.modified,
-    ...status.not_added,
-    ...status.conflicted,
-  ]) {
-    const fileRes: UpdateArtifactsResult = {
-      file: {
-        type: 'addition',
-        path: f,
-        contents: await readLocalFile(f),
-        isExecutable: await detectExecutable(f, canReadFileMode),
-      },
-    };
-    if (status.conflicted.includes(f)) {
+  // `git status` might detect a rename, which is then not contained
+  // in not_added/deleted. Ensure we respect renames as well if they happen.
+  const changes = await collectFileChanges(status, {
+    include: ['modified', 'not_added', 'conflicted', 'deleted', 'renamed'],
+    additionMetadata: async (f) => ({
+      isExecutable: await detectExecutable(f, canReadFileMode),
+    }),
+  });
+
+  for (const change of changes) {
+    const fileRes: UpdateArtifactsResult = { file: change };
+    if (change.type === 'addition' && status.conflicted.includes(change.path)) {
       // Make the reviewer aware of the conflicts.
       // This will be posted in a comment.
       fileRes.notice = {
-        file: f,
+        file: change.path,
         message:
           'This file had merge conflicts. Please check the proposed changes carefully!',
       };
     }
     res.push(fileRes);
-  }
-  for (const f of status.deleted) {
-    res.push({
-      file: {
-        type: 'deletion',
-        path: f,
-      },
-    });
-  }
-  // `git status` might detect a rename, which is then not contained
-  // in not_added/deleted. Ensure we respect renames as well if they happen.
-  for (const f of status.renamed) {
-    res.push({
-      file: {
-        type: 'deletion',
-        path: f.from,
-      },
-    });
-    res.push({
-      file: {
-        type: 'addition',
-        path: f.to,
-        contents: await readLocalFile(f.to),
-        isExecutable: await detectExecutable(f.to, canReadFileMode),
-      },
-    });
   }
   return res;
 }

--- a/lib/modules/manager/gomod/artifacts.ts
+++ b/lib/modules/manager/gomod/artifacts.ts
@@ -5,7 +5,6 @@ import upath from 'upath';
 import { GlobalConfig } from '../../../config/global.ts';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { coerceArray } from '../../../util/array.ts';
 import { getEnv } from '../../../util/env.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import { filterMap } from '../../../util/filter-map.ts';
@@ -17,6 +16,7 @@ import {
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import { withGitEnvironment } from '../../../util/git/exec.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import { isValid } from '../../versioning/semver/index.ts';
@@ -26,6 +26,7 @@ import type {
   UpdateArtifactsConfig,
   UpdateArtifactsResult,
 } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 import { getExtraDepsNotice } from './artifacts-extra.ts';
 import { getGoModulesInTidyOrder } from './package-tree.ts';
 
@@ -442,29 +443,17 @@ export async function updateArtifacts({
     const alreadyAdded = new Set<string>();
     const alreadyDeleted = new Set<string>();
     if (useVendor) {
-      for (const f of status.modified.concat(status.not_added)) {
-        if (vendorDir && f.startsWith(vendorDir)) {
-          alreadyAdded.add(f);
-          res.push({
-            file: {
-              type: 'addition',
-              path: f,
-              contents: await readLocalFile(f),
-            },
-          });
+      const vendorChanges = await collectFileChanges(status, {
+        filter: (f) => !!vendorDir && f.startsWith(vendorDir),
+      });
+      for (const change of vendorChanges) {
+        if (change.type === 'addition') {
+          alreadyAdded.add(change.path);
+        } else {
+          alreadyDeleted.add(change.path);
         }
       }
-      for (const f of coerceArray(status.deleted)) {
-        if (vendorDir && f.startsWith(vendorDir)) {
-          alreadyDeleted.add(f);
-          res.push({
-            file: {
-              type: 'deletion',
-              path: f,
-            },
-          });
-        }
-      }
+      res.push(...fileChangesToArtifactResults(vendorChanges));
     }
 
     // TODO: throws in tests (#22198)
@@ -508,27 +497,18 @@ export async function updateArtifacts({
       logger.debug(
         'Updating all modified files since generated files were added',
       );
-      for (const f of status.modified.concat(status.created)) {
-        if (!alreadyAdded.has(f)) {
-          res.push({
-            file: {
-              type: 'addition',
-              path: f,
-              contents: await readLocalFile(f),
-            },
-          });
-        }
-      }
-      for (const f of coerceArray(status.deleted)) {
-        if (!alreadyDeleted.has(f)) {
-          res.push({
-            file: {
-              type: 'deletion',
-              path: f,
-            },
-          });
-        }
-      }
+      res.push(
+        ...fileChangesToArtifactResults([
+          ...(await collectFileChanges(status, {
+            include: ['modified', 'created'],
+            filter: (f) => !alreadyAdded.has(f),
+          })),
+          ...(await collectFileChanges(status, {
+            include: ['deleted'],
+            filter: (f) => !alreadyDeleted.has(f),
+          })),
+        ]),
+      );
     }
     return res;
   } catch (err) {

--- a/lib/modules/manager/helmv3/artifacts.ts
+++ b/lib/modules/manager/helmv3/artifacts.ts
@@ -3,7 +3,6 @@ import pMap from 'p-map';
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
 import {
@@ -12,6 +11,7 @@ import {
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import * as hostRules from '../../../util/host-rules.ts';
 import { regEx } from '../../../util/regex.ts';
@@ -19,6 +19,7 @@ import * as yaml from '../../../util/yaml.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 import { generateHelmEnvs, generateLoginCmd } from './common.ts';
 import { isOCIRegistry, removeOCIPrefix } from './oci.ts';
 import type { ChartDefinition, Repository, RepositoryRule } from './types.ts';
@@ -174,35 +175,15 @@ export async function updateArtifacts({
     if (isTruthy(isUpdateOptionAddChartArchives)) {
       const chartsPath = getSiblingFileName(packageFileName, 'charts');
       const status = await getRepoStatus();
-      const chartsAddition = coerceArray(status.not_added);
-      const chartsDeletion = coerceArray(status.deleted);
-
-      for (const file of chartsAddition) {
-        // only add artifacts in the chart sub path
-        if (!isFileInDir(chartsPath, file)) {
-          continue;
-        }
-        fileChanges.push({
-          file: {
-            type: 'addition',
-            path: file,
-            contents: await readLocalFile(file),
-          },
-        });
-      }
-
-      for (const file of chartsDeletion) {
-        // only add artifacts in the chart sub path
-        if (!isFileInDir(chartsPath, file)) {
-          continue;
-        }
-        fileChanges.push({
-          file: {
-            type: 'deletion',
-            path: file,
-          },
-        });
-      }
+      fileChanges.push(
+        ...fileChangesToArtifactResults(
+          await collectFileChanges(status, {
+            include: ['not_added', 'deleted'],
+            // only add artifacts in the chart sub path
+            filter: (file) => isFileInDir(chartsPath, file),
+          }),
+        ),
+      );
     }
 
     return fileChanges.length > 0 ? fileChanges : null;

--- a/lib/modules/manager/jsonnet-bundler/artifacts.ts
+++ b/lib/modules/manager/jsonnet-bundler/artifacts.ts
@@ -1,10 +1,10 @@
 import { quote } from 'shlex';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
 import { readLocalFile } from '../../../util/fs/index.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import { regEx } from '../../../util/regex.ts';
 import type {
@@ -12,6 +12,7 @@ import type {
   UpdateArtifact,
   UpdateArtifactsResult,
 } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 
 function dependencyUrl(dep: PackageDependency): string {
   const url = dep.packageName!;
@@ -65,36 +66,7 @@ export async function updateArtifacts(
       return null;
     }
 
-    const res: UpdateArtifactsResult[] = [];
-
-    for (const f of coerceArray(status.modified)) {
-      res.push({
-        file: {
-          type: 'addition',
-          path: f,
-          contents: await readLocalFile(f),
-        },
-      });
-    }
-    for (const f of coerceArray(status.not_added)) {
-      res.push({
-        file: {
-          type: 'addition',
-          path: f,
-          contents: await readLocalFile(f),
-        },
-      });
-    }
-    for (const f of coerceArray(status.deleted)) {
-      res.push({
-        file: {
-          type: 'deletion',
-          path: f,
-        },
-      });
-    }
-
-    return res;
+    return fileChangesToArtifactResults(await collectFileChanges(status));
   } catch (err) /* istanbul ignore next */ {
     if (err.message === TEMPORARY_ERROR) {
       throw err;

--- a/lib/modules/manager/kustomize/artifacts.spec.ts
+++ b/lib/modules/manager/kustomize/artifacts.spec.ts
@@ -45,6 +45,7 @@ describe('modules/manager/kustomize/artifacts', () => {
     fs.privateCacheDir.mockReturnValue(
       '/tmp/renovate/cache/__renovate-private-cache',
     );
+    git.getRepoStatus.mockResolvedValue(partial<StatusResult>({}));
   });
 
   it('returns null if newPackageFileContent is not parseable', async () => {

--- a/lib/modules/manager/kustomize/artifacts.ts
+++ b/lib/modules/manager/kustomize/artifacts.ts
@@ -3,19 +3,19 @@ import { quote } from 'shlex';
 import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { coerceArray } from '../../../util/array.ts';
 import { exec } from '../../../util/exec/index.ts';
 import type { ExecOptions, ToolConstraint } from '../../../util/exec/types.ts';
 import {
   deleteLocalFile,
   getSiblingFileName,
   localPathExists,
-  readLocalFile,
 } from '../../../util/fs/index.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import { DockerDatasource } from '../../datasource/docker/index.ts';
 import { HelmDatasource } from '../../datasource/helm/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 import { generateHelmEnvs } from './common.ts';
 import { parseKustomize } from './extract.ts';
 
@@ -187,37 +187,13 @@ export async function updateArtifacts({
     }
 
     const status = await getRepoStatus();
-    const chartsAddition = coerceArray(status?.not_added);
-    const chartsDeletion = coerceArray(status?.deleted);
-
-    const fileChanges: UpdateArtifactsResult[] = [];
-
-    for (const file of chartsAddition) {
-      // only add artifacts in the chartHome path
-      if (!file.startsWith(chartHome)) {
-        continue;
-      }
-      fileChanges.push({
-        file: {
-          type: 'addition',
-          path: file,
-          contents: await readLocalFile(file),
-        },
-      });
-    }
-
-    for (const file of chartsDeletion) {
-      // only add artifacts in the chartHome path
-      if (!file.startsWith(chartHome)) {
-        continue;
-      }
-      fileChanges.push({
-        file: {
-          type: 'deletion',
-          path: file,
-        },
-      });
-    }
+    const fileChanges = fileChangesToArtifactResults(
+      await collectFileChanges(status, {
+        include: ['not_added', 'deleted'],
+        // only add artifacts in the chartHome path
+        filter: (file) => file.startsWith(chartHome),
+      }),
+    );
 
     return fileChanges.length > 0 ? fileChanges : null;
   } catch (err) {

--- a/lib/modules/manager/util.spec.ts
+++ b/lib/modules/manager/util.spec.ts
@@ -4,7 +4,11 @@ import { GitTagsDatasource } from '../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../datasource/gitlab-tags/index.ts';
 import { type PackageDependency } from './types.ts';
-import { applyGitSource, artifactErrorMessageFromExecError } from './util.ts';
+import {
+  applyGitSource,
+  artifactErrorMessageFromExecError,
+  fileChangesToArtifactResults,
+} from './util.ts';
 
 describe('modules/manager/util', () => {
   beforeEach(() => {
@@ -222,5 +226,17 @@ describe('modules/manager/util', () => {
     );
 
     expect(message).toBe('fallback message');
+  });
+
+  it('wraps file changes into artifact results', () => {
+    expect(
+      fileChangesToArtifactResults([
+        { type: 'addition', path: 'foo', contents: 'bar' },
+        { type: 'deletion', path: 'baz' },
+      ]),
+    ).toEqual([
+      { file: { type: 'addition', path: 'foo', contents: 'bar' } },
+      { file: { type: 'deletion', path: 'baz' } },
+    ]);
   });
 });

--- a/lib/modules/manager/util.ts
+++ b/lib/modules/manager/util.ts
@@ -1,11 +1,12 @@
 import { detectPlatform } from '../../util/common.ts';
 import type { ExecError } from '../../util/exec/exec-error.ts';
+import type { FileChange } from '../../util/git/types.ts';
 import { parseGitUrl } from '../../util/git/url.ts';
 import { GitRefsDatasource } from '../datasource/git-refs/index.ts';
 import { GitTagsDatasource } from '../datasource/git-tags/index.ts';
 import { GithubTagsDatasource } from '../datasource/github-tags/index.ts';
 import { GitlabTagsDatasource } from '../datasource/gitlab-tags/index.ts';
-import type { PackageDependency } from './types.ts';
+import type { PackageDependency, UpdateArtifactsResult } from './types.ts';
 
 export function applyGitSource(
   dep: PackageDependency,
@@ -65,4 +66,14 @@ export function artifactErrorMessageFromExecError(
   }
 
   return message;
+}
+
+/**
+ * Wraps {@link FileChange}s, e.g. the result of `collectFileChanges()`, into the
+ * result shape returned by `updateArtifacts()`.
+ */
+export function fileChangesToArtifactResults(
+  changes: FileChange[],
+): UpdateArtifactsResult[] {
+  return changes.map((file) => ({ file }));
 }

--- a/lib/modules/manager/vendir/artifacts.ts
+++ b/lib/modules/manager/vendir/artifacts.ts
@@ -1,16 +1,16 @@
 import { TEMPORARY_ERROR } from '../../../constants/error-messages.ts';
 import { logger } from '../../../logger/index.ts';
-import { coerceArray } from '../../../util/array.ts';
 import type { ExecOptions } from '../../../util/exec/types.ts';
 import {
-  getParentDir,
   getSiblingFileName,
   readLocalFile,
   writeLocalFile,
 } from '../../../util/fs/index.ts';
 import { withGitEnvironment } from '../../../util/git/exec.ts';
+import { collectFileChanges } from '../../../util/git/file-changes.ts';
 import { getRepoStatus } from '../../../util/git/index.ts';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types.ts';
+import { fileChangesToArtifactResults } from '../util.ts';
 
 const gitExec = withGitEnvironment();
 
@@ -64,35 +64,11 @@ export async function updateArtifacts({
 
     // add modified vendir archives to artifacts
     logger.debug("Adding Sync'd files to git");
-    // Files must be in the vendor path to get added
-    const vendorDir = getParentDir(packageFileName);
     const status = await getRepoStatus();
     if (status) {
-      const modifiedFiles = coerceArray(status.modified);
-      const notAddedFiles = status.not_added;
-      const deletedFiles = coerceArray(status.deleted);
-
-      for (const f of modifiedFiles.concat(notAddedFiles)) {
-        const isFileInVendorDir = f.startsWith(vendorDir);
-        if (vendorDir || isFileInVendorDir) {
-          fileChanges.push({
-            file: {
-              type: 'addition',
-              path: f,
-              contents: await readLocalFile(f),
-            },
-          });
-        }
-      }
-
-      for (const f of deletedFiles) {
-        fileChanges.push({
-          file: {
-            type: 'deletion',
-            path: f,
-          },
-        });
-      }
+      fileChanges.push(
+        ...fileChangesToArtifactResults(await collectFileChanges(status)),
+      );
     } else {
       logger.error('Failed to get git status');
     }

--- a/lib/util/git/file-changes.spec.ts
+++ b/lib/util/git/file-changes.spec.ts
@@ -1,0 +1,132 @@
+import { fs, partial } from '~test/util.ts';
+import { collectFileChanges } from './file-changes.ts';
+import type { StatusResult } from './types.ts';
+
+vi.mock('../fs/index.ts');
+
+describe('util/git/file-changes', () => {
+  beforeEach(() => {
+    fs.readLocalFile.mockImplementation((file) =>
+      Promise.resolve(`content of ${file as string}`),
+    );
+  });
+
+  it('collects modified, not added and deleted files by default', async () => {
+    const status = partial<StatusResult>({
+      modified: ['modified.txt'],
+      not_added: ['added.txt'],
+      created: ['created.txt'],
+      deleted: ['deleted.txt'],
+    });
+
+    expect(await collectFileChanges(status)).toEqual([
+      {
+        type: 'addition',
+        path: 'modified.txt',
+        contents: 'content of modified.txt',
+      },
+      {
+        type: 'addition',
+        path: 'added.txt',
+        contents: 'content of added.txt',
+      },
+      { type: 'deletion', path: 'deleted.txt' },
+    ]);
+  });
+
+  it('returns changes in the order of the included buckets', async () => {
+    const status = partial<StatusResult>({
+      modified: ['modified.txt'],
+      created: ['created.txt'],
+      conflicted: ['conflicted.txt'],
+      deleted: ['deleted.txt'],
+    });
+
+    expect(
+      await collectFileChanges(status, {
+        include: ['deleted', 'conflicted', 'created'],
+      }),
+    ).toEqual([
+      { type: 'deletion', path: 'deleted.txt' },
+      {
+        type: 'addition',
+        path: 'conflicted.txt',
+        contents: 'content of conflicted.txt',
+      },
+      {
+        type: 'addition',
+        path: 'created.txt',
+        contents: 'content of created.txt',
+      },
+    ]);
+  });
+
+  it('turns renames into a deletion and an addition', async () => {
+    const status = partial<StatusResult>({
+      renamed: [{ from: 'old.txt', to: 'new.txt' }],
+    });
+
+    expect(await collectFileChanges(status, { include: ['renamed'] })).toEqual([
+      { type: 'deletion', path: 'old.txt' },
+      { type: 'addition', path: 'new.txt', contents: 'content of new.txt' },
+    ]);
+  });
+
+  it('applies the filter to every bucket', async () => {
+    const status = partial<StatusResult>({
+      modified: ['sub/modified.txt', 'other/modified.txt'],
+      deleted: ['sub/deleted.txt', 'other/deleted.txt'],
+      renamed: [
+        { from: 'other/old.txt', to: 'sub/new.txt' },
+        { from: 'sub/old.txt', to: 'other/new.txt' },
+      ],
+    });
+
+    expect(
+      await collectFileChanges(status, {
+        include: ['modified', 'deleted', 'renamed'],
+        filter: (path) => path.startsWith('sub/'),
+      }),
+    ).toEqual([
+      {
+        type: 'addition',
+        path: 'sub/modified.txt',
+        contents: 'content of sub/modified.txt',
+      },
+      { type: 'deletion', path: 'sub/deleted.txt' },
+      {
+        type: 'addition',
+        path: 'sub/new.txt',
+        contents: 'content of sub/new.txt',
+      },
+      { type: 'deletion', path: 'sub/old.txt' },
+    ]);
+  });
+
+  it('attaches addition metadata', async () => {
+    const status = partial<StatusResult>({ not_added: ['bin/tool'] });
+
+    expect(
+      await collectFileChanges(status, {
+        include: ['not_added'],
+        additionMetadata: (path) =>
+          Promise.resolve({ isExecutable: path.startsWith('bin/') }),
+      }),
+    ).toEqual([
+      {
+        type: 'addition',
+        path: 'bin/tool',
+        contents: 'content of bin/tool',
+        isExecutable: true,
+      },
+    ]);
+  });
+
+  it('tolerates missing buckets', async () => {
+    expect(
+      await collectFileChanges(partial<StatusResult>({}), {
+        include: ['modified', 'deleted', 'renamed'],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/lib/util/git/file-changes.ts
+++ b/lib/util/git/file-changes.ts
@@ -1,0 +1,98 @@
+import { coerceArray } from '../array.ts';
+import { readLocalFile } from '../fs/index.ts';
+import type { FileAddition, FileChange, StatusResult } from './types.ts';
+
+/**
+ * The `git status` buckets which can be turned into {@link FileChange}s.
+ *
+ * All of them describe additions, except `deleted` which describes deletions
+ * and `renamed` which describes a deletion followed by an addition.
+ */
+export type RepoStatusBucket =
+  | 'modified'
+  | 'not_added'
+  | 'created'
+  | 'conflicted'
+  | 'renamed'
+  | 'deleted';
+
+/**
+ * Extra metadata which can be attached to a {@link FileAddition}.
+ */
+export type FileAdditionMetadata = Partial<
+  Omit<FileAddition, 'type' | 'path' | 'contents'>
+>;
+
+export interface CollectFileChangesOptions {
+  /**
+   * The `git status` buckets to collect, in output order.
+   *
+   * @default ['modified', 'not_added', 'deleted']
+   */
+  include?: RepoStatusBucket[];
+
+  /**
+   * Only paths for which this returns `true` are collected.
+   */
+  filter?: (path: string) => boolean;
+
+  /**
+   * Called for every addition to attach extra metadata, e.g. the executable bit.
+   */
+  additionMetadata?: (path: string) => Promise<FileAdditionMetadata>;
+}
+
+const defaultInclude: RepoStatusBucket[] = ['modified', 'not_added', 'deleted'];
+
+async function toAddition(
+  path: string,
+  additionMetadata: CollectFileChangesOptions['additionMetadata'],
+): Promise<FileAddition> {
+  return {
+    type: 'addition',
+    path,
+    contents: await readLocalFile(path),
+    ...(await additionMetadata?.(path)),
+  };
+}
+
+/**
+ * Converts the result of `getRepoStatus()` into the {@link FileChange}s which
+ * managers return as artifact updates. The contents of every addition are read
+ * from the local directory.
+ */
+export async function collectFileChanges(
+  status: StatusResult,
+  options: CollectFileChangesOptions = {},
+): Promise<FileChange[]> {
+  const { include = defaultInclude, filter, additionMetadata } = options;
+  const changes: FileChange[] = [];
+
+  for (const bucket of include) {
+    if (bucket === 'renamed') {
+      for (const { from, to } of coerceArray(status.renamed)) {
+        if (!filter || filter(from)) {
+          changes.push({ type: 'deletion', path: from });
+        }
+        if (!filter || filter(to)) {
+          changes.push(await toAddition(to, additionMetadata));
+        }
+      }
+      continue;
+    }
+
+    for (const path of coerceArray(status[bucket])) {
+      if (filter && !filter(path)) {
+        continue;
+      }
+
+      if (bucket === 'deleted') {
+        changes.push({ type: 'deletion', path });
+      } else {
+        changes.push(await toAddition(path, additionMetadata));
+      }
+    }
+  }
+
+  return changes;
+}


### PR DESCRIPTION
## Changes

Nine managers ended `updateArtifacts()` with the same loop: call `getRepoStatus()`, push an addition for every file in some union of `modified` / `not_added` / `created`, push a deletion for every file in `deleted`, usually behind a path prefix filter. The copies differed in null handling (`coerceArray(status.deleted)` vs `status.deleted || []` vs bare) and in which buckets they looked at.

- New `collectFileChanges()` in `lib/util/git/file-changes.ts` turns a `StatusResult` into `FileChange`s: it reads the contents for additions, emits deletions, and takes the buckets to include and a path filter per call. It lives in its own module because `lib/util/git/index.ts` is auto-mocked in every spec.
- New `fileChangesToArtifactResults()` in `lib/modules/manager/util.ts` wraps them into the `updateArtifacts()` result shape.
- apm, cocoapods, composer, copier, gomod (both sites), helmv3, jsonnet-bundler, kustomize and vendir use the helpers. Each site keeps its own bucket selection and path filter, so the emitted artifacts are unchanged.
- Two dead pieces of logic are dropped: vendir's `vendorDir || isFileInVendorDir` condition, which was always true, and kustomize's optional chaining on a non-nullable status, which only mattered for an unset test mock (the spec now sets it).
- hermit (symlink handling) and npm post-update (`deleted` only) keep their bespoke flows.

Bottom of stack #46094: #46090 → #46091 → #46092 → #46093.

## Context

Please select one of the following:

- [ ] This closes an existing Issue, Closes: #
- [x] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [x] Yes — substantive assistance (AI-generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

Code, tests and this description were written with Claude Code (Claude Fable 5.1) under the author's direction and review.

### Use of AI in replying to PR comments

Who answers review comments:

- [x] @secustor will read and reply directly. **Name the account.**
- [ ] An agent will draft replies and @username will read them before they are posted. **Name the account.**
- [ ] Nobody has explicitly committed to replying.

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [x] Newly added/modified unit tests, or
- [ ] No unit tests, but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>
